### PR TITLE
[BUGFIX] ManagedSynonyms language determination

### DIFF
--- a/Classes/Facet/SimpleFacetRenderer.php
+++ b/Classes/Facet/SimpleFacetRenderer.php
@@ -79,7 +79,7 @@ class Tx_Solr_Facet_SimpleFacetRenderer extends Tx_Solr_Facet_AbstractFacetRende
 
 		if ($facet['count'] > $this->solrConfiguration['search.']['faceting.']['limit']) {
 			$showAllLink = '<a href="#" class="tx-solr-facet-show-all">###LLL:faceting_showMore###</a>';
-			$showAllLink = tslib_cObj::wrap($showAllLink, $this->solrConfiguration['search.']['faceting.']['showAllLink.']['wrap']);
+			$showAllLink = $GLOBALS['TSFE']->cObj->wrap($showAllLink, $this->solrConfiguration['search.']['faceting.']['showAllLink.']['wrap']);
 			$facet['show_all_link'] = $showAllLink;
 		}
 

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -568,7 +568,7 @@ class Tx_Solr_SolrService extends Apache_Solr_Service {
 		if (is_object($schema) && isset($schema->fieldTypes)) {
 			foreach ($schema->fieldTypes as $fieldType) {
 				if ($fieldType->name === 'text') {
-					foreach ($fieldType->indexAnalyzer->filters as $filter) {
+					foreach ($fieldType->queryAnalyzer->filters as $filter) {
 						if ($filter->class === 'solr.ManagedSynonymFilterFactory') {
 							$language = $filter->managed;
 						}

--- a/Classes/SpellChecker.php
+++ b/Classes/SpellChecker.php
@@ -136,7 +136,7 @@ class Tx_Solr_SpellChecker {
 
 			$suggestions = $this->getSuggestions();
 			if($suggestions && !$suggestions['correctlySpelled'] && !empty($suggestions['collation'])) {
-				$suggestionsLink = tslib_cObj::noTrimWrap(
+				$suggestionsLink = $GLOBALS['TSFE']->cObj->noTrimWrap(
 					$this->getSuggestionQueryLink(),
 					$this->configuration['search.']['spellchecking.']['wrap']
 				);

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		}
 	],
 	"require": {
-		"php": ">5.3.0,~5.5.0"
+		"php": ">5.3.0,~5.6.0"
 	},
 	"require-dev": {
 		"typo3-ci/typo3cms": "dev-master"


### PR DESCRIPTION
The ManagedSynonymsFilterFactory was moved from indexAnalyzer to
queryAnalyzer, therefore we must look there in the schema in order
to determine the language.

Resolves: #65676
Change-Id: I63e99c240f0d019dc411d7fe56204b273e1d715c