### PR TITLE
[TASK] SOLR_RELATION respect enableFields on MM-related records

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -268,11 +268,13 @@ class Relation {
 
 		$selectUids = $relationHandler->tableArray[$foreignTableName];
 		if (is_array($selectUids) && count($selectUids) > 0) {
+			$pageSelector = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+			$whereClause = $pageSelector->enableFields( $foreignTableName );
 			$relatedRecords = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
 				'uid, pid, ' .$foreignTableLabelField,
 				$foreignTableName,
 				'uid IN (' . implode(',', $selectUids) . ')'
-					. BackendUtility::deleteClause($foreignTableName)
+					. $whereClause
 			);
 			foreach ($relatedRecords as $record) {
 				if ($GLOBALS['TSFE']->sys_language_uid > 0) {


### PR DESCRIPTION
The RelationHandler doesn't respect enableFields of the table
behind the MM-relation. Because this has been in place for quite a
long time. A new option *respectEnablefieldsMM* is introduced, which
can be set as configuration parameter when using SOLR_RELATION to
filter e.g. hidden categories.

Resolves [#65692](https://forge.typo3.org/issues/65692)