### PR TITLE
[FEATURE] Add flush errors button to backend module

### DIFF
--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -67,7 +67,7 @@ class IndexQueueModuleController extends AbstractModuleController {
 	 * @return void
 	 */
 	public function initializeIndexQueueAction() {
-		$initializedIndexingConfigurations = [];
+		$initializedIndexingConfigurations = array();
 
 		$itemIndexQueue                     = GeneralUtility::makeInstance('Tx_Solr_IndexQueue_Queue');
 		$indexingConfigurationsToInitialize = GeneralUtility::_POST('tx_solr-index-queue-initialization');
@@ -93,7 +93,7 @@ class IndexQueueModuleController extends AbstractModuleController {
 			);
 		}
 
-		$messagesForConfigurations = [];
+		$messagesForConfigurations = array();
 		foreach (array_keys($initializedIndexingConfigurations) as $indexingConfigurationName) {
 			$itemCount = $itemIndexQueue->getItemsCountBySite($this->site, $indexingConfigurationName);
 			if (!is_int($itemCount)) {
@@ -121,7 +121,7 @@ class IndexQueueModuleController extends AbstractModuleController {
 	public function flushLogErrorsAction() {
 		/** @var DatabaseConnection $database */
 		$database = $GLOBALS['TYPO3_DB'];
-		$flushResult = $database->exec_UPDATEquery('tx_solr_indexqueue_item', 'errors NOT LIKE ""', ['errors' => '']);
+		$flushResult = $database->exec_UPDATEquery('tx_solr_indexqueue_item', 'errors NOT LIKE ""', array('errors' => ''));
 
 		$message = 'All errors has been flushed';
 		$severity = FlashMessage::OK;
@@ -168,7 +168,7 @@ class IndexQueueModuleController extends AbstractModuleController {
 			'pending, erroneous'
 		);
 
-		$stats = [];
+		$stats = array();
 		foreach($indexQueueStats as $row) {
 			if($row['erroneous'] == 1) {
 				$stats['erroneous'] = $row['count'];

--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Backend\SolrModule;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Index Queue Module
@@ -86,9 +87,11 @@ class IndexQueueModuleController extends AbstractModuleController {
 				);
 			}
 		} else {
+			$messageLabel = 'solr.backend.index_queue_module.flashmessage.initialize.no_selection';
+			$titleLabel = 'solr.backend.index_queue_module.flashmessage.not_initialized.title';
 			$this->addFlashMessage(
-				'No indexing configurations selected.',
-				'Index Queue not initialized',
+				LocalizationUtility::translate($messageLabel, 'Solr'),
+				LocalizationUtility::translate($titleLabel, 'Solr'),
 				FlashMessage::WARNING
 			);
 		}
@@ -103,9 +106,11 @@ class IndexQueueModuleController extends AbstractModuleController {
 		}
 
 		if (!empty($initializedIndexingConfigurations)) {
+			$messageLabel = 'solr.backend.index_queue_module.flashmessage.initialize.success';
+			$titleLabel = 'solr.backend.index_queue_module.flashmessage.initialize.title';
 			$this->addFlashMessage(
-				'Initialized indexing configurations: ' . implode(', ', $messagesForConfigurations),
-				'Index Queue initialized',
+				LocalizationUtility::translate($messageLabel, 'Solr', array(implode(', ', $messagesForConfigurations))),
+				LocalizationUtility::translate($titleLabel, 'Solr'),
 				FlashMessage::OK
 			);
 		}
@@ -123,16 +128,16 @@ class IndexQueueModuleController extends AbstractModuleController {
 		$database = $GLOBALS['TYPO3_DB'];
 		$flushResult = $database->exec_UPDATEquery('tx_solr_indexqueue_item', 'errors NOT LIKE ""', array('errors' => ''));
 
-		$message = 'All errors has been flushed';
+		$label = 'solr.backend.index_queue_module.flashmessage.success.flush_errors';
 		$severity = FlashMessage::OK;
 		if (!$flushResult) {
-			$message = 'An error occured while removing the error log in the index queue.';
+			$label = 'solr.backend.index_queue_module.flashmessage.error.flush_errors';
 			$severity = FlashMessage::ERROR;
 		}
 
 		$this->addFlashMessage(
-			$message,
-			'Index Queue errors',
+			LocalizationUtility::translate($label, 'Solr'),
+			LocalizationUtility::translate('solr.backend.index_queue_module.flashmessage.title', 'Solr'),
 			$severity
 		);
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2015-03-30T11:42:09Z">
+		<header>
+			<generator>LFEditor</generator>
+		</header>
+		<body>
+		<trans-unit id="solr.backend.index_queue_module.description" xml:space="preserve">
+			<source>The Index Queue manages content indexing. Content enters the Index Queue by initialization below or when new content is created based on configuration. Items in the Index Queue are indexed newest changes first until all items in the queue have been indexed.</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.flush_button" xml:space="preserve">
+			<source>Flush errors</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.headline" xml:space="preserve">
+			<source>Indexing Errors</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.id" xml:space="preserve">
+			<source>ID</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.item_type" xml:space="preserve">
+			<source>Item Type</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.item_uid" xml:space="preserve">
+			<source>Item UID</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.errors.show_button" xml:space="preserve">
+			<source>Show error</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.error.flush_errors" xml:space="preserve">
+			<source>An error occured while removing the error log in the index queue.</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.no_selection" xml:space="preserve">
+			<source>No indexing configurations selected.</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.success" xml:space="preserve">
+			<source>Initialized indexing configurations: %s</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.title" xml:space="preserve">
+			<source>Index Queue initialized</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.not_initialized.title" xml:space="preserve">
+			<source>Index Queue not initialized</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.success.flush_errors" xml:space="preserve">
+			<source>All errors have been reset.</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.flashmessage.title" xml:space="preserve">
+			<source>Index Queue</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.help" xml:space="preserve">
+			<source>Initializing the Index Queue is the most complete way to force re-indexing, or to build the Index Queue for the first time. The Index Queue Worker scheduler task will then index the items listed in the Index Queue.</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.status.errors" xml:space="preserve">
+			<source> Errors:</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.status.headline" xml:space="preserve">
+			<source>Index Queue Status</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.status.indexed" xml:space="preserve">
+			<source> Indexed:</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.status.pending" xml:space="preserve">
+			<source> Pending:</source>
+		</trans-unit>
+		<trans-unit id="solr.backend.index_queue_module.title" xml:space="preserve">
+			<source>Index Queue Initialization</source>
+		</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Templates/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/IndexQueueModule/Index.html
@@ -8,25 +8,21 @@
 
 
 <div class="well">
-	The Index Queue manages content indexing. Content enters the Index
-	Queue by initialization below or when new content is created based on
-	configuration. Items in the Index Queue are indexed newest changes first
-	until all items in the queue have been indexed.
+	<f:translate key="solr.backend.index_queue_module.description" />
 </div>
 
 
 
-<h2>Index Queue Initialization</h2>
+<h2>
+	<f:translate key="solr.backend.index_queue_module.title" />
+</h2>
 
 <f:form name="editform" actionUri="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'initializeIndexQueue'} )}">
 
 	<f:format.raw>{indexQueueInitializationSelector}</f:format.raw>
 	<f:form.submit name="initializeIndexQueue" value="Queue Selected Content for Indexing" />
 	<solr:backend.button.HelpButton title="Index Queue Initialization">
-		Initializing the Index Queue is the most complete way to force
-		re-indexing, or to build the Index Queue for the first time. The Index
-		Queue Worker scheduler task will then index the items listed in the
-		Index Queue.
+		<f:translate key="solr.backend.index_queue_module.help" />
 	</solr:backend.button.HelpButton>
 
 </f:form>
@@ -41,13 +37,21 @@
 
 <div class="row-fluid">
 	<div class="span8 well">
-		<h2>Indexing Errors</h2>
+		<h2>
+			<f:translate key="solr.backend.index_queue_module.errors.headline" />
+		</h2>
 
 		<table class="table">
 			<tr>
-				<th>ID</th>
-				<th>Item Type</th>
-				<th>Item UID</th>
+				<th>
+					<f:translate key="solr.backend.index_queue_module.errors.id" />
+				</th>
+				<th>
+					<f:translate key="solr.backend.index_queue_module.errors.item_type" />
+				</th>
+				<th>
+					<f:translate key="solr.backend.index_queue_module.errors.item_uid" />
+				</th>
 				<th></th>
 			</tr>
 
@@ -60,7 +64,9 @@
 						<script type="text/plain">
 							{item.errors}
 						</script>
-						<a href="javascript:void(0);" class="show_error">Show error</a>
+						<a href="javascript:void(0);" class="show_error">
+							<f:translate key="solr.backend.index_queue_module.errors.show_button" />
+						</a>
 					</td>
 				</tr>
 			</f:for>
@@ -68,27 +74,34 @@
 
 		<f:if condition="{indexqueue_errors}">
 			<a href="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'flushLogErrors'} )}"
-				class="btn btn-default" >Flush errors</a>
+				class="btn btn-default" >
+				<f:translate key="solr.backend.index_queue_module.errors.flush_button" />
+			</a>
 		</f:if>
 	</div>
 
 	<div class="span4 well stats_container">
-		<h2>Index Queue Status</h2>
+		<h2>
+			<f:translate key="solr.backend.index_queue_module.status.headline" />
+		</h2>
 
 		<canvas id="indexqueue_stats_chart" width="100" height="100"></canvas>
 
 		<div style="clear: both;"></div>
 
 		<div class="legend">
-			<span class="color" style="background: #EB813F;"></span> Pending:
+			<span class="color" style="background: #EB813F;"></span>
+			<f:translate key="solr.backend.index_queue_module.status.pending" />
 			<span id="pending_numbers"></span>
 		</div>
 		<div class="legend">
-			<span class="color" style="background: #FF3D3D;"></span> Errors:
+			<span class="color" style="background: #FF3D3D;"></span>
+			<f:translate key="solr.backend.index_queue_module.status.errors" />
 			<span id="error_numbers"></span>
 		</div>
 		<div class="legend">
-			<span class="color" style="background: #9FC299;"></span> Indexed:
+			<span class="color" style="background: #9FC299;"></span>
+			<f:translate key="solr.backend.index_queue_module.status.indexed" />
 			<span id="indexed_numbers"></span>
 		</div>
 	</div>

--- a/Resources/Private/Templates/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/IndexQueueModule/Index.html
@@ -65,6 +65,11 @@
 				</tr>
 			</f:for>
 		</table>
+
+		<f:if condition="{indexqueue_errors}">
+			<a href="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'flushLogErrors'} )}"
+				class="btn btn-default" >Flush errors</a>
+		</f:if>
 	</div>
 
 	<div class="span4 well stats_container">

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -118,7 +118,7 @@ if (TYPO3_MODE == 'BE') {
 		ApacheSolrForTypo3\Solr\Backend\SolrModule\AdministrationModuleManager::registerModule(
 			'ApacheSolrForTypo3.' . $_EXTKEY,
 			'IndexQueue',
-			array('index,initializeIndexQueue')
+			array('index,initializeIndexQueue,flushLogErrors')
 		);
 
 		ApacheSolrForTypo3\Solr\Backend\SolrModule\AdministrationModuleManager::registerModule(


### PR DESCRIPTION
It is not possible to reset the error currently.

This pull request add an button to the backend module to flush the error field.