### PR TITLE
[BUGFIX] Fixed menu generation for facets.

### DIFF
--- a/Classes/Facet/HierarchicalFacetHelper.php
+++ b/Classes/Facet/HierarchicalFacetHelper.php
@@ -89,7 +89,7 @@ class Tx_Solr_Facet_HierarchicalFacetHelper {
 	protected function getSubMenu(array $facetOptions, $menuName, $level) {
 		$menu = array();
 
-		$subMenuEntryPrefix = $level . '-' . $menuName;
+		$subMenuEntryPrefix = $level . '-' . $menuName . '/';
 
 		foreach ($facetOptions as $facetOptionKey => $facetOption) {
 				// find the sub menu items for the current menu


### PR DESCRIPTION
* Added '/' as separator to menu entry prefix
  to prevent wrong assignments. Before 2-144/27/28 would be assigned
  as child of 1-144/2, not only 2-144/27.