### PR TITLE
[BUGFIX] endtime has to be indexed in UTC (3.1.x)

### DIFF
--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -66,20 +66,24 @@ class Tx_Solr_FieldProcessor_Service {
 				}
 
 				switch ($instruction) {
+					case 'timestampToUtcIsoDate':
+						$processor  = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_Solr_FieldProcessor_TimestampToUtcIsoDate');
+						$fieldValue = $processor->process($fieldValue);
+						break;
 					case 'timestampToIsoDate':
-						$processor  = t3lib_div::makeInstance('Tx_Solr_FieldProcessor_TimestampToIsoDate');
+						$processor  = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_Solr_FieldProcessor_TimestampToIsoDate');
 						$fieldValue = $processor->process($fieldValue);
 						break;
 					case 'pathToHierarchy':
-						$processor  = t3lib_div::makeInstance('Tx_Solr_FieldProcessor_PathToHierarchy');
+						$processor  = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_Solr_FieldProcessor_PathToHierarchy');
 						$fieldValue = $processor->process($fieldValue);
 						break;
 					case 'pageUidToHierarchy':
-						$processor  = t3lib_div::makeInstance('Tx_Solr_FieldProcessor_PageUidToHierarchy');
+						$processor  = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_Solr_FieldProcessor_PageUidToHierarchy');
 						$fieldValue = $processor->process($fieldValue);
 						break;
 					case 'categoryUidToHierarchy':
-						$processor = t3lib_div::makeInstance('Tx_Solr_FieldProcessor_CategoryUidToHierarchy');
+						$processor = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_Solr_FieldProcessor_CategoryUidToHierarchy');
 						$fieldValue = $processor->process($fieldValue);
 						break;
 					case 'uppercase':

--- a/Classes/FieldProcessor/TimestampToUtcIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToUtcIsoDate.php
@@ -1,0 +1,53 @@
+<?php
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2009-2015 Andreas Allacher <andreas.allacher@cyberhouse.at>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+
+/**
+ * A field processor that converts timestamps to ISO dates as needed by Solr
+ *
+ * @author	Andreas Allacher <andreas.allacher@cyberhouse.at>
+ * @package	TYPO3
+ * @subpackage	solr
+ */
+class Tx_Solr_FieldProcessor_TimestampToUtcIsoDate implements Tx_Solr_FieldProcessor {
+
+	/**
+	 * Expects a timestamp and converts it to an ISO 8601 date in UTC as needed by Solr.
+	 *
+	 * Example date output format: 1995-12-31T23:59:59Z
+	 * The trailing "Z" designates UTC time and is mandatory
+	 *
+	 * @param	array	Array of values, an array because of multivalued fields
+	 * @return	array	Modified array of values
+	 */
+	public function process(array $values) {
+		$results = array();
+
+		foreach ($values as $timestamp) {
+			$results[] = Tx_Solr_Util::timestampToUtcIso($timestamp);
+		}
+
+		return $results;
+	}
+}

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -32,6 +32,8 @@
  */
 class Tx_Solr_Util {
 
+	const SOLR_ISO_DATETIME_FORMAT = 'Y-m-d\TH:i:s\Z';
+
 	/**
 	 * Generates a document id for documents representing page records.
 	 *
@@ -106,11 +108,11 @@ class Tx_Solr_Util {
 	/**
 	 * Converts a date from unix timestamp to ISO 8601 format.
 	 *
-	 * @param	integer	unix timestamp
+	 * @param	integer	$timestamp unix timestamp
 	 * @return	string	the date in ISO 8601 format
 	 */
 	public static function timestampToIso($timestamp) {
-		return date('Y-m-d\TH:i:s\Z', $timestamp);
+		return date(self::SOLR_ISO_DATETIME_FORMAT, $timestamp);
 	}
 
 	/**
@@ -120,23 +122,30 @@ class Tx_Solr_Util {
 	 * @return integer unix timestamp
 	 */
 	public static function isoToTimestamp($isoTime) {
-			// FIXME use DateTime::createFromFormat (PHP 5.3+)
-		$parsedTime = strptime($isoTime, '%Y-%m-%dT%H:%M:%SZ');
+		$dateTime = \DateTime::createFromFormat(self::SOLR_ISO_DATETIME_FORMAT, $isoTime);
+		return $dateTime ? (int)$dateTime->format('U') : 0;
+	}
 
-		$timestamp = mktime(
-			$parsedTime['tm_hour'],
-			$parsedTime['tm_min'],
-			$parsedTime['tm_sec'],
-				// strptime returns the "Months since January (0-11)"
-				// while mktime expects the month to be a value
-				// between 1 and 12. Adding 1 to solve the problem
-			$parsedTime['tm_mon'] + 1,
-			$parsedTime['tm_mday'],
-				// strptime returns the "Years since 1900"
-			$parsedTime['tm_year'] + 1900
-		);
+	/**
+	 * Converts a date from unix timestamp to ISO 8601 format in UTC timezone.
+	 *
+	 * @param	integer	$timestamp unix timestamp
+	 * @return	string	the date in ISO 8601 format
+	 */
+	public static function timestampToUtcIso($timestamp) {
+		return gmdate(self::SOLR_ISO_DATETIME_FORMAT, $timestamp);
+	}
 
-		return $timestamp;
+	/**
+	 * Converts a date from ISO 8601 format in UTC timzone to unix timestamp.
+	 *
+	 * @param string $isoTime date in ISO 8601 format
+	 * @return integer unix timestamp
+	 */
+	public static function utcIsoToTimestamp($isoTime) {
+		$utcTimeZone = new \DateTimeZone('UTC');
+		$dateTime = \DateTime::createFromFormat(self::SOLR_ISO_DATETIME_FORMAT, $isoTime, $utcTimeZone);
+		return $dateTime ? (int)$dateTime->format('U') : 0;
 	}
 
 	/**

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -61,7 +61,7 @@ plugin.tx_solr {
 		fieldProcessingInstructions {
 			changed = timestampToIsoDate
 			created = timestampToIsoDate
-			endtime = timestampToIsoDate
+			endtime = timestampToUtcIsoDate
 			rootline = pageUidToHierarchy
 		}
 

--- a/ext_autoload.php
+++ b/ext_autoload.php
@@ -81,6 +81,7 @@ return array(
 	'tx_solr_fieldprocessor_pathtohierarchy' => $extensionPath . 'Classes/FieldProcessor/PathToHierarchy.php',
 	'tx_solr_fieldprocessor_service' => $extensionPath . 'Classes/FieldProcessor/Service.php',
 	'tx_solr_fieldprocessor_timestamptoisodate' => $extensionPath . 'Classes/FieldProcessor/TimestampToIsoDate.php',
+	'tx_solr_fieldprocessor_timestamptoutcisodate' => $extensionPath . 'Classes/FieldProcessor/TimestampToUtcIsoDate.php',
 
 	'tx_solr_indexqueue_abstractindexer' => $extensionPath . 'Classes/IndexQueue/AbstractIndexer.php',
 	'tx_solr_indexqueue_indexer' => $extensionPath . 'Classes/IndexQueue/Indexer.php',


### PR DESCRIPTION
this is especially important for endtime because otherwise
DocExpirationUpdateProcessorFactory might be too early
or too late in removing a document