### PR TITLE
[TASK] Avoid using deprecated methods in objectmanager

### DIFF
--- a/Classes/Backend/SolrModule/AdministrationModuleManager.php
+++ b/Classes/Backend/SolrModule/AdministrationModuleManager.php
@@ -108,7 +108,7 @@ class AdministrationModuleManager {
 	public function getModule($moduleName) {
 		$this->validateModuleIsRegistered($moduleName);
 
-		$module = $this->objectManager->create($this->getModuleControllerClassName($moduleName));
+		$module = $this->objectManager->get($this->getModuleControllerClassName($moduleName));
 		$module->setExtensionKey(self::$modules[$moduleName]['extensionKey']);
 
 		if (!($module instanceof AdministrationModuleInterface)) {

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -152,7 +152,7 @@ class AdministrationController extends ActionController {
 	protected function invokeModuleController() {
 		$activeModuleDescription = $this->moduleManager->getModuleDescription($this->activeModuleName);
 
-		$request = $this->objectManager->create('TYPO3\CMS\Extbase\Mvc\Web\Request');
+		$request = $this->objectManager->get('TYPO3\CMS\Extbase\Mvc\Web\Request');
 		/* @var \TYPO3\CMS\Extbase\Mvc\Web\Request $request */
 		$request->setControllerExtensionName(ucfirst($activeModuleDescription['extensionKey']));
 		$request->setControllerName($activeModuleDescription['controller'] . 'Module');
@@ -173,7 +173,7 @@ class AdministrationController extends ActionController {
 			$request->setArgument($argumentName, $argumentValue);
 		}
 
-		$response = $this->objectManager->create('TYPO3\CMS\Extbase\Mvc\Web\Response');
+		$response = $this->objectManager->get('TYPO3\CMS\Extbase\Mvc\Web\Response');
 		/* @var \TYPO3\CMS\Extbase\Mvc\Web\Response $response */
 
 		while (!$request->isDispatched()) {

--- a/Classes/Service/ModuleDataStorageService.php
+++ b/Classes/Service/ModuleDataStorageService.php
@@ -54,7 +54,7 @@ class ModuleDataStorageService implements SingletonInterface {
 		$moduleData = $GLOBALS['BE_USER']->getModuleData(self::KEY);
 
 		if (empty($moduleData) || !$moduleData) {
-			$moduleData = $this->objectManager->create('ApacheSolrForTypo3\\Solr\\Domain\\Model\\ModuleData');
+			$moduleData = $this->objectManager->get('ApacheSolrForTypo3\\Solr\\Domain\\Model\\ModuleData');
 		} else {
 			$moduleData = unserialize($moduleData);
 		}


### PR DESCRIPTION
Since 6.1 the method "create" in the objectManager has been
marked as deprecated.

The method "get" is available, with the same purpose.

Fixes #17 