### PR TITLE
[TASK] moves indexing of additional news content elements to separate TypoScript template

### DIFF
--- a/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
@@ -23,13 +23,6 @@ plugin.tx_solr.index.queue {
 						field = bodytext
 						noTrimWrap = || |
 					}
-
-					20 = SOLR_RELATION
-					20 {
-						localField = content_elements
-						foreignLabelField = bodytext
-						singleValueGlue = | |
-					}
 				}
 			}
 

--- a/Configuration/TypoScript/Examples/IndexQueueNewsAdditional/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueNewsAdditional/setup.txt
@@ -1,0 +1,17 @@
+
+plugin.tx_solr.index.queue {
+	news {
+		fields {
+			content {
+				cObject {
+					20 = SOLR_RELATION
+					20 {
+						localField = content_elements
+						foreignLabelField = bodytext
+						singleValueGlue = | |
+					}
+				}
+			}
+		}
+	}
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -69,6 +69,7 @@ t3lib_extMgm::addStaticFile($_EXTKEY, 'Configuration/TypoScript/OpenSearch/', 'A
 
 	// Extension Pre-Configuration
 t3lib_extMgm::addStaticFile($_EXTKEY, 'Configuration/TypoScript/Examples/IndexQueueNews/', 'Apache Solr - Index Queue Configuration for news');
+t3lib_extMgm::addStaticFile($_EXTKEY, 'Configuration/TypoScript/Examples/IndexQueueNewsAdditional/', 'Apache Solr - Index Queue Configuration for additional news content elements');
 t3lib_extMgm::addStaticFile($_EXTKEY, 'Configuration/TypoScript/Examples/IndexQueueTtNews/', 'Apache Solr - Index Queue Configuration for tt_news');
 
 	// Examples


### PR DESCRIPTION
The SOLR_RELATION for the EXT:news field "content_elements" in Configuration/TypoScript/Examples/IndexQueueNews/setup.txt should be disabled by default since it depends on the activation of this feature in EXT:news configuration in EM (records.contentElementRelation) where it is disabled by default.
Related to [Forge issue #50146](https://forge.typo3.org/issues/50146).