### PR TITLE
[BUGFIX] remove superfluous replacement of #

### DIFF
--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -515,7 +515,6 @@ class Tx_Solr_Template {
 			$iterationCount = 0;
 			foreach ($loopVariables as $value) {
 				// escape content and title
-				$value = str_replace('#', '&#35;', $value);
 				if (isset($value['content'])) {
 					$value['content'] = $this->escapeResultContent($value['content']);
 				}


### PR DESCRIPTION
With commit bf74217 there was a patch by Stefan Galinsiki merged which he authored 2012-07-26.
A year later (2013-08-19), Ingo Renner introduced patch cc79a22b with `escapeMarkers()`.

Thus `$value = str_replace('#', '&#35;', $value);` seems to be superfluous. Furthermore it creates problems with the field `fileReferenceUrl` which is used by EXT:solrfal. This field stores URLs with anchor links which break with this str_replace.