### PR TITLE
[BUGFIX] Return zero as UID in the Frontend authorization service

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
+++ b/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
@@ -49,6 +49,7 @@ class Tx_Solr_IndexQueue_FrontendHelper_AuthorizationService extends tx_sv_authb
 	 */
 	public function getUser() {
 		return array(
+			'uid'           => 0,
 			'username'      => self::SOLR_INDEXER_USERNAME,
 			'authenticated' => TRUE
 		);


### PR DESCRIPTION
The getUser() method in the frontend helper
Tx_Solr_IndexQueue_FrontendHelper_AuthorizationService
returns a zero interger as UID in the user data array to prevent
database errors during the session initialization.

Resolves issue #35 for the 3.x branch.