### PR TITLE
Move Apache_Solr_Document to namespaced version

### DIFF
--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -223,7 +223,7 @@ class Typo3PageIndexer {
 	 * @return \Apache_Solr_Document A document representing the page
 	 */
 	protected function getPageDocument() {
-		$document = GeneralUtility::makeInstance('\\Apache_Solr_Document');
+		$document = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Document');
 		/* @var $document \Apache_Solr_Document */
 		$site       = Site::getSiteByPageId($this->page->id);
 		$pageRecord = $this->page->page;


### PR DESCRIPTION
The double backslash in the makeInstance parameter causes an exception. While fixing this, I also moved to namespaced version of the class name.