### PR TITLE
Remove backslash at the beginning of makeInstance parameter

### DIFF
--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -223,7 +223,7 @@ class Typo3PageIndexer {
 	 * @return \Apache_Solr_Document A document representing the page
 	 */
 	protected function getPageDocument() {
-		$document = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Document');
+		$document = GeneralUtility::makeInstance('Apache_Solr_Document');
 		/* @var $document \Apache_Solr_Document */
 		$site       = Site::getSiteByPageId($this->page->id);
 		$pageRecord = $this->page->page;

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -223,7 +223,7 @@ class Typo3PageIndexer {
 	 * @return \Apache_Solr_Document A document representing the page
 	 */
 	protected function getPageDocument() {
-		$document = GeneralUtility::makeInstance('\\Apache_Solr_Document');
+		$document = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Document');
 		/* @var $document \Apache_Solr_Document */
 		$site       = Site::getSiteByPageId($this->page->id);
 		$pageRecord = $this->page->page;


### PR DESCRIPTION
Backslashes before the FQCN are not allowed any more in TYPO3 7.