### PR TITLE
[BUGFIX] Implement enableRecursiveValueResolution for MM relations

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -285,11 +285,19 @@ class Relation {
 					. $whereClause
 			);
 			foreach ($relatedRecords as $record) {
-                // Recursion
                 if (isset($foreignTableTca['columns'][$foreignTableLabelField]['config']['foreign_table'])  && $this->configuration['enableRecursiveValueResolution']) {
-                    t3lib_div::loadTCA($foreignTableName);
-                    $foreignTableTca  = $GLOBALS['TCA'][$foreignTableName]['columns'][$foreignTableLabelField];
-                    return $this->getRelatedItemsFromMMTable($foreignTableName, $record['uid'], $foreignTableTca);
+                    if (strpos($this->configuration['foreignLabelField'], '.') !== FALSE) {
+                        $foreignLabelFieldArr = explode('.', $this->configuration['foreignLabelField']);
+                        unset($foreignLabelFieldArr[0]);
+                        $this->configuration['foreignLabelField'] = implode('.', $foreignLabelFieldArr);
+                    }
+
+                    $this->configuration['localField'] = $foreignTableLabelField;
+
+                    $contentObject = t3lib_div::makeInstance('\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+                    $contentObject->start($record, $foreignTableName);
+
+                    return $this->getRelatedItems($contentObject);
                 }
                 else {
                     if ($GLOBALS['TSFE']->sys_language_uid > 0) {


### PR DESCRIPTION
Please see https://forge.typo3.org/issues/66179 for details.

I am not sure if the dupe check at the end is needed any longer here, in the maintenance release from TER it is in, in your master branch it's gone. Maybe this is done in a different function now or has been removed.