### PR TITLE
fix missing content field in news

### DIFF
--- a/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
@@ -16,14 +16,7 @@ plugin.tx_solr.index.queue {
 
 			content = SOLR_CONTENT
 			content {
-				cObject = COA
-				cObject {
-					10 = TEXT
-					10 {
-						field = bodytext
-						noTrimWrap = || |
-					}
-				}
+				field = bodytext
 			}
 
 			category_stringM = SOLR_RELATION


### PR DESCRIPTION
the content field for a news entry wasn't indexed by using the static typoscript example for news, provided by the extension.