### PR TITLE
[BUGFIX] Change package name of TYPO3 CMS to typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=5.3.7 <6.0",
-    "typo3/cms-core": "~6.2.14,<8.0"
+    "typo3/cms": "~6.2.14,<8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"


### PR DESCRIPTION
At the moment, the package name used in composer.json is "typo3/cms-core" instead of "typo3/cms". Thus, a installation via composer is impossible. This little change fixes this.