### PR TITLE
[BUGFIX] Fix version constraint for typo3/cms-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=5.3.7 <6.0",
-    "typo3/cms-core": "~6.2.14,<8.0"
+    "typo3/cms": "~6.2.14,<8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,7 @@
   "autoload": {
     "classmap": [
       "Lib/",
-      "Classes/",
-      "Interfaces/",
-      "PiFrequentSearches/",
-      "PiResults/",
-      "PiSearch/",
-      "Report/"
+      "Classes/"
     ]
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=5.3.7 <6.0",
-    "typo3/cms": "~6.2.14,<8.0"
+    "typo3/cms": ">=6.2.14,<8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=5.3.7 <6.0",
-    "typo3/cms": ">=6.2.14,<8.0"
+    "typo3/cms-core": ">=6.2.14,<8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.0"


### PR DESCRIPTION
In the typo3/cms-core version constraint, "~6.2.14" is used. That resolves to >=6.2.14 <6.3.0. We should use >=6.2.14 instead.