### PR TITLE
[BUGFIX] migration map loading in 7.5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,12 @@
   "extra": {
     "class-alias-maps": [
       "Migrations/Code/ClassAliasMap.php"
-    ]
+    ],
+    "helhum/class-alias-loader": {
+      "always-add-alias-loader": true,
+      "class-alias-maps": [
+        "Migrations/Code/ClassAliasMap.php"
+      ]
+    }
   }
 }


### PR DESCRIPTION
In 7.5.x the new class alias loader is used which requires Migration maps to be added differently.

I kept the old section because in 6.x the old one still applies and added the new one additionally.