### PR TITLE
[BUGFIX] correctly render selected items for 7.5 in index queue selector

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -115,10 +115,14 @@ class IndexingConfigurationSelectorField {
 	public function render() {
 			// transform selected values into the format used by TCEforms
 		$selectedValues = array();
-		foreach ($this->selectedValues as $selectedValue) {
-			$selectedValues[] = $selectedValue . '|1';
+		if (class_exists('TYPO3\CMS\Backend\Form\FormDataCompiler')) {
+			$selectedValues = $this->selectedValues;
+		} else {
+			foreach ($this->selectedValues as $selectedValue) {
+				$selectedValues[] = $selectedValue . '|1';
+			}
+			$selectedValues = implode(',', $selectedValues);
 		}
-		$selectedValues = implode(',', $selectedValues);
 
 		$tablesToIndex = $this->getIndexQueueConfigurationTableMap();
 


### PR DESCRIPTION
In 7.5 the selectorfield does not accept a comma separated list anymore but requires an array of values.