### PR TITLE
[TASK] Util::initializeTsfe call settingLocale

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -106,11 +106,6 @@ abstract class AbstractIndexer {
 		if (isset($indexingConfiguration[$solrFieldName . '.'])) {
 			// configuration found => need to resolve a cObj
 
-			// setup locales
-			if ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController) {
-				$GLOBALS['TSFE']->settingLocale();
-			}
-
 			// need to change directory to make IMAGE content objects work in BE context
 			// see http://blog.netzelf.de/lang/de/tipps-und-tricks/tslib_cobj-image-im-backend
 			$backupWorkingDirectory = getcwd();

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -348,6 +348,8 @@ class Util {
 			$GLOBALS['TSFE']->getConfigArray();
 
 			$GLOBALS['TSFE']->settingLanguage();
+			$GLOBALS['TSFE']->settingLocale();
+
 			$GLOBALS['TSFE']->newCObj();
 			$GLOBALS['TSFE']->absRefPrefix = ($GLOBALS['TSFE']->config['config']['absRefPrefix'] ? trim($GLOBALS['TSFE']->config['config']['absRefPrefix']) : '');
 			$GLOBALS['TSFE']->calculateLinkVars();


### PR DESCRIPTION
I think it would be better to call settingLocale when initializing tsfe, therefore it will also not be required to be called in AbstractIndexer.