### PR TITLE
[BUGFIX] Handling of multiple mount points to the same page

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -229,6 +229,11 @@ class RecordMonitor {
 					}
 				}
 
+				// Clear existing index queue items to prevent mount point duplicates.
+				if ($recordTable == 'pages') {
+					$this->indexQueue->deleteItem('pages', $recordUid);
+				}
+
 				if ($this->isEnabledRecord($recordTable, $record)) {
 					$configurationName = NULL;
 					if ($recordTable !== 'pages') {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -58,10 +58,12 @@ CREATE TABLE tx_solr_indexqueue_item (
 	changed int(11) DEFAULT '0' NOT NULL,
 	indexed int(11) DEFAULT '0' NOT NULL,
 	errors text NOT NULL,
+	pages_mountidentifier varchar(255) DEFAULT '' NOT NULL,
 
 	PRIMARY KEY (uid),
 	KEY changed (changed),
-	KEY item_id (item_type,item_uid)
+	KEY item_id (item_type,item_uid),
+	KEY pages_mountpoint (item_type,item_uid,has_indexing_properties,pages_mountidentifier)
 ) ENGINE=InnoDB;
 
 


### PR DESCRIPTION
The handling of mount points of pages is improved. A unique identifier
for the different mount points is added to prevent overriding
existing data in the index queue item table when there are multiple
mount points pointing to the same page.