### PR TITLE
[BUGFIX] Respect mount point in access rootline

### DIFF
--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -165,14 +165,15 @@ class Rootline {
 	 * Gets the Access Rootline for a specific page Id.
 	 *
 	 * @param integer $pageId The page Id to generate the Access Rootline for.
+	 * @param string $mountPointParameter The mount point parameter for generating the rootline.
 	 * @return \ApacheSolrForTypo3\Solr\Access\Rootline Access Rootline for the given page Id.
 	 */
-	public static function getAccessRootlineByPageId($pageId) {
+	public static function getAccessRootlineByPageId($pageId, $mountPointParameter = '') {
 		$accessRootline = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Access\\Rootline');
 
 		$pageSelector = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
 		$pageSelector->init(FALSE);
-		$rootline = $pageSelector->getRootLine($pageId);
+		$rootline = $pageSelector->getRootLine($pageId, $mountPointParameter);
 		$rootline = array_reverse($rootline);
 
 			// parent pages

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -223,8 +223,9 @@ class PageIndexer extends Indexer {
 			$path = $this->options['frontendDataHelper.']['path'];
 		}
 
+		$mountPointParameter = $this->getMountPageDataUrlParameter($item);
 		$dataUrl = $scheme . '://' . $host . $path . 'index.php?id=' . $pageId;
-		$dataUrl .= $this->getMountPageDataUrlParameter($item);
+		$dataUrl .= ($mountPointParameter !== '') ? '&MP=' . $mountPointParameter : '';
 		$dataUrl .= '&L=' . $language;
 
 		if (!GeneralUtility::isValidUrl($dataUrl)) {
@@ -284,8 +285,8 @@ class PageIndexer extends Indexer {
 		$mountPageUrlParameter = '';
 
 		if ($item->hasIndexingProperty('isMountedPage')) {
-			$mountPageUrlParameter = '&MP='
-				. $item->getIndexingProperty('mountPageSource')
+			$mountPageUrlParameter =
+				$item->getIndexingProperty('mountPageSource')
 				. '-'
 				. $item->getIndexingProperty('mountPageDestination');
 		}
@@ -369,14 +370,20 @@ class PageIndexer extends Indexer {
 	protected function getAccessRootline(Item $item, $language = 0, $contentAccessGroup = null) {
 		static $accessRootlineCache;
 
+		$mountPointParameter = $this->getMountPageDataUrlParameter($item);
+
 		$accessRootlineCacheEntryId = $item->getRecordUid() . '|' . $language;
+		if ($mountPointParameter !== '') {
+			$accessRootlineCacheEntryId .= '|' . $mountPointParameter;
+		}
 		if (!is_null($contentAccessGroup)) {
 			$accessRootlineCacheEntryId .= '|' . $contentAccessGroup;
 		}
 
 		if (!isset($accessRootlineCache[$accessRootlineCacheEntryId])) {
 			$accessRootline = \ApacheSolrForTypo3\Solr\Access\Rootline::getAccessRootlineByPageId(
-				$item->getRecordUid()
+				$item->getRecordUid(),
+				$mountPointParameter
 			);
 
 			// current page's content access groups


### PR DESCRIPTION
Tx_Solr_Access_Rootline::getAccessRootlineByPageId() now accepts
an additional parameter for the current mount point.

In the page indexer the mount point parameter is used to build
correct access rootlines for mounted pages.