### PR TITLE
[BUGFIX] Use mount point parameter in page document ID

### DIFF
--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -67,7 +67,8 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
 		$results = array();
 
 		foreach ($values as $value) {
-			$results[] = $this->getSolrRootlineForPageId($value);
+			list($rootPageUid, $mountPoint) = t3lib_div::trimExplode(',', $value, TRUE, 2);
+			$results[] = $this->getSolrRootlineForPageId($rootPageUid, $mountPoint);
 		}
 
 		return $results;
@@ -77,10 +78,11 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
 	 * Returns a Solr hierarchy notation string for rootline of given PID.
 	 *
 	 * @param integer $pageId Page ID to get a rootline as Solr hierarchy for
+	 * @param string $mountPoint The mount point parameter that will be used for building the rootline.
 	 * @return string Rootline as Solr hierarchy
 	 */
-	protected function getSolrRootlineForPageId($pageId) {
-		$pageIdRootline = $this->buildPageIdRootline($pageId);
+	protected function getSolrRootlineForPageId($pageId, $mountPoint = '') {
+		$pageIdRootline = $this->buildPageIdRootline($pageId, $mountPoint);
 		$solrRootline   = $this->buildSolrHierarchyFromIdRootline($pageIdRootline);
 
 		return $solrRootline;
@@ -90,13 +92,14 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
 	 * Builds a page's rootline of parent page Ids
 	 *
 	 * @param integer $pageId The page Id to build the rootline for
+	 * @param string $mountPoint The mount point parameter that will be passed to getRootline().
 	 * @return array Page Id rootline as array
 	 */
-	protected function buildPageIdRootline($pageId) {
+	protected function buildPageIdRootline($pageId, $mountPoint = '') {
 		$rootlinePageIds = array();
 
 		$pageSelector = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
-		$rootline     = $pageSelector->getRootLine($pageId);
+		$rootline = $pageSelector->getRootLine($pageId, (string)$mountPoint);
 
 		foreach ($rootline as $page) {
 			if ($page['is_siteroot']) {

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -268,6 +268,7 @@ class PageIndexer extends AbstractFrontendHelper {
 			$indexer->setSolrConnection($this->getSolrConnection());
 			$indexer->setPageAccessRootline($this->getAccessRootline());
 			$indexer->setPageUrl($this->generatePageUrl());
+			$indexer->setMountPointParameter($GLOBALS['TSFE']->MP);
 
 			$this->responseData['pageIndexed']          = (int)$indexer->indexPage();
 			$this->responseData['originalPageDocument'] = (array)$indexer->getPageSolrDocument();

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -254,7 +254,13 @@ class Typo3PageIndexer {
 		$document->setField('typeNum',     $this->page->type);
 		$document->setField('created',     $pageRecord['crdate']);
 		$document->setField('changed',     $pageRecord['SYS_LASTCHANGED']);
-		$document->setField('rootline',    $this->page->id);
+
+		$rootline = $this->page->id;
+		$mountPointParameter = $this->getMountPointParameter();
+		if ($mountPointParameter !== '') {
+			$rootline .= ',' . $mountPointParameter;
+		}
+		$document->setField('rootline', $rootline);
 
 		// access
 		$document->setField('access', (string)$this->pageAccessRootline);

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -41,6 +41,13 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 class Typo3PageIndexer {
 
 	/**
+	 * The mount point parameter used in the Frontend controller.
+	 *
+	 * @var string
+	 */
+	protected $mountPointParameter;
+
+	/**
 	 * Solr server connection.
 	 *
 	 * @var SolrService
@@ -232,7 +239,8 @@ class Typo3PageIndexer {
 			$this->page->id,
 			$this->page->type,
 			$this->page->sys_language_uid,
-			$this->getDocumentIdGroups()
+			$this->getDocumentIdGroups(),
+			$this->getMountPointParameter()
 		);
 		$document->setField('id',          $documentId);
 		$document->setField('site',        $site->getDomain());
@@ -458,6 +466,24 @@ class Typo3PageIndexer {
 	 */
 	public function setPageUrl($url) {
 		$this->pageUrl = $url;
+	}
+
+	/**
+	 * Sets the mount point parameter that is used in the Frontend controller.
+	 *
+	 * @param string $mountPointParameter
+	 */
+	public function setMountPointParameter($mountPointParameter) {
+		$this->mountPointParameter = (string)$mountPointParameter;
+	}
+
+	/**
+	 * Gets the mount point parameter that is used in the Frontend controller.
+	 *
+	 * @return string
+	 */
+	public function getMountPointParameter() {
+		return $this->mountPointParameter;
 	}
 
 	/**

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -47,14 +47,21 @@ class Util {
 	 * @param integer $typeNum The page's typeNum
 	 * @param integer $language the language id, defaults to 0
 	 * @param string $accessGroups comma separated list of uids of groups that have access to that page
+	 * @param string $mountPointParameter The mount point parameter that is used to access the page.
 	 * @return string The document id for that page
 	 */
-	public static function getPageDocumentId($uid, $typeNum = 0, $language = 0, $accessGroups = '0,-1') {
+	public static function getPageDocumentId($uid, $typeNum = 0, $language = 0, $accessGroups = '0,-1', $mountPointParameter = '') {
+		$additionalParameters = $typeNum . '/' . $language . '/' . $accessGroups;
+
+		if ((string)$mountPointParameter !== '') {
+			$additionalParameters = $mountPointParameter . '/' . $additionalParameters;
+		}
+
 		$documentId = self::getDocumentId(
 			'pages',
 			$uid,
 			$uid,
-			$typeNum . '/' . $language . '/' . $accessGroups
+			$additionalParameters
 		);
 
 		return $documentId;


### PR DESCRIPTION
The mount parameter that is used to access a page is now passed on
to the page indexer and will be added to the page document ID if
it is not empty. This allows a page to appear multiple times in the
index in its different mount point contexts.