### PR TITLE
[BUGFIX] Respect overlay settings of mount points

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -388,9 +388,6 @@ class RecordMonitor {
 		$pageSelect = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
 		$rootLine   = $pageSelect->getRootLine($pageId);
 
-		// remove the current page / newly created page
-		array_shift($rootLine);
-
 		$destinationMountProperties = $this->getDestinationMountPropertiesByRootLine($rootLine);
 
 		if (!empty($destinationMountProperties)) {
@@ -408,24 +405,39 @@ class RecordMonitor {
 	 */
 	protected function getDestinationMountPropertiesByRootLine(array $rootLine) {
 		$mountPages = array();
-		$pageIds    = array();
+		$subPageUids = array();
+
+		$currentPage = array_shift($rootLine);
+		$currentPageUid = (int)$currentPage['uid'];
 
 		if (!empty($rootLine)) {
 			foreach ($rootLine as $pageRecord) {
-				$pageIds[] = $pageRecord['uid'];
+				$subPageUids[] = $pageRecord['uid'];
 
 				if ($pageRecord['is_siteroot']) {
 					break;
 				}
 			}
-
-			$mountPages = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-				'uid, uid AS mountPageDestination, mount_pid AS mountPageSource, mount_pid_ol AS mountPageOverlayed',
-				'pages',
-				'doktype = 7 AND no_search = 0 AND mount_pid IN(' . implode(',', $pageIds) . ')'
-					. BackendUtility::deleteClause('pages')
-			);
 		}
+
+		if (empty($rootLine) && $currentPageUid === 0) {
+			return $mountPages;
+		}
+
+		$pageQuery = '';
+		if (!empty($subPageUids)) {
+			$pageQuery = 'mount_pid IN(' . implode(',', $subPageUids) . ')';
+		}
+		if ($currentPageUid !== 0) {
+			$pageQuery .= ' OR (mount_pid=' . $currentPageUid . ' AND mount_pid_ol=1)';
+		}
+
+		$mountPages = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+			'uid, uid AS mountPageDestination, mount_pid AS mountPageSource, mount_pid_ol AS mountPageOverlayed',
+			'pages',
+			'(' . $pageQuery . ') AND doktype = 7 AND no_search = 0'
+				. BackendUtility::deleteClause('pages')
+		);
 
 		return $mountPages;
 	}

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -95,8 +95,8 @@ plugin.tx_solr {
 					// add options for the indexer here
 				}
 
-				// only index standard pages
-				additionalWhereClause = doktype = 1 AND no_search = 0
+				// Only index standard pages and mount points that are not overlayed.
+				additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
 
 				fields {
 					sortSubTitle_stringS = subtitle


### PR DESCRIPTION
When a page is stored in the Backend and a mount point page points
to it with overlay enabled the record monitor will now also add
the overlayed page to the index queue.

Pages with disabled mount point overlay will now be indexed as
normal pages by adjusting the default additionalWhereClause config
option.