### PR TITLE
[BUGFIX] PHP Fatal Error; t3lib_div should either be \t3lib_div:: or …

### DIFF
--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -67,7 +67,7 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
 		$results = array();
 
 		foreach ($values as $value) {
-			list($rootPageUid, $mountPoint) = t3lib_div::trimExplode(',', $value, TRUE, 2);
+			list($rootPageUid, $mountPoint) = GeneralUtility::trimExplode(',', $value, TRUE, 2);
 			$results[] = $this->getSolrRootlineForPageId($rootPageUid, $mountPoint);
 		}
 


### PR DESCRIPTION
…better GeneralUtility::

* using t3lib_div in namespace context results in a fatal error (while indexing)
* should either be \t3lib_div:: or better GeneralUtility::