### PR TITLE
[BUGFIX] Load Viewhelper by Namespace if old class name not exist

### DIFF
--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -203,6 +203,12 @@ class Template {
 			$viewHelperIncludePath = ExtensionManagementUtility::extPath($extensionKey)
 				. $viewHelperPath . $possibleFilename;
 
+			// @todo only dirty solution
+			if(!class_exists($possibleClassName)) {
+				$namespaceViewHelper = 'ApacheSolrForTypo3\\Solr\\ViewHelper\\' . Util::underscoredToUpperCamelCase($helperKey);
+				return $namespaceViewHelper;
+			}
+
 			if (file_exists($viewHelperIncludePath)) {
 				include_once($viewHelperIncludePath);
 				$this->loadedHelperFiles[strtolower($helperKey)] = array(


### PR DESCRIPTION
## Load ViewHelper by Namespace

If you use composer in TYPO3 CMS 7.x without legacy classes you get an exception because class can not found 