### PR TITLE
[BUGFIX] Fix invalid operator in version_compare

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -231,7 +231,7 @@ class IndexingConfigurationSelectorField
         );
 
         $selectFieldRenderer = $formEngine = null;
-        if (version_compare(TYPO3_branch, '7.3', ' >= ')) {
+        if (version_compare(TYPO3_branch, '7.3', '>=')) {
             /** @var \TYPO3\CMS\Backend\Form\NodeFactory $nodeFactory */
             $nodeFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Backend\\Form\\NodeFactory');
             $options = array(


### PR DESCRIPTION
The operator used in ``version_compare()`` is surrounded by spaces which leads ``version_compare()`` to return null.