### PR TITLE
[BUGFIX] Check if table is loaded in TCA

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -169,7 +169,9 @@ class IndexingConfigurationSelectorField
                         $table = $solrConfiguration['index.']['queue.'][$name . '.']['table'];
                     }
 
-                    $indexingTableMap[$name] = $table;
+                    if (isset($GLOBALS['TCA'][$table])) {
+                        $indexingTableMap[$name] = $table;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Tables for indexing could be configured while depending extensions are not installed, causing SQL errors in `AbstractInitializer::buildSelectStatement()` because the table is not available in TCA then. This patch adds a check to verify whether the table being indexed is in TCA.
