### PR TITLE
[BUGFIX] Restore behaviour of getQueryUrl in getQueryLink

### DIFF
--- a/Classes/Query/LinkBuilder.php
+++ b/Classes/Query/LinkBuilder.php
@@ -227,10 +227,10 @@ class LinkBuilder
             'useCacheHash' => false,
             'no_cache' => false,
             'parameter' => $this->linkTargetPageId,
-            'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl('',
+            'additionalParams' => $queryGetParameter
+                . \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl('',
                     array($this->prefix => $queryParameters), '', true)
                 . $this->getUrlParameters()
-                . $queryGetParameter
         );
 
         // merge linkConfiguration with typolinkOptions
@@ -293,7 +293,6 @@ class LinkBuilder
     {
         $this->urlParameters = $urlParameters;
     }
-
 
 }
 


### PR DESCRIPTION
Since a2ff9e4c085cdd019cd245445407d0edc3f1e52e the rendered
link in the hidden url field is wrong because $queryGetParameter
is appended now instead of prepended like before in getQueryUrl().

This broke the generated url for numericRange facets with a query
keyword.

This patch restores the prior parameter order from getQueryUrl() in
getQueryLink().

Resolves: #104