### PR TITLE
[TASK] Implement hook in UsedFacetRenderer 

### DIFF
--- a/Classes/Facet/UsedFacetOptionsRenderer.php
+++ b/Classes/Facet/UsedFacetOptionsRenderer.php
@@ -1,0 +1,43 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Facet;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Facet Renderer Interface
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ */
+interface UsedFacetOptionsRenderer
+{
+
+    /**
+     * The implementation can overwrite the text of a used facet.
+     *
+     * @param array $options
+     * @param UsedFacetRenderer $facetRenderer
+     * @return mixed
+     */
+    public function getUsedFacetText(array $options, UsedFacetRenderer $facetRenderer);
+}

--- a/Classes/Facet/UsedFacetRenderer.php
+++ b/Classes/Facet/UsedFacetRenderer.php
@@ -159,14 +159,20 @@ class UsedFacetRenderer extends SimpleFacetOptionsRenderer
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processUsedFacetText'] as $classReference) {
+            $usedFacetOptionsRenderer = GeneralUtility::getUserObj($classReference);
             $params = array(
                 'facetName' => $this->facetName,
                 'facetValue' => $this->filterValue,
                 'facetConfiguration' => $this->facetConfiguration,
                 'facetText' => $facetText
             );
-            $procObj = GeneralUtility::getUserObj($classReference);
-            $newText = $procObj->getUsedFacetText($params, $this);
+
+            if(!$usedFacetOptionsRenderer instanceof UsedFacetOptionsRenderer) {
+                $message = 'Invalid hook configured in processUsedFacetText. Hook needs to implement Interface UsedFacetOptionsRenderer!';
+                throw new \InvalidArgumentException($message);
+            }
+
+            $newText = $usedFacetOptionsRenderer->getUsedFacetText($params, $this);
 
             if (!empty($newText)) {
                 $facetText = $newText;

--- a/Classes/Facet/UsedFacetRenderer.php
+++ b/Classes/Facet/UsedFacetRenderer.php
@@ -165,7 +165,7 @@ class UsedFacetRenderer extends SimpleFacetOptionsRenderer
                 'facetConfiguration' => $this->facetConfiguration,
                 'facetText' => $facetText
             );
-            $procObj = &t3lib_div::getUserObj($classReference);
+            $procObj = GeneralUtility::getUserObj($classReference);
             $newText = $procObj->getUsedFacetText($params, $this);
 
             if (!empty($newText)) {


### PR DESCRIPTION
Added hook to overwrite the label of a used facet. Can be used like this:

```php
$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processUsedFacetText'][] = 'MyClass';
```