### PR TITLE
[TASK] initializeHttpHost without realurl

### DIFF
--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -301,23 +301,19 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
     {
         static $hosts = array();
 
-        // relevant for realURL environments, only
-        if (ExtensionManagementUtility::isLoaded('realurl')) {
-            $rootpageId = $item->getRootPageUid();
-            $hostFound = !empty($hosts[$rootpageId]);
+        $rootpageId = $item->getRootPageUid();
+        $hostFound = !empty($hosts[$rootpageId]);
 
-            if (!$hostFound) {
-                $rootline = BackendUtility::BEgetRootLine($rootpageId);
-                $host = BackendUtility::firstDomainRecord($rootline);
+        if (!$hostFound) {
+            $rootline = BackendUtility::BEgetRootLine($rootpageId);
+            $host = BackendUtility::firstDomainRecord($rootline);
 
-                $hosts[$rootpageId] = $host;
-            }
+            $hosts[$rootpageId] = $host;
+        }
 
-            $_SERVER['HTTP_HOST'] = $hosts[$rootpageId];
-            if (version_compare(TYPO3_branch, '7.5', '>=')) {
-                GeneralUtility::flushInternalRuntimeCaches();
-            }
+        $_SERVER['HTTP_HOST'] = $hosts[$rootpageId];
+        if (version_compare(TYPO3_branch, '7.5', '>=')) {
+            GeneralUtility::flushInternalRuntimeCaches();
         }
     }
 }
-


### PR DESCRIPTION
As mentioned in https://github.com/TYPO3-Solr/ext-solr/issues/132

HTTP_HOST is used by default for typolink in ContentObjectRenderer (also 6.2), see:
https://git.typo3.org/Packages/TYPO3.CMS.git/blob/refs/heads/TYPO3_6-2:/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php#l6042

So it should also be set without realurl