### PR TITLE
[BUGFIX] Move escaping from Template.php to the point right after the retrieval from solr

### DIFF
--- a/Classes/Backend/IndexInspector/IndexInspectorRemoteController.php
+++ b/Classes/Backend/IndexInspector/IndexInspectorRemoteController.php
@@ -136,7 +136,7 @@ class IndexInspectorRemoteController
 
         $this->search->search($query, 0, 10000);
 
-        return $this->search->getResultDocuments();
+        return $this->search->getResultDocumentsEscaped();
     }
 
     /**

--- a/Classes/Plugin/Results/ResultsCommand.php
+++ b/Classes/Plugin/Results/ResultsCommand.php
@@ -127,7 +127,7 @@ class ResultsCommand implements PluginCommand
      */
     protected function getResultDocuments()
     {
-        $responseDocuments = $this->search->getResultDocuments();
+        $responseDocuments = $this->search->getResultDocumentsEscaped();
         $resultDocuments = array();
 
 
@@ -327,7 +327,7 @@ class ResultsCommand implements PluginCommand
         $label = '';
 
         $resultsFrom = $this->search->getResponseBody()->start + 1;
-        $resultsTo = $resultsFrom + count($this->search->getResultDocuments()) - 1;
+        $resultsTo = $resultsFrom + count($this->search->getResultDocumentsEscaped()) - 1;
         $resultsTotal = $this->search->getNumberOfResults();
 
         $label = strtr(

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -312,88 +312,92 @@ class Search implements SingletonInterface
         return $this->getResponse()->response;
     }
 
-	/**
-	 * Returns a list of solr fields that could be retrieved without applying htmlspecialchars
-	 *
-	 * @return array
-	 */
-	protected function getSkipEscapeSolrFields()
-	{
-		$trustedFieldArray = array();
-		if(!isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['skipEscapeFields']) ||
-			!is_string($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['skipEscapeFields'])) {
-			return $trustedFieldArray;
-		}
-
-		$trustedFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['skipEscapeFields'];
-		$trustedFieldArray = GeneralUtility::trimExplode(",", $trustedFields);
-
-		return $trustedFieldArray;
-	}
-
     /**
-     * @deprecated use getResultEscapedDocuments now when possible
-     * @return array
-     */
-	public function getResultDocuments()
-	{
-		return $this->getResponseBody()->docs;
-	}
-
-	/**
-	 * Returns all result documents but applies htmlspecialchars on all fields retrieved
-	 * from solr except the configured fields in
-	 *
-	 * plugin.tx_solr.search.skipEscapeFields
+     * Returns a list of solr fields that could be retrieved without applying htmlspecialchars
      *
      * @return array
-	 */
-	public function getResultDocumentsEscaped()
-	{
-		return $this->applyHtmlSpecialCharsOnAllFields($this->getResponseBody()->docs);
-	}
+     */
+    protected function getTrustedSolrFields()
+    {
+        $trustedFields = array();
+        if (!isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields']) ||
+            !is_string($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'])
+        ) {
+            return $trustedFields;
+        }
 
-	/**
-	 * This method is used to apply htmlspecialchars on all document fields that
-	 * are not configured to be secure. Secure mean that we know where the content is comming from.
-	 *
-	 * @param array $docs
-	 * @return array
-	 */
-	protected function applyHtmlSpecialCharsOnAllFields(array $docs)
-	{
-		$trustedSolrFields = $this->getSkipEscapeSolrFields();
-		foreach($docs as $key => $doc) {
-			$fieldNames = $doc->getFieldNames();
-			foreach($fieldNames as $fieldName) {
-				if(in_array($fieldName, $trustedSolrFields) ) {
-					// we skip this field, since it was marked as secure
-					continue;
-				}
-				$doc->{$fieldName} = $this->applyHtmlSpecialCharsOnSingleFieldValue($doc->{$fieldName});
-			}
-			$docs[$key] = $doc;
-		}
-		return $docs;
-	}
+        $trustedFieldsSetting = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'];
+        $trustedFields = GeneralUtility::trimExplode(",", $trustedFieldsSetting);
 
-	/**
-	 * Applies htmlspecialchars on all items of an array of a single value.
-	 *
-	 * @param $fieldValue
-	 * @return array|string
-	 */
-	protected function applyHtmlSpecialCharsOnSingleFieldValue($fieldValue)
-	{
-		if(is_array($fieldValue)) {
-			foreach($fieldValue as $key => $fieldValueItem) {
-				$fieldValue[$key] = htmlspecialchars($fieldValueItem, NULL, NULL, FALSE);
-			}
-		} else {
-			$fieldValue = htmlspecialchars($fieldValue, NULL, NULL, FALSE);
-		}
-		return $fieldValue;
-	}
+        return $trustedFields;
+    }
+
+    /**
+     * Returns all results documents.
+     *
+     * @deprecated since 3.1, use getResultEscapedDocuments now when possible, will be removed two version later
+     *
+     * @return \Apache_Solr_Document[]
+     */
+    public function getResultDocuments()
+    {
+        return $this->getResponseBody()->docs;
+    }
+
+    /**
+     * Returns all result documents but applies htmlspecialchars on all fields retrieved
+     * from solr except the configured fields in
+     *
+     * plugin.tx_solr.search.trustedFields
+     *
+     * @return \Apache_Solr_Document[]
+     */
+    public function getResultDocumentsEscaped()
+    {
+        return $this->applyHtmlSpecialCharsOnAllFields($this->getResponseBody()->docs);
+    }
+
+    /**
+     * This method is used to apply htmlspecialchars on all document fields that
+     * are not configured to be secure. Secure mean that we know where the content is comming from.
+     *
+     * @param array $docs
+     * @return array
+     */
+    protected function applyHtmlSpecialCharsOnAllFields(array $docs)
+    {
+        $trustedSolrFields = $this->getTrustedSolrFields();
+        foreach ($docs as $key => $doc) {
+            $fieldNames = $doc->getFieldNames();
+            foreach ($fieldNames as $fieldName) {
+                if (in_array($fieldName, $trustedSolrFields)) {
+                    // we skip this field, since it was marked as secure
+                    continue;
+                }
+                $doc->{$fieldName} = $this->applyHtmlSpecialCharsOnSingleFieldValue($doc->{$fieldName});
+            }
+            $docs[$key] = $doc;
+        }
+        return $docs;
+    }
+
+    /**
+     * Applies htmlspecialchars on all items of an array of a single value.
+     *
+     * @param $fieldValue
+     * @return array|string
+     */
+    protected function applyHtmlSpecialCharsOnSingleFieldValue($fieldValue)
+    {
+        if (is_array($fieldValue)) {
+            foreach ($fieldValue as $key => $fieldValueItem) {
+                $fieldValue[$key] = htmlspecialchars($fieldValueItem, NULL, NULL, FALSE);
+            }
+        } else {
+            $fieldValue = htmlspecialchars($fieldValue, NULL, NULL, FALSE);
+        }
+        return $fieldValue;
+    }
 
     /**
      * Gets the time Solr took to execute the query and return the result.

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -334,33 +334,6 @@ class Template
     }
 
     /**
-     * Escapes a document's content field taking into account the wrap setting
-     * for highlighting keywords
-     *
-     * @param string $content content field value
-     * @return string escaped content
-     */
-    protected function escapeResultContent($content)
-    {
-        $content = htmlspecialchars($content, null, null, false);
-
-        $configuration = Util::getSolrConfiguration();
-        $highlightingWrap = $configuration['search.']['results.']['resultsHighlighting.']['wrap'];
-        $highlightingWrap = explode('|', $highlightingWrap);
-
-        $pattern = '/'
-            . htmlspecialchars($highlightingWrap[0], null, null, false)
-            . '(.+?)'
-            . str_replace('/', '\/', htmlspecialchars($highlightingWrap[1]))
-            . '/is';
-        $replacement = $highlightingWrap[0] . '$1' . $highlightingWrap[1];
-
-        $content = preg_replace($pattern, $replacement, $content);
-
-        return $content;
-    }
-
-    /**
      * cleans the template from non-replaced markers and subparts
      *
      * @return void
@@ -570,14 +543,6 @@ class Template
         if (count($foundMarkers)) {
             $iterationCount = 0;
             foreach ($loopVariables as $value) {
-                // escape content and title
-                if (isset($value['content'])) {
-                    $value['content'] = $this->escapeResultContent($value['content']);
-                }
-                if (isset($value['title'])) {
-                    $value['title'] = htmlspecialchars($value['title'], null,
-                        null, false);
-                }
 
                 $resolvedMarkers = $this->resolveVariableMarkers($foundMarkers,
                     $value);

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -106,9 +106,9 @@ plugin.tx_solr {
 	}
 
 	search {
-	    // fields that are allowed to contain html and should be skipped during the escaping after retrieval from solr
-	    // by default all fields get escaped and nothing will be skipped
-	    skipEscapeFields =
+		// fields that are allowed to contain html and should be skipped during the escaping after retrieval from solr
+		// by default all fields get escaped and nothing will be skipped
+	 	trustedFields =
 
 		targetPage = {$plugin.tx_solr.search.targetPage}
 

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -106,6 +106,10 @@ plugin.tx_solr {
 	}
 
 	search {
+	    // fields that are allowed to contain html and should be skipped during the escaping after retrieval from solr
+	    // by default all fields get escaped and nothing will be skipped
+	    skipEscapeFields =
+
 		targetPage = {$plugin.tx_solr.search.targetPage}
 
 		initializeWithEmptyQuery = 0


### PR DESCRIPTION
Implemented escaping of fields directly after retrieval from solr and added configuration for fields that should not be escaped "plugin.tx_solr.search.skipEscapeFields". And also removed htmlspecialchar calls from Template.php

Fix for issue #122 