### PR TITLE
config.absRefPrefix = auto not handled correct by JavascriptManager #135

### DIFF
--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -169,6 +169,9 @@ class JavascriptManager
         $filePathPrefix = '';
         if (!empty($GLOBALS['TSFE']->config['config']['absRefPrefix'])) {
             $filePathPrefix = $GLOBALS['TSFE']->config['config']['absRefPrefix'];
+            if ($filePathPrefix === 'auto') {
+                $filePathPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_PATH');
+            }
         }
 
         // add files


### PR DESCRIPTION
Applied patch from review.typo3.org (https://review.typo3.org/#/c/29747/4/typo3/sysext/frontend/Classes/Page/PageGenerator.php)  also on JavascriptManager.php

Fixes #135 