### PR TITLE
[BUGFIX] cleanup TSFE if initializeTsfe = false

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -314,6 +314,8 @@ class Util
                 $pageSelect = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
                 $rootLine = $pageSelect->getRootLine($pageId);
 
+                $initializedTsfe = false;
+                $initializedPageSelect = false;
                 if (empty($GLOBALS['TSFE']->sys_page)) {
                     if (empty($GLOBALS['TSFE'])) {
                         $GLOBALS['TSFE'] = new \stdClass();
@@ -321,9 +323,11 @@ class Util
                         $GLOBALS['TSFE']->tmpl->rootLine = $rootLine;
                         $GLOBALS['TSFE']->sys_page = $pageSelect;
                         $GLOBALS['TSFE']->id = $pageId;
+                        $initializedTsfe = true;
                     }
 
                     $GLOBALS['TSFE']->sys_page = $pageSelect;
+                    $initializedPageSelect = true;
                 }
 
                 $tmpl = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService');
@@ -335,6 +339,13 @@ class Util
                 $configuration = $tmpl->ext_getSetup($tmpl->setup, $path);
 
                 $configurationCache[$cacheId] = $configuration[0];
+
+                if ($initializedPageSelect) {
+                    $GLOBALS['TSFE']->sys_page = null;
+                }
+                if ($initializedTsfe) {
+                    unset($GLOBALS['TSFE']);
+                }
             }
         }
 


### PR DESCRIPTION
It is necessary to clean up TSFE object if initializeTsfe = false, otherwise checks regarding existing TSFE object in Backend will produce the wrong result (e.g. \TYPO3\CMS\Rtehtmlarea\RteHtmlAreaApi::writeTemporaryFile).
For instance, in 7.6.0 if one has a text element with RTE and saves (without closing) the linkhandler will not open as the generated url is missing the necessary ../