### PR TITLE
Bugfix/111 lowercase synonyms and stopwords

### DIFF
--- a/Classes/Backend/SolrModule/AbstractModuleController.php
+++ b/Classes/Backend/SolrModule/AbstractModuleController.php
@@ -81,10 +81,8 @@ abstract class AbstractModuleController extends ActionController implements Admi
 
     /**
      * @var \ApacheSolrForTypo3\Solr\Util\StringHelper
-     * @inject
      */
     protected $stringHelper;
-
 
     /**
      * Gets the module name.
@@ -132,7 +130,7 @@ abstract class AbstractModuleController extends ActionController implements Admi
      *
      * @param \ApacheSolrForTypo3\Solr\Util\StringHelper $stringHelper
      */
-    public function setStringHelper(StringHelper $stringHelper)
+    public function injectStringHelper(StringHelper $stringHelper)
     {
         $this->stringHelper = $stringHelper;
     }

--- a/Classes/Backend/SolrModule/AbstractModuleController.php
+++ b/Classes/Backend/SolrModule/AbstractModuleController.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Backend\SolrModule;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Util\StringHelper;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
@@ -78,6 +79,12 @@ abstract class AbstractModuleController extends ActionController implements Admi
      */
     protected $site;
 
+    /**
+     * @var \ApacheSolrForTypo3\Solr\Util\StringHelper
+     * @inject
+     */
+    protected $stringHelper;
+
 
     /**
      * Gets the module name.
@@ -117,6 +124,17 @@ abstract class AbstractModuleController extends ActionController implements Admi
     public function getExtensionKey()
     {
         return $this->extensionKey;
+    }
+
+    /**
+     * Method to pass a StringHelper object.
+     * Use to overwrite injected object in unit test context.
+     *
+     * @param \ApacheSolrForTypo3\Solr\Util\StringHelper $stringHelper
+     */
+    public function setStringHelper(StringHelper $stringHelper)
+    {
+        $this->stringHelper = $stringHelper;
     }
 
     /**

--- a/Classes/Backend/SolrModule/StopWordsModuleController.php
+++ b/Classes/Backend/SolrModule/StopWordsModuleController.php
@@ -74,8 +74,9 @@ class StopWordsModuleController extends AbstractModuleController
         $solrConnection = $this->getSelectedCoreSolrConnection();
 
         $postParameters = GeneralUtility::_POST('tx_solr_tools_solradministration');
-        $newStopWords = GeneralUtility::trimExplode("\n",
-            $postParameters['stopWords'], true);
+
+        $newStopWords = $this->stringHelper->toLower($postParameters['stopWords']);
+        $newStopWords = GeneralUtility::trimExplode("\n", $newStopWords, true);
         $oldStopWords = $solrConnection->getStopWords();
 
         $wordsRemoved = true;
@@ -98,7 +99,6 @@ class StopWordsModuleController extends AbstractModuleController
         if (!empty($addedStopWords)) {
                 // lowercase stopword before saving because terms get lowercased
                 // before stopword filtering
-            $addedStopWords = strtolower($addedStopWords);
             $wordsAddedResponse = $solrConnection->addStopWords($addedStopWords);
             $wordsAdded = ($wordsAddedResponse->getHttpStatus() == 200);
         }

--- a/Classes/Backend/SolrModule/StopWordsModuleController.php
+++ b/Classes/Backend/SolrModule/StopWordsModuleController.php
@@ -75,6 +75,7 @@ class StopWordsModuleController extends AbstractModuleController
 
         $postParameters = GeneralUtility::_POST('tx_solr_tools_solradministration');
 
+        // lowercase stopword before saving because terms get lowercased before stopword filtering
         $newStopWords = $this->stringHelper->toLower($postParameters['stopWords']);
         $newStopWords = GeneralUtility::trimExplode("\n", $newStopWords, true);
         $oldStopWords = $solrConnection->getStopWords();
@@ -97,8 +98,6 @@ class StopWordsModuleController extends AbstractModuleController
         $wordsAdded = true;
         $addedStopWords = array_diff($newStopWords, $oldStopWords);
         if (!empty($addedStopWords)) {
-                // lowercase stopword before saving because terms get lowercased
-                // before stopword filtering
             $wordsAddedResponse = $solrConnection->addStopWords($addedStopWords);
             $wordsAdded = ($wordsAddedResponse->getHttpStatus() == 200);
         }

--- a/Classes/Backend/SolrModule/StopWordsModuleController.php
+++ b/Classes/Backend/SolrModule/StopWordsModuleController.php
@@ -96,6 +96,9 @@ class StopWordsModuleController extends AbstractModuleController
         $wordsAdded = true;
         $addedStopWords = array_diff($newStopWords, $oldStopWords);
         if (!empty($addedStopWords)) {
+                // lowercase stopword before saving because terms get lowercased
+                // before stopword filtering
+            $addedStopWords = strtolower($addedStopWords);
             $wordsAddedResponse = $solrConnection->addStopWords($addedStopWords);
             $wordsAdded = ($wordsAddedResponse->getHttpStatus() == 200);
         }

--- a/Classes/Backend/SolrModule/SynonymsModuleController.php
+++ b/Classes/Backend/SolrModule/SynonymsModuleController.php
@@ -87,8 +87,8 @@ class SynonymsModuleController extends AbstractModuleController
                 FlashMessage::ERROR
             );
         } else {
-            $baseWord = $synonymMap['baseWord'];
-            $synonyms = $synonymMap['synonyms'];
+            $baseWord = strtolower($synonymMap['baseWord']);
+            $synonyms = strtolower($synonymMap['synonyms']);
 
             $solrConnection->addSynonym(
                 $baseWord,

--- a/Classes/Backend/SolrModule/SynonymsModuleController.php
+++ b/Classes/Backend/SolrModule/SynonymsModuleController.php
@@ -87,8 +87,8 @@ class SynonymsModuleController extends AbstractModuleController
                 FlashMessage::ERROR
             );
         } else {
-            $baseWord = strtolower($synonymMap['baseWord']);
-            $synonyms = strtolower($synonymMap['synonyms']);
+            $baseWord = $this->stringHelper->toLower($synonymMap['baseWord']);
+            $synonyms = $this->stringHelper->toLower($synonymMap['synonyms']);
 
             $solrConnection->addSynonym(
                 $baseWord,

--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -51,7 +51,7 @@ class SchemaStatus implements StatusProviderInterface
      *
      * @var string
      */
-    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-3-1-0--20150614';
+    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-3-1-0--20151117';
 
     /**
      * Compiles a collection of schema version checks against each configured

--- a/Classes/Util/StringHelper.php
+++ b/Classes/Util/StringHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Util;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011-2015 Timo Schmidt <timo.schmidt@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Helper utility class used for string manipulation. Can be injected into your module
+ * and mocked in the unit test context.
+ *
+ * Class StringHelper
+ * @package ApacheSolrForTypo3\Solr\Util
+ */
+class StringHelper {
+
+    /**
+     * Lowercases a string with the TYPO3 Core functionality.
+     *
+     * @param string $input
+     * @param string $charset
+     * @return string
+     */
+    public function toLower($input, $charset = 'utf-8')
+    {
+        return $GLOBALS['LANG']->csConvObj->conv_case($charset, $input, 'toLower');
+    }
+}

--- a/Resources/Private/Templates/StopWordsModule/Index.html
+++ b/Resources/Private/Templates/StopWordsModule/Index.html
@@ -9,7 +9,7 @@
 
 <solr:backend.menu.CoreSelectorMenu/>
 
-<h3 style="margin-top: -20px;">Stop Word List (Comma Separated List, Lowercased)</h3>
+<h3 style="margin-top: -20px;">Stop Word List (Separated with line breaks, Lowercased)</h3>
 <div class="row-fluid section section-with-header">
 
 	<f:if condition="{stopWordsCount} == 0">

--- a/Resources/Private/Templates/StopWordsModule/Index.html
+++ b/Resources/Private/Templates/StopWordsModule/Index.html
@@ -9,7 +9,7 @@
 
 <solr:backend.menu.CoreSelectorMenu/>
 
-<h3 style="margin-top: -20px;">Stop Word List</h3>
+<h3 style="margin-top: -20px;">Stop Word List (Comma Separated List, Lowercased)</h3>
 <div class="row-fluid section section-with-header">
 
 	<f:if condition="{stopWordsCount} == 0">

--- a/Resources/Private/Templates/SynonymsModule/Index.html
+++ b/Resources/Private/Templates/SynonymsModule/Index.html
@@ -34,13 +34,13 @@
 	</f:else>
 </f:if>
 
-<h3>Add Synonyms</h3>
+<h3>Add Synonyms (Lowercase)</h3>
 <div class="section">
 	<f:form actionUri="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'addSynonyms'} )}" id="add-synonyms">
 		<div class="form-group">
 			<label for="baseWord">Base Word</label>
 			<f:form.textfield id="baseWord" name="baseWord" class="form-control" />
-			<span class="example">f.e. iPhone</span>
+			<span class="example">f.e. iphone</span>
 		</div>
 		<div class="form-group">
 			<label for="synonyms">Synonyms</label>

--- a/Resources/Solr/typo3cores/conf/arabic/schema.xml
+++ b/Resources/Solr/typo3cores/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="arabic/protwords.txt"/>
 			<filter class="solr.ArabicStemFilterFactory"/>
@@ -71,9 +74,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="arabic/protwords.txt"/>
 			<filter class="solr.ArabicStemFilterFactory"/>
@@ -88,8 +93,6 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -99,6 +102,10 @@
 				preserveOriginal="1"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="arabic/protwords.txt"/>
 			<filter class="solr.ArabicStemFilterFactory"/>
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -113,6 +120,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -122,8 +130,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.ArabicStemFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/armenian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +90,6 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -95,6 +99,10 @@
 				preserveOriginal="1"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -107,6 +115,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -116,6 +125,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/basque/schema.xml
+++ b/Resources/Solr/typo3cores/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +89,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +102,7 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +114,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +124,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Solr/typo3cores/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
 			<filter class="solr.BrazilianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -70,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
 			<filter class="solr.BrazilianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -85,9 +90,11 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -96,7 +103,7 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
 			<filter class="solr.BrazilianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -109,7 +116,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian-portuguese"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -117,8 +126,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian-portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian-portuguese"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/bulgarian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
 			<filter class="solr.BulgarianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -70,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
 			<filter class="solr.BulgarianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -86,8 +91,6 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -97,6 +100,10 @@
 				preserveOriginal="1"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
 			<filter class="solr.BulgarianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -109,7 +116,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.BulgarianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -118,8 +127,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.BulgarianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/burmese/schema.xml
+++ b/Resources/Solr/typo3cores/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/catalan/schema.xml
+++ b/Resources/Solr/typo3cores/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +89,10 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +101,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +112,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +122,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/chinese/schema.xml
+++ b/Resources/Solr/typo3cores/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/czech/schema.xml
+++ b/Resources/Solr/typo3cores/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +90,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +103,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -104,20 +112,22 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 			<filter class="solr.StandardFilterFactory" />
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory" />
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+
 			<filter class="solr.StandardFilterFactory" />
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/danish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,11 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -53,9 +56,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -68,10 +74,13 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" preserveOriginal="1"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -83,7 +92,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -91,8 +102,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/dutch/schema.xml
+++ b/Resources/Solr/typo3cores/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -53,8 +53,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -62,9 +66,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -76,9 +83,11 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -87,7 +96,7 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -99,7 +108,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -107,8 +118,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/english/schema.xml
+++ b/Resources/Solr/typo3cores/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,11 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
+
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -61,9 +64,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -76,8 +81,6 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -86,6 +89,10 @@
 				preserveOriginal="1"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
+
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -98,6 +105,8 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -106,8 +115,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/finnish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +73,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +91,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +104,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +115,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +125,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/french/schema.xml
+++ b/Resources/Solr/typo3cores/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -63,9 +63,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -77,8 +79,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
@@ -88,7 +93,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -111,6 +115,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/galician/schema.xml
+++ b/Resources/Solr/typo3cores/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -70,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -86,8 +91,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -96,7 +104,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -109,7 +116,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -118,8 +127,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/generic/schema.xml
+++ b/Resources/Solr/typo3cores/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -40,8 +40,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
 			<!-- no stemming -->
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -56,9 +60,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<!-- no stemming -->
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -72,8 +79,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -81,7 +91,7 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<!-- no stemming -->
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -93,7 +103,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -101,8 +113,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/german/schema.xml
+++ b/Resources/Solr/typo3cores/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -54,6 +54,8 @@
 			/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
 				dictionary="german/german-common-nouns.txt"
 				minWordSize="5"
@@ -133,6 +135,7 @@
 				onlyLongestMatch="false"
 			/>
 
+			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/german/schema.xml
+++ b/Resources/Solr/typo3cores/conf/german/schema.xml
@@ -54,6 +54,7 @@
 			/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
 
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
@@ -81,8 +82,10 @@
 				preserveOriginal="1"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
+
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -126,7 +129,6 @@
 		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
 				dictionary="german/german-common-nouns.txt"
 				minWordSize="5"
@@ -144,8 +146,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/german/schema.xml
+++ b/Resources/Solr/typo3cores/conf/german/schema.xml
@@ -128,6 +128,7 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
 				dictionary="german/german-common-nouns.txt"

--- a/Resources/Solr/typo3cores/conf/greek/schema.xml
+++ b/Resources/Solr/typo3cores/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
 			<filter class="solr.GreekStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -70,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
-			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
 			<filter class="solr.GreekStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -86,8 +91,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -96,7 +104,7 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
 			<filter class="solr.GreekStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -109,7 +117,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -117,8 +127,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/hindi/schema.xml
+++ b/Resources/Solr/typo3cores/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
 			<filter class="solr.HindiStemFilterFactory"/>
 			<filter class="solr.IndicNormalizationFilterFactory"/>
@@ -72,9 +75,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
 			<filter class="solr.HindiStemFilterFactory"/>
 			<filter class="solr.IndicNormalizationFilterFactory"/>
@@ -89,9 +94,11 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -100,7 +107,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
 			<filter class="solr.HindiStemFilterFactory"/>
 			<filter class="solr.IndicNormalizationFilterFactory"/>
@@ -115,7 +121,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.IndicNormalizationFilterFactory"/>
 			<filter class="solr.HindiNormalizationFilterFactory"/>
@@ -125,8 +133,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.IndicNormalizationFilterFactory"/>
 			<filter class="solr.HindiNormalizationFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/hungarian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -51,8 +51,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -67,9 +70,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -82,8 +87,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -92,7 +100,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -104,7 +111,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -112,8 +121,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/indonesian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -70,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -85,9 +90,11 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -96,7 +103,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -109,7 +115,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -118,8 +126,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/italian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -61,9 +65,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -76,8 +83,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -86,7 +96,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -98,7 +107,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,8 +117,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/japanese/schema.xml
+++ b/Resources/Solr/typo3cores/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/khmer/schema.xml
+++ b/Resources/Solr/typo3cores/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/korean/schema.xml
+++ b/Resources/Solr/typo3cores/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/lao/schema.xml
+++ b/Resources/Solr/typo3cores/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/typo3cores/conf/norwegian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +89,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +102,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +113,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +123,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/persian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
 			<filter class="solr.PersianNormalizationFilterFactory"/>
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -71,9 +74,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
 			<filter class="solr.PersianNormalizationFilterFactory"/>
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -87,6 +92,7 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
@@ -98,7 +104,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
 			<filter class="solr.PersianNormalizationFilterFactory"/>
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -112,7 +117,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.PersianNormalizationFilterFactory"/>
@@ -122,8 +129,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.PersianNormalizationFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/polish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -53,9 +57,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -68,10 +75,12 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" preserveOriginal="1"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -83,7 +92,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -92,8 +103,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Solr/typo3cores/conf/portuguese/schema.xml
+++ b/Resources/Solr/typo3cores/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +89,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +102,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +113,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +123,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/romanian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -83,6 +88,7 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
@@ -94,7 +100,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +111,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +121,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/russian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -60,10 +64,13 @@
 				catenateAll="0"
 				splitOnCaseChange="1"
 				preserveOriginal="1"
-			/>>
+			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -75,11 +82,12 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" preserveOriginal="1"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -91,7 +99,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -99,8 +109,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/spanish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -61,9 +65,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -75,8 +82,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -85,7 +95,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -97,7 +106,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -105,8 +116,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/swedish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +72,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -84,8 +89,11 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+
 			<filter class="solr.WordDelimiterFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
@@ -94,7 +102,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +113,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +123,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/thai/schema.xml
+++ b/Resources/Solr/typo3cores/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.ThaiWordFilterFactory"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
 			<filter class="solr.PorterStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -54,9 +58,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.ThaiWordFilterFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
 			<filter class="solr.PorterStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -71,9 +78,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.ThaiWordFilterFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
 			<filter class="solr.PorterStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -86,7 +96,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.ThaiWordFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -94,8 +106,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.ThaiWordFilterFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/thai/schema.xml
+++ b/Resources/Solr/typo3cores/conf/thai/schema.xml
@@ -97,6 +97,8 @@
 
 			<filter class="solr.ThaiWordFilterFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Solr/typo3cores/conf/turkish/schema.xml
+++ b/Resources/Solr/typo3cores/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -52,8 +52,12 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -69,9 +73,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
-			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -83,6 +89,7 @@
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
@@ -94,7 +101,6 @@
 				catenateAll="0"
 				preserveOriginal="1"
 			/>
-			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -106,7 +112,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -114,8 +122,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Solr/typo3cores/conf/ukrainian/schema.xml
+++ b/Resources/Solr/typo3cores/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-3-1-0--20150614" version="1.5" >
+<schema name="tx_solr-3-1-0--20151117" version="1.5" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should
@@ -44,8 +44,12 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
-			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -60,9 +64,11 @@
 				splitOnCaseChange="1"
 				preserveOriginal="1"
 			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -75,10 +81,12 @@
 		<analyzer>
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
 			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" preserveOriginal="1"/>
-			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -90,7 +98,9 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -98,8 +108,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+
 			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>


### PR DESCRIPTION
In the following pull request we've:

- Applied the lowercasing before expanding the synonyms in all schemata
- Lowercase stopwords and synonyms before saving them to solr

Stopwords and Synonyms need to be recreated afterwards.