### PR TITLE
[BUGFIX] Assign undefined variable $pageId

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -212,6 +212,7 @@ class PageIndexerRequest
         $headers = $this->header;
         $headers[] = TYPO3_user_agent;
         $itemId = $this->indexQueueItem->getIndexQueueUid();
+        $pageId = $this->indexQueueItem->getRecordPageId();
 
         $indexerRequestData = array(
             'requestId' => $this->requestId,

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -217,6 +217,7 @@ class PageIndexerRequest
         $indexerRequestData = array(
             'requestId' => $this->requestId,
             'item' => $itemId,
+            'page' => $pageId,
             'actions' => implode(',', $this->actions),
             'hash' => md5(
                 $itemId . '|' .


### PR DESCRIPTION
Assign the pid of the currently processed record to the undefined ``$pageId`` variable.