### PR TITLE
[FEATURE] Add signal after IndexQueueWorkerTask::indexItems

### DIFF
--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -109,6 +109,18 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
                 );
             }
         }
+        $this->emitAfterIndexItemsSignal($itemsToIndex);
+    }
+
+    /**
+     * Emits a signal after all items was indexed
+     *
+     * @param array $itemsToIndex
+     */
+    protected function emitAfterIndexItemsSignal($itemsToIndex)
+    {
+        $signalSlotDispatcher = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+        $signalSlotDispatcher->dispatch(__CLASS__, 'afterIndexItems', array($itemsToIndex, $this));
     }
 
     /**


### PR DESCRIPTION
Usefull to add postprocessing after the indexing. Some cache clearing in my case.