### PR TITLE
[BUGFIX] Added missing trailing namespace back slashes.

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -41,7 +41,7 @@ $EM_CONF[$_EXTKEY] = array(
         ),
         'psr-4' => array(
             'ApacheSolrForTypo3\\Solr\\' => 'Classes/',
-            'ApacheSolrForTypo3\\Solr\\Tests' => 'Tests/'
+            'ApacheSolrForTypo3\\Solr\\Tests\\' => 'Tests/'
         )
     )
 );


### PR DESCRIPTION
Fixes failed installation in non composer mode on 7.6.0