### PR TITLE
[Bugfix] Added functionallity to resolve affected pages when "extendToSubpages" is set and "hidden" flag is changed

### DIFF
--- a/Classes/AbstractDataHandlerListener.php
+++ b/Classes/AbstractDataHandlerListener.php
@@ -1,0 +1,163 @@
+<?php
+namespace ApacheSolrForTypo3\Solr;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Changes in TYPO3 have an impact on the solr content and are catched
+ * by the GarbageCollector and RecordMonitor. Both act as a TCE Main Hook.
+ *
+ * This base class is used to share functionallity that are needed for both
+ * to perform the changes in the data handler on the solr index.
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+abstract class AbstractDataHandlerListener
+{
+
+    /**
+     * @return array
+     */
+    private function getAllRelevantFieldsForCurrentState()
+    {
+        $allCurrentStateFieldnames = array();
+
+        foreach ($this->getUpdateSubPagesRecursiveTriggerConfiguration() as $triggerConfiguration) {
+            if (!isset($triggerConfiguration['currentState']) || !is_array($triggerConfiguration['currentState'])) {
+                // when no "currentState" configuration for the trigger exists we can skip it
+                continue;
+            }
+
+            // we collect the currentState fields to return a unique list of all fields
+            $allCurrentStateFieldnames = array_merge($allCurrentStateFieldnames, array_keys($triggerConfiguration['currentState']));
+        }
+
+        return array_unique($allCurrentStateFieldnames);
+    }
+
+    /**
+     * When the extend to subpages flag was set, we determine the affected subpages and return them.
+     *
+     * @param integer $pageId
+     * @return array
+     */
+    protected function getSubPageIds($pageId)
+    {
+        /** @var $queryGenerator \TYPO3\CMS\Core\Database\QueryGenerator */
+        $queryGenerator = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Database\\QueryGenerator');
+
+        // here we retrieve only the subpages of this page because the permission clause is not evaluated
+        // on the root node.
+        $permissionClause = ' 1 ' . BackendUtility::BEenableFields('pages');
+        $treePageIdList = $queryGenerator->getTreeList($pageId, 20, 0, $permissionClause);
+        $treePageIds = array_map('intval', explode(',', $treePageIdList));
+
+            // the first one can be ignored because this is the page isself
+        array_shift($treePageIds);
+
+        return $treePageIds;
+    }
+
+    /**
+     * @param integer $pageId
+     * @param array $changedFields
+     * @return bool
+     */
+    protected function isRecursiveUpdateRequired($pageId, $changedFields)
+    {
+        $fieldsForCurrentState = $this->getAllRelevantFieldsForCurrentState();
+        $fieldListToRetrieve = implode(",", $fieldsForCurrentState);
+        $page = BackendUtility::getRecord('pages', $pageId, $fieldListToRetrieve, '', false);
+
+        foreach ($this->getUpdateSubPagesRecursiveTriggerConfiguration() as $triggerConfiguration) {
+            $allCurrentStateFieldsMatch = $this->getAllCurrentStateFieldsMatch($triggerConfiguration, $page);
+            $allChangeSetValuesMatch = $this->getAllChangeSetValuesMatch($triggerConfiguration, $changedFields);
+            $aMatchingTriggerHasBeenFound = $allCurrentStateFieldsMatch && $allChangeSetValuesMatch;
+            if ($aMatchingTriggerHasBeenFound) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $triggerConfiguration
+     * @param array $pageRecord
+     * @return bool
+     */
+    private function getAllCurrentStateFieldsMatch($triggerConfiguration, $pageRecord)
+    {
+        $allCurrentStateFieldsMatch = true;
+        foreach ($triggerConfiguration['currentState'] as $expectedCurrentFieldName => $expectedCurrentValue) {
+            if ($pageRecord[$expectedCurrentFieldName] != $expectedCurrentValue) {
+                $allCurrentStateFieldsMatch = false;
+                break;
+            }
+        }
+        return $allCurrentStateFieldsMatch;
+    }
+
+    /**
+     * @param array $triggerConfiguration
+     * @param array $changedFields
+     * @return bool
+     */
+    private function getAllChangeSetValuesMatch($triggerConfiguration, $changedFields)
+    {
+        $allChangeSetValuesMatch = true;
+        foreach ($triggerConfiguration['changeSet'] as $expectedChangeSetFieldName => $expectedChangeSetValue) {
+            if ($changedFields[$expectedChangeSetFieldName] != $expectedChangeSetValue) {
+                $allChangeSetValuesMatch = false;
+                break;
+            }
+        }
+        return $allChangeSetValuesMatch;
+    }
+
+    /**
+     * The implementation of this method need to retrieve a configuration to determine which record data
+     * and change combination required a recursive change.
+     *
+     * The structure needs to be:
+     *
+     * array(
+     *      array(
+     *           'currentState' => array('fieldName1' => 'value1'),
+     *           'changeSet' => array('fieldName1' => 'value1')
+     *      )
+     * )
+     *
+     * When the all values of the currentState AND all values of the changeSet match, a recursive update
+     * will be triggered.
+     *
+     * @return array
+     */
+    abstract protected function getUpdateSubPagesRecursiveTriggerConfiguration();
+}

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -80,13 +80,13 @@ class GarbageCollector extends AbstractDataHandlerListener
         return array(
             // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 1
             'extendToSubpageEnabledAndHiddenFlagWasAdded' => array(
-                'currentState' =>  array('extendToSubpages' => 1),
-                'changeSet' => array('hidden' => 1)
+                'currentState' =>  array('extendToSubpages' => "1"),
+                'changeSet' => array('hidden' => "1")
             ),
             // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 1
             'hiddenIsEnabledAndExtendToSubPagesWasAdded' => array(
-                'currentState' =>  array('hidden' => 1),
-                'changeSet' => array('extendToSubpages' => 1)
+                'currentState' =>  array('hidden' => "1"),
+                'changeSet' => array('extendToSubpages' => "1")
             )
         );
     }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -77,13 +77,13 @@ class RecordMonitor extends AbstractDataHandlerListener
         return array(
             // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 0 => requeue subpages
             'extendToSubpageEnabledAndHiddenFlagWasRemoved' => array(
-                'currentState' =>  array('extendToSubpages' => 1),
-                'changeSet' => array('hidden' => 0)
+                'currentState' =>  array('extendToSubpages' => "1"),
+                'changeSet' => array('hidden' => "0")
             ),
             // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 0 => requeue subpages
             'hiddenIsEnabledAndExtendToSubPagesWasRemoved' => array(
-                'currentState' =>  array('hidden' => 1),
-                'changeSet' => array('extendToSubpages' => 0)
+                'currentState' =>  array('hidden' => "1"),
+                'changeSet' => array('extendToSubpages' => "0")
             )
         );
     }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\AbstractDataHandlerListener;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -38,7 +39,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @package TYPO3
  * @subpackage solr
  */
-class RecordMonitor
+class RecordMonitor extends AbstractDataHandlerListener
 {
 
     /**
@@ -57,7 +58,6 @@ class RecordMonitor
      */
     protected $indexQueue;
 
-
     /**
      * Constructor
      *
@@ -65,6 +65,27 @@ class RecordMonitor
     public function __construct()
     {
         $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\IndexQueue\\Queue');
+    }
+
+    /**
+     * Holds the configuration when a recursive page queing should be triggered.
+     *
+     * @var array
+     */
+    protected function getUpdateSubPagesRecursiveTriggerConfiguration()
+    {
+        return array(
+            // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 0 => requeue subpages
+            'extendToSubpageEnabledAndHiddenFlagWasRemoved' => array(
+                'currentState' =>  array('extendToSubpages' => 1),
+                'changeSet' => array('hidden' => 0)
+            ),
+            // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 0 => requeue subpages
+            'hiddenIsEnabledAndExtendToSubPagesWasRemoved' => array(
+                'currentState' =>  array('hidden' => 1),
+                'changeSet' => array('extendToSubpages' => 0)
+            )
+        );
     }
 
     /**
@@ -276,6 +297,13 @@ class RecordMonitor
                 if ($recordTable == 'pages') {
                     $this->updateCanonicalPages($recordUid);
                     $this->updateMountPages($recordUid);
+
+                    if ($this->isRecursiveUpdateRequired($recordUid, $fields)) {
+                        $treePageIds = $this->getSubPageIds($recordUid);
+                        foreach ($treePageIds as $treePageId) {
+                            $this->indexQueue->updateItem('pages', $treePageId);
+                        }
+                    }
                 }
             } else {
                 // TODO move this part to the garbage collector

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -85,7 +85,7 @@ plugin.tx_solr {
 				initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
 
 				// allowed page types (doktype) when indexing records from table "pages"
-				allowedPageTypes = 1,7
+				allowedPageTypes = 1,7,4
 
 				indexingPriority = 0
 
@@ -95,7 +95,7 @@ plugin.tx_solr {
 				}
 
 				// Only index standard pages and mount points that are not overlayed.
-				additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+				additionalWhereClause = (doktype = 1 OR doktype=4 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
 
                 //exclude some html parts inside TYPO3SEARCH markers by classname (comma list)
                 excludeContentByClass = typo3-search-exclude

--- a/Tests/Build/IntegrationTests.xml
+++ b/Tests/Build/IntegrationTests.xml
@@ -18,4 +18,9 @@
 			<directory>../Integration/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">../../Classes/</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/Tests/Build/UnitTests.xml
+++ b/Tests/Build/UnitTests.xml
@@ -19,5 +19,9 @@
 			<directory>../Unit/</directory>
 		</testsuite>
 	</testsuites>
-
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">../../Classes/</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/Tests/Integration/Fixtures/can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set.xml
+++ b/Tests/Integration/Fixtures/can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+
+    <pages>
+        <uid>100</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>10</pid>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/Fixtures/can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set_multiple_subpages.xml
+++ b/Tests/Integration/Fixtures/can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set_multiple_subpages.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+    <pages>
+        <uid>11</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+    <pages>
+        <uid>12</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+</dataset>

--- a/Tests/Integration/Fixtures/can_queue_a_page_and_remove_it_with_the_garbage_collector.xml
+++ b/Tests/Integration/Fixtures/can_queue_a_page_and_remove_it_with_the_garbage_collector.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Solr</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -1,0 +1,190 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2015 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\GarbageCollector;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solrfal\Queue\Queue;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\FormProtection\Exception;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * This testcase is used to check if the GarbageCollector can delete garbage from the
+ * solr server as expected
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class GarbageCollectorTest extends IntegrationTest
+{
+
+    /**
+     * @var RecordMonitor
+     */
+    protected $recordMonitor;
+
+    /**
+     * @var DataHandler
+     */
+    protected $dataHandler;
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    /**
+     * @var GarbageCollector
+     */
+    protected $garbageCollector;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->recordMonitor = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor');
+        $this->dataHandler = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
+        $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Queue');
+        $this->garbageCollector = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\GarbageCollector');
+
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertEmptyIndexQueue()
+    {
+        $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertNotEmptyIndexQueue()
+    {
+        $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to be not empty.');
+    }
+
+    /**
+     * @param $amount
+     */
+    protected function assertIndexQueryContainsItemAmount($amount)
+    {
+        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to contain '.(int) $amount.' items.');
+    }
+
+    /**
+     * @test
+     */
+    public function canQueueAPageAndRemoveItWithTheGarbageCollector() {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('can_queue_a_page_and_remove_it_with_the_garbage_collector.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        $dataHandler = $this->dataHandler;
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, array(), $dataHandler);
+
+        // we expect that one item is now in the solr server
+        $this->assertIndexQueryContainsItemAmount(1);
+
+        $this->garbageCollector->collectGarbage('pages', 1);
+
+        // finally we expect that the index is empty again
+        $this->assertEmptyIndexQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet() {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        $this->indexQueue->updateItem('pages', 1);
+        $this->indexQueue->updateItem('pages', 10);
+        $this->indexQueue->updateItem('pages', 100);
+
+        // we expected that three pages are now in the index
+        $this->assertIndexQueryContainsItemAmount(3);
+
+        // simulate the database change and build a faked changeset
+        $database->exec_UPDATEquery('pages','uid=1',array('hidden' => 1));
+        $changeSet = array('hidden' => 1);
+
+        $dataHandler = $this->dataHandler;
+        $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+
+        // finally we expect that the index is empty again because the root page with "extendToSubPages" has been set to
+        // hidden = 1
+        $this->assertEmptyIndexQueue();
+    }
+
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages() {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set_multiple_subpages.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        $this->indexQueue->updateItem('pages', 1);
+        $this->indexQueue->updateItem('pages', 10);
+        $this->indexQueue->updateItem('pages', 11);
+        $this->indexQueue->updateItem('pages', 12);
+
+        // we expected that three pages are now in the index
+        $this->assertIndexQueryContainsItemAmount(4);
+
+        // simulate the database change and build a faked changeset
+        $database->exec_UPDATEquery('pages','uid=1',array('hidden' => 1));
+        $changeSet = array('hidden' => 1);
+
+        $dataHandler = $this->dataHandler;
+        $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+
+        // finally we expect that the index is empty again because the root page with "extendToSubPages" has been set to
+        // hidden = 1
+        $this->assertEmptyIndexQueue();
+    }
+}
+

--- a/Tests/Integration/IndexQueue/Fixtures/queue_is_not_filled_when_item_is_set_to_hidden.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/queue_is_not_filled_when_item_is_set_to_hidden.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+    <pages>
+        <uid>100</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>10</pid>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/reindex_subpages_when_extendToSubpages_set_and_hidden_removed.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/reindex_subpages_when_extendToSubpages_set_and_hidden_removed.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>1</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+
+    <pages>
+        <uid>100</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>10</pid>
+    </pages>
+    <pages>
+        <uid>11</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+        <hidden>1</hidden>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>1</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+    </pages>
+
+    <pages>
+        <uid>100</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>10</pid>
+    </pages>
+    <pages>
+        <uid>11</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+        <hidden>1</hidden>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -77,7 +78,16 @@ class RecordMonitorTest extends IntegrationTest
     protected function assertNotEmptyIndexQueue()
     {
         $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to be not empty');
+            'Index queue is empty and was expected to be not empty.');
+    }
+
+    /**
+     * @param $amount
+     */
+    protected function assertIndexQueryContainsItemAmount($amount)
+    {
+        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to contain '.(int) $amount.' items.');
     }
 
     /**
@@ -162,5 +172,56 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertSame(1, count($items));
         $this->assertSame('foo', $items[0]->getIndexingConfigurationName(),
             'Item was queued with unexpected configuration');
+    }
+
+    /**
+     * @test
+     */
+    public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved()
+    {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('reindex_subpages_when_extendToSubpages_set_and_hidden_removed.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        // simulate the database change and build a faked changeset
+        $database->exec_UPDATEquery('pages','uid=1',array('hidden' => 0));
+        $changeSet = array('hidden' => 0);
+
+        $dataHandler = $this->dataHandler;
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+
+        // we expect that all subpages of 1 and 1 its selft have been requeued but not more
+        // pages with uid 1, 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueryContainsItemAmount(3);
+    }
+
+
+    /**
+     * @test
+     */
+    public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved()
+    {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        // simulate the database change and build a faked changeset
+        $database->exec_UPDATEquery('pages','uid=1',array('extendToSubpages' => 0));
+        $changeSet = array('extendToSubpages' => 0);
+
+        $dataHandler = $this->dataHandler;
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+
+        // we expect that all subpages of 1 have been requeued, but 1 not because it is still hidden
+        // pages with uid 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueryContainsItemAmount(2);
     }
 }

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -224,4 +224,29 @@ class RecordMonitorTest extends IntegrationTest
         // pages with uid 10 and 100 should be in index, but 11 not
         $this->assertIndexQueryContainsItemAmount(2);
     }
+
+    /**
+     * @test
+     */
+    public function queueIsNotFilledWhenItemIsSetToHidden()
+    {
+        /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
+        $database = $GLOBALS['TYPO3_DB'];
+        $database->debugOutput = true;
+        $this->importDataSetFromFixture('reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml');
+
+        // we expect that the index queue is empty before we start
+        $this->assertEmptyIndexQueue();
+
+        // simulate the database change and build a faked changeset
+        $database->exec_UPDATEquery('pages','uid=1',array('hidden' => 1));
+        $changeSet = array('hidden' => 1);
+
+        $dataHandler = $this->dataHandler;
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+
+        // we assert that the index queue is still empty because the page was only set to hidden
+        $this->assertEmptyIndexQueue();
+
+    }
 }


### PR DESCRIPTION
Added functionality apply recursive changes in RecordMonitor and GarbageCollector when a combination of values in the Record and ChangeSet match to a configured configuration.

* Added tests for RecordMonitor and GarbageCollector
* Implemented recursive indexing and deletion, when "extendToSubpage" and "hidden" occures in the relevant combination
* Refactored RecordMonitor and GarbageCollector to have a shared BaseClass "AbstractDataHandlerListener"

Fixes: #53 