### PR TITLE
Use PageRenderer instance

### DIFF
--- a/Classes/Backend/IndexInspector/IndexInspector.php
+++ b/Classes/Backend/IndexInspector/IndexInspector.php
@@ -26,6 +26,8 @@ namespace ApacheSolrForTypo3\Solr\Backend\IndexInspector;
 
 use ApacheSolrForTypo3\Solr\Search;
 use TYPO3\CMS\Backend\Module\AbstractFunctionModule;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Index Inspector to see what documents have been indexed for a selected page.
@@ -98,7 +100,9 @@ class IndexInspector extends AbstractFunctionModule
 
     protected function initializeExtJs()
     {
-        $pageRenderer = $this->document->getPageRenderer();
+
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
         $pageRenderer->loadExtJS();
         $pageRenderer->addInlineSettingArray(

--- a/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
+++ b/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
@@ -4,7 +4,8 @@ if (!defined('TYPO3_MODE')) {
 }
 // Adds JavaScript for page tree context menu to the BE
 if (is_object($TYPO3backend)) {
-    $pageRenderer = $GLOBALS['TBE_TEMPLATE']->getPageRenderer();
+    /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
+    $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
 
     $javascriptPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('solr') . 'Resources/JavaScript/ContextMenu/';
     $pageRenderer->addJsFile($javascriptPath . 'initializesolrconnectionsclickmenuaction.js');

--- a/Classes/ViewHelpers/Backend/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Backend/ScriptViewHelper.php
@@ -24,6 +24,8 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
 
 /**
@@ -46,8 +48,8 @@ class ScriptViewHelper extends AbstractBackendViewHelper
      */
     public function render($file)
     {
-        $doc = $this->getDocInstance();
-        $pageRenderer = $doc->getPageRenderer();
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
         $pageRenderer->addJsFile($file);
     }

--- a/Classes/ViewHelpers/Backend/StyleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/StyleViewHelper.php
@@ -24,6 +24,8 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
 
 /**
@@ -46,8 +48,8 @@ class StyleViewHelper extends AbstractBackendViewHelper
      */
     public function render($file)
     {
-        $doc = $this->getDocInstance();
-        $pageRenderer = $doc->getPageRenderer();
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
         $pageRenderer->addCssFile($file);
     }


### PR DESCRIPTION
Retrieving the PageRenderer has been removed from several locations
in the TYPO3 core, so a new instance of the PageRenderer class has
to be created in order to use it properly.