### PR TITLE
Add class identifier to prevent errors in TYPO3 8 backend

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -118,7 +118,7 @@ if (TYPO3_MODE == 'BE') {
     );
 
     // register Clear Cache Menu hook
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['clearSolrConnectionCache'] = '&ApacheSolrForTypo3\\Solr\\ConnectionManager';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['clearSolrConnectionCache'] = \ApacheSolrForTypo3\Solr\ConnectionManager::class;
 
     // register Clear Cache Menu ajax call
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(


### PR DESCRIPTION
The TYPO3 backend throws an error the ClearCacheActionsHookInterface
has to be implemented. This is resolved by adding the class identifier
instead of a string in the hook configuration.