### PR TITLE
[TASK] Introduce main configuration object

### DIFF
--- a/Classes/AdditionalFieldsIndexer.php
+++ b/Classes/AdditionalFieldsIndexer.php
@@ -41,6 +41,15 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
 {
 
     /**
+     * @var array
+     */
+    protected $configuration;
+
+    public function __construct() {
+        $this->configuration = Util::getSolrConfiguration();
+    }
+
+    /**
      * Returns a substitute document for the currently being indexed page.
      *
      * Uses the original document and adds fields as defined in
@@ -89,7 +98,7 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
     protected function getAdditionalFieldNames()
     {
         $additionalFieldNames = array();
-        $additionalFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['additionalFields.'];
+        $additionalFields = $this->configuration['index.']['additionalFields.'];
 
         if (is_array($additionalFields)) {
             foreach ($additionalFields as $fieldName => $fieldValue) {
@@ -114,7 +123,7 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
     protected function getFieldValue($fieldName)
     {
         $fieldValue = '';
-        $additionalFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['additionalFields.'];
+        $additionalFields = $this->configuration['index.']['additionalFields.'];
 
         // support for cObject if the value is a configuration
         if (is_array($additionalFields[$fieldName . '.'])) {

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -80,7 +80,8 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
                 2
             );
 
-            $solrConfiguration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['solr.'];
+            $configuration = Util::getSolrConfiguration();
+            $solrConfiguration = $configuration['solr.'];
 
             $host = $solrConfiguration['host'];
             $port = $solrConfiguration['port'];

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -28,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 // TODO use/extend ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer
 use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
 use ApacheSolrForTypo3\Solr\SubstitutePageIndexer;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -40,6 +41,14 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PageFieldMappingIndexer implements SubstitutePageIndexer
 {
+    /**
+     * @var array
+     */
+    protected $configuration;
+
+    public function __construct() {
+        $this->configuration = Util::getSolrConfiguration();
+    }
 
     /**
      * Returns a substitute document for the currently being indexed page.
@@ -97,7 +106,7 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
     protected function getMappedFieldNames()
     {
         $mappedFieldNames = array();
-        $mappedFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['fields.'];
+        $mappedFields = $this->configuration['index.']['queue.']['pages.']['fields.'];
 
         foreach ($mappedFields as $indexFieldName => $recordFieldName) {
             if (is_array($recordFieldName)) {
@@ -124,7 +133,7 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
     {
         $fieldValue = '';
 
-        $indexingConfiguration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['fields.'];
+        $indexingConfiguration = $this->configuration['index.']['queue.']['pages.']['fields.'];
         $pageRecord = $GLOBALS['TSFE']->page;
 
 

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\SolrService;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -264,9 +265,10 @@ class PageIndexer extends AbstractFrontendHelper
     public function hook_indexContent(TypoScriptFrontendController $page)
     {
         $this->page = $page;
+        $configuration = Util::getSolrConfiguration();
 
         if (!$this->page->config['config']['index_enable']) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['pageIndexed']) {
+            if ($configuration['logging.']['indexing.']['pageIndexed']) {
                 GeneralUtility::devLog('Indexing is disabled. Set config.index_enable = 1 .',
                     'solr', 3);
             }
@@ -289,7 +291,7 @@ class PageIndexer extends AbstractFrontendHelper
                 $this->responseData['documentsSentToSolr'][] = (array)$document;
             }
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($configuration['tx_solr.']['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while trying to index page ' . $page->id,
                     'solr', 3, array(
                         $e->__toString()
@@ -297,7 +299,7 @@ class PageIndexer extends AbstractFrontendHelper
             }
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['pageIndexed']) {
+        if ($configuration['logging.']['indexing.']['pageIndexed']) {
             $success = $this->responseData['pageIndexed'] ? 'Success' : 'Failed';
             $severity = $this->responseData['pageIndexed'] ? -1 : 3;
 

--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -104,8 +104,7 @@ class JavascriptManager
     public function loadFile($fileKey)
     {
         if (!array_key_exists($fileKey, self::$files)) {
-            $typoScriptPath = 'plugin.tx_solr.javascriptFiles.' . $fileKey;
-            $fileReference = Util::getTypoScriptValue($typoScriptPath);
+            $fileReference = $this->configuration['javascriptFiles.'][$fileKey];
 
             if (!empty($fileReference)) {
                 self::$files[$fileKey] = array(
@@ -125,7 +124,7 @@ class JavascriptManager
      */
     public function addJavascriptToPage()
     {
-        $position = Util::getTypoScriptValue('plugin.tx_solr.javascriptFiles.loadIn');
+        $position = $this->configuration['javascriptFiles.']['loadIn'];
 
         if (empty($position)) {
             $position = self::POSITION_NONE;

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -130,7 +130,7 @@ abstract class PluginBase extends AbstractPlugin
 
             $content = $this->postRender($content);
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->conf['logging.']['exceptions']) {
                 GeneralUtility::devLog(
                     $e->getCode() . ': ' . $e->__toString(),
                     'solr',
@@ -182,11 +182,11 @@ abstract class PluginBase extends AbstractPlugin
      */
     protected function initialize($configuration)
     {
-        $this->conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
-        ArrayUtility::mergeRecursiveWithOverrule(
-            $this->conf,
-            $configuration
-        );
+
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $typoScriptConfiguration */
+        $typoScriptConfiguration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        // since TypoScriptConfiguration is a singleton the internal configuration has to be reinitialized for every plugin instance
+        $this->conf = $typoScriptConfiguration->initialize($configuration);
 
         $this->initializeLanguageFactory();
         $this->pi_setPiVarDefaults();

--- a/Classes/Plugin/Results/Results.php
+++ b/Classes/Plugin/Results/Results.php
@@ -214,7 +214,7 @@ class Results extends CommandPluginBase
 
         // TODO check whether a search has been conducted already?
         if ($this->solrAvailable && (isset($rawUserQuery) || $this->conf['search.']['initializeWithEmptyQuery'] || $this->conf['search.']['initializeWithQuery'])) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['searchWords']) {
+            if ($this->conf['logging.']['query.']['searchWords']) {
                 GeneralUtility::devLog('received search query', 'solr', 0,
                     array($rawUserQuery));
             }
@@ -328,6 +328,8 @@ class Results extends CommandPluginBase
      */
     protected function overrideTyposcriptWithFlexformSettings()
     {
+        $flexFormConfiguration = array();
+
         // initialize with empty query, useful when no search has been
         // conducted yet but needs to show facets already.
         $initializeWithEmptyQuery = $this->pi_getFFvalue(
@@ -336,7 +338,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($initializeWithEmptyQuery) {
-            $this->conf['search.']['initializeWithEmptyQuery'] = 1;
+            $flexFormConfiguration['search.']['initializeWithEmptyQuery'] = 1;
         }
 
         $showResultsOfInitialEmptyQuery = $this->pi_getFFvalue(
@@ -345,7 +347,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($showResultsOfInitialEmptyQuery) {
-            $this->conf['search.']['showResultsOfInitialEmptyQuery'] = 1;
+            $flexFormConfiguration['search.']['showResultsOfInitialEmptyQuery'] = 1;
         }
 
         // initialize with non-empty query
@@ -355,7 +357,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($initialQuery) {
-            $this->conf['search.']['initializeWithQuery'] = $initialQuery;
+            $flexFormConfiguration['search.']['initializeWithQuery'] = $initialQuery;
         }
 
         $showResultsOfInitialQuery = $this->pi_getFFvalue(
@@ -364,7 +366,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($showResultsOfInitialQuery) {
-            $this->conf['search.']['showResultsOfInitialQuery'] = 1;
+            $flexFormConfiguration['search.']['showResultsOfInitialQuery'] = 1;
         }
 
         // target page
@@ -375,38 +377,42 @@ class Results extends CommandPluginBase
             $targetPage = $flexformTargetPage;
         }
         if (!empty($targetPage)) {
-            $this->conf['search.']['targetPage'] = $targetPage;
+            $flexFormConfiguration['search.']['targetPage'] = $targetPage;
         } else {
-            $this->conf['search.']['targetPage'] = $GLOBALS['TSFE']->id;
+            $flexFormConfiguration['search.']['targetPage'] = $GLOBALS['TSFE']->id;
         }
 
         // boost function
         $boostFunction = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'boostFunction', 'sQuery');
         if ($boostFunction) {
-            $this->conf['search.']['query.']['boostFunction'] = $boostFunction;
+            $flexFormConfiguration['search.']['query.']['boostFunction'] = $boostFunction;
         }
 
         // boost query
         $boostQuery = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'boostQuery', 'sQuery');
         if ($boostQuery) {
-            $this->conf['search.']['query.']['boostQuery'] = $boostQuery;
+            $flexFormConfiguration['search.']['query.']['boostQuery'] = $boostQuery;
         }
 
         // sorting
         $flexformSorting = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'sortBy', 'sQuery');
         if ($flexformSorting) {
-            $this->conf['search.']['query.']['sortBy'] = $flexformSorting;
+            $flexFormConfiguration['search.']['query.']['sortBy'] = $flexformSorting;
         }
 
         // results per page
         $resultsPerPage = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'resultsPerPage', 'sQuery');
         if ($resultsPerPage) {
-            $this->conf['search.']['results.']['resultsPerPage'] = $resultsPerPage;
+            $flexFormConfiguration['search.']['results.']['resultsPerPage'] = $resultsPerPage;
         }
+
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $typoScriptConfiguration */
+        $typoScriptConfiguration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        $this->conf = $typoScriptConfiguration->mergeConfigurationRecursiveWithOverrule($flexFormConfiguration);
     }
 
     /**

--- a/Classes/Plugin/Results/ResultsCommand.php
+++ b/Classes/Plugin/Results/ResultsCommand.php
@@ -188,7 +188,7 @@ class ResultsCommand implements PluginCommand
     protected function processDocumentFieldsToArray(
         \Apache_Solr_Document $document
     ) {
-        $processingInstructions = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['results.']['fieldProcessingInstructions.'];
+        $processingInstructions = $this->configuration['search.']['results.']['fieldProcessingInstructions.'];
         $availableFields = $document->getFieldNames();
         $result = array();
 

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -746,7 +746,8 @@ class Query
     public function addFilter($filterString)
     {
         // TODO refactor to split filter field and filter value, @see Drupal
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['filters']) {
+        $configuration = Util::getSolrConfiguration();
+        if ($configuration['logging.']['query.']['filters']) {
             GeneralUtility::devLog('adding filter', 'solr', 0,
                 array($filterString));
         }

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -70,6 +70,7 @@ class Search implements SingletonInterface
     protected $hasSearched = false;
 
 
+
     // TODO Override __clone to reset $response and $hasSearched
 
     /**
@@ -125,6 +126,8 @@ class Search implements SingletonInterface
      */
     public function search(Query $query, $offset = 0, $limit = 10)
     {
+        $configuration = Util::getSolrConfiguration();
+
         $query = $this->modifyQuery($query);
         $this->query = $query;
 
@@ -140,7 +143,7 @@ class Search implements SingletonInterface
                 $query->getQueryParameters()
             );
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['queryString']) {
+            if ($configuration['logging.']['query.']['queryString']) {
                 GeneralUtility::devLog('Querying Solr, getting result', 'solr',
                     0, array(
                         'query string' => $query->getQueryString(),
@@ -152,7 +155,7 @@ class Search implements SingletonInterface
         } catch (\RuntimeException $e) {
             $response = $this->solr->getResponse();
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while querying Solr', 'solr',
                     3, array(
                         'exception' => $e->__toString(),
@@ -254,7 +257,8 @@ class Search implements SingletonInterface
 
             $solrAvailable = true;
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            $configuration = Util::getSolrConfiguration();
+            if ($configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('exception while trying to ping the solr server',
                     'solr', 3, array(
                         $e->__toString()
@@ -318,13 +322,14 @@ class Search implements SingletonInterface
     protected function getTrustedSolrFields()
     {
         $trustedFields = array();
-        if (!isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields']) ||
-            !is_string($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'])
+        $configuration = Util::getSolrConfiguration();
+        if (!isset($configuration['search.']['trustedFields']) ||
+            !is_string($configuration['search.']['trustedFields'])
         ) {
             return $trustedFields;
         }
 
-        $trustedFieldsSetting = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'];
+        $trustedFieldsSetting = $configuration['search.']['trustedFields'];
         $trustedFields = GeneralUtility::trimExplode(",", $trustedFieldsSetting);
 
         return $trustedFields;

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -94,6 +94,11 @@ class SolrService extends \Apache_Solr_Service
     protected $schemaName = null;
     protected $solrconfigName = null;
 
+    /**
+     * @var array
+     */
+    protected $configuration;
+
 
     /**
      * Constructor
@@ -110,6 +115,7 @@ class SolrService extends \Apache_Solr_Service
         $scheme = 'http'
     ) {
         $this->setScheme($scheme);
+        $this->configuration = Util::getSolrConfiguration();
 
         parent::__construct($host, $port, $path);
     }
@@ -420,7 +426,7 @@ class SolrService extends \Apache_Solr_Service
             $response = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawGet'] || $response->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawGet'] || $response->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'response' => (array)$response
@@ -627,7 +633,7 @@ class SolrService extends \Apache_Solr_Service
             $response = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawPost'] || $response->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawPost'] || $response->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'content' => $rawPost,
@@ -739,7 +745,7 @@ class SolrService extends \Apache_Solr_Service
             $solrResponse = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawDelete'] || $solrResponse->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawDelete'] || $solrResponse->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'response' => (array)$solrResponse

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -185,7 +185,8 @@ class Template
                     $success = $this->addViewHelperObject($helperName,
                         $helperInstance);
                 } catch (\Exception $e) {
-                    if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+                    $configuration = Util::getSolrConfiguration();
+                    if ($configuration['tx_solr.']['logging.']['exceptions']) {
                         GeneralUtility::devLog('exception while adding a viewhelper',
                             'solr', 3, array(
                                 $e->__toString()
@@ -493,7 +494,8 @@ class Template
             try {
                 $viewHelperContent = $viewHelper->execute($viewHelperArguments);
             } catch (\UnexpectedValueException $e) {
-                if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+                $configuration = Util::getSolrConfiguration();
+                if ($configuration['tx_solr.']['logging.']['exceptions']) {
                     GeneralUtility::devLog('Exception while rendering a viewhelper',
                         'solr', 3, array(
                             $e->__toString()

--- a/Classes/Typo3Environment.php
+++ b/Classes/Typo3Environment.php
@@ -43,6 +43,7 @@ class Typo3Environment implements SingletonInterface
      */
     public function isFileIndexingEnabled()
     {
-        return (boolean)$GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['files'];
+        $configuration = Util::getSolrConfiguration();
+        return (boolean)$configuration['index.']['files'];
     }
 }

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -60,8 +60,8 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
         $indexableContent = implode($indexableContents[0], '');
 
         $indexableContent = $this->excludeContentByClass($indexableContent);
-
-        if (empty($indexableContent) && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['missingTypo3SearchMarkers']) {
+        $configuration = Util::getSolrConfiguration();
+        if (empty($indexableContent) && $configuration['logging.']['indexing.']['missingTypo3SearchMarkers']) {
             GeneralUtility::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
         }
 

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -95,6 +95,10 @@ class Typo3PageIndexer
      */
     protected $documentsSentToSolr = array();
 
+    /**
+     * @var array
+     */
+    protected $configuration;
 
     /**
      * Constructor
@@ -105,6 +109,7 @@ class Typo3PageIndexer
     {
         $this->page = $page;
         $this->pageUrl = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+        $this->configuration = Util::getSolrConfiguration();
 
         try {
             $this->initializeSolrConnection();
@@ -112,7 +117,7 @@ class Typo3PageIndexer
             $this->log($e->getMessage() . ' Error code: ' . $e->getCode(), 3);
 
             // TODO extract to a class "ExceptionLogger"
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while trying to index a page',
                     'solr', 3, array(
                         $e->__toString()
@@ -169,7 +174,7 @@ class Typo3PageIndexer
             $GLOBALS['TT']->setTSlogMessage('tx_solr: ' . $message, $errorNum);
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing']) {
+        if ($this->configuration['logging.']['indexing']) {
             if (!empty($data)) {
                 $logData = array();
                 foreach ($data as $value) {
@@ -473,11 +478,11 @@ class Typo3PageIndexer
      */
     protected function processDocuments(array $documents)
     {
-        if (is_array($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['fieldProcessingInstructions.'])) {
+        if (is_array($this->configuration['index.']['fieldProcessingInstructions.'])) {
             $service = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\FieldProcessor\\Service');
             $service->processDocuments(
                 $documents,
-                $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['fieldProcessingInstructions.']
+                $this->configuration['index.']['fieldProcessingInstructions.']
             );
         }
     }
@@ -516,7 +521,7 @@ class Typo3PageIndexer
         } catch (\Exception $e) {
             $this->log($e->getMessage() . ' Error code: ' . $e->getCode(), 2);
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while adding documents',
                     'solr', 3, array(
                         $e->__toString()

--- a/Classes/TypoScriptConfiguration.php
+++ b/Classes/TypoScriptConfiguration.php
@@ -1,0 +1,199 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Marc Bastian Heinrichs <mbh@mbh-software.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+namespace ApacheSolrForTypo3\Solr;
+
+use InvalidArgumentException;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+/**
+ * Remote API related methods
+ *
+ * @package TYPO3
+ * @subpackage solr
+ */
+class TypoScriptConfiguration implements SingletonInterface
+{
+
+    /**
+     * Holds the solr configuration
+     *
+     * @var array
+     */
+    protected $configuration = array();
+
+    /**
+     * @param $configuration
+     * @return array
+     */
+    public function initialize($configuration) {
+        $this->reset();
+        return $this->mergeConfigurationRecursiveWithOverrule($configuration);
+    }
+
+    /**
+     * Resets the internal configuration to typoscript path plugin.tx_solr., if set.
+     */
+    public function reset() {
+        if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']) && is_array($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'])) {
+            $this->configuration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+        }
+    }
+
+    /**
+     * Returns the solr configuration
+     *
+     * In the context of an frontend content element the path plugin.tx_solr is
+     * merged recursive with overrule with the content element specific typoscript
+     * settings, like plugin.tx_solr_PiResults_Results, and possible flex form settings
+     * (depends on the solr plugin).
+     *
+     * @return array
+     */
+    public function get() {
+        return $this->configuration;
+    }
+
+    /**
+     * Gets the value from a given TypoScript path.
+     *
+     * In the context of an frontend content element the path plugin.tx_solr is
+     * merged recursive with overrule with the content element specific typoscript
+     * settings, like plugin.tx_solr_PiResults_Results, and possible flex form settings
+     * (depends on the solr plugin).
+     *
+     * Example: plugin.tx_solr.search.targetPage
+     * returns $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['targetPage']
+     *
+     * @param string $path TypoScript path
+     * @return array The TypoScript object defined by the given path
+     * @throws InvalidArgumentException
+     */
+    public function getValueByPath($path)
+    {
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Parameter $path is not a string',
+                1325623321);
+        }
+
+        $pathExploded = explode('.', trim($path));
+        $pathBranch = $this->getPathBranch($pathExploded);
+
+        $segmentCount = count($pathExploded);
+        for ($i = 0; $i < $segmentCount; $i++) {
+            $segment = $pathExploded[$i];
+
+            if ($i == ($segmentCount - 1)) {
+                $pathBranch = $pathBranch[$segment];
+            } else {
+                $pathBranch = $pathBranch[$segment . '.'];
+            }
+        }
+
+        return $pathBranch;
+    }
+
+    /**
+     * Gets the parent TypoScript Object from a given TypoScript path.
+     *
+     * In the context of an frontend content element the path plugin.tx_solr is
+     * merged recursive with overrule with the content element specific typoscript
+     * settings, like plugin.tx_solr_PiResults_Results, and possible flex form settings
+     * (depends on the solr plugin).
+     *
+     * Example: plugin.tx_solr.index.queue.tt_news.fields.content
+     * returns $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content.']
+     * which is a SOLR_CONTENT cObj.
+     *
+     * @param string $path TypoScript path
+     * @return array The TypoScript object defined by the given path
+     * @throws InvalidArgumentException
+     */
+    public function getObjectByPath($path)
+    {
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Parameter $path is not a string',
+                1325627243);
+        }
+
+        $pathExploded = explode('.', trim($path));
+        // remove last object
+        $lastPathSegment = array_pop($pathExploded);
+        $pathBranch = $this->getPathBranch($pathExploded);
+
+        foreach ($pathExploded as $segment) {
+            if (!array_key_exists($segment . '.', $pathBranch)) {
+                throw new InvalidArgumentException(
+                    'TypoScript object path "' . htmlspecialchars($path) . '" does not exist',
+                    1325627264
+                );
+            }
+            $pathBranch = $pathBranch[$segment . '.'];
+        }
+
+        return $pathBranch;
+    }
+
+    /**
+     * Checks whether a given TypoScript path is valid.
+     *
+     * @param string $path TypoScript path
+     * @return boolean TRUE if the path resolves, FALSE otherwise
+     */
+    public function isValidPath($path)
+    {
+        $isValidPath = false;
+
+        $pathValue = $this->getValueByPath($path);
+        if (!is_null($pathValue)) {
+            $isValidPath = true;
+        }
+
+        return $isValidPath;
+    }
+
+    protected function getPathBranch($pathExploded) {
+        if ($pathExploded[0] === 'plugin' && $pathExploded[1] === 'tx_solr') {
+            $pathBranch = array('plugin.' => array('tx_solr.' => $this->configuration));
+        } else {
+            $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
+        }
+        return $pathBranch;
+    }
+
+    /**
+     * Returns the freshly merged solr configuration
+     *
+     * @param array $configuration
+     * @return array
+     */
+    public function mergeConfigurationRecursiveWithOverrule(array $configuration) {
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $this->configuration,
+            $configuration
+        );
+        return $this->configuration;
+    }
+}

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -227,9 +227,9 @@ class Util
      */
     public static function getSolrConfiguration()
     {
-        // TODO if in BE, create a fake TSFE and retrieve the configuration
-        // TODO merge flexform configuration
-        return $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        return $configuration->get();
     }
 
     /**
@@ -491,30 +491,15 @@ class Util
      * @param string $path TypoScript path
      * @return array The TypoScript object defined by the given path
      * @throws InvalidArgumentException
+     *
+     * @deprecated since 3.2, use TypoScriptConfiguration::getObjectByPath() instead, will be removed in version 4.0
      */
     public static function getTypoScriptObject($path)
     {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException('Parameter $path is not a string',
-                1325627243);
-        }
-
-        $pathExploded = explode('.', trim($path));
-        // remove last object
-        $lastPathSegment = array_pop($pathExploded);
-        $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
-
-        foreach ($pathExploded as $segment) {
-            if (!array_key_exists($segment . '.', $pathBranch)) {
-                throw new InvalidArgumentException(
-                    'TypoScript object path "' . htmlspecialchars($path) . '" does not exist',
-                    1325627264
-                );
-            }
-            $pathBranch = $pathBranch[$segment . '.'];
-        }
-
-        return $pathBranch;
+        GeneralUtility::logDeprecatedFunction();
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        return $configuration->getObjectByPath($path);
     }
 
     /**
@@ -522,17 +507,15 @@ class Util
      *
      * @param string $path TypoScript path
      * @return boolean TRUE if the path resolves, FALSE otherwise
+     *
+     * @deprecated since 3.2, use TypoScriptConfiguration::isValidPath() instead, will be removed in version 4.0
      */
     public static function isValidTypoScriptPath($path)
     {
-        $isValidPath = false;
-
-        $pathValue = self::getTypoScriptValue($path);
-        if (!is_null($pathValue)) {
-            $isValidPath = true;
-        }
-
-        return $isValidPath;
+        GeneralUtility::logDeprecatedFunction();
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        return $configuration->isValidPath($path);
     }
 
     /**
@@ -544,29 +527,15 @@ class Util
      * @param string $path TypoScript path
      * @return array The TypoScript object defined by the given path
      * @throws InvalidArgumentException
+     *
+     * @deprecated since 3.2, use TypoScriptConfiguration::getValueByPath() instead, will be removed in version 4.0
      */
     public static function getTypoScriptValue($path)
     {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException('Parameter $path is not a string',
-                1325623321);
-        }
-
-        $pathExploded = explode('.', trim($path));
-        $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
-
-        $segmentCount = count($pathExploded);
-        for ($i = 0; $i < $segmentCount; $i++) {
-            $segment = $pathExploded[$i];
-
-            if ($i == ($segmentCount - 1)) {
-                $pathBranch = $pathBranch[$segment];
-            } else {
-                $pathBranch = $pathBranch[$segment . '.'];
-            }
-        }
-
-        return $pathBranch;
+        GeneralUtility::logDeprecatedFunction();
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        return $configuration->getValueByPath($path);
     }
 
     /**

--- a/Classes/ViewHelper/Date.php
+++ b/Classes/ViewHelper/Date.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -55,7 +56,8 @@ class Date implements ViewHelper
     public function __construct(array $arguments = array())
     {
         if (is_null($this->dateFormat) || is_null($this->contentObject)) {
-            $this->dateFormat = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['general.']['dateFormat.'];
+            $configuration = Util::getSolrConfiguration();
+            $this->dateFormat = $configuration['general.']['dateFormat.'];
             $this->contentObject = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
         }
     }
@@ -71,7 +73,6 @@ class Date implements ViewHelper
         $content = '';
 
         if (count($arguments) > 1) {
-            $this->dateFormat = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['general.']['dateFormat.'];
             $this->dateFormat['date'] = $arguments[1];
         }
 

--- a/Classes/ViewHelper/Facet.php
+++ b/Classes/ViewHelper/Facet.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -52,7 +53,7 @@ class Facet extends AbstractSubpartViewHelper
     public function __construct(array $arguments = array())
     {
         if (is_null($this->configuration)) {
-            $this->configuration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+            $this->configuration = Util::getSolrConfiguration();
         }
     }
 

--- a/Classes/ViewHelper/Link.php
+++ b/Classes/ViewHelper/Link.php
@@ -85,9 +85,11 @@ class Link implements ViewHelper
         if (is_numeric($linkArgument)) {
             $linkTarget = intval($linkArgument);
         } elseif (!empty($linkArgument) && is_string($linkArgument)) {
-            if (Util::isValidTypoScriptPath($linkArgument)) {
+            /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+            $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+            if ($configuration->isValidPath($linkArgument)) {
                 try {
-                    $typoscript = Util::getTypoScriptObject($linkArgument);
+                    $typoscript = $configuration->getObjectByPath($linkArgument);
                     $pathExploded = explode('.', $linkArgument);
                     $lastPathSegment = array_pop($pathExploded);
 

--- a/Classes/ViewHelper/Lll.php
+++ b/Classes/ViewHelper/Lll.php
@@ -25,7 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\LanguageFileUnavailableException;
-use TYPO3\CMS\Core\FormProtection\Exception;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -95,7 +95,7 @@ class Lll implements ViewHelper
      */
     protected function loadLL()
     {
-        $configuration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+        $configuration = Util::getSolrConfiguration();;
 
         $this->localLang[$this->languageFile] = $this->languageFactory->getParsedData(
             $this->languageFile,

--- a/Classes/ViewHelper/SolrLink.php
+++ b/Classes/ViewHelper/SolrLink.php
@@ -137,7 +137,9 @@ class SolrLink implements ViewHelper
         } elseif (is_string($linkArgument) && !empty($linkArgument)) {
             // interpret a TypoScript path
             try {
-                $typoscript = Util::getTypoScriptObject($linkArgument);
+                /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+                $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+                $typoscript = $configuration->getObjectByPath($linkArgument);
                 $pathExploded = explode('.', $linkArgument);
                 $lastPathSegment = array_pop($pathExploded);
 

--- a/Classes/ViewHelper/Ts.php
+++ b/Classes/ViewHelper/Ts.php
@@ -83,7 +83,9 @@ class Ts implements ViewHelper
         $value = '';
         $pathExploded = explode('.', trim($path));
         $lastPathSegment = array_pop($pathExploded);
-        $pathBranch = Util::getTypoScriptObject($path);
+        /** @var \ApacheSolrForTypo3\Solr\TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\TypoScriptConfiguration');
+        $pathBranch = $configuration->getObjectByPath($path);
 
         // generate ts content
         $cObj = $this->getContentObject();


### PR DESCRIPTION
This patch streamlines the typoscript configuration handling.
At various places the typoscript configuration path plugin.tx_solr. is
used, also in context of a content object. So typoscript settings that
should affect a single content element path like plugin.tx_solr_PiResults_Results.
was ignored. Also the flexform settings are merged in the main
configuration object now.

For now it does not support nested solr plugins.

Resolves: #163