### PR TITLE
[TASK] Introduce main configuration object

### DIFF
--- a/Classes/AdditionalFieldsIndexer.php
+++ b/Classes/AdditionalFieldsIndexer.php
@@ -41,6 +41,16 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
 {
 
     /**
+     * @var array
+     */
+    protected $configuration;
+
+    public function __construct()
+    {
+        $this->configuration = Util::getSolrConfiguration();
+    }
+
+    /**
      * Returns a substitute document for the currently being indexed page.
      *
      * Uses the original document and adds fields as defined in
@@ -89,7 +99,7 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
     protected function getAdditionalFieldNames()
     {
         $additionalFieldNames = array();
-        $additionalFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['additionalFields.'];
+        $additionalFields = $this->configuration['index.']['additionalFields.'];
 
         if (is_array($additionalFields)) {
             foreach ($additionalFields as $fieldName => $fieldValue) {
@@ -114,7 +124,7 @@ class AdditionalFieldsIndexer implements SubstitutePageIndexer
     protected function getFieldValue($fieldName)
     {
         $fieldValue = '';
-        $additionalFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['additionalFields.'];
+        $additionalFields = $this->configuration['index.']['additionalFields.'];
 
         // support for cObject if the value is a configuration
         if (is_array($additionalFields[$fieldName . '.'])) {

--- a/Classes/Configuration/ConfigurationManager.php
+++ b/Classes/Configuration/ConfigurationManager.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Schmidt <timo.schmidt@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Configuration manager old the configuration instance.
+ * Singleton
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class ConfigurationManager implements SingletonInterface
+{
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $typoScriptConfiguration = null;
+
+    /**
+     * @param array $configurationArray
+     */
+    public function __construct(array $configurationArray = null)
+    {
+        $this->initialize($configurationArray);
+    }
+
+    /**
+     * Resets the state of the configuration manager.
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * @param \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration $typoScriptConfiguration
+     */
+    public function setTypoScriptConfiguration($typoScriptConfiguration)
+    {
+        $this->typoScriptConfiguration = $typoScriptConfiguration;
+    }
+
+    /**
+     * @return \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration
+     */
+    public function getTypoScriptConfiguration()
+    {
+        return $this->typoScriptConfiguration;
+    }
+
+    /**
+     * @param array $configurationArray
+     */
+    private function initialize(array $configurationArray = null)
+    {
+        if ($configurationArray == null) {
+            if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']) && is_array($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'])) {
+                $configurationArray = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+            } else {
+                $configurationArray = array();
+            }
+        }
+
+        $this->typoScriptConfiguration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\TypoScriptConfiguration', $configurationArray);
+    }
+}

--- a/Classes/Configuration/ConfigurationManager.php
+++ b/Classes/Configuration/ConfigurationManager.php
@@ -63,14 +63,6 @@ class ConfigurationManager implements SingletonInterface
     }
 
     /**
-     * @param \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration $typoScriptConfiguration
-     */
-    public function setTypoScriptConfiguration($typoScriptConfiguration)
-    {
-        $this->typoScriptConfiguration = $typoScriptConfiguration;
-    }
-
-    /**
      * @return \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration
      */
     public function getTypoScriptConfiguration()
@@ -79,16 +71,23 @@ class ConfigurationManager implements SingletonInterface
     }
 
     /**
+     * @throws \InvalidArgumentException
      * @param array $configurationArray
      */
     private function initialize(array $configurationArray = null)
     {
         if ($configurationArray == null) {
-            if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']) && is_array($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'])) {
-                $configurationArray = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
-            } else {
-                $configurationArray = array();
+            if (!empty($GLOBALS['TSFE']->tmpl->setup) && is_array($GLOBALS['TSFE']->tmpl->setup)) {
+                $configurationArray = $GLOBALS['TSFE']->tmpl->setup;
             }
+        }
+
+        if (! is_array($configurationArray)) {
+            $configurationArray = array();
+        }
+
+        if (!isset($configurationArray['plugin.']['tx_solr.'])) {
+            $configurationArray['plugin.']['tx_solr.'] = array();
         }
 
         $this->typoScriptConfiguration = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\TypoScriptConfiguration', $configurationArray);

--- a/Classes/Configuration/TypoScriptConfiguration.php
+++ b/Classes/Configuration/TypoScriptConfiguration.php
@@ -1,0 +1,268 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Marc Bastian Heinrichs <mbh@mbh-software.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+namespace ApacheSolrForTypo3\Solr\Configuration;
+
+use InvalidArgumentException;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TypoScript configuration object, used to read all TypoScript configuration.
+ *
+ * The TypoScriptConfiguration was introduced in order to be able to replace the old,
+ * array based configuration with one configuration object.
+ *
+ * To read the configuration, you should use
+ *
+ * $configuration->getValueByPath
+ *
+ * or
+ *
+ * $configuration->isValidPath
+ *
+ * to check if an configuration path exists.
+ *
+ * To ensure Backwards compatibility the TypoScriptConfiguration object implements the
+ * ArrayAccess interface (offsetGet,offsetExists,offsetUnset and offsetSet)
+ *
+ * This was only introduced to be backwards compatible in logTerm only "getValueByPath", "isValidPath" or
+ * speaking methods for configuration settings should be used!
+ *
+ * @author Marc Bastian Heinrichs <mbh@mbh-software.de>
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class TypoScriptConfiguration implements \ArrayAccess
+{
+
+    /**
+     * Holds the solr configuration
+     *
+     * @var array
+     */
+    protected $configuration = array();
+
+    /**
+     * @param array $configuration
+     */
+    public function __construct(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Gets the value from a given TypoScript path.
+     *
+     * In the context of an frontend content element the path plugin.tx_solr is
+     * merged recursive with overrule with the content element specific typoscript
+     * settings, like plugin.tx_solr_PiResults_Results, and possible flex form settings
+     * (depends on the solr plugin).
+     *
+     * Example: plugin.tx_solr.search.targetPage
+     * returns $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['targetPage']
+     *
+     * @param string $path TypoScript path
+     * @return array The TypoScript object defined by the given path
+     * @throws InvalidArgumentException
+     */
+    public function getValueByPath($path)
+    {
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Parameter $path is not a string',
+                1325623321);
+        }
+
+        $pathExploded = explode('.', trim($path));
+        $pathBranch = $this->getPathBranch($pathExploded);
+
+        $segmentCount = count($pathExploded);
+        for ($i = 0; $i < $segmentCount; $i++) {
+            $segment = $pathExploded[$i];
+
+            if ($i == ($segmentCount - 1)) {
+                $pathBranch = $pathBranch[$segment];
+            } else {
+                $pathBranch = $pathBranch[$segment . '.'];
+            }
+        }
+
+        return $pathBranch;
+    }
+
+    /**
+     * Gets the parent TypoScript Object from a given TypoScript path.
+     *
+     * In the context of an frontend content element the path plugin.tx_solr is
+     * merged recursive with overrule with the content element specific typoscript
+     * settings, like plugin.tx_solr_PiResults_Results, and possible flex form settings
+     * (depends on the solr plugin).
+     *
+     * Example: plugin.tx_solr.index.queue.tt_news.fields.content
+     * returns $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content.']
+     * which is a SOLR_CONTENT cObj.
+     *
+     * @param string $path TypoScript path
+     * @return array The TypoScript object defined by the given path
+     * @throws InvalidArgumentException
+     */
+    public function getObjectByPath($path)
+    {
+        if (!is_string($path)) {
+            throw new InvalidArgumentException('Parameter $path is not a string',
+                1325627243);
+        }
+
+        $pathExploded = explode('.', trim($path));
+        // remove last object
+        $lastPathSegment = array_pop($pathExploded);
+        $pathBranch = $this->getPathBranch($pathExploded);
+
+        foreach ($pathExploded as $segment) {
+            if (!array_key_exists($segment . '.', $pathBranch)) {
+                throw new InvalidArgumentException(
+                    'TypoScript object path "' . htmlspecialchars($path) . '" does not exist',
+                    1325627264
+                );
+            }
+            $pathBranch = $pathBranch[$segment . '.'];
+        }
+
+        return $pathBranch;
+    }
+
+    /**
+     * Checks whether a given TypoScript path is valid.
+     *
+     * @param string $path TypoScript path
+     * @return boolean TRUE if the path resolves, FALSE otherwise
+     */
+    public function isValidPath($path)
+    {
+        $isValidPath = false;
+
+        $pathValue = $this->getValueByPath($path);
+        if (!is_null($pathValue)) {
+            $isValidPath = true;
+        }
+
+        return $isValidPath;
+    }
+
+    /**
+     * @param array $pathExploded
+     * @return array
+     */
+    protected function getPathBranch(array $pathExploded)
+    {
+        if ($pathExploded[0] === 'plugin' && $pathExploded[1] === 'tx_solr') {
+            $pathBranch = array('plugin.' => array('tx_solr.' => $this->configuration));
+        } else {
+            $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
+        }
+        return $pathBranch;
+    }
+
+    /**
+     * Merges a configuration with another configuration a
+     *
+     * @param array $configuration
+     * @return array
+     */
+    public function merge(array $configuration)
+    {
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $this->configuration,
+            $configuration
+        );
+    }
+
+    /**
+     * This method is used to allow the usage of the new configuration object with the array_key,
+     * same to the previous configuration.
+     *
+     * isset($config['tx_solr']['configPath']);
+     *
+     *
+     * @deprecated since 4.0, use TypoScriptConfiguration::isValidPath() instead, will be removed in version 5.0
+     * introduced to track the old array style usage
+     * @param  string $offset
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+        return array_key_exists($offset, $this->configuration);
+    }
+
+    /**
+     * This method is used to allow the usage of the new configuration object with the array_key,
+     * same to the previous configuration.
+     *
+     * $config['tx_solr']['configPath'];
+     *
+     * @deprecated since 4.0, use TypoScriptConfiguration::getValueByPath() instead, will be removed in version 5.0
+     * introduced to track the old array style usage
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+
+        if (!$this->offsetExists($offset)) {
+            return null;
+        }
+
+        return $this->configuration[$offset];
+    }
+
+    /**
+     * Throws an exception because the configuration should not be changed from outside.
+
+     * @deprecated since 4.0 will be removed in version 5.0 introduced to track the old array style usage
+     * @throws \Exception
+     */
+    public function offsetSet($offset, $value)
+    {
+        GeneralUtility::logDeprecatedFunction();
+
+        throw new \Exception('The configuration is readonly');
+    }
+
+    /**
+     * Throws an exception because the configuration options should not be unsetted from outside.
+     *
+     * @deprecated since 4.0 will be removed in version 5.0 introduced to track the old array style usage
+     * @throws \Exception
+     */
+    public function offsetUnset($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+
+        throw new \Exception('The configuration is readonly');
+    }
+}

--- a/Classes/Configuration/TypoScriptConfiguration.php
+++ b/Classes/Configuration/TypoScriptConfiguration.php
@@ -97,7 +97,7 @@ class TypoScriptConfiguration implements \ArrayAccess
         }
 
         $pathExploded = explode('.', trim($path));
-        $pathBranch = $this->getPathBranch($pathExploded);
+        $pathBranch = $this->configuration;
 
         $segmentCount = count($pathExploded);
         for ($i = 0; $i < $segmentCount; $i++) {
@@ -139,7 +139,7 @@ class TypoScriptConfiguration implements \ArrayAccess
         $pathExploded = explode('.', trim($path));
         // remove last object
         $lastPathSegment = array_pop($pathExploded);
-        $pathBranch = $this->getPathBranch($pathExploded);
+        $pathBranch = $this->configuration;
 
         foreach ($pathExploded as $segment) {
             if (!array_key_exists($segment . '.', $pathBranch)) {
@@ -173,31 +173,19 @@ class TypoScriptConfiguration implements \ArrayAccess
     }
 
     /**
-     * @param array $pathExploded
-     * @return array
-     */
-    protected function getPathBranch(array $pathExploded)
-    {
-        if ($pathExploded[0] === 'plugin' && $pathExploded[1] === 'tx_solr') {
-            $pathBranch = array('plugin.' => array('tx_solr.' => $this->configuration));
-        } else {
-            $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
-        }
-        return $pathBranch;
-    }
-
-    /**
      * Merges a configuration with another configuration a
      *
-     * @param array $configuration
-     * @return array
+     * @param array $configurationToMerge
+     * @return TypoScriptConfiguration
      */
-    public function merge(array $configuration)
+    public function mergeSolrConfiguration(array $configurationToMerge)
     {
         ArrayUtility::mergeRecursiveWithOverrule(
-            $this->configuration,
-            $configuration
+            $this->configuration['plugin.']['tx_solr.'],
+            $configurationToMerge
         );
+
+        return $this;
     }
 
     /**
@@ -215,7 +203,7 @@ class TypoScriptConfiguration implements \ArrayAccess
     public function offsetExists($offset)
     {
         GeneralUtility::logDeprecatedFunction();
-        return array_key_exists($offset, $this->configuration);
+        return array_key_exists($offset, $this->configuration['plugin.']['tx_solr.']);
     }
 
     /**
@@ -237,7 +225,7 @@ class TypoScriptConfiguration implements \ArrayAccess
             return null;
         }
 
-        return $this->configuration[$offset];
+        return $this->configuration['plugin.']['tx_solr.'][$offset];
     }
 
     /**

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -80,7 +80,8 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
                 2
             );
 
-            $solrConfiguration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['solr.'];
+            $configuration = Util::getSolrConfiguration();
+            $solrConfiguration = $configuration['solr.'];
 
             $host = $solrConfiguration['host'];
             $port = $solrConfiguration['port'];

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -28,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 // TODO use/extend ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer
 use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
 use ApacheSolrForTypo3\Solr\SubstitutePageIndexer;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -40,6 +41,15 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PageFieldMappingIndexer implements SubstitutePageIndexer
 {
+    /**
+     * @var \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration
+     */
+    protected $configuration;
+
+    public function __construct()
+    {
+        $this->configuration = Util::getSolrConfiguration();
+    }
 
     /**
      * Returns a substitute document for the currently being indexed page.
@@ -97,7 +107,7 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
     protected function getMappedFieldNames()
     {
         $mappedFieldNames = array();
-        $mappedFields = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['fields.'];
+        $mappedFields = $this->configuration['index.']['queue.']['pages.']['fields.'];
 
         foreach ($mappedFields as $indexFieldName => $recordFieldName) {
             if (is_array($recordFieldName)) {
@@ -124,7 +134,7 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
     {
         $fieldValue = '';
 
-        $indexingConfiguration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['fields.'];
+        $indexingConfiguration = $this->configuration['index.']['queue.']['pages.']['fields.'];
         $pageRecord = $GLOBALS['TSFE']->page;
 
 

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\SolrService;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -264,9 +265,10 @@ class PageIndexer extends AbstractFrontendHelper
     public function hook_indexContent(TypoScriptFrontendController $page)
     {
         $this->page = $page;
+        $configuration = Util::getSolrConfiguration();
 
         if (!$this->page->config['config']['index_enable']) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['pageIndexed']) {
+            if ($configuration['logging.']['indexing.']['pageIndexed']) {
                 GeneralUtility::devLog('Indexing is disabled. Set config.index_enable = 1 .',
                     'solr', 3);
             }
@@ -289,7 +291,7 @@ class PageIndexer extends AbstractFrontendHelper
                 $this->responseData['documentsSentToSolr'][] = (array)$document;
             }
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($configuration['tx_solr.']['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while trying to index page ' . $page->id,
                     'solr', 3, array(
                         $e->__toString()
@@ -297,7 +299,7 @@ class PageIndexer extends AbstractFrontendHelper
             }
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['pageIndexed']) {
+        if ($configuration['logging.']['indexing.']['pageIndexed']) {
             $success = $this->responseData['pageIndexed'] ? 'Success' : 'Failed';
             $severity = $this->responseData['pageIndexed'] ? -1 : 3;
 

--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -104,8 +104,7 @@ class JavascriptManager
     public function loadFile($fileKey)
     {
         if (!array_key_exists($fileKey, self::$files)) {
-            $typoScriptPath = 'plugin.tx_solr.javascriptFiles.' . $fileKey;
-            $fileReference = Util::getTypoScriptValue($typoScriptPath);
+            $fileReference = $this->configuration['javascriptFiles.'][$fileKey];
 
             if (!empty($fileReference)) {
                 self::$files[$fileKey] = array(
@@ -125,7 +124,7 @@ class JavascriptManager
      */
     public function addJavascriptToPage()
     {
-        $position = Util::getTypoScriptValue('plugin.tx_solr.javascriptFiles.loadIn');
+        $position = $this->configuration['javascriptFiles.']['loadIn'];
 
         if (empty($position)) {
             $position = self::POSITION_NONE;

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -100,7 +100,6 @@ abstract class PluginBase extends AbstractPlugin
      */
     private $rawUserQuery;
 
-
     // Main
 
 
@@ -130,7 +129,7 @@ abstract class PluginBase extends AbstractPlugin
 
             $content = $this->postRender($content);
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->conf['logging.']['exceptions']) {
                 GeneralUtility::devLog(
                     $e->getCode() . ': ' . $e->__toString(),
                     'solr',
@@ -182,11 +181,13 @@ abstract class PluginBase extends AbstractPlugin
      */
     protected function initialize($configuration)
     {
-        $this->conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
-        ArrayUtility::mergeRecursiveWithOverrule(
-            $this->conf,
-            $configuration
-        );
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
+        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
+        $typoScriptConfiguration->merge($configuration);
+        $configurationManager->setTypoScriptConfiguration($typoScriptConfiguration);
+
+        $this->conf = $typoScriptConfiguration;
 
         $this->initializeLanguageFactory();
         $this->pi_setPiVarDefaults();

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -129,6 +129,7 @@ abstract class PluginBase extends AbstractPlugin
 
             $content = $this->postRender($content);
         } catch (\Exception $e) {
+            var_dump($e->getMessage());
             if ($this->conf['logging.']['exceptions']) {
                 GeneralUtility::devLog(
                     $e->getCode() . ': ' . $e->__toString(),
@@ -183,10 +184,7 @@ abstract class PluginBase extends AbstractPlugin
     {
         /** @var $configurationManager \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager */
         $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
-        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
-        $typoScriptConfiguration->merge($configuration);
-        $configurationManager->setTypoScriptConfiguration($typoScriptConfiguration);
-
+        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($configuration);
         $this->conf = $typoScriptConfiguration;
 
         $this->initializeLanguageFactory();

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -129,7 +129,6 @@ abstract class PluginBase extends AbstractPlugin
 
             $content = $this->postRender($content);
         } catch (\Exception $e) {
-            var_dump($e->getMessage());
             if ($this->conf['logging.']['exceptions']) {
                 GeneralUtility::devLog(
                     $e->getCode() . ': ' . $e->__toString(),

--- a/Classes/Plugin/Results/Results.php
+++ b/Classes/Plugin/Results/Results.php
@@ -214,7 +214,7 @@ class Results extends CommandPluginBase
 
         // TODO check whether a search has been conducted already?
         if ($this->solrAvailable && (isset($rawUserQuery) || $this->conf['search.']['initializeWithEmptyQuery'] || $this->conf['search.']['initializeWithQuery'])) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['searchWords']) {
+            if ($this->conf['logging.']['query.']['searchWords']) {
                 GeneralUtility::devLog('received search query', 'solr', 0,
                     array($rawUserQuery));
             }
@@ -328,6 +328,8 @@ class Results extends CommandPluginBase
      */
     protected function overrideTyposcriptWithFlexformSettings()
     {
+        $flexFormConfiguration = array();
+
         // initialize with empty query, useful when no search has been
         // conducted yet but needs to show facets already.
         $initializeWithEmptyQuery = $this->pi_getFFvalue(
@@ -336,7 +338,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($initializeWithEmptyQuery) {
-            $this->conf['search.']['initializeWithEmptyQuery'] = 1;
+            $flexFormConfiguration['search.']['initializeWithEmptyQuery'] = 1;
         }
 
         $showResultsOfInitialEmptyQuery = $this->pi_getFFvalue(
@@ -345,7 +347,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($showResultsOfInitialEmptyQuery) {
-            $this->conf['search.']['showResultsOfInitialEmptyQuery'] = 1;
+            $flexFormConfiguration['search.']['showResultsOfInitialEmptyQuery'] = 1;
         }
 
         // initialize with non-empty query
@@ -355,7 +357,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($initialQuery) {
-            $this->conf['search.']['initializeWithQuery'] = $initialQuery;
+            $flexFormConfiguration['search.']['initializeWithQuery'] = $initialQuery;
         }
 
         $showResultsOfInitialQuery = $this->pi_getFFvalue(
@@ -364,7 +366,7 @@ class Results extends CommandPluginBase
             'sQuery'
         );
         if ($showResultsOfInitialQuery) {
-            $this->conf['search.']['showResultsOfInitialQuery'] = 1;
+            $flexFormConfiguration['search.']['showResultsOfInitialQuery'] = 1;
         }
 
         // target page
@@ -375,38 +377,46 @@ class Results extends CommandPluginBase
             $targetPage = $flexformTargetPage;
         }
         if (!empty($targetPage)) {
-            $this->conf['search.']['targetPage'] = $targetPage;
+            $flexFormConfiguration['search.']['targetPage'] = $targetPage;
         } else {
-            $this->conf['search.']['targetPage'] = $GLOBALS['TSFE']->id;
+            $flexFormConfiguration['search.']['targetPage'] = $GLOBALS['TSFE']->id;
         }
 
         // boost function
         $boostFunction = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'boostFunction', 'sQuery');
         if ($boostFunction) {
-            $this->conf['search.']['query.']['boostFunction'] = $boostFunction;
+            $flexFormConfiguration['search.']['query.']['boostFunction'] = $boostFunction;
         }
 
         // boost query
         $boostQuery = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'boostQuery', 'sQuery');
         if ($boostQuery) {
-            $this->conf['search.']['query.']['boostQuery'] = $boostQuery;
+            $flexFormConfiguration['search.']['query.']['boostQuery'] = $boostQuery;
         }
 
         // sorting
         $flexformSorting = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'sortBy', 'sQuery');
         if ($flexformSorting) {
-            $this->conf['search.']['query.']['sortBy'] = $flexformSorting;
+            $flexFormConfiguration['search.']['query.']['sortBy'] = $flexformSorting;
         }
 
         // results per page
         $resultsPerPage = $this->pi_getFFvalue($this->cObj->data['pi_flexform'],
             'resultsPerPage', 'sQuery');
         if ($resultsPerPage) {
-            $this->conf['search.']['results.']['resultsPerPage'] = $resultsPerPage;
+            $flexFormConfiguration['search.']['results.']['resultsPerPage'] = $resultsPerPage;
         }
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
+        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
+        $typoScriptConfiguration->merge($flexFormConfiguration);
+        $configurationManager->setTypoScriptConfiguration($typoScriptConfiguration);
+
+        $this->conf = $typoScriptConfiguration;
     }
 
     /**

--- a/Classes/Plugin/Results/Results.php
+++ b/Classes/Plugin/Results/Results.php
@@ -412,9 +412,7 @@ class Results extends CommandPluginBase
 
         /** @var $configurationManager \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager */
         $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
-        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
-        $typoScriptConfiguration->merge($flexFormConfiguration);
-        $configurationManager->setTypoScriptConfiguration($typoScriptConfiguration);
+        $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($flexFormConfiguration);
 
         $this->conf = $typoScriptConfiguration;
     }

--- a/Classes/Plugin/Results/ResultsCommand.php
+++ b/Classes/Plugin/Results/ResultsCommand.php
@@ -188,7 +188,7 @@ class ResultsCommand implements PluginCommand
     protected function processDocumentFieldsToArray(
         \Apache_Solr_Document $document
     ) {
-        $processingInstructions = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['results.']['fieldProcessingInstructions.'];
+        $processingInstructions = $this->configuration['search.']['results.']['fieldProcessingInstructions.'];
         $availableFields = $document->getFieldNames();
         $result = array();
 

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -746,7 +746,8 @@ class Query
     public function addFilter($filterString)
     {
         // TODO refactor to split filter field and filter value, @see Drupal
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['filters']) {
+        $configuration = Util::getSolrConfiguration();
+        if ($configuration['logging.']['query.']['filters']) {
             GeneralUtility::devLog('adding filter', 'solr', 0,
                 array($filterString));
         }

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -70,6 +70,7 @@ class Search implements SingletonInterface
     protected $hasSearched = false;
 
 
+
     // TODO Override __clone to reset $response and $hasSearched
 
     /**
@@ -125,6 +126,8 @@ class Search implements SingletonInterface
      */
     public function search(Query $query, $offset = 0, $limit = 10)
     {
+        $configuration = Util::getSolrConfiguration();
+
         $query = $this->modifyQuery($query);
         $this->query = $query;
 
@@ -140,7 +143,7 @@ class Search implements SingletonInterface
                 $query->getQueryParameters()
             );
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['queryString']) {
+            if ($configuration['logging.']['query.']['queryString']) {
                 GeneralUtility::devLog('Querying Solr, getting result', 'solr',
                     0, array(
                         'query string' => $query->getQueryString(),
@@ -152,7 +155,7 @@ class Search implements SingletonInterface
         } catch (\RuntimeException $e) {
             $response = $this->solr->getResponse();
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while querying Solr', 'solr',
                     3, array(
                         'exception' => $e->__toString(),
@@ -254,7 +257,8 @@ class Search implements SingletonInterface
 
             $solrAvailable = true;
         } catch (\Exception $e) {
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            $configuration = Util::getSolrConfiguration();
+            if ($configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('exception while trying to ping the solr server',
                     'solr', 3, array(
                         $e->__toString()
@@ -318,13 +322,14 @@ class Search implements SingletonInterface
     protected function getTrustedSolrFields()
     {
         $trustedFields = array();
-        if (!isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields']) ||
-            !is_string($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'])
+        $configuration = Util::getSolrConfiguration();
+        if (!isset($configuration['search.']['trustedFields']) ||
+            !is_string($configuration['search.']['trustedFields'])
         ) {
             return $trustedFields;
         }
 
-        $trustedFieldsSetting = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['search.']['trustedFields'];
+        $trustedFieldsSetting = $configuration['search.']['trustedFields'];
         $trustedFields = GeneralUtility::trimExplode(",", $trustedFieldsSetting);
 
         return $trustedFields;

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -94,6 +94,11 @@ class SolrService extends \Apache_Solr_Service
     protected $schemaName = null;
     protected $solrconfigName = null;
 
+    /**
+     * @var array
+     */
+    protected $configuration;
+
 
     /**
      * Constructor
@@ -110,6 +115,7 @@ class SolrService extends \Apache_Solr_Service
         $scheme = 'http'
     ) {
         $this->setScheme($scheme);
+        $this->configuration = Util::getSolrConfiguration();
 
         parent::__construct($host, $port, $path);
     }
@@ -420,7 +426,7 @@ class SolrService extends \Apache_Solr_Service
             $response = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawGet'] || $response->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawGet'] || $response->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'response' => (array)$response
@@ -627,7 +633,7 @@ class SolrService extends \Apache_Solr_Service
             $response = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawPost'] || $response->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawPost'] || $response->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'content' => $rawPost,
@@ -739,7 +745,7 @@ class SolrService extends \Apache_Solr_Service
             $solrResponse = $e->getResponse();
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['rawDelete'] || $solrResponse->getHttpStatus() != 200) {
+        if ($this->configuration['logging.']['query.']['rawDelete'] || $solrResponse->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'response' => (array)$solrResponse

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -185,7 +185,8 @@ class Template
                     $success = $this->addViewHelperObject($helperName,
                         $helperInstance);
                 } catch (\Exception $e) {
-                    if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+                    $configuration = Util::getSolrConfiguration();
+                    if ($configuration['tx_solr.']['logging.']['exceptions']) {
                         GeneralUtility::devLog('exception while adding a viewhelper',
                             'solr', 3, array(
                                 $e->__toString()
@@ -493,7 +494,8 @@ class Template
             try {
                 $viewHelperContent = $viewHelper->execute($viewHelperArguments);
             } catch (\UnexpectedValueException $e) {
-                if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+                $configuration = Util::getSolrConfiguration();
+                if ($configuration['tx_solr.']['logging.']['exceptions']) {
                     GeneralUtility::devLog('Exception while rendering a viewhelper',
                         'solr', 3, array(
                             $e->__toString()

--- a/Classes/Typo3Environment.php
+++ b/Classes/Typo3Environment.php
@@ -43,6 +43,7 @@ class Typo3Environment implements SingletonInterface
      */
     public function isFileIndexingEnabled()
     {
-        return (boolean)$GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['files'];
+        $configuration = Util::getSolrConfiguration();
+        return (boolean)$configuration['index.']['files'];
     }
 }

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -60,8 +60,8 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
         $indexableContent = implode($indexableContents[0], '');
 
         $indexableContent = $this->excludeContentByClass($indexableContent);
-
-        if (empty($indexableContent) && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['missingTypo3SearchMarkers']) {
+        $configuration = Util::getSolrConfiguration();
+        if (empty($indexableContent) && $configuration['logging.']['indexing.']['missingTypo3SearchMarkers']) {
             GeneralUtility::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
         }
 

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -95,6 +95,10 @@ class Typo3PageIndexer
      */
     protected $documentsSentToSolr = array();
 
+    /**
+     * @var array
+     */
+    protected $configuration;
 
     /**
      * Constructor
@@ -105,6 +109,7 @@ class Typo3PageIndexer
     {
         $this->page = $page;
         $this->pageUrl = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+        $this->configuration = Util::getSolrConfiguration();
 
         try {
             $this->initializeSolrConnection();
@@ -112,7 +117,7 @@ class Typo3PageIndexer
             $this->log($e->getMessage() . ' Error code: ' . $e->getCode(), 3);
 
             // TODO extract to a class "ExceptionLogger"
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while trying to index a page',
                     'solr', 3, array(
                         $e->__toString()
@@ -169,7 +174,7 @@ class Typo3PageIndexer
             $GLOBALS['TT']->setTSlogMessage('tx_solr: ' . $message, $errorNum);
         }
 
-        if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing']) {
+        if ($this->configuration['logging.']['indexing']) {
             if (!empty($data)) {
                 $logData = array();
                 foreach ($data as $value) {
@@ -473,11 +478,11 @@ class Typo3PageIndexer
      */
     protected function processDocuments(array $documents)
     {
-        if (is_array($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['fieldProcessingInstructions.'])) {
+        if (is_array($this->configuration['index.']['fieldProcessingInstructions.'])) {
             $service = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\FieldProcessor\\Service');
             $service->processDocuments(
                 $documents,
-                $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['fieldProcessingInstructions.']
+                $this->configuration['index.']['fieldProcessingInstructions.']
             );
         }
     }
@@ -516,7 +521,7 @@ class Typo3PageIndexer
         } catch (\Exception $e) {
             $this->log($e->getMessage() . ' Error code: ' . $e->getCode(), 2);
 
-            if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['exceptions']) {
+            if ($this->configuration['logging.']['exceptions']) {
                 GeneralUtility::devLog('Exception while adding documents',
                     'solr', 3, array(
                         $e->__toString()

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -191,13 +191,23 @@ class Util
      * Shortcut to retrieve the TypoScript configuration for EXT:solr
      * (plugin.tx_solr) from TSFE.
      *
-     * @return array EXT:solr TypoScript configuration from plugin.tx_solr
+     * @return \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration
      */
     public static function getSolrConfiguration()
     {
-        // TODO if in BE, create a fake TSFE and retrieve the configuration
-        // TODO merge flexform configuration
-        return $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+        $configurationManager = self::getConfigurationManager();
+
+        return $configurationManager->getTypoScriptConfiguration();
+    }
+
+    /**
+     * @return Configuration\ConfigurationManager
+     */
+    private static function getConfigurationManager()
+    {
+        /** @var \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager $configurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
+        return $configurationManager;
     }
 
     /**
@@ -485,30 +495,13 @@ class Util
      * @param string $path TypoScript path
      * @return array The TypoScript object defined by the given path
      * @throws InvalidArgumentException
+     *
+     * @deprecated since 4.0, use TypoScriptConfiguration::getObjectByPath() instead, will be removed in version 5.0
      */
     public static function getTypoScriptObject($path)
     {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException('Parameter $path is not a string',
-                1325627243);
-        }
-
-        $pathExploded = explode('.', trim($path));
-        // remove last object
-        $lastPathSegment = array_pop($pathExploded);
-        $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
-
-        foreach ($pathExploded as $segment) {
-            if (!array_key_exists($segment . '.', $pathBranch)) {
-                throw new InvalidArgumentException(
-                    'TypoScript object path "' . htmlspecialchars($path) . '" does not exist',
-                    1325627264
-                );
-            }
-            $pathBranch = $pathBranch[$segment . '.'];
-        }
-
-        return $pathBranch;
+        GeneralUtility::logDeprecatedFunction();
+        return self::getConfigurationManager()->getTypoScriptConfiguration()->getObjectByPath($path);
     }
 
     /**
@@ -516,17 +509,13 @@ class Util
      *
      * @param string $path TypoScript path
      * @return boolean TRUE if the path resolves, FALSE otherwise
+     *
+     * @deprecated since 4.0, use TypoScriptConfiguration::isValidPath() instead, will be removed in version 5.0
      */
     public static function isValidTypoScriptPath($path)
     {
-        $isValidPath = false;
-
-        $pathValue = self::getTypoScriptValue($path);
-        if (!is_null($pathValue)) {
-            $isValidPath = true;
-        }
-
-        return $isValidPath;
+        GeneralUtility::logDeprecatedFunction();
+        return self::getConfigurationManager()->getTypoScriptConfiguration()->isValidPath($path);
     }
 
     /**
@@ -538,29 +527,13 @@ class Util
      * @param string $path TypoScript path
      * @return array The TypoScript object defined by the given path
      * @throws InvalidArgumentException
+     *
+     * @deprecated since 4.0, use TypoScriptConfiguration::getValueByPath() instead, will be removed in version 5.0
      */
     public static function getTypoScriptValue($path)
     {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException('Parameter $path is not a string',
-                1325623321);
-        }
-
-        $pathExploded = explode('.', trim($path));
-        $pathBranch = $GLOBALS['TSFE']->tmpl->setup;
-
-        $segmentCount = count($pathExploded);
-        for ($i = 0; $i < $segmentCount; $i++) {
-            $segment = $pathExploded[$i];
-
-            if ($i == ($segmentCount - 1)) {
-                $pathBranch = $pathBranch[$segment];
-            } else {
-                $pathBranch = $pathBranch[$segment . '.'];
-            }
-        }
-
-        return $pathBranch;
+        GeneralUtility::logDeprecatedFunction();
+        return self::getConfigurationManager()->getTypoScriptConfiguration()->getValueByPath($path);
     }
 
     /**

--- a/Classes/ViewHelper/Date.php
+++ b/Classes/ViewHelper/Date.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -55,7 +56,8 @@ class Date implements ViewHelper
     public function __construct(array $arguments = array())
     {
         if (is_null($this->dateFormat) || is_null($this->contentObject)) {
-            $this->dateFormat = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['general.']['dateFormat.'];
+            $configuration = Util::getSolrConfiguration();
+            $this->dateFormat = $configuration['general.']['dateFormat.'];
             $this->contentObject = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
         }
     }
@@ -71,7 +73,6 @@ class Date implements ViewHelper
         $content = '';
 
         if (count($arguments) > 1) {
-            $this->dateFormat = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['general.']['dateFormat.'];
             $this->dateFormat['date'] = $arguments[1];
         }
 

--- a/Classes/ViewHelper/Facet.php
+++ b/Classes/ViewHelper/Facet.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -52,7 +53,7 @@ class Facet extends AbstractSubpartViewHelper
     public function __construct(array $arguments = array())
     {
         if (is_null($this->configuration)) {
-            $this->configuration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+            $this->configuration = Util::getSolrConfiguration();
         }
     }
 

--- a/Classes/ViewHelper/Link.php
+++ b/Classes/ViewHelper/Link.php
@@ -85,9 +85,11 @@ class Link implements ViewHelper
         if (is_numeric($linkArgument)) {
             $linkTarget = intval($linkArgument);
         } elseif (!empty($linkArgument) && is_string($linkArgument)) {
-            if (Util::isValidTypoScriptPath($linkArgument)) {
+            /** @var \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration $configuration */
+            $configuration = Util::getSolrConfiguration();
+            if ($configuration->isValidPath($linkArgument)) {
                 try {
-                    $typoscript = Util::getTypoScriptObject($linkArgument);
+                    $typoscript = $configuration->getObjectByPath($linkArgument);
                     $pathExploded = explode('.', $linkArgument);
                     $lastPathSegment = array_pop($pathExploded);
 

--- a/Classes/ViewHelper/Lll.php
+++ b/Classes/ViewHelper/Lll.php
@@ -25,7 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\LanguageFileUnavailableException;
-use TYPO3\CMS\Core\FormProtection\Exception;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -95,7 +95,7 @@ class Lll implements ViewHelper
      */
     protected function loadLL()
     {
-        $configuration = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.'];
+        $configuration = Util::getSolrConfiguration();
 
         $this->localLang[$this->languageFile] = $this->languageFactory->getParsedData(
             $this->languageFile,

--- a/Classes/ViewHelper/SolrLink.php
+++ b/Classes/ViewHelper/SolrLink.php
@@ -137,7 +137,9 @@ class SolrLink implements ViewHelper
         } elseif (is_string($linkArgument) && !empty($linkArgument)) {
             // interpret a TypoScript path
             try {
-                $typoscript = Util::getTypoScriptObject($linkArgument);
+                /** @var \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration $configuration */
+                $configuration = Util::getSolrConfiguration();
+                $typoscript = $configuration->getObjectByPath($linkArgument);
                 $pathExploded = explode('.', $linkArgument);
                 $lastPathSegment = array_pop($pathExploded);
 

--- a/Classes/ViewHelper/Ts.php
+++ b/Classes/ViewHelper/Ts.php
@@ -83,7 +83,9 @@ class Ts implements ViewHelper
         $value = '';
         $pathExploded = explode('.', trim($path));
         $lastPathSegment = array_pop($pathExploded);
-        $pathBranch = Util::getTypoScriptObject($path);
+        /** @var \ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration $configuration */
+        $configuration = Util::getSolrConfiguration();
+        $pathBranch = $configuration->getObjectByPath($path);
 
         // generate ts content
         $cObj = $this->getContentObject();

--- a/Tests/Integration/Fixtures/can_search.xml
+++ b/Tests/Integration/Fixtures/can_search.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Search Test</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -70,43 +70,6 @@ class PageIndexerTest extends IntegrationTest
         $solrContent = file_get_contents('http://localhost:8080/solr/core_en/select?q=*:*');
         $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
         $this->assertContains('"title":"hello solr"', $solrContent, 'Could not index document into solr');
-
-        // cleanup the solr server
-        /** @var  $connectionManager \ApacheSolrForTypo3\Solr\ConnectionManager */
-        $connectionManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\ConnectionManager');
-        $solrServices = $connectionManager->getAllConnections();
-        foreach ($solrServices as $solrService) {
-            $solrService->deleteByQuery('*:*');
-            $solrService->commit();
-        }
-
-        // we wait to make sure the document will be deleted in solr
-        sleep(3);
-
-        $solrContent = file_get_contents('http://localhost:8080/solr/core_en/select?q=*:*');
-        $this->assertContains('"numFound":0', $solrContent, 'Could not index document into solr');
-    }
-
-    /**
-     * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
-     */
-    protected function getConfiguredTSFE($TYPO3_CONF_VARS = array(), $id = 1, $type = 0)
-    {
-        /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
-        $TSFE = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController',
-            $TYPO3_CONF_VARS, $id, $type);
-
-        \TYPO3\CMS\Frontend\Utility\EidUtility::initLanguage();
-        $TSFE->initFEuser();
-        $TSFE->set_no_cache();
-        $TSFE->checkAlternativeIdMethods();
-        $TSFE->determineId();
-        $TSFE->initTemplate();
-        $TSFE->getConfigArray();
-        \TYPO3\CMS\Core\Core\Bootstrap::getInstance();
-        $TSFE->settingLanguage();
-        $TSFE->settingLocale();
-
-        return $TSFE;
+        $this->cleanUpSolrServerAndAssertEmpty();
     }
 }

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2015 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Site;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Test class to perform a search on a real solr server
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class SearchTest extends IntegrationTest
+{
+    /**
+     * @test
+     */
+    public function canSearchForADocument()
+    {
+        $this->importDataSetFromFixture('can_search.xml');
+
+        $GLOBALS['TT'] = $this->getMock('\\TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker', array(), array(), '', false);
+        $fakeTSFE = $this->getConfiguredTSFE();
+        $GLOBALS['TSFE'] = $fakeTSFE;
+
+        /** @var $pageIndexer \ApacheSolrForTypo3\Solr\Typo3PageIndexer */
+        $pageIndexer = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Typo3PageIndexer', $fakeTSFE);
+        $pageIndexer->indexPage();
+
+        sleep(3);
+
+            /** @var $searchInstance \ApacheSolrForTypo3\Solr\Search */
+        $searchInstance = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Search');
+
+            /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Query');
+        $query->useRawQueryString(true);
+        $query->setQueryFieldsFromString('content^40.0, title^5.0, keywords^2.0, tagsH1^5.0, tagsH2H3^3.0, tagsH4H5H6^2.0, tagsInline^1.0');
+        $query->setQueryString('hello');
+
+        $searchResponse = $searchInstance->search($query);
+        $rawResponse = $searchResponse->getRawResponse();
+        $this->assertContains('"numFound":1', $rawResponse, 'Could not index document into solr');
+        $this->assertContains('"title":"Hello Search Test"', $rawResponse, 'Could not index document into solr');
+        $this->cleanUpSolrServerAndAssertEmpty();
+    }
+}

--- a/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase to check if the configuration object can be used as expected
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class TypoScriptConfigurationTest extends UnitTest
+{
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $configuration;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $fakeConfigurationArray = array();
+        $fakeConfigurationArray['index.']['queue.']['tt_news.']['fields.']['content'] = 'SOLR_CONTENT';
+        $fakeConfigurationArray['index.']['queue.']['tt_news.']['fields.']['content.']['field'] = 'bodytext';
+        $this->configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetValueByPath()
+    {
+        $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
+        $this->assertSame('SOLR_CONTENT', $this->configuration->getValueByPath($testPath), 'Could not get configuration value by path');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetObjectByPath()
+    {
+        $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
+        $expectedResult = array(
+            'content' => 'SOLR_CONTENT',
+            'content.' => array('field' => 'bodytext')
+        );
+
+        $this->assertSame($expectedResult, $this->configuration->getObjectByPath($testPath), 'Could not get configuration object by path');
+    }
+
+    /**
+     * @test
+     */
+    public function canUseAsArrayForBackwardsCompatibility()
+    {
+        $value = $this->configuration['index.']['queue.']['tt_news.']['fields.']['content'];
+        $this->assertSame($value, 'SOLR_CONTENT', 'Can not use the configuration object with array access as backwards compatible implementation');
+    }
+}

--- a/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
@@ -49,8 +49,8 @@ class TypoScriptConfigurationTest extends UnitTest
     public function setUp()
     {
         $fakeConfigurationArray = array();
-        $fakeConfigurationArray['index.']['queue.']['tt_news.']['fields.']['content'] = 'SOLR_CONTENT';
-        $fakeConfigurationArray['index.']['queue.']['tt_news.']['fields.']['content.']['field'] = 'bodytext';
+        $fakeConfigurationArray['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content'] = 'SOLR_CONTENT';
+        $fakeConfigurationArray['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content.']['field'] = 'bodytext';
         $this->configuration = new TypoScriptConfiguration($fakeConfigurationArray);
     }
 

--- a/Tests/Unit/ViewHelper/TsTest.php
+++ b/Tests/Unit/ViewHelper/TsTest.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelper;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Util;
 use ApacheSolrForTypo3\Solr\ViewHelper\Ts;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * PHP Unit test for view helper Tx_Solr_viewhelper_Ts
@@ -52,7 +53,6 @@ class TsTest extends UnitTest
     {
         $this->skipInVersionBelow('7.6');
         $TSFE = $this->getDumbMock('\\TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController');
-
 
         $GLOBALS['TSFE'] = $TSFE;
         /** @var $GLOBALS ['TSFE']->tmpl  \TYPO3\CMS\Core\TypoScript\TemplateService */
@@ -92,6 +92,9 @@ class TsTest extends UnitTest
         $cObj->setContentObjectClassMap(array(
             'TEXT' => 'TYPO3\\CMS\\Frontend\\ContentObject\\TextContentObject'
         ));
+        /** @var \ApacheSolrForTypo3\Solr\Configuration\ConfigurationManager $configurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Configuration\\ConfigurationManager');
+        $configurationManager->reset();
 
         $this->viewHelper = new Ts();
         $this->viewHelper->setContentObject($cObj);


### PR DESCRIPTION
This patch streamlines the typoscript configuration handling.
At various places the typoscript configuration path plugin.tx_solr. is
used, also in context of a content object. So typoscript settings that
should affect a single content element path like plugin.tx_solr_PiResults_Results.
was ignored. Also the flexform settings are merged in the main
configuration object now.

The TypoScriptConfiguration object support array access for backwards compatibility.
In the long run, we should use speaking methods or "getObjectByPath" or "getValueByPath"

For now it does not support nested solr plugins.

Resolves: #163

This pull request is based on @Mabahe pull request with the addition that, the configuration object can be used with array access operators for backwards compatibility and adds some unit and integrations tests.