### PR TITLE
[BUGFIX] Fixed wrong cache group configuration.

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -305,7 +305,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'] = array('groups');
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'] = array('all');
 }
 
 


### PR DESCRIPTION
Using cache group all to clear the cache when the "Flush general cache" is used on TYPO3

Fixes: #215 