### PR TITLE
Added configuration "plugin.tx_solr.results.resultsHighlighting.useFastVectorHighlighter" to use a faster highlighter when needed.

### DIFF
--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -90,12 +90,16 @@ class Query
     private $rawQueryString = false;
 
     /**
-     * Constructor
-     *
+     * @param string $keywords
+     * @param null $solrConfiguration
      */
-    public function __construct($keywords)
+    public function __construct($keywords, $solrConfiguration = null)
     {
-        $this->solrConfiguration = Util::getSolrConfiguration();
+        if ($solrConfiguration == null) {
+            $this->solrConfiguration = Util::getSolrConfiguration();
+        } else {
+            $this->solrConfiguration = $solrConfiguration;
+        }
 
         $this->fieldList = array('*', 'score');
         $this->setKeywords($keywords);
@@ -1148,10 +1152,23 @@ class Query
                 $this->queryParameters['hl.fl'] = $this->solrConfiguration['search.']['results.']['resultsHighlighting.']['highlightFields'];
             }
 
+
+            if (isset($this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter']) &&
+                $this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] == 1) {
+                $this->queryParameters['hl.useFastVectorHighlighter'] = 'true';
+            }
+
             $wrap = explode('|',
                 $this->solrConfiguration['search.']['results.']['resultsHighlighting.']['wrap']);
-            $this->queryParameters['hl.simple.pre'] = $wrap[0];
-            $this->queryParameters['hl.simple.post'] = $wrap[1];
+
+            if (isset($this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter']) &&
+                $this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] == 1) {
+                $this->queryParameters['hl.tag.pre'] = $wrap[0];
+                $this->queryParameters['hl.tag.post'] = $wrap[1];
+            } else {
+                $this->queryParameters['hl.simple.pre'] = $wrap[0];
+                $this->queryParameters['hl.simple.post'] = $wrap[1];
+            }
         } else {
             // remove all hl.* settings
             foreach ($this->queryParameters as $key => $value) {

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -1155,6 +1155,9 @@ class Query
 
             if (isset($this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter']) &&
                 $this->solrConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] == 1) {
+                if ($fragmentSize <= 18) {
+                    throw new \InvalidArgumentException("The setting useFastVectorHighlighter can only be used with a fragementSize larger then 18");
+                }
                 $this->queryParameters['hl.useFastVectorHighlighter'] = 'true';
             }
 

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -153,6 +153,9 @@ plugin.tx_solr {
 		results {
 			resultsHighlighting = 0
 			resultsHighlighting {
+				 // can be used to increase the highlighting performance
+				 // requires the field is termVectors=on, termPositions=on and termOffsets=on which is set for content.
+				useFastVectorHighlighter = 0
 				highlightFields = content
 				fragmentSize = 200
 				fragmentSeparator = [...]

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -153,8 +153,9 @@ plugin.tx_solr {
 		results {
 			resultsHighlighting = 0
 			resultsHighlighting {
-				 // can be used to increase the highlighting performance
-				 // requires the field is termVectors=on, termPositions=on and termOffsets=on which is set for content.
+				 // can be used to increase the highlighting performance requires the field is termVectors=on,
+				 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
+				 // then 18
 				useFastVectorHighlighter = 0
 				highlightFields = content
 				fragmentSize = 200

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @package TYPO3
  * @subpackage solr
  */
-class QueryTestCase extends UnitTest
+class QueryTest extends UnitTest
 {
 
     /**
@@ -200,5 +200,71 @@ class QueryTestCase extends UnitTest
                 'Query contains grouping parameter "' . $queryParameter . '"'
             );
         }
+    }
+
+    /**
+     * @test
+     */
+    public function canEnableHighlighting()
+    {
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test');
+        $query->setHighlighting(true);
+        $queryParameters = $query->getQueryParameters();
+
+        $this->assertSame("true", $queryParameters["hl"], 'Enable highlighting did not set the "hl" query parameter');
+        $this->assertSame(200, $queryParameters["hl.fragsize"], 'hl.fragsize was not set to the default value of 200');
+    }
+
+
+    /**
+     * @test
+     */
+    public function canSetHighlightingFieldList()
+    {
+        $fakeConfiguration = array();
+        $fakeConfiguration['search.']['results.']['resultsHighlighting.']['highlightFields'] = 'title';
+
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test', $fakeConfiguration);
+        $query->setHighlighting(true);
+        $queryParameters = $query->getQueryParameters();
+
+        $this->assertSame("true", $queryParameters["hl"], 'Enable highlighting did not set the "hl" query parameter');
+        $this->assertSame("title", $queryParameters["hl.fl"], 'Can set highlighting field list');
+    }
+
+    /**
+     * @test
+     */
+    public function canUseFastVectorHighlighting()
+    {
+        $fakeConfiguration = array();
+        $fakeConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] = 1;
+
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test', $fakeConfiguration);
+        $query->setHighlighting(true);
+        $queryParameters = $query->getQueryParameters();
+
+        $this->assertSame("true", $queryParameters["hl"], 'Enable highlighting did not set the "hl" query parameter');
+        $this->assertSame("true", $queryParameters["hl.useFastVectorHighlighter"], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
+    }
+
+    /**
+     * @test
+     */
+    public function canDisableFastVectorHighlighting()
+    {
+        $fakeConfiguration = array();
+        $fakeConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] = 0;
+
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test', $fakeConfiguration);
+        $query->setHighlighting(true);
+        $queryParameters = $query->getQueryParameters();
+
+        $this->assertSame("true", $queryParameters["hl"], 'Enable highlighting did not set the "hl" query parameter');
+        $this->assertNull($queryParameters["hl.useFastVectorHighlighter"], 'FastVectorHighlighter was disabled but still requested');
     }
 }

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -267,4 +267,19 @@ class QueryTest extends UnitTest
         $this->assertSame("true", $queryParameters["hl"], 'Enable highlighting did not set the "hl" query parameter');
         $this->assertNull($queryParameters["hl.useFastVectorHighlighter"], 'FastVectorHighlighter was disabled but still requested');
     }
+
+    /**
+     * @test
+     */
+    public function canThrowExceptionWhenFastVectorHighlighterIsUsedWithFragSizeEqualsZero()
+    {
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $fakeConfiguration = array();
+        $fakeConfiguration['search.']['results.']['resultsHighlighting.']['useFastVectorHighlighter'] = 1;
+
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test', $fakeConfiguration);
+        $query->setHighlighting(true, 0);
+    }
 }


### PR DESCRIPTION
Can be used to enable "hl.useFastVectorHighlighter" to improve the highlighting performance.

Fixes: #193 