### PR TITLE
[BUGFIX] Add url as default trusted fields because of & in the url

### DIFF
--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -110,8 +110,9 @@ plugin.tx_solr {
 
 	search {
 		// fields that are allowed to contain html and should be skipped during escaping after retrieval from Solr
-		// by default all fields will be escaped and none are considered trusted
-	 	trustedFields =
+		// by default all fields expect url get escaped, you might need to add other url fields here as well because of &
+		// characters in the url.
+		trustedFields = url
 
 		targetPage = {$plugin.tx_solr.search.targetPage}
 


### PR DESCRIPTION
I propose to add url as default trustedField because & charcters could be in there and would get escaped, what is not wanted in this case.

Fixes: #219 