### PR TITLE
[BUGFIX] Charset not respeceted in Typo3PageContentExtractor::excludeContentByClass

### DIFF
--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -81,9 +81,9 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
             return $indexableContent;
         }
 
-        $doc = new \DOMDocument();
+        $doc = new \DOMDocument('1.0', 'UTF-8');
         libxml_use_internal_errors(true);
-        $doc->loadHTML($indexableContent);
+        $doc->loadHTML('<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . $indexableContent);
         $xpath = new \DOMXPath($doc);
         $excludeParts = GeneralUtility::trimExplode(',', $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['excludeContentByClass'], true);
         foreach ($excludeParts as $excludePart) {
@@ -94,9 +94,12 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
                 }
             }
         }
-        #from http://php.net/manual/en/domdocument.savehtml.php
-        $indexableContent = trim(preg_replace('/^<!DOCTYPE.+?>/', '', str_replace(array('<html>', '</html>', '<body>', '</body>'), array('', '', '', ''), $doc->saveHTML())));
-        return $indexableContent;
+        $html = $doc->saveHTML($doc->documentElement->parentNode);
+        // remove XML-Preamble, newlines and doctype
+        $html = preg_replace('/(<\?xml[^>]+\?>|\r?\n|<!DOCTYPE.+?>)/imS', '', $html);
+        $html = str_replace(array('<html>', '</html>', '<body>', '</body>'), array('', '', '', ''), $html);
+
+        return $html;
     }
 
     /**

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -55,14 +55,13 @@ class Typo3PageContentExtractorTest extends UnitTest
     public function changesNbspToSpace()
     {
         $content = '<!-- TYPO3SEARCH_begin -->In Olten&nbsp;ist<!-- TYPO3SEARCH_end -->';
-        $expectedResult = 'In Olten ist';
+        $expectedResult = 'In Olten ist';
 
         $contentExtractor = GeneralUtility::makeInstance(
             'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
             $content
         );
         $actualResult = $contentExtractor->getIndexableContent();
-
         $this->assertEquals($expectedResult, $actualResult);
     }
 
@@ -81,5 +80,41 @@ class Typo3PageContentExtractorTest extends UnitTest
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
         $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function excludeContentKeepsEncodingForUmlaut()
+    {
+        $content = '<!-- TYPO3SEARCH_begin --><div class="typo3-search-exclude">Remove me</div><p>Was ein schöner Tag</p><!-- TYPO3SEARCH_end -->';
+
+        $contentExtractor = GeneralUtility::makeInstance(
+            'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
+            $content
+        );
+
+        $actualResult = $contentExtractor->excludeContentByClass($content);
+
+        $this->assertContains('Was ein schöner Tag', $actualResult);
+        $this->assertNotContains('Remove me', $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function excludeContentKeepsEncodingForEuroSign()
+    {
+        $content = '<!-- TYPO3SEARCH_begin --><div class="typo3-search-exclude">Remove me</div><p>100€</p><!-- TYPO3SEARCH_end -->';
+
+        $contentExtractor = GeneralUtility::makeInstance(
+            'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
+            $content
+        );
+
+        $actualResult = $contentExtractor->excludeContentByClass($content);
+
+        $this->assertContains('100€', $actualResult);
+        $this->assertNotContains('Remove me', $actualResult);
     }
 }


### PR DESCRIPTION
Make sure that parsed content is supposed to be UTF-8.

Fixes #218 