### PR TITLE
Backport fix for #48 to 3.0.x

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -223,7 +223,7 @@ class Tx_Solr_IndexQueue_RecordMonitor {
 				if ($this->isEnabledRecord($recordTable, $record)) {
 					$configurationName = NULL;
 					if ($recordTable !== 'pages') {
-						$configurationName = $this->getIndexingConfigurationName($table, $uid);
+						$configurationName = $this->getIndexingConfigurationName($recordTable, $recordUid);
 					}
 
 					$this->indexQueue->updateItem($recordTable, $recordUid, $configurationName);


### PR DESCRIPTION
Backports the fix from #48 (Indexing of records crash when indexing configuraiton and table name is different when new record created) to the 3.0.x branch.

