### PR TITLE
Added SearchResult object and configuration to be able to configure an own class as search result object.

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/SearchResult.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Query;
+use ApacheSolrForTypo3\Solr\Search;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Proxy class for \Apache_Solr_Document to customize \Apache_Solr_Document without
+ * changing the library code.
+ *
+ * Implements
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class SearchResult extends \Apache_Solr_Document
+{
+
+    /**
+     * @var bool
+     */
+    protected $throwExceptions = false;
+
+    /**
+     * @param \Apache_Solr_Document $document
+     * @param bool $throwExceptions
+     */
+    public function __construct(\Apache_Solr_Document $document, $throwExceptions = false)
+    {
+        $this->throwExceptions = false;
+        $this->_documentBoost = $document->_documentBoost;
+        $this->_fields = $document->_fields;
+        $this->_fieldBoosts = $document->_fieldBoosts;
+    }
+
+    /**
+     * @param string $name
+     * @param array $arguments
+     * @return null
+     * @throws \Exception
+     * @throws \RuntimeException
+     */
+    public function __call($name, $arguments)
+    {
+        try {
+            return parent::__call($name, $arguments);
+        } catch (\RuntimeException $e) {
+            if ($this->throwExceptions) {
+                throw $e;
+            }
+        }
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -314,3 +314,9 @@ if (TYPO3_MODE == 'BE') {
         '_CLI_solr'
     );
 }
+
+# ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
+
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '])) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '] = 'ApacheSolrForTypo3\\Solr\\Domain\\Search\\ResultSet\\SearchResult';
+}


### PR DESCRIPTION
Added SearchResult object and configuration to be able to configure an own class as search result object.

$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName ']

Fixes: #251