### PR TITLE
[BUGFIX] PHP7 compatibility for several classes

### DIFF
--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -249,10 +249,11 @@ abstract class PluginBase extends AbstractPlugin
      * Also locallang values set in the TypoScript property "_LOCAL_LANG" are
      * merged onto the values found in the "locallang" file.
      * Supported file extensions xlf, xml, php
-     *
+     * 
+     * @param string $languageFilePath path to the plugin language file in format EXT:....
      * @return void
      */
-    public function pi_loadLL()
+    public function pi_loadLL($languageFilePath = '')
     {
         if (!$this->LOCAL_LANG_loaded && $this->scriptRelPath) {
             $pathElements = pathinfo($this->scriptRelPath);

--- a/Classes/Plugin/Results/Results.php
+++ b/Classes/Plugin/Results/Results.php
@@ -264,7 +264,7 @@ class Results extends CommandPluginBase
      * @param Template $template The template object as initialized thus far.
      * @return Template The modified template instance with additional variables available for rendering.
      */
-    protected function postInitializeTemplateEngine($template)
+    protected function postInitializeTemplateEngine(Template $template)
     {
         $template->addVariable('tx_solr', $this->getSolrVariables());
 

--- a/Classes/Plugin/Search/Search.php
+++ b/Classes/Plugin/Search/Search.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Plugin\Search;
 
 use ApacheSolrForTypo3\Solr\CommandResolver;
 use ApacheSolrForTypo3\Solr\Plugin\CommandPluginBase;
+use ApacheSolrForTypo3\Solr\Template;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -93,9 +94,9 @@ class Search extends CommandPluginBase
 
     /**
      * Post initialization of the template engine.
-     *
+     * @param Template $template
      */
-    protected function postInitializeTemplateEngine($template)
+    protected function postInitializeTemplateEngine(Template $template)
     {
         $template->addVariable('tx_solr', $this->getSolrVariables());
 

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -148,12 +148,13 @@ class SolrService extends \Apache_Solr_Service
      * @param integer $offset result offset for pagination
      * @param integer $limit number of results to retrieve
      * @param array $params additional HTTP GET parameters
+     * @param string $method The HTTP method (Apache_Solr_Service::METHOD_GET or Apache_Solr_Service::METHOD::POST)
      * @return \Apache_Solr_Response Solr response
      * @throws \RuntimeException if Solr returns a HTTP status code other than 200
      */
-    public function search($query, $offset = 0, $limit = 10, $params = array())
+    public function search($query, $offset = 0, $limit = 10, $params = array(), $method = self::METHOD_GET)
     {
-        $response = parent::search($query, $offset, $limit, $params);
+        $response = parent::search($query, $offset, $limit, $params, $method);
         $this->hasSearched = true;
 
         $this->responseCache = $response;


### PR DESCRIPTION
For PHP7 the signature of a method should be identical to the parent class.