### PR TITLE
Install php-cs-fixer via composer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,9 +218,8 @@ All classes are using the psr-2 coding standard (http://www.php-fig.org/psr/psr-
 If you want to check the codestyle locally before you commit or just automatically want to fix it there is a great tool (when you remove --dry-run the php-cs-fixer also fixes all violations):
 
 ```bash
-wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer
-chmod u+x php-cs-fixer
-./php-cs-fixer fix -v --level=psr2 --dry-run Classes
+composer install
+./.Build/bin/php-cs-fixer fix -v --level=psr2 --dry-run Classes
 ```
 
 ### Namespacing and Package Structure

--- a/Tests/Build/cibuild.sh
+++ b/Tests/Build/cibuild.sh
@@ -9,10 +9,10 @@ if [ $TRAVIS ]; then
     export PATH="$PATH:$HOME/.composer/vendor/bin"
 fi
 
-php-cs-fixer --version > /dev/null 2>&1
+.Build/bin/php-cs-fixer --version > /dev/null 2>&1
 if [ $? -eq "0" ]; then
     echo "Check PSR-2 compliance"
-    php-cs-fixer fix -v --level=psr2 --dry-run Classes
+    .Build/bin/php-cs-fixer fix -v --level=psr2 --dry-run Classes
 
     if [ $? -ne "0" ]; then
         echo "Some files are not PSR-2 compliant"

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,11 @@
   },
   "require": {
     "php": ">=5.5.0",
-    "typo3/cms-core": ">=7.6.0"
+    "typo3/cms": ">=7.6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=4.8.0 <6.0.0"
+    "phpunit/phpunit": ">=4.8.0 <6.0.0",
+    "fabpot/php-cs-fixer": "~1.11"
   },
   "replace": {
     "solr": "self.version",


### PR DESCRIPTION
php-cs-fixer should be installed via composer instead of require a global binary