### PR TITLE
Overwritting labels with TypoScript not working

### DIFF
--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -272,22 +272,26 @@ abstract class PluginBase extends AbstractPlugin
                 }
             }
             // Overlaying labels from TypoScript (including fictitious language keys for non-system languages!):
-            if (isset($this->conf['_LOCAL_LANG.'])) {
-                // Clear the "unset memory"
-                $this->LOCAL_LANG_UNSET = array();
-                foreach ($this->conf['_LOCAL_LANG.'] as $languageKey => $languageArray) {
-                    // Remove the dot after the language key
-                    $languageKey = substr($languageKey, 0, -1);
-                    // Don't process label if the language is not loaded
-                    if (is_array($languageArray) && isset($this->LOCAL_LANG[$languageKey])) {
-                        foreach ($languageArray as $labelKey => $labelValue) {
-                            if (!is_array($labelValue)) {
-                                $this->LOCAL_LANG[$languageKey][$labelKey][0]['target'] = $labelValue;
-                                $this->LOCAL_LANG_charset[$languageKey][$labelKey] = 'utf-8';
+            $translationInTypoScript = $this->typoScriptConfiguration->getLocalLangConfiguration();
 
-                                if ($labelValue === '') {
-                                    $this->LOCAL_LANG_UNSET[$languageKey][$labelKey] = '';
-                                }
+            if (count($translationInTypoScript) == 0) {
+                return;
+            }
+
+            // Clear the "unset memory"
+            $this->LOCAL_LANG_UNSET = array();
+            foreach ($translationInTypoScript as $languageKey => $languageArray) {
+                // Remove the dot after the language key
+                $languageKey = substr($languageKey, 0, -1);
+                // Don't process label if the language is not loaded
+                if (is_array($languageArray) && isset($this->LOCAL_LANG[$languageKey])) {
+                    foreach ($languageArray as $labelKey => $labelValue) {
+                        if (!is_array($labelValue)) {
+                            $this->LOCAL_LANG[$languageKey][$labelKey][0]['target'] = $labelValue;
+                            $this->LOCAL_LANG_charset[$languageKey][$labelKey] = 'utf-8';
+
+                            if ($labelValue === '') {
+                                $this->LOCAL_LANG_UNSET[$languageKey][$labelKey] = '';
                             }
                         }
                     }

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -267,6 +267,25 @@ class ResultsTest extends AbstractPluginTest
     }
 
     /**
+     * @test
+     */
+    public function canAddCustomTranslationsInTYPOScript()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2), 'can_render_results_plugin.xml');
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['_LOCAL_LANG.']['default.']['results_range'] = 'My own label';
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = '*';
+
+        $resultPage = $searchResults->main('', array());
+        $this->assertContains('My own label', $resultPage, 'Could not find custom TypoScript label');
+    }
+
+    /**
      * Assertion to check if the pagination markup is present in the response.
      *
      * @param string $content


### PR DESCRIPTION
Retrieve configured labels from typoscriptConfiguration and assign them in the plugin.

Fixes: #267