### PR TITLE
[BUGFIX] JavaScript files get lost when concatenation and compression is enabled

### DIFF
--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -110,7 +110,7 @@ class JavascriptManager
             if (!empty($fileReference)) {
                 self::$files[$fileKey] = array(
                     'addedToPage' => false,
-                    'file' => GeneralUtility::createVersionNumberedFilename($GLOBALS['TSFE']->tmpl->getFileName($fileReference))
+                    'file' => $GLOBALS['TSFE']->tmpl->getFileName($fileReference)
                 );
             }
         }


### PR DESCRIPTION
Remove versioned file name from JavaScript manager, because this is done one by the PageRenderer now.

This pr resolved the issue for 3.1.x we need to apply it on master as well. I would create a seperate pr for this.

Fixes: #264