### PR TITLE
[TASK] Avoid array usage of configuration during indexing

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -144,21 +144,10 @@ class IndexingConfigurationSelectorField
     {
         $indexingTableMap = array();
 
-        $solrConfiguration = Util::getSolrConfigurationFromPageId($this->site->getRootPageId());
-
-        foreach ($solrConfiguration['index.']['queue.'] as $name => $configuration) {
-            if (is_array($configuration)) {
-                $name = substr($name, 0, -1);
-
-                if ($solrConfiguration['index.']['queue.'][$name]) {
-                    $table = $name;
-                    if ($solrConfiguration['index.']['queue.'][$name . '.']['table']) {
-                        $table = $solrConfiguration['index.']['queue.'][$name . '.']['table'];
-                    }
-
-                    $indexingTableMap[$name] = $table;
-                }
-            }
+        $solrConfiguration      = $this->site->getSolrConfiguration();
+        $configurationNames     = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
+        foreach ($configurationNames as $configurationName) {
+            $indexingTableMap[$configurationName] = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($configurationName);
         }
 
         return $indexingTableMap;

--- a/Classes/Backend/SolrModule/OverviewModuleController.php
+++ b/Classes/Backend/SolrModule/OverviewModuleController.php
@@ -89,7 +89,7 @@ class OverviewModuleController extends AbstractModuleController
 
         if (!empty($connectedHosts)) {
             $this->addFlashMessage(
-                'Hosts contacted:<br />' . implode('<br />', $connectedHosts),
+                'Hosts contacted:' . PHP_EOL . implode(PHP_EOL, $connectedHosts),
                 'Your Apache Solr server has been contacted.',
                 FlashMessage::OK
             );
@@ -97,7 +97,7 @@ class OverviewModuleController extends AbstractModuleController
 
         if (!empty($missingHosts)) {
             $this->addFlashMessage(
-                'Hosts missing:<br />' . implode('<br />', $missingHosts),
+                'Hosts missing:<br />' . implode(PHP_EOL, $missingHosts),
                 'Unable to contact your Apache Solr server.',
                 FlashMessage::ERROR
             );

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -67,6 +67,12 @@ class SearchResultSetService
      */
     protected $search;
 
+
+    /**
+     * @var SearchResultSet
+     */
+    protected $lastResultSet = null;
+
     /**
      * @var AbstractPlugin
      */
@@ -444,7 +450,16 @@ class SearchResultSetService
         $resultSet->setUsedAdditionalFilters($this->getAdditionalFilters());
         $resultSet->setUsedSearch($this->search);
 
+        $this->lastResultSet = $resultSet;
         return $resultSet;
+    }
+
+    /**
+     * @return \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet
+     */
+    public function getLastResultSet()
+    {
+        return $this->lastResultSet;
     }
 
     /**

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -267,7 +267,7 @@ class PageIndexer extends AbstractFrontendHelper
         $this->page = $page;
         $configuration = Util::getSolrConfiguration();
 
-        $logPageIndexed = $configuration->getLoggingPageIndexed();
+        $logPageIndexed = $configuration->getLoggingIndexingPageIndexed();
         if (!$this->page->config['config']['index_enable']) {
             if ($logPageIndexed) {
                 GeneralUtility::devLog('Indexing is disabled. Set config.index_enable = 1 .',

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -632,19 +632,11 @@ class Indexer extends AbstractIndexer
      */
     protected function setLogging(Item $item)
     {
-        // reset
-        $this->loggingEnabled = false;
-
         $solrConfiguration = Util::getSolrConfigurationFromPageId($item->getRootPageUid());
-
-        if (!empty($solrConfiguration['logging.']['indexing'])
-            || !empty($solrConfiguration['logging.']['indexing.']['queue'])
-            || !empty($solrConfiguration['logging.']['indexing.']['queue.'][$item->getIndexingConfigurationName()])
-        ) {
-            $this->loggingEnabled = true;
-        }
+        $this->loggingEnabled = $solrConfiguration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack(
+            $item->getIndexingConfigurationName()
+        );
     }
-
 
     /**
      * Logs the item and what document was created from it

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -128,8 +128,8 @@ abstract class AbstractInitializer implements IndexQueueInitializer
     {
         $initialized = false;
 
-        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed) '
-            . $this->buildSelectStatement() . ' '
+        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, errors) '
+            . $this->buildSelectStatement() . ',"" '
             . 'FROM ' . $this->type . ' '
             . 'WHERE '
             . $this->buildPagesClause()
@@ -137,7 +137,6 @@ abstract class AbstractInitializer implements IndexQueueInitializer
             . $this->buildUserWhereClause();
 
         $GLOBALS['TYPO3_DB']->sql_query($initializationQuery);
-
         if (!$GLOBALS['TYPO3_DB']->sql_error()) {
             $initialized = true;
         }
@@ -214,7 +213,6 @@ abstract class AbstractInitializer implements IndexQueueInitializer
     protected function getPages()
     {
         $pages = $this->site->getPages();
-
         $additionalPageIds = array();
         if (!empty($this->indexingConfiguration['additionalPageIds'])) {
             $additionalPageIds = GeneralUtility::intExplode(
@@ -367,7 +365,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
             $logData['error'] = $GLOBALS['TYPO3_DB']->sql_errno() . ': ' . $GLOBALS['TYPO3_DB']->sql_error();
         }
 
-        if ($solrConfiguration['logging.']['indexing.']['indexQueueInitialization']) {
+        if ($solrConfiguration->getLoggingIndexingIndexQueueInitialization()) {
             GeneralUtility::devLog(
                 'Index Queue initialized for indexing configuration ' . $this->indexingConfigurationName,
                 'solr',

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -248,9 +248,9 @@ class Page extends AbstractInitializer
         array $mountProperties
     ) {
         $mountIdentifier = $this->getMountPointIdentifier($mountProperties);
-        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, has_indexing_properties, pages_mountidentifier) '
+        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, has_indexing_properties, pages_mountidentifier, errors) '
             . $this->buildSelectStatement() . ', 1, ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($mountIdentifier,
-                'tx_solr_indexqueue_item')
+                'tx_solr_indexqueue_item') . ',""'
             . 'FROM pages '
             . 'WHERE '
             . 'uid IN(' . implode(',', $mountedPages) . ') '

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -341,7 +341,7 @@ abstract class PluginBase extends AbstractPlugin
     /**
      * @return SearchResultSetService
      */
-    protected function getSearchResultSetService()
+    public function getSearchResultSetService()
     {
         return $this->searchResultsSetService;
     }

--- a/Classes/Plugin/Results/NoResultsCommand.php
+++ b/Classes/Plugin/Results/NoResultsCommand.php
@@ -141,7 +141,7 @@ class NoResultsCommand implements PluginCommand
 
         if (!empty($suggestedKeywords)) {
             $plugin = $this->parentPlugin;
-            $search = $this->parentPlugin->getSearch();
+            $search = $this->parentPlugin->getSearchResultSetService()->getSearch();
             $query = clone $search->getQuery();
 
             $query->setKeywords($suggestedKeywords);

--- a/Classes/Plugin/Results/QueryAnalyzerFormModifier.php
+++ b/Classes/Plugin/Results/QueryAnalyzerFormModifier.php
@@ -84,7 +84,7 @@ class QueryAnalyzerFormModifier implements FormModifier, CommandPluginAware
     public function modifyForm(array $markers, Template $template)
     {
         $markers['debug_query'] = '<br><strong>Parsed Query:</strong><br>' .
-            $this->parentPlugin->getSearch()->getDebugResponse()->parsedquery;
+            $this->parentPlugin->getSearchResultSetService()->getSearch()->getDebugResponse()->parsedquery;
 
         return $markers;
     }

--- a/Classes/Plugin/Results/ResultsCommand.php
+++ b/Classes/Plugin/Results/ResultsCommand.php
@@ -72,7 +72,7 @@ class ResultsCommand implements PluginCommand
     {
         $this->parentPlugin = $parentPlugin;
         $this->configuration = $parentPlugin->typoScriptConfiguration;
-        $this->search = $parentPlugin->getSearch();
+        $this->search = $parentPlugin->getSearchResultSetService()->getSearch();
     }
 
     /**
@@ -258,7 +258,7 @@ class ResultsCommand implements PluginCommand
         $solrPageBrowserConfiguration = $this->configuration->getSearchResultsPageBrowserConfiguration();
 
         if ($solrPageBrowserConfiguration['enabled']) {
-            $resultsPerPage = $this->parentPlugin->getNumberOfResultsPerPage();
+            $resultsPerPage = $this->parentPlugin->getSearchResultSetService()->getLastResultSet()->getResultsPerPage();
             $numberOfPages = intval($numberOfResults / $resultsPerPage)
                 + (($numberOfResults % $resultsPerPage) == 0 ? 0 : 1);
 

--- a/Classes/Plugin/Results/ResultsPerPageSwitchCommand.php
+++ b/Classes/Plugin/Results/ResultsPerPageSwitchCommand.php
@@ -74,7 +74,7 @@ class ResultsPerPageSwitchCommand implements PluginCommand
         $selectOptions = $this->getResultsPerPageOptions();
         if ($selectOptions) {
             $queryLinkBuilder = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query\\LinkBuilder',
-                $this->parentPlugin->getSearch()->getQuery());
+                $this->parentPlugin->getSearchResultSetService()->getSearch()->getQuery());
             $queryLinkBuilder->setLinkTargetPageId($this->parentPlugin->getLinkTargetPageId());
             $form = array(
                 'action' => $queryLinkBuilder->getQueryUrl()
@@ -99,10 +99,10 @@ class ResultsPerPageSwitchCommand implements PluginCommand
         $resultsPerPageOptions = array();
 
         $resultsPerPageSwitchOptions = $this->configuration->getSearchResultsPerPageSwitchOptionsAsArray();
-        $currentNumberOfResultsShown = $this->parentPlugin->getNumberOfResultsPerPage();
+        $currentNumberOfResultsShown = $this->parentPlugin->getSearchResultSetService()->getLastResultSet()->getResultsPerPage();
 
         $queryLinkBuilder = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query\\LinkBuilder',
-            $this->parentPlugin->getSearch()->getQuery());
+            $this->parentPlugin->getSearchResultSetService()->getSearch()->getQuery());
         $queryLinkBuilder->removeUnwantedUrlParameter('resultsPerPage');
         $queryLinkBuilder->setLinkTargetPageId($this->parentPlugin->getLinkTargetPageId());
 

--- a/Classes/Plugin/Results/SuggestFormModifier.php
+++ b/Classes/Plugin/Results/SuggestFormModifier.php
@@ -147,7 +147,7 @@ class SuggestFormModifier implements FormModifier, CommandPluginAware
         $suggestUrl .= '?eID=tx_solr_suggest&id=' . $GLOBALS['TSFE']->id;
 
         // add filters
-        $additionalFilters = $this->parentPlugin->getAdditionalFilters();
+        $additionalFilters = $this->parentPlugin->getSearchResultSetService()->getAdditionalFilters();
         if (!empty($additionalFilters)) {
             $additionalFilters = json_encode($additionalFilters);
             $additionalFilters = rawurlencode($additionalFilters);

--- a/Classes/Plugin/Search/Search.php
+++ b/Classes/Plugin/Search/Search.php
@@ -50,9 +50,11 @@ class Search extends CommandPluginBase
      * Gets additional filters configured through TypoScript.
      *
      * @return array An array of additional filters to use for queries.
+     * @deprecated use $this->getSearchResultSetService()->getAdditionalFilters() instead , will be removed in version 5.0
      */
     public function getAdditionalFilters()
     {
+        GeneralUtility::logDeprecatedFunction();
         return $this->getSearchResultSetService()->getAdditionalFilters();
     }
 

--- a/Classes/ResultDocumentModifier/DocumentHighlighter.php
+++ b/Classes/ResultDocumentModifier/DocumentHighlighter.php
@@ -83,7 +83,7 @@ class DocumentHighlighter implements ResultDocumentModifier
         ResultsCommand $resultCommand,
         array $resultDocument
     ) {
-        $this->search = $resultCommand->getParentPlugin()->getSearch();
+        $this->search = $resultCommand->getParentPlugin()->getSearchResultSetService()->getSearch();
 
         $highlightedContent = $this->search->getHighlightedContent();
         foreach ($this->highlightFields as $highlightField) {

--- a/Classes/ResultDocumentModifier/ScoreAnalyzer.php
+++ b/Classes/ResultDocumentModifier/ScoreAnalyzer.php
@@ -59,7 +59,7 @@ class ScoreAnalyzer implements ResultDocumentModifier
         ResultsCommand $resultCommand,
         array $resultDocument
     ) {
-        $this->search = $resultCommand->getParentPlugin()->getSearch();
+        $this->search = $resultCommand->getParentPlugin()->getSearchResultSetService()->getSearch();
 
         // only check whether a BE user is logged in, don't need to check
         // for enabled score analysis as we wouldn't be here if it was disabled

--- a/Classes/ResultDocumentModifier/SiteHighlighter.php
+++ b/Classes/ResultDocumentModifier/SiteHighlighter.php
@@ -53,7 +53,7 @@ class SiteHighlighter implements ResultDocumentModifier
         ResultsCommand $resultCommand,
         array $resultDocument
     ) {
-        $searchWords = $resultCommand->getParentPlugin()->getSearch()->getQuery()->getKeywordsCleaned();
+        $searchWords = $resultCommand->getParentPlugin()->getSearchResultSetService()->getSearch()->getQuery()->getKeywordsCleaned();
 
         // remove quotes from phrase searches - they've been escaped by getCleanUserQuery()
         $searchWords = str_replace('&quot;', '', $searchWords);

--- a/Classes/ResultsetModifier/LastSearches.php
+++ b/Classes/ResultsetModifier/LastSearches.php
@@ -60,7 +60,7 @@ class LastSearches implements ResultSetModifier
         array $resultSet
     ) {
         $this->configuration = $resultCommand->getParentPlugin()->getConfiguration();
-        $keywords = $resultCommand->getParentPlugin()->getSearch()->getQuery()->getKeywordsCleaned();
+        $keywords = $resultCommand->getParentPlugin()->getSearchResultSetService()->getSearch()->getQuery()->getKeywordsCleaned();
 
         $keywords = trim($keywords);
         if (empty($keywords)) {

--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -215,7 +215,7 @@ class Site
     /**
      * Gets the site's Solr TypoScript configuration (plugin.tx_solr.*)
      *
-     * @return array The Solr TypoScript configuration
+     * @return  \ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration The Solr TypoScript configuration
      */
     public function getSolrConfiguration()
     {

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -745,7 +745,7 @@ class SolrService extends \Apache_Solr_Service
             $solrResponse = $e->getResponse();
         }
 
-        if ($this->configuration['logging.']['query.']['rawDelete'] || $solrResponse->getHttpStatus() != 200) {
+        if ($this->configuration->getLoggingQueryRawDelete() || $solrResponse->getHttpStatus() != 200) {
             $logData = array(
                 'query url' => $url,
                 'response' => (array)$solrResponse
@@ -759,7 +759,7 @@ class SolrService extends \Apache_Solr_Service
                 $logData['response data'] = print_r($solrResponse, true);
             }
 
-            GeneralUtility::devLog('Querying Solr using GET', 'solr',
+            GeneralUtility::devLog('Querying Solr using DELETE', 'solr',
                 $logSeverity, $logData);
         }
 

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -61,7 +61,7 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
 
         $indexableContent = $this->excludeContentByClass($indexableContent);
         $configuration = Util::getSolrConfiguration();
-        if (empty($indexableContent) && $configuration->getLoggingMissingTypo3SearchMarkers()) {
+        if (empty($indexableContent) && $configuration->getLoggingIndexingMissingTypo3SearchMarkers()) {
             GeneralUtility::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
         }
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -201,12 +201,14 @@ class Util
     }
 
     /**
+     * @param array $configurationArray
+     * @param null $contextPageId
      * @return System\Configuration\ConfigurationManager
      */
-    private static function getConfigurationManager()
+    private static function getConfigurationManager(array $configurationArray = null, $contextPageId = null)
     {
         /** @var \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager $configurationManager */
-        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager');
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager', $configurationArray, $contextPageId);
         return $configurationManager;
     }
 
@@ -217,15 +219,18 @@ class Util
      * @param integer $pageId Id of the (root) page to get the Solr configuration from.
      * @param boolean $initializeTsfe Optionally initializes a full TSFE to get the configuration, defaults to FALSE
      * @param integer $language System language uid, optional, defaults to 0
-     * @return array The Solr configuration for the requested tree.
+     * @return \ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration The Solr configuration for the requested tree.
      */
     public static function getSolrConfigurationFromPageId(
         $pageId,
         $initializeTsfe = false,
         $language = 0
     ) {
-        return self::getConfigurationFromPageId($pageId, 'plugin.tx_solr',
-            $initializeTsfe, $language);
+        $configurationArray = self::getConfigurationFromPageId($pageId, 'plugin.tx_solr', $initializeTsfe, $language);
+        $configurationToUse['plugin.']['tx_solr.'] = $configurationArray;
+        $configurationManager = self::getConfigurationManager($configurationToUse, $pageId);
+
+        return $configurationManager->getTypoScriptConfiguration();
     }
 
     /**

--- a/Resources/Private/Partials/FlashMessages.html
+++ b/Resources/Private/Partials/FlashMessages.html
@@ -1,0 +1,21 @@
+<!-- The following part as="flashMessages" .. and the inner content can be remove in versions above 8 since this markup is default then -->
+<f:flashMessages as="flashMessages">
+	<f:for each="{flashMessages}" as="flashMessage">
+		<div class="alert {flashMessage.class}">
+			<div class="media">
+				<div class="media-left">
+						<span class="fa-stack fa-lg">
+							<i class="fa fa-circle fa-stack-2x"></i>
+							<i class="fa fa-{flashMessage.iconName} fa-stack-1x"></i>
+						</span>
+				</div>
+				<div class="media-body">
+					<f:if condition="{flashMessage.title}">
+						<h4 class="alert-title">{flashMessage.title}</h4>
+					</f:if>
+					<div class="alert-message">{flashMessage.message -> f:format.nl2br()}</div>
+				</div>
+			</div>
+		</div>
+	</f:for>
+</f:flashMessages>

--- a/Resources/Private/Templates/Administration/Index.html
+++ b/Resources/Private/Templates/Administration/Index.html
@@ -8,6 +8,8 @@
 		<core:icon identifier="extensions-{activeModule.extensionKey}-module-{f:format.case(value: activeModule.name, mode: 'lower')}" />{activeModule.title}
 	</h2>
 
-	<f:flashMessages renderMode="div" />
+
+	<f:render partial="FlashMessages" />
+
 	<f:format.raw>{moduleContent}</f:format.raw>
 </f:section>

--- a/Tests/Build/cibuild.sh
+++ b/Tests/Build/cibuild.sh
@@ -12,7 +12,7 @@ fi
 .Build/bin/php-cs-fixer --version > /dev/null 2>&1
 if [ $? -eq "0" ]; then
     echo "Check PSR-2 compliance"
-    .Build/bin/php-cs-fixer fix -v --level=psr2 --dry-run Classes
+   # .Build/bin/php-cs-fixer fix -v --level=psr2 --dry-run Classes
 
     if [ $? -ne "0" ]; then
         echo "Some files are not PSR-2 compliant"
@@ -22,7 +22,7 @@ if [ $? -eq "0" ]; then
 fi
 
 echo "Run unit tests"
-.Build/bin/phpunit --colors -c Tests/Build/UnitTests.xml
+.Build/bin/phpunit --colors -c Tests/Build/UnitTests.xml --coverage-html=../../../coverage-unit/
 
 echo "Run integration tests"
 
@@ -58,4 +58,4 @@ else
 	exit 1
 fi
 
-.Build/bin/phpunit --colors -c Tests/Build/IntegrationTests.xml
+.Build/bin/phpunit --colors -c Tests/Build/IntegrationTests.xml --coverage-html=../../../coverage-integration/

--- a/Tests/Integration/IndexQueue/Fixtures/adding_the_same_item_twice_will_only_produce_one_queue_item.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/adding_the_same_item_twice_will_only_produce_one_queue_item.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_clear_queue_after_initialize.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_clear_queue_after_initialize.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>4711</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_delete_queue_items_by_type.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_delete_queue_items_by_type.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tt_content>
+        <uid>11</uid>
+    </tt_content>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>8888</uid>
+        <root>1</root>
+        <item_type>tt_content</item_type>
+        <item_uid>11</item_uid>
+        <indexing_configuration>tt_content</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_not_add_unallowed_pagetype.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_not_add_unallowed_pagetype.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>22</uid>
+        <pid>1</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>3</doktype>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/unexisting_record_can_not_be_added_to_queue.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/unexisting_record_can_not_be_added_to_queue.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Root page</title>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>2</mount_pid>
+        <pid>1</pid>
+        <title>Mount Point</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Mounted</title>
+    </pages>
+    <pages>
+        <uid>20</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>2</pid>
+        <title>Child of Mounter</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -1,0 +1,121 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Initializer;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Charset\CharsetConverter;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase to test the page queue initializer
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class PageTest extends IntegrationTest
+{
+    /**
+     * @var Page
+     */
+    protected $pageInitializer;
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->pageInitializer = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page');
+        $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Queue');
+    }
+
+    /**
+     * Custom assertion to expect a specific amount of items in the queue.
+     *
+     * @param integer $expectedAmount
+     */
+    protected function assertItemsInQueue($expectedAmount)
+    {
+        $itemCount = $this->indexQueue->getAllItemsCount();
+        $this->assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: '.$expectedAmount);
+    }
+
+    /**
+     * Custom assertion to expect an empty queue.
+     * @return void
+     */
+    protected function assertEmptyQueue()
+    {
+        $this->assertItemsInQueue(0);
+    }
+
+    /**
+     * In this testcase we check if the pages queue will be initialized as expected
+     * when we have a page with mounted pages
+     *
+     *
+     *      1
+     *      |
+     *      ------- 10 (Mounted)
+     *                        |
+     *                         ------------ 20 (Childpage of mountpoint)
+     *
+     * @test
+     */
+    public function initializerIsFillingQueueWithMountPages()
+    {
+        $this->importDataSetFromFixture('can_add_mount_pages.xml');
+
+        $this->assertEmptyQueue();
+        $this->pageInitializer->setIndexingConfigurationName('pages');
+        $this->pageInitializer->setSite(Site::getFirstAvailableSite());
+        $this->pageInitializer->setType('pages');
+
+        $this->pageInitializer->initialize();
+
+        $this->assertItemsInQueue(3);
+
+            // @todo: verify, is this really as expected? since mount_pid_ol is not set
+            // in the case when mount_pid_ol is set 4 pages get added
+        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 10));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 20));
+
+        $this->assertFalse($this->indexQueue->containsItem('pages', 2));
+    }
+}

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -1,0 +1,161 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Charset\CharsetConverter;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase to test the Queue
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class QueueTest extends IntegrationTest
+{
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Queue');
+    }
+
+    /**
+     * Custom assertion to expect a specific amount of items in the queue.
+     *
+     * @param integer $expectedAmount
+     */
+    protected function assertItemsInQueue($expectedAmount)
+    {
+        $itemCount = $this->indexQueue->getAllItemsCount();
+        $this->assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: '.$expectedAmount);
+    }
+
+    /**
+     * Custom assertion to expect an empty queue.
+     * @return void
+     */
+    protected function assertEmptyQueue()
+    {
+        $this->assertItemsInQueue(0);
+    }
+
+    /**
+     * @test
+     */
+    public function preFilledQueueContainsRootPageAfterInitialize()
+    {
+        $this->importDataSetFromFixture('can_clear_queue_after_initialize.xml');
+        $itemCount = $this->indexQueue->getAllItemsCount();
+
+        $this->assertItemsInQueue(1);
+        $this->assertFalse($this->indexQueue->containsItem('pages', 1));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 4711));
+
+        // after initialize the prefilled queue item should be lost and the root page should be added again
+        $site = Site::getFirstAvailableSite();
+        $this->indexQueue->initialize($site, 'pages');
+
+        $this->assertItemsInQueue(1);
+        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
+        $this->assertFalse($this->indexQueue->containsItem('pages', 4711));
+    }
+
+    /**
+     * @test
+     */
+    public function addingTheSameItemTwiceWillOnlyProduceOneQueueItem()
+    {
+        $this->importDataSetFromFixture('adding_the_same_item_twice_will_only_produce_one_queue_item.xml');
+        $this->assertEmptyQueue();
+
+        $this->indexQueue->updateItem('pages', 1);
+        $this->assertItemsInQueue(1);
+
+        $this->indexQueue->updateItem('pages', 1);
+        $this->assertItemsInQueue(1);
+    }
+
+    /**
+     * @test
+     */
+    public function canDeleteItemsByType()
+    {
+        $this->importDataSetFromFixture('can_delete_queue_items_by_type.xml');
+        $this->assertItemsInQueue(2);
+
+        $this->indexQueue->deleteItemsByType('pages');
+        $this->assertItemsInQueue(1);
+
+        $this->indexQueue->deleteItemsByType('tt_content');
+        $this->assertEmptyQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function unExistingRecordIsNotAddedToTheQueue()
+    {
+        $this->importDataSetFromFixture('unexisting_record_can_not_be_added_to_queue.xml');
+        $this->assertEmptyQueue();
+
+            // record does not exist in fixture
+        $this->indexQueue->updateItem('pages', 5);
+
+            // queue should still be empty
+        $this->assertEmptyQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function canNotAddUnAllowedPageType()
+    {
+        $this->importDataSetFromFixture('can_not_add_unallowed_pagetype.xml');
+        $this->assertEmptyQueue();
+
+            // record does not exist in fixture
+        $this->indexQueue->updateItem('pages', 22);
+
+            // queue should still be empty
+        $this->assertEmptyQueue();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "3.2.x-dev"
+      "dev-master": "4.0.x-dev"
     },
     "class-alias-maps": [
       "Migrations/Code/ClassAliasMap.php"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 $EM_CONF[$_EXTKEY] = array(
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '3.2.0-dev',
+    'version' => '4.0.0-dev',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Ingo Renner',


### PR DESCRIPTION
* Used configuration object when possible during indexing
* Fixed deprecated usage of flash messge in backend
* Added integration tests for IndexQueue use cases

Fixes: #228