### PR TITLE
[BUGFIX] JavaScript files get lost if concatenation and compression are enabled

### DIFF
--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -109,7 +109,7 @@ class JavascriptManager
             if (!empty($fileReference)) {
                 self::$files[$fileKey] = array(
                     'addedToPage' => false,
-                    'file' => GeneralUtility::createVersionNumberedFilename($GLOBALS['TSFE']->tmpl->getFileName($fileReference))
+                    'file' => $GLOBALS['TSFE']->tmpl->getFileName($fileReference)
                 );
             }
         }


### PR DESCRIPTION
Remove versioned file name from JavaScript manager, because this is one by the PageRenderer now.

Fixes: #264