### PR TITLE
[TASK]  Remove q.op

### DIFF
--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -50,7 +50,7 @@ class SolrConfigStatus implements StatusProviderInterface
      *
      * @var string
      */
-    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-4-0-0--20160127';
+    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-4-0-0--20160330';
 
     /**
      * Compiles a collection of solrconfig version checks against each configured

--- a/Resources/Solr/typo3cores/conf/solrconfig.xml
+++ b/Resources/Solr/typo3cores/conf/solrconfig.xml
@@ -10,7 +10,7 @@
 	status report - \ApacheSolrForTypo3\Solr\Report\SolrConfigStatus - checking
 	against this name property, that status check must be updated as well.
 -->
-<config name="tx_solr-4-0-0--20160127">
+<config name="tx_solr-4-0-0--20160330">
 
 	<luceneMatchVersion>4.10.4</luceneMatchVersion>
 
@@ -176,22 +176,21 @@
 		<lst name="defaults">
 			<str name="defType">edismax</str>
 			<str name="echoParams">explicit</str>
-			<str name="q.op">OR</str>
 			<str name="qf">content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline^1.0</str>
 			<str name="pf">content^2.0</str>
 			<str name="df">content</str>
 			<int name="ps">15</int>
-	
+
 			<str name="mm">2&lt;-35%</str>
-	
+
 			<str name="hl.fl">title,content</str>
 			<int name="hl.snippets">3</int>
 			<str name="hl.mergeContiguous">true</str>
 			<str name="hl.requireFieldMatch">true</str>
-	
+
 			<str name="f.content.hl.alternateField">content</str>
 			<str name="f.content.hl.maxAlternateFieldLength">200</str>
-	
+
 			<str name="spellcheck">false</str>
 			<str name="spellcheck.onlyMorePopular">false</str>
 			<str name="spellcheck.extendedResults">false</str>
@@ -218,7 +217,7 @@
 		</lst>
 	</requestHandler>
 
-	
+
 	<requestHandler name="/browse" class="solr.SearchHandler">
 		<lst name="defaults">
 			<str name="echoParams">explicit</str>


### PR DESCRIPTION
Since the mm parameter is set as default value for the search request handler q.op has no effect and should be removed

Fixes: #283 
