### PR TITLE
[TASK] Fixed 8.0 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - TYPO3_DATABASE_PASSWORD=""
   matrix:
     - TYPO3_VERSION="~7.6.4"
+    - TYPO3_VERSION="~8.0.0"
     - TYPO3_VERSION="dev-master"
 
 matrix:
@@ -27,6 +28,10 @@ matrix:
       env: TYPO3_VERSION="dev-master"
     - php: 5.6
       env: TYPO3_VERSION="dev-master"
+    - php: 5.5
+      env: TYPO3_VERSION="~8.0.0"
+    - php: 5.6
+      env: TYPO3_VERSION="~8.0.0"
 
 before_install:
   - composer self-update

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -83,15 +83,15 @@ class UserGroupDetector
     public function activate()
     {
         // register hooks
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['isOutputting'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->disableFrontendOutput';
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->disableCaching';
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->deactivateTcaFrontendGroupEnableFields';
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_checkEnableFields'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->checkEnableFields';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['isOutputting'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->disableFrontendOutput';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->disableCaching';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->deactivateTcaFrontendGroupEnableFields';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_checkEnableFields'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector->checkEnableFields';
 
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPage'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPageOverlay'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPage'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPageOverlay'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
 
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['postInit'][__CLASS__] = '&ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['postInit'][__CLASS__] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\UserGroupDetector';
     }
 
     /**

--- a/Classes/ViewHelpers/Backend/AbstractSolrBackendViewHelper.php
+++ b/Classes/ViewHelpers/Backend/AbstractSolrBackendViewHelper.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -26,29 +27,18 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
 
-/**
- * View helper to load a CSS file
- *
- * = Examples =
- *
- * <code title="Default">
- * <solr:backend.style file="{f:uri.resource(path:'StyleSheets/Backend/IndexQueueModule.css')}" />
- * </code>
- * <output>
- * Loads the given file and adds it to the backend module.
- * </output>
- */
-class StyleViewHelper extends AbstractSolrBackendViewHelper
+abstract class AbstractSolrBackendViewHelper extends AbstractBackendViewHelper
 {
-    /**
-     * @param string $file CSS file to load in the backend module
-     */
-    public function render($file)
-    {
-        /** @var PageRenderer $pageRenderer */
-        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-        $pageRenderer->addCssFile($file);
-    }
+    /**
+     * @var bool
+     */
+    protected $escapeChildren = true;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = true;
 }

--- a/Classes/ViewHelpers/Backend/AbstractSolrTagBasedViewHelper.php
+++ b/Classes/ViewHelpers/Backend/AbstractSolrTagBasedViewHelper.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -26,29 +27,18 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
-/**
- * View helper to load a CSS file
- *
- * = Examples =
- *
- * <code title="Default">
- * <solr:backend.style file="{f:uri.resource(path:'StyleSheets/Backend/IndexQueueModule.css')}" />
- * </code>
- * <output>
- * Loads the given file and adds it to the backend module.
- * </output>
- */
-class StyleViewHelper extends AbstractSolrBackendViewHelper
+abstract class AbstractSolrTagBasedViewHelper extends AbstractTagBasedViewHelper
 {
-    /**
-     * @param string $file CSS file to load in the backend module
-     */
-    public function render($file)
-    {
-        /** @var PageRenderer $pageRenderer */
-        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-        $pageRenderer->addCssFile($file);
-    }
+    /**
+     * @var bool
+     */
+    protected $escapeChildren = true;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = true;
 }

--- a/Classes/ViewHelpers/Backend/AbstractSolrViewHelper.php
+++ b/Classes/ViewHelpers/Backend/AbstractSolrViewHelper.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -26,29 +27,18 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
-/**
- * View helper to load a CSS file
- *
- * = Examples =
- *
- * <code title="Default">
- * <solr:backend.style file="{f:uri.resource(path:'StyleSheets/Backend/IndexQueueModule.css')}" />
- * </code>
- * <output>
- * Loads the given file and adds it to the backend module.
- * </output>
- */
-class StyleViewHelper extends AbstractSolrBackendViewHelper
+abstract class AbstractSolrViewHelper extends AbstractViewHelper
 {
-    /**
-     * @param string $file CSS file to load in the backend module
-     */
-    public function render($file)
-    {
-        /** @var PageRenderer $pageRenderer */
-        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-        $pageRenderer->addCssFile($file);
-    }
+    /**
+     * @var bool
+     */
+    protected $escapeChildren = true;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = true;
 }

--- a/Classes/ViewHelpers/Backend/Button/HelpButtonViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Button/HelpButtonViewHelper.php
@@ -24,15 +24,20 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Button;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrViewHelper;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * View helper to return a help button
  *
  */
-class HelpButtonViewHelper extends AbstractViewHelper
+class HelpButtonViewHelper extends AbstractSolrViewHelper
 {
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
 
     /**
      * Render a help button wit the given title and content

--- a/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
@@ -24,14 +24,14 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Menu;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrTagBasedViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
  * Core selector menu view helper
  *
  */
-class CoreSelectorMenuViewHelper extends AbstractTagBasedViewHelper
+class CoreSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
 {
 
     /**
@@ -45,7 +45,6 @@ class CoreSelectorMenuViewHelper extends AbstractTagBasedViewHelper
      */
     protected $moduleDataStorageService;
 
-
     /**
      * Initialize the arguments.
      *
@@ -53,6 +52,8 @@ class CoreSelectorMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
+
         $this->registerUniversalTagAttributes();
     }
 

--- a/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
@@ -25,13 +25,13 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Menu;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Site;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrTagBasedViewHelper;
 
 /**
  * Site selector menu view helper
  *
  */
-class SiteSelectorMenuViewHelper extends AbstractTagBasedViewHelper
+class SiteSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
 {
 
     /**
@@ -45,7 +45,6 @@ class SiteSelectorMenuViewHelper extends AbstractTagBasedViewHelper
      */
     protected $moduleDataStorageService;
 
-
     /**
      * Initialize the arguments.
      *
@@ -53,6 +52,8 @@ class SiteSelectorMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
+
         $this->registerTagAttribute('name', 'string',
             'Name of the select field');
         $this->registerUniversalTagAttributes();

--- a/Classes/ViewHelpers/Backend/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Backend/ScriptViewHelper.php
@@ -26,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
 
 /**
  * View helper to load a JavaScript file
@@ -40,7 +39,7 @@ use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
  * Loads the given file and adds it to the backend module.
  * </output>
  */
-class ScriptViewHelper extends AbstractBackendViewHelper
+class ScriptViewHelper extends AbstractSolrBackendViewHelper
 {
 
     /**

--- a/Classes/ViewHelpers/Backend/SitesViewHelper.php
+++ b/Classes/ViewHelpers/Backend/SitesViewHelper.php
@@ -37,13 +37,23 @@ use ApacheSolrForTypo3\Solr\Site;
  *      </f:if>
  * </solr:backend.sites>
  */
-class SitesViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
+class SitesViewHelper extends AbstractSolrViewHelper
 {
     /**
      * @var \ApacheSolrForTypo3\Solr\Service\ModuleDataStorageService
      * @inject
      */
     protected $moduleDataStorageService;
+
+    /**
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
 
     /**
      * @return mixed

--- a/Resources/Private/Templates/SynonymsModule/Index.html
+++ b/Resources/Private/Templates/SynonymsModule/Index.html
@@ -1,4 +1,5 @@
 {namespace solr=ApacheSolrForTypo3\Solr\ViewHelpers}
+{namespace core=TYPO3\CMS\Core\ViewHelpers}
 
 <f:render partial="CoreSelector" />
 
@@ -16,11 +17,9 @@
 					<td>{baseWord}</td>
 					<td>{synonymList}</td>
 					<td>
-						<f:be.buttons.icon
-							uri="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'deleteSynonyms', baseWord: '{baseWord}'})}"
-							icon="actions-edit-delete"
-							title="Remove Synonym Mapping"
-						/>
+						<a href="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'deleteSynonyms', baseWord: '{baseWord}'})}" title="Remove Synonym Mapping">
+							<core:icon identifier="actions-edit-delete" />
+						</a>
 					</td>
 				</tr>
 				</f:for>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
     'constraints' => array(
         'depends' => array(
             'scheduler' => '',
-            'typo3' => '7.6.0-7.99.99'
+            'typo3' => '7.6.0-8.0.99'
         ),
         'conflicts' => array(),
         'suggests' => array(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -43,7 +43,6 @@ if (TYPO3_MODE === 'BE') {
 }
 
 if (TYPO3_MODE == 'BE') {
-    $fileExtension = 'svg';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
         'ApacheSolrForTypo3.' . $_EXTKEY,
         'tools',
@@ -55,7 +54,7 @@ if (TYPO3_MODE == 'BE') {
         ),
         array(
             'access' => 'admin',
-            'iconIdentifier' => 'extensions-solr-module-administration',
+            'icon' => 'EXT:solr/Resources/Public/Images/Icons/ModuleAdministration.svg',
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/ModuleAdministration/locallang.xlf',
         )
     );


### PR DESCRIPTION
* Icon was not showing in TYPO3 8.0
* Remove Hook registration by reference in UserGroupDetector since it is allready a singleton and registration with & is deprecated
* Added base class for ViewHelpers with new properties escapeOutput and escapeChildren
* Remove usage of $GLOBALS['TT']

Fixes: #273