### PR TITLE
[BUGFIX] ReIndex task is not working

### DIFF
--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -93,11 +93,7 @@ class ReIndexTask extends AbstractTask
         $typesToCleanUp = array();
 
         foreach ($this->indexingConfigurationsToReIndex as $indexingConfigurationName) {
-            $type = Queue::getTableToIndexByIndexingConfigurationName(
-                $solrConfiguration,
-                $indexingConfigurationName
-            );
-
+            $type = $solrConfiguration->getIndexQueueConfigurationByName($indexingConfigurationName);
             $typesToCleanUp[] = $type;
         }
 

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -84,7 +84,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @param $amount
      */
-    protected function assertIndexQueryContainsItemAmount($amount)
+    protected function assertIndexQueueContainsItemAmount($amount)
     {
         $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
             'Index queue is empty and was expected to contain '.(int) $amount.' items.');
@@ -195,7 +195,7 @@ class RecordMonitorTest extends IntegrationTest
 
         // we expect that all subpages of 1 and 1 its selft have been requeued but not more
         // pages with uid 1, 10 and 100 should be in index, but 11 not
-        $this->assertIndexQueryContainsItemAmount(3);
+        $this->assertIndexQueueContainsItemAmount(3);
     }
 
 
@@ -221,7 +221,7 @@ class RecordMonitorTest extends IntegrationTest
 
         // we expect that all subpages of 1 have been requeued, but 1 not because it is still hidden
         // pages with uid 10 and 100 should be in index, but 11 not
-        $this->assertIndexQueryContainsItemAmount(2);
+        $this->assertIndexQueueContainsItemAmount(2);
     }
 
     /**

--- a/Tests/Integration/Task/Fixtures/can_reindex_task_fill_queue.xml
+++ b/Tests/Integration/Task/Fixtures/can_reindex_task_fill_queue.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Rootpage</title>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>Childpage</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -106,9 +106,32 @@ class IndexQueueWorkerTest extends IntegrationTest
         $indexQueueQueueWorkerTask = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask');
         $indexQueueQueueWorkerTask->setDocumentsToIndexLimit(1);
         $indexQueueQueueWorkerTask->setSite($site);
+
+        $progressBefore = $indexQueueQueueWorkerTask->getProgress();
         $indexQueueQueueWorkerTask->execute();
+        $progressAfter = $indexQueueQueueWorkerTask->getProgress();
 
         // we expect that the index queue is empty before we start
         $this->assertTrue($this->indexQueue->containsIndexedItem('pages', 1));
+        $this->assertEquals(0.0, $progressBefore, 'Wrong progress before');
+        $this->assertEquals(100.0, $progressAfter, 'Wrong progress after');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetAdditionalInformationFromTask()
+    {
+        $this->importDataSetFromFixture('can_trigger_frontend_calls_for_page_index.xml');
+        $site = Site::getFirstAvailableSite();
+        /** @var $indexQueueQueueWorkerTask \ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask */
+        $indexQueueQueueWorkerTask = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask');
+        $indexQueueQueueWorkerTask->setDocumentsToIndexLimit(1);
+        $indexQueueQueueWorkerTask->setSite($site);
+
+        $additionalInformation = $indexQueueQueueWorkerTask->getAdditionalInformation();
+
+        $this->assertContains('Root Page ID: 1', $additionalInformation);
+        $this->assertContains('Site: page for testing', $additionalInformation);
     }
 }

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Task\ReIndexTask;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TestCase to check if the index queue can be initialized by the ReIndex Task
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class ReIndexTaskTest extends IntegrationTest
+{
+    /**
+     * @var ReIndexTask
+     */
+    protected $task;
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->task = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Task\ReIndexTask');
+        $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Queue');
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertEmptyIndexQueue()
+    {
+        $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertNotEmptyIndexQueue()
+    {
+        $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to be not empty.');
+    }
+
+    /**
+     * @param $amount
+     */
+    protected function assertIndexQueryContainsItemAmount($amount)
+    {
+        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to contain '.(int) $amount.' items.');
+    }
+
+    /**
+     * @test
+     */
+    public function testIfTheQueueIsFilledAfterTaskWasRunning()
+    {
+        $this->importDataSetFromFixture('can_reindex_task_fill_queue.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->task->setSite(Site::getFirstAvailableSite());
+        $this->task->setIndexingConfigurationsToReIndex(array('pages'));
+        $this->task->execute();
+
+        $this->assertIndexQueryContainsItemAmount(2);
+    }
+
+    /**
+     * @test
+     */
+    public function testCanGetAdditionalInformationFromTask()
+    {
+        $this->importDataSetFromFixture('can_reindex_task_fill_queue.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->task->setSite(Site::getFirstAvailableSite());
+        $this->task->setIndexingConfigurationsToReIndex(array('pages'));
+        $additionalInformation = $this->task->getAdditionalInformation();
+
+        $this->assertContains('Indexing Configurations: pages', $additionalInformation);
+        $this->assertContains('Root Page ID: 1', $additionalInformation);
+    }
+}


### PR DESCRIPTION
ReIndex task was not running, because deprecated method was used.

Fixes: #288