### PR TITLE
[TASK] Avoid array usage of configuration

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -187,22 +187,10 @@ class IndexService
      */
     protected function getIndexerByItem($indexingConfigurationName)
     {
-        $indexerClass = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\Indexer';
-        $indexerOptions = array();
+        $indexerClass = $this->configuration->getIndexQueueIndexerByConfigurationName($indexingConfigurationName);
+        $indexerConfiguration = $this->configuration->getIndexQueueIndexerConfigurationByConfigurationName($indexingConfigurationName);
 
-        // allow to overwrite indexers per indexing configuration
-        if (isset($this->configuration['index.']['queue.'][$indexingConfigurationName . '.']['indexer'])) {
-            $indexerClass = $this->configuration['index.']['queue.'][$indexingConfigurationName . '.']['indexer'];
-        }
-
-        // get indexer options
-        if (isset($this->configuration['index.']['queue.'][$indexingConfigurationName . '.']['indexer.'])
-            && !empty($this->configuration['index.']['queue.'][$indexingConfigurationName . '.']['indexer.'])
-        ) {
-            $indexerOptions = $this->configuration['index.']['queue.'][$indexingConfigurationName . '.']['indexer.'];
-        }
-
-        $indexer = GeneralUtility::makeInstance($indexerClass, $indexerOptions);
+        $indexer = GeneralUtility::makeInstance($indexerClass, $indexerConfiguration);
         if (!($indexer instanceof Indexer)) {
             throw new \RuntimeException(
                 'The indexer class "' . $indexerClass . '" for indexing configuration "' . $indexingConfigurationName . '" is not a valid indexer. Must be a subclass of ApacheSolrForTypo3\Solr\IndexQueue\Indexer.',

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -37,7 +38,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Ingo Renner <ingo@typo3.org>
  * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
-class GarbageCollector extends AbstractDataHandlerListener
+class GarbageCollector extends AbstractDataHandlerListener implements SingletonInterface
 {
 
     protected $trackedRecords = array();

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.xml
@@ -38,8 +38,13 @@
                             rootline = pageUidToHierarchy
                         }
 
-                        queue {
+                        additionalFields {
+                            additional_sortSubTitle_stringS = subtitle
+                            additional_custom_stringS = TEXT
+                            additional_custom_stringS.value = my text
+                        }
 
+                        queue {
                             // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
 
                             pages = 1
@@ -61,8 +66,6 @@
 
                                 fields {
                                     sortSubTitle_stringS = subtitle
-                                    custom_stringS = TEXT
-                                    custom_stringS.value = my text
                                 }
                             }
 

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -54,10 +54,55 @@ class PageIndexerTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_index_into_solr.xml');
 
+        $this->executePageIndexer();
+
+        // we wait to make sure the document will be available in solr
+        sleep(3);
+
+        $solrContent = file_get_contents('http://localhost:8080/solr/core_en/select?q=*:*');
+        $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
+        $this->assertContains('"custom_stringS":"my text"', $solrContent, 'Document does not contains value build with typoscript');
+    }
+
+    /**
+     * @test
+     */
+    public function canIndexPageIntoSolrWithAdditionalFields()
+    {
+        //@todo additional fields indexer requires the hook to be activated which is normally done in ext_localconf.php
+            // this needs to be unified with the PageFieldMappingIndexer registration.
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer'] = 'ApacheSolrForTypo3\\Solr\\AdditionalFieldsIndexer';
+
+        $this->importDataSetFromFixture('can_index_with_additional_fields_into_solr.xml');
+        $this->executePageIndexer();
+
+        // we wait to make sure the document will be available in solr
+        sleep(3);
+
+        $solrContent = file_get_contents('http://localhost:8080/solr/core_en/select?q=*:*');
+
+            // field values from index.queue.pages.fields.
+        $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
+
+            // field values from index.additionalFields
+        $this->assertContains('"additional_sortSubTitle_stringS":"subtitle"', $solrContent, 'Document does not contains value from index.additionFields');
+        $this->assertContains('"additional_custom_stringS":"my text"', $solrContent, 'Document does not contains value from index.additionFields');
+    }
+
+    /**
+     * @return void
+     */
+    protected function executePageIndexer()
+    {
         $GLOBALS['TT'] = $this->getMock('\\TYPO3\\CMS\\Core\\TimeTracker\\TimeTracker', array(), array(), '', false);
 
         $TSFE = $this->getConfiguredTSFE();
         $TSFE->config['config']['index_enable'] = 1;
+        $TSFE->cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
         $GLOBALS['TSFE'] = $TSFE;
 
 
@@ -72,12 +117,5 @@ class PageIndexerTest extends IntegrationTest
         $pageIndexer->activate();
         $pageIndexer->processRequest($request, $response);
         $pageIndexer->hook_indexContent($TSFE);
-
-        // we wait to make sure the document will be available in solr
-        sleep(3);
-
-        $solrContent = file_get_contents('http://localhost:8080/solr/core_en/select?q=*:*');
-        $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertContains('"title":"hello solr"', $solrContent, 'Could not index document into solr');
     }
 }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -339,4 +339,150 @@ class TypoScriptConfigurationTest extends UnitTest
         $this->assertTrue($configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('tt_content'),
             'Wrong logging state for tt_content index queue');
     }
+
+    /**
+     * @test
+     */
+    public function canGetIndexFieldsConfigurationByConfigurationName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'fields.' => array(
+                            'sortSubTitle_stringS' => 'subtitle'
+                        )
+                    )
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedConfiguration = $configuration->getIndexQueueFieldsConfigurationByConfigurationName('pages');
+        $this->assertEquals(array('sortSubTitle_stringS' => 'subtitle'), $retrievedConfiguration);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueueMappedFieldNamesByConfigurationName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'fields.' => array(
+                            'sortSubTitle_stringS' => 'subtitle',
+                            'subTitle_stringM' => 'subtitle',
+                            'fooShouldBeSkipped.' => array()
+                        )
+                    )
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $mappedFieldNames = $configuration->getIndexQueueMappedFieldsByConfigurationName('pages');
+        $this->assertEquals(array('sortSubTitle_stringS', 'subTitle_stringM'), $mappedFieldNames);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexAdditionalFieldsConfiguration()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'additionalFields.' => array(
+                    'additional_sortSubTitle_stringS' => 'subtitle'
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedConfiguration = $configuration->getIndexAdditionalFieldsConfiguration();
+        $this->assertEquals(array('additional_sortSubTitle_stringS' => 'subtitle'), $retrievedConfiguration);
+    }
+
+
+
+    /**
+     * @test
+     */
+    public function canGetIndexMappedAdditionalFieldNames()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'additionalFields.' => array(
+                    'additional_sortSubTitle_stringS' => 'subtitle'
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedConfiguration = $configuration->getIndexMappedAdditionalFieldNames();
+        $this->assertEquals(array('additional_sortSubTitle_stringS'), $retrievedConfiguration);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueueIndexerByConfigurationName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'indexer' => 'Foobar'
+                    )
+                )
+            )
+        );
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $configuredIndexer = $configuration->getIndexQueueIndexerByConfigurationName('pages');
+        $this->assertSame('Foobar', $configuredIndexer, 'Retrieved unexpected indexer from typoscript configuration');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueueIndexerConfigurationByConfigurationName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'indexer' => 'Foobar',
+                        'indexer.' => array('configuration' => 'test')
+                    )
+                )
+            )
+        );
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $configuredIndexer = $configuration->getIndexQueueIndexerConfigurationByConfigurationName('pages');
+        $this->assertSame(array('configuration' => 'test'), $configuredIndexer, 'Retrieved unexpected indexer configuration from typoscript configuration');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueuePagesAllowedPageTypesArray()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'allowedPageTypes' => '1,2, 7'
+                    )
+                )
+            )
+        );
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $allowedPageTypes = $configuration->getIndexQueuePagesAllowedPageTypesArray();
+        $this->assertEquals(array(1, 2, 7), $allowedPageTypes, 'Can not get allowed pagestype from configuration');
+    }
 }

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -130,8 +130,8 @@ if (TYPO3_MODE == 'BE') {
     // for certain scenarios items must be removed by GC first, and then be re-added to to Index Queue
 
     // hooking into TCE Main to monitor record updates that may require deleting documents from the index
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = '&ApacheSolrForTypo3\\Solr\\GarbageCollector';
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = '&ApacheSolrForTypo3\\Solr\\GarbageCollector';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = 'ApacheSolrForTypo3\\Solr\\GarbageCollector';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = 'ApacheSolrForTypo3\\Solr\\GarbageCollector';
 
     // hooking into TCE Main to monitor record updates that may require reindexing by the index queue
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = 'ApacheSolrForTypo3\\Solr\\IndexQueue\\RecordMonitor';


### PR DESCRIPTION
* Use TypoScriptConfiguration during indexing in
	* AdditionFieldsIndexer
	* PageFieldMappingIndexer
	* IndexService
* Make GarbageCollector as Singleton since registration by reference is deprecated
and is not allowed since TYPO3 8.0

Fixes: #228