### PR TITLE
[TASK] Remove legacy code for TYPO3 Versions below 7.6

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -165,9 +165,8 @@ class IndexService
             unset($_SERVER['HTTP_HOST']);
         }
 
-        if (version_compare(TYPO3_branch, '7.5', '>=')) {
-            GeneralUtility::flushInternalRuntimeCaches();
-        }
+        // needed since TYPO3 7.5
+        GeneralUtility::flushInternalRuntimeCaches();
 
         return $itemIndexed;
     }
@@ -257,8 +256,8 @@ class IndexService
         }
 
         $_SERVER['HTTP_HOST'] = $hosts[$rootpageId];
-        if (version_compare(TYPO3_branch, '7.5', '>=')) {
-            GeneralUtility::flushInternalRuntimeCaches();
-        }
+
+        // needed since TYPO3 7.5
+        GeneralUtility::flushInternalRuntimeCaches();
     }
 }

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -138,24 +138,21 @@ class ReIndexTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
     protected function getIndexingConfigurationSelector()
     {
         $selectorMarkup = 'Please select a site first.';
+        $this->getPageRenderer()->addCssFile('../typo3conf/ext/solr/Resources/Css/Backend/indexingconfigurationselectorfield.css');
 
-        if (version_compare(TYPO3_branch, '7.6', '>=')) {
-            $this->getPageRenderer()->addCssFile('../typo3conf/ext/solr/Resources/Css/Backend/indexingconfigurationselectorfield.css');
-        } else {
-            $this->schedulerModule->doc->getPageRenderer()->addCssFile('../typo3conf/ext/solr/Resources/Css/Backend/indexingconfigurationselectorfield.css');
+        if (is_null($this->site)) {
+            return $selectorMarkup;
         }
 
+        $selectorField = GeneralUtility::makeInstance(
+            'ApacheSolrForTypo3\\Solr\\Backend\\IndexingConfigurationSelectorField',
+            $this->site
+        );
 
-        if (!is_null($this->site)) {
-            $selectorField = GeneralUtility::makeInstance(
-                'ApacheSolrForTypo3\\Solr\\Backend\\IndexingConfigurationSelectorField',
-                $this->site
-            );
-            $selectorField->setFormElementName('tx_scheduler[indexingConfigurations]');
-            $selectorField->setSelectedValues($this->task->getIndexingConfigurationsToReIndex());
+        $selectorField->setFormElementName('tx_scheduler[indexingConfigurations]');
+        $selectorField->setSelectedValues($this->task->getIndexingConfigurationsToReIndex());
 
-            $selectorMarkup = $selectorField->render();
-        }
+        $selectorMarkup = $selectorField->render();
 
         return $selectorMarkup;
     }


### PR DESCRIPTION
* Remove legacy code for TYPO3 Versions below 7.6 LTS
* Small refactoring with guard clause for early return

Fixes: #293 