### PR TITLE
[BUGFIX] absRefPrefix auto is now resolved as in the TYPO3 core - RELEASE-3.1.x

### DIFF
--- a/Classes/JavascriptManager.php
+++ b/Classes/JavascriptManager.php
@@ -165,13 +165,7 @@ class JavascriptManager
      */
     public function buildJavascriptTags()
     {
-        $filePathPrefix = '';
-        if (!empty($GLOBALS['TSFE']->config['config']['absRefPrefix'])) {
-            $filePathPrefix = $GLOBALS['TSFE']->config['config']['absRefPrefix'];
-            if ($filePathPrefix === 'auto') {
-                $filePathPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_PATH');
-            }
-        }
+        $filePathPrefix = Util::getAbsRefPrefixFromTSFE($GLOBALS['TSFE']);
 
         // add files
         foreach (self::$files as $identifier => $file) {

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr;
 use InvalidArgumentException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Utility class for tx_solr
@@ -397,7 +398,7 @@ class Util
             }
 
             $GLOBALS['TSFE']->newCObj();
-            $GLOBALS['TSFE']->absRefPrefix = ($GLOBALS['TSFE']->config['config']['absRefPrefix'] ? trim($GLOBALS['TSFE']->config['config']['absRefPrefix']) : '');
+            $GLOBALS['TSFE']->absRefPrefix = self::getAbsRefPrefixFromTSFE($GLOBALS['TSFE']);
             $GLOBALS['TSFE']->calculateLinkVars();
 
             if ($useCache) {
@@ -717,5 +718,27 @@ class Util
         }
 
         return true;
+    }
+
+    /**
+     * Resolves the configured absRefPrefix to a valid value and resolved if absRefPrefix
+     * is set to "auto".
+     *
+     * @param TypoScriptFrontendController $TSFE
+     * @return string
+     */
+    public static function getAbsRefPrefixFromTSFE(TypoScriptFrontendController $TSFE)
+    {
+        $absRefPrefix = '';
+        if (empty($TSFE->config['config']['absRefPrefix'])) {
+            return $absRefPrefix;
+        }
+
+        $absRefPrefix = trim($TSFE->config['config']['absRefPrefix']);
+        if ($absRefPrefix === 'auto') {
+            $absRefPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_PATH');
+        }
+
+        return $absRefPrefix;
     }
 }


### PR DESCRIPTION
* Moved logic from JavaScriptManager into Util
* Refactore usage in JavaScriptManager and Util::initializeTsfe

Fixes: #276