### PR TITLE
[BUGFIX] excludeContentByClass is slowing down indexing - dev-master

### DIFF
--- a/Classes/HtmlContentExtractor.php
+++ b/Classes/HtmlContentExtractor.php
@@ -23,7 +23,7 @@ namespace ApacheSolrForTypo3\Solr;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 
 /**
  * A content extractor to get clean, indexable content from HTML markup.
@@ -85,6 +85,11 @@ class HtmlContentExtractor
     );
 
     /**
+     * @var TypoScriptConfiguration
+     */
+    private $configuration;
+
+    /**
      * Constructor.
      *
      * @param string $content Content HTML markup
@@ -92,6 +97,26 @@ class HtmlContentExtractor
     public function __construct($content)
     {
         $this->content = $content;
+    }
+
+    /**
+     * @return TypoScriptConfiguration|array
+     */
+    protected function getConfiguration()
+    {
+        if ($this->configuration == null) {
+            $this->configuration = Util::getSolrConfiguration();
+        }
+
+        return $this->configuration;
+    }
+
+    /**
+     * @param TypoScriptConfiguration $configuration
+     */
+    public function setConfiguration(TypoScriptConfiguration $configuration)
+    {
+        $this->configuration = $configuration;
     }
 
     /**

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -428,6 +428,26 @@ class TypoScriptConfiguration implements \ArrayAccess
     }
 
     /**
+     * Returns the configured excludeContentByClass patterns as array.
+     *
+     * plugin.tx_solr.index.queue.pages.excludeContentByClass
+     *
+     * @param array $defaultIfEmpty
+     * @return array
+     */
+    public function getIndexQueuePagesExcludeContentByClassArray($defaultIfEmpty = array())
+    {
+        $path = 'plugin.tx_solr.index.queue.pages.excludeContentByClass';
+        $result = $this->getValueByPathOrDefaultValue($path, '');
+
+        if (trim($result) == '') {
+            return $defaultIfEmpty;
+        }
+
+        return GeneralUtility::trimExplode(',', $result);
+    }
+
+    /**
      * Returns the configured database table for an indexing queue configuration or
      * the configurationName itself that is used by convention as tableName when no
      * other tablename is present.

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -723,4 +723,35 @@ class Util
 
         return $absRefPrefix;
     }
+
+    /**
+     * This function can be used to check if one of the strings in needles is
+     * contained in the haystack.
+     *
+     *
+     * Example:
+     *
+     * haystack: the brown fox
+     * needles: ['hello', 'world']
+     * result: false
+     *
+     * haystack: the brown fox
+     * needles: ['is', 'fox']
+     * result: true
+     *
+     * @param string $haystack
+     * @param array $needles
+     * @return bool
+     */
+    public static function containsOneOfTheStrings($haystack, array $needles)
+    {
+        foreach ($needles as $needle) {
+            $position = strpos($haystack, $needle);
+            if ($position !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -485,4 +485,24 @@ class TypoScriptConfigurationTest extends UnitTest
         $allowedPageTypes = $configuration->getIndexQueuePagesAllowedPageTypesArray();
         $this->assertEquals(array(1, 2, 7), $allowedPageTypes, 'Can not get allowed pagestype from configuration');
     }
+
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueuePagesExcludeContentByClassArray()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'pages.' => array(
+                        'excludeContentByClass' => 'excludeClass'
+                    )
+                )
+            )
+        );
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $excludeClasses = $configuration->getIndexQueuePagesExcludeContentByClassArray();
+        $this->assertEquals(array('excludeClass'), $excludeClasses, 'Can not get exclude patterns from configuration');
+    }
 }

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -36,16 +37,17 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class Typo3PageContentExtractorTest extends UnitTest
 {
 
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $typoScripConfigurationMock;
+
     public function setUp()
     {
-        $TSFE = $this->getDumbMock('\\TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController');
-
-        $GLOBALS['TSFE'] = $TSFE;
-        /** @var $GLOBALS ['TSFE']->tmpl  \TYPO3\CMS\Core\TypoScript\TemplateService */
-        $GLOBALS['TSFE']->tmpl = $this->getMock('\\TYPO3\\CMS\\Core\\TypoScript\\TemplateService', array('linkData'));
-        $GLOBALS['TSFE']->tmpl->init();
-        $GLOBALS['TSFE']->tmpl->getFileName_backPath = PATH_site;
-        $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['index.']['queue.']['pages.']['excludeContentByClass'] = 'typo3-search-exclude';
+        $this->typoScripConfigurationMock = $this->getDumbMock('ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration');
+        $this->typoScripConfigurationMock->expects($this->once())->method(
+            'getIndexQueuePagesExcludeContentByClassArray'
+        )->will($this->returnValue(array('typo3-search-exclude')));
     }
 
 
@@ -61,6 +63,7 @@ class Typo3PageContentExtractorTest extends UnitTest
             'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
             $content
         );
+        $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
         $actualResult = $contentExtractor->getIndexableContent();
         $this->assertEquals($expectedResult, $actualResult);
     }
@@ -77,6 +80,7 @@ class Typo3PageContentExtractorTest extends UnitTest
             'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
             $content
         );
+        $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
         $this->assertEquals($expectedResult, $actualResult);
@@ -93,6 +97,7 @@ class Typo3PageContentExtractorTest extends UnitTest
             'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
             $content
         );
+        $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
 
@@ -111,6 +116,7 @@ class Typo3PageContentExtractorTest extends UnitTest
             'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
             $content
         );
+        $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
 


### PR DESCRIPTION
Checked content now if one of the strings exist and do dom initialization only
when a configured excludeClass was found.

Fixes: #227