### PR TITLE
[BUGFIX] Search with whitespace only should be threated as empty search

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -108,6 +108,40 @@ class SearchRequest implements SingletonInterface
     }
 
     /**
+     * Method to check if the query string is an empty string
+     * (also empty string or whitespaces only are handled as empty).
+     *
+     * When no query string is set (null) the method returns false.
+     * @return bool
+     */
+    public function getRawUserQueryIsEmptyString()
+    {
+        $query = $this->getArgumentByKey('q', null);
+
+        if ($query === null) {
+            return false;
+        }
+
+        if (trim($query) === '') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * This method returns true when no querystring is present at all.
+     * Which means no search by the user was triggered
+     *
+     * @return boolean
+     */
+    public function getRawUserQueryIsNull()
+    {
+        $query = $this->getArgumentByKey('q', null);
+        return $query === null;
+    }
+
+    /**
      * Returns the passed resultsPerPage value
      * @return integer|null
      */

--- a/Classes/Plugin/Results/ErrorsCommand.php
+++ b/Classes/Plugin/Results/ErrorsCommand.php
@@ -94,12 +94,10 @@ class ErrorsCommand implements PluginCommand
         $errors = array();
 
         // detect empty user queries
-        $userQuery = $this->parentPlugin->getRawUserQuery();
+        $resultService = $this->parentPlugin->getSearchResultSetService();
+        $searchWasTriggeredWithEmptyQuery = $resultService->getLastSearchWasExecutedWithEmptyQueryString();
 
-        if (!is_null($userQuery)
-            && !$this->configuration->getSearchQueryAllowEmptyQuery()
-            && empty($userQuery)
-        ) {
+        if ($searchWasTriggeredWithEmptyQuery && !$this->configuration->getSearchQueryAllowEmptyQuery()) {
             $errors[] = array(
                 'message' => '###LLL:error_emptyQuery###',
                 'code' => 1300893669

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -270,6 +270,93 @@ class ResultsTest extends AbstractPluginTest
     /**
      * @test
      */
+    public function canDoAnInitialSearchWhenAnEmptyQueryStringWasPassed()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = '';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Found 2 results', $resultPage, 'Unexpected response for initial search');
+    }
+
+
+    /**
+     * @test
+     */
+    public function canDoAnInitialSearchWhenAnQueryStringWithWhitespacesOnlyWasPassed()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = ' ';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Found 2 results', $resultPage, 'Initialsearch was not triggered when whitspace query was passed');
+    }
+
+    /**
+     * @test
+     */
+    public function canNotDoInitialSearchWhenEmptyQueryStringWasPassedAndAllowEmptyQueryIsDisabled()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+        $overwriteConfiguration['search.']['query.']['allowEmptyQuery'] = 0;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = '';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Please enter your search', $resultPage, 'Did not render hierarchy facet in the response');
+    }
+
+    /**
+     * @test
+     */
+    public function canNotDoInitialSearchWhenAQueryStringWithWhitespacesOnlyWasPassedAndAllowEmptyQueryIsDisabled()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+        $overwriteConfiguration['search.']['query.']['allowEmptyQuery'] = 0;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = ' ';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Please enter your search', $resultPage, 'Did not render hierarchy facet in the response');
+    }
+
+    /**
+     * @test
+     */
     public function canApplyCustomTypoScriptFilters()
     {
         $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');


### PR DESCRIPTION
Searches with whitespaces only are handled now as a search with an empty query string ""

Fixes: #236