### PR TITLE
Bugfix/master/311 configuration managet should return same instance for same arguments only

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -108,6 +108,40 @@ class SearchRequest implements SingletonInterface
     }
 
     /**
+     * Method to check if the query string is an empty string
+     * (also empty string or whitespaces only are handled as empty).
+     *
+     * When no query string is set (null) the method returns false.
+     * @return bool
+     */
+    public function getRawUserQueryIsEmptyString()
+    {
+        $query = $this->getArgumentByKey('q', null);
+
+        if ($query === null) {
+            return false;
+        }
+
+        if (trim($query) === '') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * This method returns true when no querystring is present at all.
+     * Which means no search by the user was triggered
+     *
+     * @return boolean
+     */
+    public function getRawUserQueryIsNull()
+    {
+        $query = $this->getArgumentByKey('q', null);
+        return $query === null;
+    }
+
+    /**
      * Returns the passed resultsPerPage value
      * @return integer|null
      */

--- a/Classes/Plugin/Results/ErrorsCommand.php
+++ b/Classes/Plugin/Results/ErrorsCommand.php
@@ -94,12 +94,10 @@ class ErrorsCommand implements PluginCommand
         $errors = array();
 
         // detect empty user queries
-        $userQuery = $this->parentPlugin->getRawUserQuery();
+        $resultService = $this->parentPlugin->getSearchResultSetService();
+        $searchWasTriggeredWithEmptyQuery = $resultService->getLastSearchWasExecutedWithEmptyQueryString();
 
-        if (!is_null($userQuery)
-            && !$this->configuration->getSearchQueryAllowEmptyQuery()
-            && empty($userQuery)
-        ) {
+        if ($searchWasTriggeredWithEmptyQuery && !$this->configuration->getSearchQueryAllowEmptyQuery()) {
             $errors[] = array(
                 'message' => '###LLL:error_emptyQuery###',
                 'code' => 1300893669

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -204,14 +204,12 @@ class Util
     }
 
     /**
-     * @param array $configurationArray
-     * @param null $contextPageId
      * @return ConfigurationManager
      */
-    private static function getConfigurationManager(array $configurationArray = null, $contextPageId = null)
+    private static function getConfigurationManager()
     {
         /** @var \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager $configurationManager */
-        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager', $configurationArray, $contextPageId);
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager');
         return $configurationManager;
     }
 
@@ -262,21 +260,21 @@ class Util
         if ($initializeTsfe) {
             self::initializeTsfe($pageId, $language);
             if (!empty($configurationToUse)) {
-                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
             }
 
             $configurationToUse = self::getConfigurationFromInitializedTSFE($path);
             $cache->set($cacheId, $configurationToUse);
         } else {
             if (!empty($configurationToUse)) {
-                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
             }
 
             $configurationToUse = self::getConfigurationFromExistingTSFE($pageId, $path, $language);
             $cache->set($cacheId, $configurationToUse);
         }
 
-        return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+        return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
     }
 
     /**
@@ -284,15 +282,17 @@ class Util
      *
      * @param array $configurationToUse
      * @param int $pageId
+     * @param int $languageId
+     * @param string $typoScriptPath
      * @return TypoScriptConfiguration
      */
-    protected static function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId)
+    protected static function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId, $languageId, $typoScriptPath)
     {
         $configurationArray = array();
         $configurationArray['plugin.']['tx_solr.'] = $configurationToUse;
-        $configurationManager = self::getConfigurationManager($configurationArray, $pageId);
+        $configurationManager = self::getConfigurationManager();
 
-        return $configurationManager->getTypoScriptConfiguration();
+        return $configurationManager->getTypoScriptConfiguration($configurationArray, $pageId, $languageId, $typoScriptPath);
     }
 
     /**

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -270,6 +270,93 @@ class ResultsTest extends AbstractPluginTest
     /**
      * @test
      */
+    public function canDoAnInitialSearchWhenAnEmptyQueryStringWasPassed()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = '';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Found 2 results', $resultPage, 'Unexpected response for initial search');
+    }
+
+
+    /**
+     * @test
+     */
+    public function canDoAnInitialSearchWhenAnQueryStringWithWhitespacesOnlyWasPassed()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = ' ';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Found 2 results', $resultPage, 'Initialsearch was not triggered when whitspace query was passed');
+    }
+
+    /**
+     * @test
+     */
+    public function canNotDoInitialSearchWhenEmptyQueryStringWasPassedAndAllowEmptyQueryIsDisabled()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+        $overwriteConfiguration['search.']['query.']['allowEmptyQuery'] = 0;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = '';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Please enter your search', $resultPage, 'Did not render hierarchy facet in the response');
+    }
+
+    /**
+     * @test
+     */
+    public function canNotDoInitialSearchWhenAQueryStringWithWhitespacesOnlyWasPassedAndAllowEmptyQueryIsDisabled()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');
+
+        $overwriteConfiguration = array();
+        $overwriteConfiguration['search.']['initializeWithQuery'] = 'products';
+        $overwriteConfiguration['search.']['showResultsOfInitialQuery'] = 1;
+        $overwriteConfiguration['search.']['query.']['allowEmptyQuery'] = 0;
+
+        /** @var $configurationManager \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager');
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+
+        $_GET['q'] = ' ';
+        $resultPage = $searchResults->main('', array());
+
+        $this->assertContains('Please enter your search', $resultPage, 'Did not render hierarchy facet in the response');
+    }
+
+    /**
+     * @test
+     */
     public function canApplyCustomTypoScriptFilters()
     {
         $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1, 2, 3, 4, 5, 6, 7, 8), 'can_render_results_plugin.xml');

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -63,10 +63,10 @@ class ResultsTest extends AbstractPluginTest
 
         $result = $searchResults->main('', array());
 
-        $sortingLink = '<a href="index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20desc">Title</a>';
+        $sortingLink = 'q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20desc">Title</a>';
         $this->assertContains($sortingLink, $result, 'Could not find sorting link in search result');
 
-        $subTitleFacetingLink = 'index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20asc&amp;foo=bar';
+        $subTitleFacetingLink = 'q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20asc&amp;foo=bar';
         $this->assertContains($subTitleFacetingLink, $result, 'Could not find faceting link in results');
 
         $productDescription = 'jeans products';
@@ -244,7 +244,7 @@ class ResultsTest extends AbstractPluginTest
 
         $this->assertContains('facet-type-hierarchy', $resultPage, 'Did not render hierarchy facet in the response');
         $this->assertContains('class="rootlinefacet-item"', $resultPage, 'Hierarchy facet items did not contain expected class from TypoScript');
-        $this->assertContains('index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
+        $this->assertContains('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
     }
 
     /**


### PR DESCRIPTION
The ConfigurationManager->getTypoScriptConfiguration now returns the same Configuration only when the same arguments have been passed.

Fixes: #311