### PR TITLE
[BUGFIX] The ConfigurationManager should return the same configuration only for the same arguments.

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -204,14 +204,12 @@ class Util
     }
 
     /**
-     * @param array $configurationArray
-     * @param null $contextPageId
      * @return ConfigurationManager
      */
-    private static function getConfigurationManager(array $configurationArray = null, $contextPageId = null)
+    private static function getConfigurationManager()
     {
         /** @var \ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager $configurationManager */
-        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager', $configurationArray, $contextPageId);
+        $configurationManager = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\System\\Configuration\\ConfigurationManager');
         return $configurationManager;
     }
 
@@ -262,21 +260,21 @@ class Util
         if ($initializeTsfe) {
             self::initializeTsfe($pageId, $language);
             if (!empty($configurationToUse)) {
-                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
             }
 
             $configurationToUse = self::getConfigurationFromInitializedTSFE($path);
             $cache->set($cacheId, $configurationToUse);
         } else {
             if (!empty($configurationToUse)) {
-                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+                return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
             }
 
             $configurationToUse = self::getConfigurationFromExistingTSFE($pageId, $path, $language);
             $cache->set($cacheId, $configurationToUse);
         }
 
-        return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId);
+        return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
     }
 
     /**
@@ -284,15 +282,17 @@ class Util
      *
      * @param array $configurationToUse
      * @param int $pageId
+     * @param int $languageId
+     * @param string $typoScriptPath
      * @return TypoScriptConfiguration
      */
-    protected static function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId)
+    protected static function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId, $languageId, $typoScriptPath)
     {
         $configurationArray = array();
         $configurationArray['plugin.']['tx_solr.'] = $configurationToUse;
-        $configurationManager = self::getConfigurationManager($configurationArray, $pageId);
+        $configurationManager = self::getConfigurationManager();
 
-        return $configurationManager->getTypoScriptConfiguration();
+        return $configurationManager->getTypoScriptConfiguration($configurationArray, $pageId, $languageId, $typoScriptPath);
     }
 
     /**

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -63,10 +63,10 @@ class ResultsTest extends AbstractPluginTest
 
         $result = $searchResults->main('', array());
 
-        $sortingLink = '<a href="index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20desc">Title</a>';
+        $sortingLink = 'q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20desc">Title</a>';
         $this->assertContains($sortingLink, $result, 'Could not find sorting link in search result');
 
-        $subTitleFacetingLink = 'index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20asc&amp;foo=bar';
+        $subTitleFacetingLink = 'q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=subtitle%253Amen&amp;tx_solr%5Bsort%5D=title%20asc&amp;foo=bar';
         $this->assertContains($subTitleFacetingLink, $result, 'Could not find faceting link in results');
 
         $productDescription = 'jeans products';
@@ -244,7 +244,7 @@ class ResultsTest extends AbstractPluginTest
 
         $this->assertContains('facet-type-hierarchy', $resultPage, 'Did not render hierarchy facet in the response');
         $this->assertContains('class="rootlinefacet-item"', $resultPage, 'Hierarchy facet items did not contain expected class from TypoScript');
-        $this->assertContains('index.php?id=1&amp;q=prices&amp;tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
+        $this->assertContains('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
     }
 
     /**


### PR DESCRIPTION
The configurationManager returns the same configuration only in the same context (rootPage, configurationArray, language and TypoScript path)

Fixes: #311