### PR TITLE
[TASK] Improve performance of record indexer

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -82,8 +82,7 @@ class Indexer extends AbstractIndexer
      *
      * @var array
      */
-    protected $sysLanguageOverlay = array();
-
+    protected static $sysLanguageOverlay = array();
 
     /**
      * Constructor
@@ -192,9 +191,9 @@ class Indexer extends AbstractIndexer
     {
         $rootPageUid = $item->getRootPageUid();
         $overlayIdentifier = $rootPageUid . '|' . $language;
-        if (!isset($this->sysLanguageOverlay[$overlayIdentifier])) {
+        if (!isset(self::$sysLanguageOverlay[$overlayIdentifier])) {
             Util::initializeTsfe($rootPageUid, $language);
-            $this->sysLanguageOverlay[$overlayIdentifier] = $GLOBALS['TSFE']->sys_language_contentOL;
+            self::$sysLanguageOverlay[$overlayIdentifier] = $GLOBALS['TSFE']->sys_language_contentOL;
         }
 
         $itemRecord = $item->getRecord();
@@ -207,7 +206,7 @@ class Indexer extends AbstractIndexer
                 $item->getType(),
                 $itemRecord,
                 $language,
-                $this->sysLanguageOverlay[$rootPageUid . '|' . $language]
+                self::$sysLanguageOverlay[$overlayIdentifier]
             );
         }
 
@@ -243,7 +242,7 @@ class Indexer extends AbstractIndexer
 
         $languageField = $GLOBALS['TCA'][$item->getType()]['ctrl']['languageField'];
         if ($itemRecord[$translationOriginalPointerField] == 0
-            && $this->sysLanguageOverlay[$overlayIdentifier] != 1
+            && self::$sysLanguageOverlay[$overlayIdentifier] != 1
             && !empty($languageField)
             && $itemRecord[$languageField] != $language
             && $itemRecord[$languageField] != '-1'


### PR DESCRIPTION
Cache for language information is not kept across instances of the indexer. Each new record
requires a new instance of the indexer but language information does not change between creation of
indexer instances. Language information is obtained by instantiating TSFE and parsing TS templates.
This can take 0.5-2 seconds depending on the amount of TypoScript. It makes sense to cache this
information statically. It helps to shorten indexing times dramatically and lower CPU usage on
the server.