### PR TITLE
[BUGFIX] Util::getConfigurationFromPageId is returning an array instead of an empty TypoScriptConfigruation

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -109,7 +109,7 @@ class RecordMonitor extends AbstractDataHandlerListener
             // skip workspaces: index only LIVE workspace
             $this->indexQueue->updateItem('pages',
                 $tceMain->getPID($table, $uid),
-                NULL,
+                null,
                 time()
             );
         }

--- a/Tests/Unit/UtilTest.php
+++ b/Tests/Unit/UtilTest.php
@@ -1,0 +1,18 @@
+<?php
+
+
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Util;
+
+class UtilTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function getConfigurationFromPageIdReturnsEmptyConfigurationForPageIdZero()
+    {
+        $configuration = Util::getConfigurationFromPageId(0, 'plugin.tx_solr', false, 0, false);
+        $this->assertInstanceOf('ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration', $configuration);
+    }
+}


### PR DESCRIPTION
Util::getConfigurationFromPageId  will now return an empty TypoScriptConfiguration as expected and annotated.

* Also added a unit test
* Allow to skip caching

Fixes: #315