### PR TITLE
[TASK] Support phrases inside a query string - release-3.1.x

### DIFF
--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -251,26 +251,63 @@ class Query
      */
     public function escape($string)
     {
-        if (!is_numeric($string)) {
-            if (preg_match('/\W/', $string) == 1) {
-                // multiple words
-
-                $stringLength = strlen($string);
-                if ($string{0} == '"' && $string{$stringLength - 1} == '"') {
-                    // phrase
-                    $string = trim($string, '"');
-                    $string = $this->escapePhrase($string);
-                } else {
-                    $string = $this->escapeSpecialCharacters($string);
-                }
-            } else {
-                $string = $this->escapeSpecialCharacters($string);
-            }
+        // when we have a numeric string only, nothing needs to be done
+        if (is_numeric($string)) {
+            return $string;
         }
 
-        return $string;
+        // when no whitespaces are in the query we can also just escape the special characters
+        if (preg_match('/\W/', $string) != 1) {
+            return $this->escapeSpecialCharacters($string);
+        }
+
+        // when there are no quotes inside the query string we can also just escape the whole string
+        $hasQuotes = strrpos($string, '"') !== false;
+        if (!$hasQuotes) {
+            return $this->escapeSpecialCharacters($string);
+        }
+
+        $result = $this->tokenizeByQuotesAndEscapeDependingOnContext($string);
+
+        return $result;
     }
 
+    /**
+     * This method is used to escape the content in the query string surrounded by quotes
+     * different then when it is not in a quoted context.
+     *
+     * @param string $string
+     * @return string
+     */
+    protected function tokenizeByQuotesAndEscapeDependingOnContext($string)
+    {
+        $result = '';
+        $quotesCount = substr_count($string, '"');
+        $isEvenAmountOfQuotes = $quotesCount % 2 === 0;
+
+        // go over all quote segments and apply escapePhrase inside a quoted
+        // context and escapeSpecialCharacters outside the quoted context.
+        $segments = explode('"', $string);
+        $segmentsIndex = 0;
+        foreach ($segments as $segment) {
+            $isInQuote = $segmentsIndex % 2 !== 0;
+            $isLastQuote = $segmentsIndex === $quotesCount;
+
+            if ($isLastQuote && !$isEvenAmountOfQuotes) {
+                $result .= '\"';
+            }
+
+            if ($isInQuote && !$isLastQuote) {
+                $result .= $this->escapePhrase($segment);
+            } else {
+                $result .= $this->escapeSpecialCharacters($segment);
+            }
+
+            $segmentsIndex++;
+        }
+
+        return $result;
+    }
 
     // pagination
 

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -1,0 +1,81 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Query;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tests the ApacheSolrForTypo3\Solr\Query class
+ *
+ * @author Ingo Renner <ingo@typo3.org>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class QueryTest extends UnitTest
+{
+
+    /**
+     * @return array
+     */
+    public function escapeQueryDataProvider()
+    {
+        return array(
+            'empty' => array('input' => '', 'expectedOutput' => ''),
+            'simple' => array('input' => 'foo', 'expectedOutput' => 'foo'),
+            'single quoted word' => array('input' => '"world"', 'expectedOutput' => '"world"'),
+            'simple quoted phrase' => array('input' => '"hello world"', 'expectedOutput' => '"hello world"'),
+            'simple quoted phrase with ~' => array('input' => '"hello world~"', 'expectedOutput' => '"hello world~"'),
+            'simple phrase with ~' => array('input' => 'hello world~', 'expectedOutput' => 'hello world\~'),
+            'single quote' =>  array('input' => '20" monitor', 'expectedOutput' => '20\" monitor'),
+            'rounded brackets many words' => array('input' => 'hello (world)', 'expectedOutput' => 'hello \(world\)'),
+            'rounded brackets one word' => array('input' => '(world)', 'expectedOutput' => '\(world\)'),
+            'plus character is kept' => array('input' => 'foo +bar -world', 'expectedOutput' => 'foo +bar -world'),
+            '&& character is kept' => array('input' => 'hello && world', 'expectedOutput' => 'hello && world'),
+            '! character is kept' => array('input' => 'hello !world', 'expectedOutput' => 'hello !world'),
+            '* character is kept' => array('input' => 'hello *world', 'expectedOutput' => 'hello *world'),
+            '? character is kept' => array('input' => 'hello ?world', 'expectedOutput' => 'hello ?world'),
+            'ö character is kept' => array('input' => 'schöner tag', 'expectedOutput' => 'schöner tag'),
+            'numeric is kept' => array('input' => 42, 'expectedOutput' => 42),
+            'combined quoted phrase' => array('input' => '"hello world" or planet', 'expectedOutput' => '"hello world" or planet'),
+            'two combined quoted phrases' => array('input' => '"hello world" or "hello planet"', 'expectedOutput' => '"hello world" or "hello planet"'),
+            'combined quoted phrase mixed with escape character' => array('input' => '"hello world" or (planet)', 'expectedOutput' => '"hello world" or \(planet\)')
+        );
+    }
+
+    /**
+     * @dataProvider escapeQueryDataProvider
+     * @test
+     */
+    public function canEscapeAsExpected($input, $expectedOutput)
+    {
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Query', 'test');
+
+        $output = $query->escape($input);
+        $this->assertSame($expectedOutput, $output, 'Query was not escaped as expected');
+    }
+}


### PR DESCRIPTION
Before only the usage of "hello world" as a phrase was supported. The usage of more complex phrase queries e.g. `"hello world" or "hello planet"`was not supported.

This pull request:

1. adds test cases for the escape method of the query for the previous use cases
2. implements the context depending (inside or outside a phrase) escaping for multiple phrases

Fixes: #307