### PR TITLE
[BUGFIX] Fix cleanup of storage configuration

### DIFF
--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -95,6 +95,9 @@ class ReIndexTask extends AbstractTask
         foreach ($this->indexingConfigurationsToReIndex as $indexingConfigurationName) {
             $type = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
             $typesToCleanUp[] = $type;
+            if ($type === 'sys_file_storage') {
+                $typesToCleanUp[] = 'tx_solr_file';
+            }
         }
 
         foreach ($solrServers as $solrServer) {


### PR DESCRIPTION
In case the configuration is for a storage, the type field in the index is set to tx_solr_file and not sys_file_storage.
The ReindexTask must use the correct type to cleanup the index, else old records will not be deleted and never removed from index.
