### PR TITLE
[BUGFIX] Added AbstractIndexer::isAllowedToOverrideField to check if a field is allowed  to be overwritten with the typoscript configuration.

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -46,6 +46,22 @@ abstract class AbstractIndexer
 
 
     /**
+     * Holds field names that are denied to overwrite in thy indexing configuration.
+     *
+     * @var array
+     */
+    protected static $unAllowedOverrideFields = array('type');
+
+    /**
+     * @param string $solrFieldName
+     * @return bool
+     */
+    public static function isAllowedToOverrideField($solrFieldName)
+    {
+        return !in_array($solrFieldName, self::$unAllowedOverrideFields);
+    }
+
+    /**
      * Adds fields to the document as defined in $indexingConfiguration
      *
      * @param \Apache_Solr_Document $document base document to add fields to
@@ -66,9 +82,9 @@ abstract class AbstractIndexer
                 continue;
             }
 
-            if ($solrFieldName == 'type') {
+            if (!self::isAllowedToOverrideField($solrFieldName)) {
                 throw new InvalidFieldNameException(
-                    'Must not overwrite field "type".',
+                    'Must not overwrite field .' . $solrFieldName,
                     1435441863
                 );
             }

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 
 // TODO use/extend ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer
 use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\InvalidFieldNameException;
 use ApacheSolrForTypo3\Solr\SubstitutePageIndexer;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Util;
@@ -99,6 +100,7 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
     /**
      * Gets the mapped fields as an array mapping field names to values.
      *
+     * @throws InvalidFieldNameException
      * @return array An array mapping field names to their values.
      */
     protected function getMappedFields()
@@ -106,6 +108,12 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
         $fields = array();
 
         foreach ($this->mappedFieldNames as $mappedFieldName) {
+            if (!AbstractIndexer::isAllowedToOverrideField($mappedFieldName)) {
+                throw new InvalidFieldNameException(
+                    'Must not overwrite field "type".',
+                    1435441863
+                );
+            }
             $fields[$mappedFieldName] = $this->resolveFieldValue($mappedFieldName);
         }
 

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
+use ApacheSolrForTypo3\Solr\Query;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase for AbstractIndexer
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+class AbstractIndexerTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function testTypeIsNotAllowedOverride()
+    {
+        $this->assertFalse(AbstractIndexer::isAllowedToOverrideField('type'), 'Type is allowed to override');
+        $this->assertTrue(AbstractIndexer::isAllowedToOverrideField('test_stringS'), 'New dynamic fields was not indicated to be overrideable');
+    }
+}


### PR DESCRIPTION
Adds function AbstractIndexer::isAllowedToOverrideField  in AbstractIndexer and use it in

* AbstractIndexer::addDocumentFieldsFromTyposcript 
* PageFieldMappingIndexer::getMappedFields

Fixes: #232