### PR TITLE
[BUGFIX] Re-Index after deleting a content element - release-3.1.x

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -388,18 +388,23 @@ class Queue
      *      different value for non-database-record types.
      * @param string $indexingConfiguration The item's indexing configuration to use.
      *      Optional, overwrites existing / determined configuration.
+     * @param int $forcedChangeTime The change time for the item if set, otherwise
+     *          value from getItemChangedTime() is used.
      */
     public function updateItem(
         $itemType,
         $itemUid,
-        $indexingConfiguration = null
+        $indexingConfiguration = null,
+        $forcedChangeTime = 0
     ) {
         $itemInQueue = $this->containsItem($itemType, $itemUid);
 
         if ($itemInQueue) {
             // update if that item is in the queue already
             $changes = array(
-                'changed' => $this->getItemChangedTime($itemType, $itemUid)
+                'changed' => ($forcedChangeTime > 0)
+                                ? $forcedChangeTime
+                                : $this->getItemChangedTime($itemType, $itemUid)
             );
 
             if (!empty($indexingConfiguration)) {

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -86,7 +86,10 @@ class RecordMonitor
         if ($command == 'delete' && $table == 'tt_content' && $GLOBALS['BE_USER']->workspace == 0) {
             // skip workspaces: index only LIVE workspace
             $this->indexQueue->updateItem('pages',
-                $tceMain->getPID($table, $uid));
+                $tceMain->getPID($table, $uid),
+                null,
+                time()
+            );
         }
     }
 


### PR DESCRIPTION
Pass $forcedChangeTime to updateItem() instead of creating it within the function depending on itemType pages

fixes #231