### PR TITLE
[BUGFIX] Search with whitespace only should be threated as empty search

### DIFF
--- a/Classes/PluginBase/PluginBase.php
+++ b/Classes/PluginBase/PluginBase.php
@@ -545,6 +545,39 @@ abstract class Tx_Solr_PluginBase_PluginBase extends tslib_pibase {
 	public function getRawUserQuery() {
 		return $this->rawUserQuery;
 	}
+
+	/**
+	 * Method to check if the query string is an empty string
+	 * (also empty string or whitespaces only are handled as empty).
+	 *
+	 * When no query string is set (null) the method returns false.
+	 * @return bool
+	 */
+	public function getRawUserQueryIsEmptyString() {
+		$query = $this->getRawUserQuery();
+
+		if ($query === NULL) {
+			return FALSE;
+		}
+
+		if (trim($query) === '') {
+			return TRUE;
+		}
+
+		return FALSE;
+	}
+
+	/**
+	 * This method returns true when no query string is present at all.
+	 * Which means no search by the user was triggered
+	 *
+	 * @return boolean
+	 */
+	public function getRawUserQueryIsNull() {
+		$query = $this->getRawUserQuery();
+		return $query === NULL;
+	}
+
 }
 
 

--- a/PiResults/ErrorsCommand.php
+++ b/PiResults/ErrorsCommand.php
@@ -86,9 +86,9 @@ class Tx_Solr_PiResults_ErrorsCommand implements Tx_Solr_PluginCommand {
 			// detect empty user queries
 		$userQuery = $this->parentPlugin->getRawUserQuery();
 
-		if (!is_null($userQuery)
+		if (!$this->parentPlugin->getRawUserQueryIsNull()
 			&& !$this->configuration['search.']['query.']['allowEmptyQuery']
-			&& empty($userQuery)
+			&& $this->parentPlugin->getRawUserQueryIsEmptyString()
 		) {
 			$errors[] = array(
 				'message' => '###LLL:error_emptyQuery###',

--- a/PiResults/Results.php
+++ b/PiResults/Results.php
@@ -197,8 +197,16 @@ class Tx_Solr_PiResults_Results extends Tx_Solr_PluginBase_CommandPluginBase {
 
 		$this->initializeAdditionalFilters($query);
 
-			// TODO check whether a search has been conducted already?
-		if ($this->solrAvailable && (isset($rawUserQuery) || $this->conf['search.']['initializeWithEmptyQuery'] || $this->conf['search.']['initializeWithQuery'])) {
+		if (!$this->conf['search.']['query.']['allowEmptyQuery'] && $this->getRawUserQueryIsEmptyString()) {
+			// If empty query is not allowed, but query is an empty string, don't perform a search
+			return FALSE;
+		}
+
+		// TODO check whether a search has been conducted already?
+		if ($this->solrAvailable
+			&& !$this->getRawUserQueryIsNull()
+			|| $this->conf['search.']['initializeWithEmptyQuery']
+			|| $this->conf['search.']['initializeWithQuery']) {
 
 			if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['searchWords']) {
 				t3lib_div::devLog('received search query', 'solr', 0, array($rawUserQuery));


### PR DESCRIPTION
Searches with whitespaces only are handled now as a search with an empty
query string "" unless an empty search query is explicitly allowed.

Fixes: #236