### PR TITLE
[TASK] Allow to register own SearchResultSet and transform/process it…

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetProcessor.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+/**
+ * The implementation can be used to influence a SearchResultSet that is
+ * created and processed in the SearchResultSetService.
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
+ */
+interface SearchResultSetProcessor
+{
+    /**
+     * The implementation can be used to influence a SearchResultSet that is
+     * created and processed in the SearchResultSetService.
+     *
+     * @param SearchResultSet $resultSet
+     * @return mixed
+     */
+    public function process(SearchResultSet $resultSet);
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -320,3 +320,7 @@ if (TYPO3_MODE == 'BE') {
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '])) {
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '] = 'ApacheSolrForTypo3\\Solr\\Domain\\Search\\ResultSet\\SearchResult';
 }
+
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassName '])) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassName '] = 'ApacheSolrForTypo3\\Solr\\Domain\\Search\\ResultSet\\SearchResultSet';
+}


### PR DESCRIPTION
… with a hook

Added the possibility to use own SearchResultSet with:

$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassName '] = 'MyClass';

and added hooks before and after search.

Fixes: #336