### PR TITLE
[BUGFIX] Search with whitespace only should be threated as empty search - release-3.1.x

### DIFF
--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -584,4 +584,35 @@ abstract class PluginBase extends AbstractPlugin
     {
         return $this->rawUserQuery;
     }
+
+    /**
+     * Method to check if the query string is an empty string
+     * (also empty string or whitespaces only are handled as empty).
+     *
+     * When no query string is set (null) the method returns false.
+     * @return bool
+     */
+    public function getRawUserQueryIsEmptyString()
+    {
+        $query = $this->getRawUserQuery();
+        if ($query === null) {
+            return false;
+        }
+        if (trim($query) === '') {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * This method returns true when no query string is present at all.
+     * Which means no search by the user was triggered
+     *
+     * @return boolean
+     */
+    public function getRawUserQueryIsNull()
+    {
+        $query = $this->getRawUserQuery();
+        return $query === null;
+    }
 }

--- a/Classes/Plugin/Results/ErrorsCommand.php
+++ b/Classes/Plugin/Results/ErrorsCommand.php
@@ -96,9 +96,9 @@ class ErrorsCommand implements PluginCommand
         // detect empty user queries
         $userQuery = $this->parentPlugin->getRawUserQuery();
 
-        if (!is_null($userQuery)
+        if (!$this->parentPlugin->getRawUserQueryIsNull()
             && !$this->configuration['search.']['query.']['allowEmptyQuery']
-            && empty($userQuery)
+            && $this->parentPlugin->getRawUserQueryIsEmptyString()
         ) {
             $errors[] = array(
                 'message' => '###LLL:error_emptyQuery###',

--- a/Classes/Plugin/Results/Results.php
+++ b/Classes/Plugin/Results/Results.php
@@ -212,8 +212,16 @@ class Results extends CommandPluginBase
 
         $this->initializeAdditionalFilters($query);
 
+        if (!$this->conf['search.']['query.']['allowEmptyQuery'] && $this->getRawUserQueryIsEmptyString()) {
+            // If empty query is not allowed, but query is an empty string, don't perform a search
+            return false;
+        }
+
         // TODO check whether a search has been conducted already?
-        if ($this->solrAvailable && (isset($rawUserQuery) || $this->conf['search.']['initializeWithEmptyQuery'] || $this->conf['search.']['initializeWithQuery'])) {
+        if ($this->solrAvailable
+            && !$this->getRawUserQueryIsNull()
+            || $this->conf['search.']['initializeWithEmptyQuery']
+            || $this->conf['search.']['initializeWithQuery']) {
             if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['query.']['searchWords']) {
                 GeneralUtility::devLog('received search query', 'solr', 0,
                     array($rawUserQuery));


### PR DESCRIPTION
Searches with whitespaces only are handled now as a search with an empty
query string "" unless an empty search query is explicitly allowed.

Fixes: #236