### PR TITLE
[TASK] Use FastVectorHighlighter by default without configuration

### DIFF
--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -1193,16 +1193,13 @@ class Query
                 $this->queryParameters['hl.fl'] = $highlightingFields;
             }
 
-            $useFastVectorHighlighter = $this->solrConfiguration->getSearchResultsHighlightingUseFastVectorHighlighter();
-            if ($useFastVectorHighlighter) {
-                if ($fragmentSize <= 18) {
-                    throw new \InvalidArgumentException("The setting useFastVectorHighlighter can only be used with a fragementSize larger then 18");
-                }
-                $this->queryParameters['hl.useFastVectorHighlighter'] = 'true';
-            }
-
+            // the fast vector highlighter can only be used, when the fragmentSize is
+            // higher then 17 otherwise solr throws an exception
+            $useFastVectorHighlighter = ($fragmentSize >= 18);
             $wrap = explode('|', $this->solrConfiguration->getSearchResultsHighlightingWrap());
+
             if ($useFastVectorHighlighter) {
+                $this->queryParameters['hl.useFastVectorHighlighter'] = 'true';
                 $this->queryParameters['hl.tag.pre'] = $wrap[0];
                 $this->queryParameters['hl.tag.post'] = $wrap[1];
             } else {

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1459,20 +1459,6 @@ class TypoScriptConfiguration implements \ArrayAccess
     }
 
     /**
-     * Return if the fastVectorHighlighter should be used or not.
-     *
-     * plugin.tx_solr.search.results.resultsHighlighting.useFastVectorHighlighter
-     *
-     * @param bool $defaultIfEmpty
-     * @return bool
-     */
-    public function getSearchResultsHighlightingUseFastVectorHighlighter($defaultIfEmpty = false)
-    {
-        $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.results.resultsHighlighting.useFastVectorHighlighter', $defaultIfEmpty);
-        return $this->getBool($result);
-    }
-
-    /**
      * Returns the configured wrap for the resultHighlighting.
      *
      * plugin.tx_solr.search.results.resultsHighlighting.wrap

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -154,10 +154,6 @@ plugin.tx_solr {
 		results {
 			resultsHighlighting = 0
 			resultsHighlighting {
-				 // can be used to increase the highlighting performance requires the field is termVectors=on,
-				 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
-				 // then 18
-				useFastVectorHighlighter = 0
 				highlightFields = content
 				fragmentSize = 200
 				fragmentSeparator = [...]

--- a/Tests/Integration/Plugin/FrequentSearches/Fixtures/can_render_frequentSearches_plugin.xml
+++ b/Tests/Integration/Plugin/FrequentSearches/Fixtures/can_render_frequentSearches_plugin.xml
@@ -196,10 +196,6 @@
                         results {
                             resultsHighlighting = 1
                             resultsHighlighting {
-                                 // can be used to increase the highlighting performance requires the field is termVectors=on,
-                                 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
-                                 // then 18
-                                useFastVectorHighlighter = 0
                                 highlightFields = content
                                 fragmentSize = 20
                                 fragmentSeparator = [...]

--- a/Tests/Integration/Plugin/Results/Fixtures/can_render_results_plugin.xml
+++ b/Tests/Integration/Plugin/Results/Fixtures/can_render_results_plugin.xml
@@ -196,12 +196,8 @@
                         results {
                             resultsHighlighting = 1
                             resultsHighlighting {
-                                 // can be used to increase the highlighting performance requires the field is termVectors=on,
-                                 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
-                                 // then 18
-                                useFastVectorHighlighter = 0
                                 highlightFields = content
-                                fragmentSize = 20
+                                fragmentSize = 200
                                 fragmentSeparator = [...]
 
                                 wrap = <span class="results-highlight">|</span>

--- a/Tests/Integration/Plugin/Search/Fixtures/can_render_search_plugin.xml
+++ b/Tests/Integration/Plugin/Search/Fixtures/can_render_search_plugin.xml
@@ -196,10 +196,6 @@
                         results {
                             resultsHighlighting = 1
                             resultsHighlighting {
-                                 // can be used to increase the highlighting performance requires the field is termVectors=on,
-                                 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
-                                 // then 18
-                                useFastVectorHighlighter = 0
                                 highlightFields = content
                                 fragmentSize = 20
                                 fragmentSeparator = [...]


### PR DESCRIPTION
The FastVectorHighlighter will now be used by default when a fragmentSize larger then 17 is configured.

Fixes: #193