### PR TITLE
Bugfix Issue #363 Fixing FlashMessageQueue::addMessage

### DIFF
--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -51,6 +51,7 @@ class Page extends AbstractInitializer
      */
     public function __construct()
     {
+        $this->flashMessageQueue = new FlashMessageQueue("solr_queue");
         $this->type = 'pages';
         $this->indexingConfigurationName = 'pages';
     }
@@ -193,7 +194,7 @@ class Page extends AbstractInitializer
                 'Failed to initialize Mount Page tree. ',
                 FlashMessage::ERROR
             );
-            FlashMessageQueue::addMessage($flashMessage);
+            $this->flashMessageQueue->addMessage($flashMessage);
         }
 
         if (!$this->mountedPageExists($mountPage['mountPageSource'])) {
@@ -209,7 +210,7 @@ class Page extends AbstractInitializer
                 'Failed to initialize Mount Page tree. ',
                 FlashMessage::ERROR
             );
-            FlashMessageQueue::addMessage($flashMessage);
+            $this->flashMessageQueue->addMessage($flashMessage);
         }
 
         return $isValidMountPage;


### PR DESCRIPTION
Hi there,
after I installed 4.0.0 of ext-solr, I ran into an exception message while I was trying to "Queue Selected 
Items for Indexing" in the Search backend module. 

https://github.com/TYPO3-Solr/ext-solr/issues/363

It would be great if you would accept this change. If not like this, then maybe in a similar fashion.

Thanks,

Gerald  