### PR TITLE
[BUGFIX] Parent plugin is not passed to search result set service in PluginBase - dev-master

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -106,6 +106,14 @@ class SearchResultSetService
     }
 
     /**
+     * @return AbstractPlugin
+     */
+    public function getParentPlugin()
+    {
+        return $this->parentPlugin;
+    }
+
+    /**
      * @param bool $useCache
      * @return bool
      */

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -333,7 +333,7 @@ abstract class PluginBase extends AbstractPlugin
 
         $search = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Search', $solrConnection);
         /** @var $this->searchService ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService */
-        $this->searchResultsSetService = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService', $this->typoScriptConfiguration, $search);
+        $this->searchResultsSetService = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService', $this->typoScriptConfiguration, $search, $this);
         $this->solrAvailable = $this->searchResultsSetService->getIsSolrAvailable();
         $this->search = $this->searchResultsSetService->getSearch();
     }

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -427,4 +427,21 @@ class ResultsTest extends AbstractPluginTest
     {
         $this->assertContains('Nothing found', $content, 'Asserted that nothing was found but the text, that nothing was found was not present in the response');
     }
+
+
+    /**
+     * We expected that the parent plugin is correctly set when the pi plugin was rendered
+     * @test
+     */
+    public function parentPluginIsPassedToSearchResultService()
+    {
+        $searchResults = $this->importTestDataSetAndGetInitializedPlugin(array(1), 'can_render_results_plugin.xml');
+
+        $_GET['q'] = '*';
+
+        $searchResults->main('', array());
+        $parentPlugin = $searchResults->getSearchResultSetService()->getParentPlugin();
+
+        $this->assertInstanceOf('TYPO3\CMS\Frontend\Plugin\AbstractPlugin', $parentPlugin);
+    }
 }


### PR DESCRIPTION
Parent plugin is not passed to search result set service in PluginBase

* Passed parent plugin to SearchResultSet service
* Added regression test

Fixes: #366