### PR TITLE
[BUGFIX] Avoid fatal when indexing configuration is empty

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -269,6 +269,10 @@ class Indexer extends AbstractIndexer
         $solrConfiguration = Util::getSolrConfigurationFromPageId($item->getRootPageUid(),
             true, $language);
 
+        if (empty($solrConfiguration['index.']['queue.'][$item->getIndexingConfigurationName() . '.']['fields.'])) {
+            throw new \RuntimeException('The item indexing configuration "' . $item->getIndexingConfigurationName() . '" on root page uid ' . $item->getRootPageUid() . ' could not be found!', 1455530112);
+        }
+
         return $solrConfiguration['index.']['queue.'][$item->getIndexingConfigurationName() . '.']['fields.'];
     }
 


### PR DESCRIPTION
Throw an exception instead to trigger a failed indexing.

 Resolves: #371