### PR TITLE
[BUGFIX] Fix flash message queue usage and display of flash messages

### DIFF
--- a/Classes/Backend/SolrModule/AbstractModuleController.php
+++ b/Classes/Backend/SolrModule/AbstractModuleController.php
@@ -254,4 +254,18 @@ abstract class AbstractModuleController extends ActionController implements Admi
 
         return $currentCoreConnection;
     }
+
+    /**
+     * Adds flash massages from another flash message queue, e.g. solr.queue.initializer
+     *
+     * @param string $identifier
+     * @return void
+     */
+    protected function addFlashMessagesByQueueIdentifier($identifier)
+    {
+        $flashMessages = $this->controllerContext->getFlashMessageQueue($identifier)->getAllMessages();
+        foreach ($flashMessages as $message) {
+            $this->addFlashMessage($message->getMessage(), $message->getTitle, $message->getSeverity());
+        }
+    }
 }

--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -219,6 +219,8 @@ class IndexQueueModuleController extends AbstractModuleController
                 LocalizationUtility::translate($titleLabel, 'Solr'),
                 FlashMessage::OK
             );
+
+            $this->addFlashMessagesByQueueIdentifier('solr.queue.initializer');
         }
 
         $this->forward('index');

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -70,9 +70,24 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     protected $indexingConfigurationName;
 
+    /**
+     * Flash message queue
+     *
+     * @var \TYPO3\CMS\Core\Messaging\FlashMessageQueue
+     */
+    protected $flashMessageQueue;
 
     // Object initialization
 
+    /**
+     * Constructor, prepares the flash message queue
+     *
+     */
+    public function __construct()
+    {
+        $flashMessageService = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessageService');
+        $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
+    }
 
     /**
      * Sets the site for the initializer.

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -51,7 +51,8 @@ class Page extends AbstractInitializer
      */
     public function __construct()
     {
-        $this->flashMessageQueue = new FlashMessageQueue("solr_queue");
+        parent::__construct();
+
         $this->type = 'pages';
         $this->indexingConfigurationName = 'pages';
     }

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
@@ -100,4 +100,12 @@
         <pid>2</pid>
         <title>Child of Mounter</title>
     </pages>
+    <pages>
+        <uid>40</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <pid>1</pid>
+        <mount_pid>0</mount_pid>
+        <title>Invalid Mount Point</title>
+    </pages>
 </dataset>


### PR DESCRIPTION
If invalid mount points were found while initializing the page index
queue, flash messages are added to a flash message queue, but
addMessage() mustn't be called statically and backend module has to
consider the queue initializer flash massages.

Fixes: #363