### PR TITLE
[BUGFIX] Backport fix of flash message queue usage and display of flash messages to release-3.1.x

### DIFF
--- a/Classes/Backend/SolrModule/AbstractModuleController.php
+++ b/Classes/Backend/SolrModule/AbstractModuleController.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\Utility\StringUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Abstract Module
@@ -253,5 +254,20 @@ abstract class AbstractModuleController extends ActionController implements Admi
         }
 
         return $currentCoreConnection;
+    }
+
+    /**
+     * Adds flash massages from another flash message queue, e.g. solr.queue.initializer
+     *
+     * @param string $identifier
+     * @return void
+     */
+    protected function addFlashMessagesByQueueIdentifier($identifier)
+    {
+        $flashMessageService = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessageService');
+        $flashMessages = $flashMessageService->getMessageQueueByIdentifier($identifier)->getAllMessages();
+        foreach ($flashMessages as $message) {
+            $this->addFlashMessage($message->getMessage(), $message->getTitle, $message->getSeverity());
+        }
     }
 }

--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -219,6 +219,8 @@ class IndexQueueModuleController extends AbstractModuleController
                 LocalizationUtility::translate($titleLabel, 'Solr'),
                 FlashMessage::OK
             );
+
+            $this->addFlashMessagesByQueueIdentifier('solr.queue.initializer');
         }
 
         $this->forward('index');

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -70,9 +70,24 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     protected $indexingConfigurationName;
 
+    /**
+     * Flash message queue
+     *
+     * @var \TYPO3\CMS\Core\Messaging\FlashMessageQueue
+     */
+    protected $flashMessageQueue;
 
     // Object initialization
 
+    /**
+     * Constructor, prepares the flash message queue
+     *
+     */
+    public function __construct()
+    {
+        $flashMessageService = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessageService');
+        $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
+    }
 
     /**
      * Sets the site for the initializer.
@@ -128,8 +143,8 @@ abstract class AbstractInitializer implements IndexQueueInitializer
     {
         $initialized = false;
 
-        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed) '
-            . $this->buildSelectStatement() . ' '
+        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, errors) '
+            . $this->buildSelectStatement() . ',"" '
             . 'FROM ' . $this->type . ' '
             . 'WHERE '
             . $this->buildPagesClause()

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -51,6 +51,8 @@ class Page extends AbstractInitializer
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->type = 'pages';
         $this->indexingConfigurationName = 'pages';
     }
@@ -193,7 +195,7 @@ class Page extends AbstractInitializer
                 'Failed to initialize Mount Page tree. ',
                 FlashMessage::ERROR
             );
-            FlashMessageQueue::addMessage($flashMessage);
+            $this->flashMessageQueue->addMessage($flashMessage);
         }
 
         if (!$this->mountedPageExists($mountPage['mountPageSource'])) {
@@ -209,7 +211,7 @@ class Page extends AbstractInitializer
                 'Failed to initialize Mount Page tree. ',
                 FlashMessage::ERROR
             );
-            FlashMessageQueue::addMessage($flashMessage);
+            $this->flashMessageQueue->addMessage($flashMessage);
         }
 
         return $isValidMountPage;
@@ -248,9 +250,9 @@ class Page extends AbstractInitializer
         array $mountProperties
     ) {
         $mountIdentifier = $this->getMountPointIdentifier($mountProperties);
-        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, has_indexing_properties, pages_mountidentifier) '
+        $initializationQuery = 'INSERT INTO tx_solr_indexqueue_item (root, item_type, item_uid, indexing_configuration, indexing_priority, changed, has_indexing_properties, pages_mountidentifier, errors) '
             . $this->buildSelectStatement() . ', 1, ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($mountIdentifier,
-                'tx_solr_indexqueue_item')
+                'tx_solr_indexqueue_item') . ',""'
             . 'FROM pages '
             . 'WHERE '
             . 'uid IN(' . implode(',', $mountedPages) . ') '

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8080
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Root page</title>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>2</mount_pid>
+        <pid>1</pid>
+        <title>Mount Point</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Mounted</title>
+    </pages>
+    <pages>
+        <uid>20</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>2</pid>
+        <title>Child of Mounter</title>
+    </pages>
+    <pages>
+        <uid>40</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <pid>1</pid>
+        <mount_pid>0</mount_pid>
+        <title>Invalid Mount Point</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -1,0 +1,151 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Initializer;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Charset\CharsetConverter;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase to test the page queue initializer
+ *
+ * @author Timo Schmidt
+ * @package TYPO3
+ * @subpackage solr
+ */
+class PageTest extends IntegrationTest
+{
+    /**
+     * @var Page
+     */
+    protected $pageInitializer;
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->setUpBackendUserFromFixture(1);
+        $this->pageInitializer = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page');
+        $this->indexQueue = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\IndexQueue\Queue');
+    }
+
+    /**
+     * Custom assertion to expect a specific amount of items in the queue.
+     *
+     * @param integer $expectedAmount
+     */
+    protected function assertItemsInQueue($expectedAmount)
+    {
+        $itemCount = $this->indexQueue->getAllItemsCount();
+        $this->assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: '.$expectedAmount);
+    }
+
+    /**
+     * Custom assertion to expect an empty queue.
+     * @return void
+     */
+    protected function assertEmptyQueue()
+    {
+        $this->assertItemsInQueue(0);
+    }
+
+    /**
+     * Initialize page index queue
+     *
+     * @return void
+     */
+    protected function initializePageIndexQueue()
+    {
+        $this->pageInitializer->setIndexingConfigurationName('pages');
+        $this->pageInitializer->setSite(Site::getFirstAvailableSite());
+        $this->pageInitializer->setType('pages');
+        $this->pageInitializer->initialize();
+    }
+
+    /**
+     * In this testcase we check if the pages queue will be initialized as expected
+     * when we have a page with mounted pages
+     *
+     *
+     *      1
+     *      |
+     *      ------- 10 (Mounted)
+     *                        |
+     *                         ------------ 20 (Childpage of mountpoint)
+     *
+     * @test
+     */
+    public function initializerIsFillingQueueWithMountPages()
+    {
+        $this->importDataSetFromFixture('can_add_mount_pages.xml');
+
+        $this->assertEmptyQueue();
+        $this->initializePageIndexQueue();
+
+        $this->assertItemsInQueue(4);
+
+            // @todo: verify, is this really as expected? since mount_pid_ol is not set
+            // in the case when mount_pid_ol is set 4 pages get added
+        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 10));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 20));
+
+        $this->assertFalse($this->indexQueue->containsItem('pages', 2));
+    }
+
+    /**
+     * Check if invalid mount page is ignored and messages were added to the flash
+     * message queue
+     *
+     * @test
+     */
+    public function initializerAddsInfoMessagesAboutInvalidMountPages()
+    {
+        $this->importDataSetFromFixture('can_add_mount_pages.xml');
+
+        $this->assertEmptyQueue();
+        $this->initializePageIndexQueue();
+
+        $this->assertItemsInQueue(4);
+
+        $flashMessageService = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessageService');
+        $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
+        $this->assertEquals(2, count($flashMessageQueue->getAllMessages()));
+    }
+}


### PR DESCRIPTION
If invalid mount points were found while initializing the page index
queue, flash messages are added to a flash message queue, but
addMessage() mustn't be called statically and backend module has to
consider the queue initializer flash massages.

Fixes: #363