### PR TITLE
[BUGFIX] Sorting key in SearchRquest should be sorting name instead of solr field name.

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -281,7 +281,7 @@ class SearchRequest
     }
 
     /**
-     * Helper function to get the sorting field or direction.
+     * Helper function to get the sorting configuration name or direction.
      *
      * @param $index
      * @return null
@@ -298,11 +298,11 @@ class SearchRequest
     }
 
     /**
-     * Returns the sorting field name that is currently used.
+     * Returns the sorting configuration name that is currently used.
      *
      * @return string
      */
-    public function getSortingField()
+    public function getSortingName()
     {
         return $this->getSortingPart(0);
     }
@@ -329,14 +329,14 @@ class SearchRequest
     }
 
     /**
-     * @param string $fieldName
+     * @param string $sortingName
      * @param string $direction (asc or desc)
      *
      * @return SearchRequest
      */
-    public function setSorting($fieldName, $direction = 'asc')
+    public function setSorting($sortingName, $direction = 'asc')
     {
-        $value = $fieldName.' '.$direction;
+        $value = $sortingName.' '.$direction;
         $path = $this->prefixWithNamespace('sort');
         $this->argumentsAccessor->set($path, $value);
         $this->stateChanged = true;

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -242,7 +242,7 @@ class SearchRequestTest extends UnitTest
         $query = 'q=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
-        $this->assertSame('title', $request->getSortingField(), 'Expected sorting fields was title');
+        $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
         $this->assertSame('asc', $request->getSortingDirection(), 'Expected sorting direction was asc');
     }
 
@@ -254,7 +254,7 @@ class SearchRequestTest extends UnitTest
         $query = 'q=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
-        $this->assertSame('title', $request->getSortingField(), 'Expected sorting fields was title');
+        $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
         $requestAsArray = $request->getAsArray();
         $this->assertTrue(isset($requestAsArray['tx_solr']['sort']), 'Sorting was not set but was expected to be set');
 


### PR DESCRIPTION
Sorting key in SearchRquest should be sorting name instead of solr field name.

Fixes: #409