### PR TITLE
[TASK] Add a unique id to the request

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -41,6 +41,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SearchRequest
 {
+    /**
+     * @var string
+     */
+    protected $id;
 
     /**
      * @var string
@@ -101,8 +105,16 @@ class SearchRequest
         $this->contextPageUid = $pageUid;
         $this->contextSystemLanguageUid = $sysLanguageUid;
         $this->contextTypoScriptConfiguration = $typoScriptConfiguration;
-
+        $this->id = spl_object_hash($this);
         $this->reset();
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
     }
 
     /**
@@ -436,8 +448,17 @@ class SearchRequest
     {
         $path = $this->prefixWithNamespace('resultsPerPage');
         $this->argumentsAccessor->set($path, $resultsPerPage);
+        $this->stateChanged = true;
 
         return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getStateChanged()
+    {
+        return $this->stateChanged;
     }
 
     /**
@@ -484,6 +505,7 @@ class SearchRequest
     public function reset()
     {
         $this->argumentsAccessor = new ArrayAccessor($this->persistedArguments);
+        $this->stateChanged = false;
         return $this;
     }
 

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -279,6 +279,25 @@ class SearchRequestTest extends UnitTest
     }
 
     /**
+     * @test
+     */
+    public function twoDifferentRequestsHaveADifferentId()
+    {
+        $newSearchRequest = new SearchRequest();
+        $this->assertNotEquals($newSearchRequest->getId(), $this->searchRequest->getId(), 'Two different requests seem to have the same id');
+    }
+
+    /**
+     * @test
+     */
+    public function setPerPageWillMarkedTheRequestAsChanged()
+    {
+        $this->assertFalse($this->searchRequest->getStateChanged());
+        $this->searchRequest->setResultsPerPage(10);
+        $this->assertTrue($this->searchRequest->getStateChanged());
+    }
+
+    /**
      * @param $query
      * @return SearchRequest
      */


### PR DESCRIPTION
* Adds a unique id to the request object
* Fixed a bug that the stateChanged property is set when the setResultsPerPage method is called

Fixes: #414