### PR TITLE
[BUGFIX] TypoScript configuration should use configurationAccess also for writing

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1201,7 +1201,7 @@ class TypoScriptConfiguration
      */
     public function setSearchQueryFilterConfiguration(array $configuration)
     {
-        $this->configuration['plugin.']['tx_solr.']['search.']['query.']['filter.'] = $configuration;
+        $this->configurationAccess->set('plugin.tx_solr.search.query.filter.', $configuration);
     }
 
     /**
@@ -1211,7 +1211,7 @@ class TypoScriptConfiguration
      */
     public function removeSearchQueryFilterForPageSections()
     {
-        unset($this->configuration['plugin.']['tx_solr.']['search.']['query.']['filter.']['__pageSections']);
+        $this->configurationAccess->reset('plugin.tx_solr.search.query.filter.__pageSections');
     }
 
     /**
@@ -1226,7 +1226,6 @@ class TypoScriptConfiguration
     {
         return $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.queryFields', $defaultIfEmpty);
     }
-
 
     /**
      * Returns the configured returnFields as array.

--- a/Classes/System/Util/ArrayAccessor.php
+++ b/Classes/System/Util/ArrayAccessor.php
@@ -224,18 +224,19 @@ class ArrayAccessor
     protected function resetDeepElementWithLoop($pathArray)
     {
         $currentElement = &$this->data;
-        foreach ($pathArray as $key => $pathSegment) {
-            if (!isset($currentElement[$pathSegment])) {
-                $currentElement[$pathSegment] = array();
-            }
 
+        foreach ($pathArray as $key => $pathSegment) {
             unset($pathArray[$key]);
             // if segments are left the item does not exist
             if (count($pathArray) === 0) {
                 unset($currentElement[$pathSegment]);
+                // when the element is empty after unsetting the path segment, we can remove it completely
+                if (empty($currentElement)) {
+                    unset($currentElement);
+                }
+            } else {
+                $currentElement = &$currentElement[$pathSegment];
             }
-
-            $currentElement = &$currentElement[$pathSegment];
         }
     }
 

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -496,4 +496,59 @@ class TypoScriptConfigurationTest extends UnitTest
         $excludeClasses = $configuration->getIndexQueuePagesExcludeContentByClassArray();
         $this->assertEquals(array('excludeClass'), $excludeClasses, 'Can not get exclude patterns from configuration');
     }
+
+    /**
+     * @test
+     */
+    public function canSetSearchQueryFilterConfiguration()
+    {
+        $configuration = new TypoScriptConfiguration([]);
+        $this->assertEquals([], $configuration->getSearchQueryFilterConfiguration());
+        $configuration->setSearchQueryFilterConfiguration(['foo']);
+        $this->assertEquals(['foo'], $configuration->getSearchQueryFilterConfiguration());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemovePageSectionFilter()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'search.' => array(
+                'query.' => array(
+                    'filter.' => array(
+                        '__pageSections' => '1,2,3'
+                    )
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $this->assertEquals(['__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
+
+        $configuration->removeSearchQueryFilterForPageSections();
+        $this->assertEquals([], $configuration->getSearchQueryFilterConfiguration());
+    }
+
+    /**
+     * @test
+     */
+    public function removePageSectionFilterIsKeepingOtherFilters()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'search.' => array(
+                'query.' => array(
+                    'filter.' => array(
+                        'type:pages', '__pageSections' => '1,2,3'
+                    )
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $this->assertEquals(['type:pages','__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
+
+        $configuration->removeSearchQueryFilterForPageSections();
+        $this->assertEquals(['type:pages'], $configuration->getSearchQueryFilterConfiguration());
+    }
 }

--- a/Tests/Unit/System/Util/ArrayAccessorTest.php
+++ b/Tests/Unit/System/Util/ArrayAccessorTest.php
@@ -86,4 +86,48 @@ class ArrayAccessorTest extends UnitTest
         $this->assertSame(null, $arrayAccessor->get('one:two:a'));
         $this->assertSame(222, $arrayAccessor->get('one:two:b'));
     }
+
+
+    /**
+     * @test
+     */
+    public function resetIsRemovingEmptyNodes()
+    {
+        $data = ['one' => ['two' => ['a' => 111, 'b' => 222]]];
+        // can set and get a simple value
+        $arrayAccessor = new ArrayAccessor($data);
+        $this->assertSame(111, $arrayAccessor->get('one:two:a'));
+        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+
+        $arrayAccessor->reset('one:two:a');
+
+        $this->assertSame(null, $arrayAccessor->get('one:two:a'));
+        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+        $this->assertSame(['b' => 222], $arrayAccessor->get('one:two'));
+    }
+
+    /**
+     * @test
+     */
+    public function resetIsRemovingSubNodesAndEmptyNodes()
+    {
+        $data = [
+            'one' => [
+                'two' => ['a' => 111, 'b' => 222],
+                'three' => 333
+            ]
+        ];
+        // can set and get a simple value
+        $arrayAccessor = new ArrayAccessor($data);
+        $this->assertSame(111, $arrayAccessor->get('one:two:a'));
+        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+
+        $arrayAccessor->reset('one:two');
+
+        $this->assertSame(null, $arrayAccessor->get('one:two:a'));
+        $this->assertSame(null, $arrayAccessor->get('one:two:b'));
+        $this->assertSame(null, $arrayAccessor->get('one:two'));
+
+        $this->assertSame(333, $arrayAccessor->get('one:three'));
+    }
 }


### PR DESCRIPTION

* Use ArrayAccessor::set and reset
* Added unit tests

Fixes: #420