### PR TITLE
Feature: Enable extension of relation where clause

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -95,6 +95,10 @@ class Relation
 
         $relatedItems = $this->getRelatedItems($parentContentObject);
 
+        if (!empty($this->configuration['removeDuplicateValues'])) {
+            $relatedItems = array_unique($relatedItems);
+        }
+
         if (empty($configuration['multiValue'])) {
             // single value, need to concatenate related items
             $singleValueGlue = ', ';
@@ -225,9 +229,6 @@ class Relation
                 }
             }
 
-            if (!empty($this->configuration['removeDuplicateValues'])) {
-                $relatedItems = array_unique($relatedItems);
-            }
         }
 
         return $relatedItems;
@@ -345,10 +346,6 @@ class Relation
             if (!empty($resolveRelatedValue) || !$this->configuration['removeEmptyValues']) {
                 $relatedItems[] = $resolveRelatedValue;
             }
-        }
-
-        if (!empty($this->configuration['removeDuplicateValues'])) {
-            $relatedItems = array_unique($relatedItems);
         }
 
         return $relatedItems;

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -404,13 +404,18 @@ class Relation
     /**
      * Return records via relation.
      *
-     * TODO: Finish method, refactor to contain code from both methods.
-     * Split if code get's huge.
+     * @param string $foreignTable The table to fetch records from.
+     * @param array $uids The uids to fetch from table.
+     * @param string $whereClause The where clause to append.
      *
      * @return array
      */
-    protected function getRelatedRecords($foreignTable, $uids, $whereClause)
+    protected function getRelatedRecords($foreignTable, array $uids, $whereClause)
     {
+        if (isset($this->configuration['additionalWhere'])) {
+            $whereClause .= ' AND ' . $this->configuration['additionalWhere'];
+        }
+
         return $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
             '*',
             $foreignTable,


### PR DESCRIPTION
This allows to configure different fields for same relation with additional where clauses.
E.g. to select different categories by there parent.
Example configuration:
```
                        news_stringM = SOLR_RELATION
                        news_stringM {
                            localField = categories
                            foreignLabelField = title
                            multiValue = 1
                            additionalWhere = sys_category.parent = 1
                        }

                        regions_stringM < .news_stringM
                        regions_stringM {
                            additionalWhere = sys_category.parent = 2
                        }

                        product_stringM < .news_stringM
                        product_stringM {
                            additionalWhere = sys_category.parent = 6
                        }
```
Will result in:
![image](https://cloud.githubusercontent.com/assets/354250/15612646/f842b79a-242f-11e6-9a25-bf349a50b959.png)