### PR TITLE
[TASK] Add additionalWhereClause to SOLR_RELATION

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_direct_relationAndAdditionalWhere.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_direct_relationAndAdditionalWhere.xml
@@ -5,7 +5,7 @@
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8080/solr/core_en/";}}</entry_value>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -15,9 +15,6 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-
-                config.sys_language_mode = ignore
-                config.sys_language_uid = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
@@ -64,8 +61,9 @@
                                     title = title
                                     category_stringM = SOLR_RELATION
                                     category_stringM {
-                                        localField = tags
+                                        localField = category
                                         multiValue = 1
+                                        additionalWhere = pid=2
                                     }
                                 }
                             }
@@ -81,41 +79,28 @@
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
     </pages>
-    <pages_language_overlay>
+    <pages>
         <uid>2</uid>
-        <pid>1</pid>
-        <sys_language_uid>1</sys_language_uid>
+        <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-    </pages_language_overlay>
+    </pages>
     <tx_fakeextension_domain_model_bar>
-        <uid>88</uid>
+        <uid>111</uid>
         <pid>1</pid>
-        <title>orignal</title>
+        <title>testnews</title>
+        <category>4711,8888</category>
     </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_bar>
-        <uid>99</uid>
+    <tx_fakeextension_domain_model_directrelated>
+        <uid>4711</uid>
         <pid>1</pid>
-        <title>translation</title>
-        <sys_language_uid>1</sys_language_uid>
-        <l10n_parent>88</l10n_parent>
-    </tx_fakeextension_domain_model_bar>
+        <category>the category</category>
+    </tx_fakeextension_domain_model_directrelated>
 
-    <tx_fakeextension_domain_model_related_mm>
-        <uid_local>99</uid_local>
-        <uid_foreign>12</uid_foreign>
-        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
-    </tx_fakeextension_domain_model_related_mm>
+    <tx_fakeextension_domain_model_directrelated>
+        <uid>8888</uid>
+        <pid>2</pid>
+        <category>another category</category>
+    </tx_fakeextension_domain_model_directrelated>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>8</uid>
-        <pid>1</pid>
-        <tag>the tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
-
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>12</uid>
-        <pid>1</pid>
-        <tag>translated tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mm_relationAndAdditionalWhere.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mm_relationAndAdditionalWhere.xml
@@ -5,7 +5,7 @@
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8080/solr/core_en/";}}</entry_value>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8080";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8080/solr/core_en/";}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -15,9 +15,6 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-
-                config.sys_language_mode = ignore
-                config.sys_language_uid = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
@@ -66,6 +63,7 @@
                                     category_stringM {
                                         localField = tags
                                         multiValue = 1
+                                        additionalWhere = pid=2
                                     }
                                 }
                             }
@@ -81,29 +79,28 @@
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
     </pages>
-    <pages_language_overlay>
+    <pages>
         <uid>2</uid>
-        <pid>1</pid>
-        <sys_language_uid>1</sys_language_uid>
+        <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-    </pages_language_overlay>
+        <pid>1</pid>
+    </pages>
     <tx_fakeextension_domain_model_bar>
         <uid>88</uid>
         <pid>1</pid>
-        <title>orignal</title>
-    </tx_fakeextension_domain_model_bar>
-
-    <tx_fakeextension_domain_model_bar>
-        <uid>99</uid>
-        <pid>1</pid>
-        <title>translation</title>
-        <sys_language_uid>1</sys_language_uid>
-        <l10n_parent>88</l10n_parent>
+        <title>testnews</title>
     </tx_fakeextension_domain_model_bar>
 
     <tx_fakeextension_domain_model_related_mm>
-        <uid_local>99</uid_local>
-        <uid_foreign>12</uid_foreign>
+        <uid_local>88</uid_local>
+        <uid_foreign>8</uid_foreign>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>18</uid_foreign>
         <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
     </tx_fakeextension_domain_model_related_mm>
 
@@ -114,8 +111,9 @@
     </tx_fakeextension_domain_model_mmrelated>
 
     <tx_fakeextension_domain_model_mmrelated>
-        <uid>12</uid>
-        <pid>1</pid>
-        <tag>translated tag</tag>
+        <uid>18</uid>
+        <pid>2</pid>
+        <tag>another tag</tag>
     </tx_fakeextension_domain_model_mmrelated>
+
 </dataset>

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -546,7 +546,7 @@ class TypoScriptConfigurationTest extends UnitTest
         );
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['type:pages','__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
+        $this->assertEquals(['type:pages', '__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
 
         $configuration->removeSearchQueryFilterForPageSections();
         $this->assertEquals(['type:pages'], $configuration->getSearchQueryFilterConfiguration());


### PR DESCRIPTION
* Only check once for duplicate values
* As the code could be replaced with same approach as done in another
  function, use core API instead of custom implementation and reduce
  code
* Also refactor sql query to own method
* This allows to configure different fields for same relation with
  additional where clauses.
  E.g. to select different categories by there parent.

Fixes: #426