### PR TITLE
[FEATURE] Enable indexing of HTML Content

### DIFF
--- a/Resources/Private/Php/SolrPhpClient/Apache/Solr/Service.php
+++ b/Resources/Private/Php/SolrPhpClient/Apache/Solr/Service.php
@@ -689,7 +689,7 @@ class Apache_Solr_Service
                         // only set the boost for the first field in the set
                         $fieldBoost = false;
                     }
-					
+
                     $xml .= '><![CDATA[' . $multivalue . ']]></field>';
                 }
             } else {
@@ -698,7 +698,7 @@ class Apache_Solr_Service
                 if ($fieldBoost !== false) {
                     $xml .= ' boost="' . $fieldBoost . '"';
                 }
-				
+
                 $xml .= '><![CDATA[' . $value . ']]></field>';
             }
         }

--- a/Resources/Private/Php/SolrPhpClient/Apache/Solr/Service.php
+++ b/Resources/Private/Php/SolrPhpClient/Apache/Solr/Service.php
@@ -689,11 +689,8 @@ class Apache_Solr_Service
                         // only set the boost for the first field in the set
                         $fieldBoost = false;
                     }
-
-                    $multivalue = htmlspecialchars($multivalue, ENT_NOQUOTES,
-                        'UTF-8');
-
-                    $xml .= '>' . $multivalue . '</field>';
+					
+                    $xml .= '><![CDATA[' . $multivalue . ']]></field>';
                 }
             } else {
                 $xml .= '<field name="' . $key . '"';
@@ -701,10 +698,8 @@ class Apache_Solr_Service
                 if ($fieldBoost !== false) {
                     $xml .= ' boost="' . $fieldBoost . '"';
                 }
-
-                $value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
-
-                $xml .= '>' . $value . '</field>';
+				
+                $xml .= '><![CDATA[' . $value . ']]></field>';
             }
         }
 


### PR DESCRIPTION
We would like to enable indexing of HTML Content so we can use tags like sub/sup in Title and Content of the SOLR search results.

This change allows HTML-Tags to be indexed correctly (no more htmlspecialchars), we did however not figure out (yet) how to display them correctly in the search results (they still get converted at some point). Any ideas? :)