### PR TITLE
[BUGFIX] Numeric range facet doesn't support negative numbers

### DIFF
--- a/Classes/Query/FilterEncoder/Range.php
+++ b/Classes/Query/FilterEncoder/Range.php
@@ -6,6 +6,7 @@ namespace ApacheSolrForTypo3\Solr\Query\FilterEncoder;
  *
  *  (c) 2010-2011 Markus Goldbach <markus.goldbach@dkd.de>
  *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2016 Markus Friedrich <markus.friedrich@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -32,6 +33,7 @@ use ApacheSolrForTypo3\Solr\Facet\FacetBuilder;
  *
  * @author Markus Goldbach <markus.goldbach@dkd.de>
  * @author Ingo Renner <ingo@typo3.org>
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class Range implements FilterEncoder, FacetBuilder
 {
@@ -42,7 +44,6 @@ class Range implements FilterEncoder, FacetBuilder
      * @var string
      */
     const DELIMITER = '-';
-
 
     /**
      * Takes a filter value and encodes it to a human readable format to be
@@ -64,12 +65,19 @@ class Range implements FilterEncoder, FacetBuilder
      * @param string $range The range filter from the URL.
      * @param array $configuration Facet configuration
      * @return string Lucene query language filter to be used for querying Solr
+     * @throws \InvalidArgumentException
      */
     public function decodeFilter($range, array $configuration = array())
     {
-        $range = explode(self::DELIMITER, $range);
+        preg_match('/(-?\d*?)' . self::DELIMITER . '(-?\d*)/', $range, $filterParts);
+        if ($filterParts[1] == '' || $filterParts[2] == '') {
+            throw new \InvalidArgumentException(
+                'Invalid numeric range given',
+                1466062730
+            );
+        }
 
-        return '[' . $range[0] . ' TO ' . $range[1] . ']';
+        return '[' . (int) $filterParts[1] . ' TO ' . (int)  $filterParts[2] . ']';
     }
 
     /**

--- a/Tests/Unit/Query/FilterEncoder/RangeTest.php
+++ b/Tests/Unit/Query/FilterEncoder/RangeTest.php
@@ -6,6 +6,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\FilterEncoder;
  *
  *  (c) 2010-2011 Markus Goldbach <markus.goldbach@dkd.de>
  *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2016 Markus Friedrich <markus.friedrich@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -29,13 +30,19 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- *
  * Testcase for query parser range
- * @author Markus Goldbach
+ *
+ * @author Markus Goldbach <markus.goldbach@dkd.de>
+ * @author Ingo Renner <ingo@typo3.org>
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ * @package TYPO3
+ * @subpackage solr
  */
 class RangeTest extends UnitTest
 {
     /**
+     * Parser to build Solr range queries
+     *
      * @var \ApacheSolrForTypo3\Solr\Query\FilterEncoder\Range
      */
     protected $rangeParser;
@@ -46,13 +53,45 @@ class RangeTest extends UnitTest
     }
 
     /**
-     * @test
+     * Provides data for filter decoding tests
+     *
+     * @return array
      */
-    public function canParseRangeQuery()
+    public function rangeQueryParsingDataProvider()
     {
-        $expected = '[firstValue TO secondValue]';
-        $actual = $this->rangeParser->decodeFilter('firstValue-secondValue');
+        return array(
+            array('firstValue' => '50', 'secondValue' => '100', 'expected' => '[50 TO 100]'),
+            array('firstValue' => '-10', 'secondValue' => '20', 'expected' => '[-10 TO 20]'),
+            array('firstValue' => '-10', 'secondValue' => '-5', 'expected' => '[-10 TO -5]')
+        );
+    }
 
-        $this->assertEquals($expected, $actual);
+    /**
+     * Test the filter decoding
+     *
+     * @dataProvider rangeQueryParsingDataProvider
+     * @test
+     *
+     * @param string $firstValue
+     * @param string $secondValue
+     * @param string $expectedResult
+     * @return void
+     */
+    public function canParseRangeQuery($firstValue, $secondValue, $expectedResult)
+    {
+        $actual = $this->rangeParser->decodeFilter($firstValue . '-' . $secondValue);
+        $this->assertEquals($expectedResult, $actual);
+    }
+
+    /**
+     * Test the handling of invalid parameters
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @return void
+     */
+    public function canHandleInvalidParameters()
+    {
+        $this->rangeParser->decodeFilter('invalid-value');
     }
 }


### PR DESCRIPTION
Configuring numeric ranges containing negative numbers leads to invalid
queries, since the filter decoding couldn't handle negative numbers.
This commit improves the filter part detection, forces integer values
and extends the existing unit tests. 

Fixes: #448