### PR TITLE
[BUGFIX] Rename "additionalWhere" to "additionalWhereClause" to have a consistent naming

### DIFF
--- a/Classes/ContentObject/Multivalue.php
+++ b/Classes/ContentObject/Multivalue.php
@@ -59,7 +59,7 @@ class Multivalue
      * @param string $name content object name 'SOLR_MULTIVALUE'
      * @param array $configuration for the content object, expects keys 'separator' and 'field'
      * @param string $TyposcriptKey not used
-     * @param TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObject parent cObj
+     * @param \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObject parent cObj
      * @return string serialized array representation of the given list
      */
     public function cObjGetSingleExt(

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -418,8 +418,8 @@ class Relation
      */
     protected function getRelatedRecords($foreignTable, array $uids, $whereClause)
     {
-        if (isset($this->configuration['additionalWhere'])) {
-            $whereClause .= ' AND ' . $this->configuration['additionalWhere'];
+        if (isset($this->configuration['additionalWhereClause'])) {
+            $whereClause .= ' AND ' . $this->configuration['additionalWhereClause'];
         }
 
         return $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_direct_relationAndAdditionalWhere.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_direct_relationAndAdditionalWhere.xml
@@ -63,7 +63,7 @@
                                     category_stringM {
                                         localField = category
                                         multiValue = 1
-                                        additionalWhere = pid=2
+                                        additionalWhereClause = pid=2
                                     }
                                 }
                             }

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mm_relationAndAdditionalWhere.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mm_relationAndAdditionalWhere.xml
@@ -63,7 +63,7 @@
                                     category_stringM {
                                         localField = tags
                                         multiValue = 1
-                                        additionalWhere = pid=2
+                                        additionalWhereClause = pid=2
                                     }
                                 }
                             }


### PR DESCRIPTION
Rename the setting to have a consitent naming.

Fixes: #459