### PR TITLE
[BUGFIX] Keep selected site in scheduler task

### DIFF
--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -124,7 +124,7 @@ class Site
 
         foreach ($sites as $site) {
             $selectedAttribute = '';
-            if ($site == $selectedSite) {
+            if ($site->getRootPageId() == $selectedSite->getRootPageId()) {
                 $selectedAttribute = ' selected="selected"';
             }
 


### PR DESCRIPTION
* As objects aren't the same, the comparison always failed
* That lead to wrong configuration if someone edited and
  saved the record without noticing the mistake