### PR TITLE
[BUGFIX] Test with collapse field is broken with "64 bit numeric collapse fields are not supported"

### DIFF
--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -329,6 +329,7 @@ plugin.tx_solr {
 		variants = 0
 		variants {
 			expand = 1
+			// variantField needs to be a string or a numeric field
 			variantField = variantId
 			limit = 10
 		}

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1274,6 +1274,8 @@ variants.variantField
 
 Used to expand the document variants to the document.variants property.
 
+**Note:**: The field must be a numeric field or a string field! Not a text field!
+
 :Type: String
 :TS Path: plugin.tx_solr.search.variants.variantField
 :Since: 6.0

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
@@ -284,61 +284,68 @@
         <pid>1</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>Socks</title>
-        <subtitle>Men</subtitle>
+        <title>Woman Products</title>
     </pages>
     <pages>
         <uid>3</uid>
         <pid>1</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>Jeans</title>
-        <subtitle>Men</subtitle>
+        <title>Men Products</title>
     </pages>
     <pages>
         <uid>4</uid>
-        <pid>1</pid>
+        <pid>3</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>Shoes</title>
-        <subtitle>Woman</subtitle>
+        <title>Men Socks</title>
     </pages>
     <pages>
         <uid>5</uid>
-        <pid>1</pid>
+        <pid>3</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>T-Shirts</title>
-        <subtitle>Woman</subtitle>
+        <title>Men Jeans</title>
     </pages>
     <pages>
         <uid>6</uid>
-        <pid>1</pid>
+        <pid>2</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>T-Shirts</title>
-        <subtitle>Men</subtitle>
+        <title>Woman Shoes</title>
     </pages>
     <pages>
         <uid>7</uid>
-        <pid>1</pid>
+        <pid>2</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>Sweatshirts</title>
-        <subtitle>Men</subtitle>
+        <title>Woman T-Shirts</title>
     </pages>
     <pages>
         <uid>8</uid>
-        <pid>1</pid>
+        <pid>3</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
-        <title>Sweatshirts</title>
-        <subtitle>Woman</subtitle>
+        <title>Men T-Shirts</title>
+    </pages>
+    <pages>
+        <uid>9</uid>
+        <pid>3</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Men Sweatshirts</title>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <pid>2</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Woman Sweatshirts</title>
     </pages>
 
     <tt_content>
         <uid>1</uid>
-        <pid>2</pid>
+        <pid>4</pid>
         <CType>text</CType>
         <bodytext>Our awesome new sock products prices starting at 10€</bodytext>
         <colPos>0</colPos>
@@ -346,7 +353,7 @@
 
     <tt_content>
         <uid>2</uid>
-        <pid>3</pid>
+        <pid>5</pid>
         <CType>text</CType>
         <bodytext>Our awesome men jeans products prices starting at 50€</bodytext>
         <colPos>0</colPos>
@@ -354,7 +361,7 @@
 
     <tt_content>
         <uid>3</uid>
-        <pid>3</pid>
+        <pid>5</pid>
         <CType>text</CType>
         <bodytext>Men jeans with best prices</bodytext>
         <colPos>0</colPos>

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -74,7 +74,8 @@ class SearchResultSetServiceTest extends IntegrationTest
      */
     public function canGetVariants()
     {
-        $this->indexPageIdsFromFixture('can_get_searchResultSet.xml', [1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $this->indexPageIdsFromFixture('can_get_searchResultSet.xml', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         sleep(1);
         $solrConnection = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\ConnectionManager')
@@ -85,7 +86,7 @@ class SearchResultSetServiceTest extends IntegrationTest
            'search.' =>[
                'variants' => 1,
                'variants.' => [
-                   'variantField' => 'subTitle',
+                   'variantField' => 'pid',
                    'expand' => 1,
                    'limit' => 11
                ]
@@ -93,7 +94,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         ]);
 
         $this->assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
-        $this->assertEquals('subTitle', $typoScriptConfiguration->getSearchVariantsField());
+        $this->assertEquals('pid', $typoScriptConfiguration->getSearchVariantsField());
         $this->assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
 
         $search = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\Search', $solrConnection);
@@ -107,10 +108,16 @@ class SearchResultSetServiceTest extends IntegrationTest
         $searchResultSet = $searchResultsSetService->search($searchRequest);
 
         $searchResults = $searchResultSet->getSearchResults();
-        $firstResult = $searchResults[0];
+        $this->assertSame(3, count($searchResults), 'There should be three results at all');
 
-        // We assume that the first result has three variants.
-        $this->assertSame(3, count($firstResult->getVariants()));
+        // We assume that the first result has one variants.
+        $firstResult = $searchResults[0];
+        $this->assertSame(1, count($firstResult->getVariants()));
+
+        $secondResult = $searchResults[1];
+        $this->assertSame(3, count($secondResult->getVariants()));
+        $this->assertSame('Men Socks', $secondResult->getTitle());
+
 
         // And every variant is indicated to be a variant.
         foreach ($firstResult->getVariants() as $variant) {


### PR DESCRIPTION
This PR fixes the broken test for the variants against solr6

Reason: Only string and numeric fields should be used for field collapsing. In the testcase we used a text field.
This worked in Apache Solr 4.10.4 but not in 6.1.0 and was not intendet to work at all.

Since the error message in Apache Solr is missleading an Issue was created for that:

https://issues.apache.org/jira/browse/SOLR-9409

Because of that, the testcase was changed to use the numeric "pid" field for the grouping.