### PR TITLE
[Task] Update to current schema version

### DIFF
--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/arabic/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/armenian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/basque/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/bulgarian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/burmese/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/catalan/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/chinese/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/czech/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/danish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/dutch/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/english/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/finnish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/french/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/galician/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/general_schema_types.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/general_schema_types.xml
@@ -15,7 +15,7 @@
 		limits compression (if enabled in the derived fields) to values which
 		exceed a certain size (in characters).
 	-->
-	<fieldType name="string"  class="solr.StrField"  sortMissingLast="true" omitNorms="true"/>
+	<fieldType name="string"  class="solr.StrField"  sortMissingLast="true" omitNorms="true" useDocValuesAsStored="false" />
 
 	<!-- boolean type: "true" or "false" -->
 	<fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
@@ -39,10 +39,10 @@
 	<!--
 		Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
 	-->
-	<fieldType name="integer" class="solr.TrieIntField"    precisionStep="0" positionIncrementGap="0" omitNorms="true" />
-	<fieldType name="float"   class="solr.TrieFloatField"  precisionStep="0" positionIncrementGap="0" omitNorms="true" />
-	<fieldType name="long"    class="solr.TrieLongField"   precisionStep="0" positionIncrementGap="0" omitNorms="true" />
-	<fieldType name="double"  class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0" omitNorms="true" />
+	<fieldType name="integer" class="solr.TrieIntField"    precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="float"   class="solr.TrieFloatField"  precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="long"    class="solr.TrieLongField"   precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="double"  class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
 
 	<!--
 		Numeric field types that index each value at various levels of precision
@@ -54,12 +54,12 @@
 		indexed per value, slightly larger index size, and faster range queries.
 		A precisionStep of 0 disables indexing at different precision levels.
 	-->
-	<fieldType name="tint"     class="solr.TrieIntField"    precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" />
-	<fieldType name="tfloat"   class="solr.TrieFloatField"  precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" />
-	<fieldType name="tlong"    class="solr.TrieLongField"   precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" />
-	<fieldType name="tdouble"  class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" />
+	<fieldType name="tint"     class="solr.TrieIntField"    precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
+	<fieldType name="tfloat"   class="solr.TrieFloatField"  precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
+	<fieldType name="tlong"    class="solr.TrieLongField"   precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
+	<fieldType name="tdouble"  class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
 
-	<fieldType name="tdouble4" class="solr.TrieDoubleField" precisionStep="4" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" />
+	<fieldType name="tdouble4" class="solr.TrieDoubleField" precisionStep="4" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
 
 	<!--
 		The format for this date field is of the form 1995-12-31T23:59:59Z, and
@@ -84,7 +84,7 @@
 
 		Note: For faster range queries, consider the tdate type
 	-->
-	<fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0" sortMissingLast="true" omitNorms="true" />
+	<fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0" sortMissingLast="true" omitNorms="true" useDocValuesAsStored="false" />
 
 	<!-- A Trie based date field for faster date range queries and date faceting. -->
 	<fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0" omitNorms="true" />

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/generic/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/german/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/greek/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/hindi/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/hungarian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/indonesian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/italian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/japanese/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/khmer/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/korean/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/lao/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/norwegian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/persian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/polish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/portuguese/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/romanian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/russian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/spanish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/swedish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/thai/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/turkish/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Solr/configsets/ext_solr_6_0_0/conf/ukrainian/schema.xml
+++ b/Resources/Solr/configsets/ext_solr_6_0_0/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-6-0-0--20160725" version="1.5" >
+<schema name="tx_solr-6-0-0--20160725" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should


### PR DESCRIPTION
Updates to schema version 1.6 and sets "useDocValuesAsStored" to false
to prevent behavior changes.

Related: #569