### PR TITLE
[FEATURE] Add hook to manupilate data after they are fetch from database

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -830,6 +830,14 @@ class Queue
                 'uid'
             );
             $tableRecords[$table] = $records;
+
+            if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'])) {
+                $params = ['table' => $table, 'uids' => $uids, 'tableRecords' => &$tableRecords];
+                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'] as $reference) {
+                    GeneralUtility::callUserFunction($reference, $params, $this);
+                }
+                unset($params);
+            }
         }
 
         // creating index queue item objects and assigning / mapping


### PR DESCRIPTION
In some cases you want to index external records for example
products from a ecommerce platform. In this case the records
are not in the TYPO3 database and we need only the id to index
them with our own indexer.