### PR TITLE
[TASK] Backport other runtime fixes for Search.php and FrequentSearches.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_install:
   - composer self-update
   - composer --version
-  - composer global require fabpot/php-cs-fixer
+  - composer global require fabpot/php-cs-fixer:v1.11.6
 
 install: Tests/Build/bootstrap.sh
 script: Tests/Build/cibuild.sh

--- a/Classes/Plugin/FrequentSearches/FrequentSearches.php
+++ b/Classes/Plugin/FrequentSearches/FrequentSearches.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Plugin\FrequentSearches;
 
 use ApacheSolrForTypo3\Solr\CommandResolver;
 use ApacheSolrForTypo3\Solr\Plugin\CommandPluginBase;
+use ApacheSolrForTypo3\Solr\Template;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -83,7 +84,7 @@ class FrequentSearches extends CommandPluginBase
      * Post initialization of the template engine.
      *
      */
-    protected function postInitializeTemplateEngine($template)
+    protected function postInitializeTemplateEngine(Template $template)
     {
         $template->addVariable('tx_solr', $this->getSolrVariables());
 

--- a/Classes/Plugin/Search/Search.php
+++ b/Classes/Plugin/Search/Search.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Plugin\Search;
 
 use ApacheSolrForTypo3\Solr\CommandResolver;
 use ApacheSolrForTypo3\Solr\Plugin\CommandPluginBase;
+use ApacheSolrForTypo3\Solr\Template;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -139,7 +140,7 @@ class Search extends CommandPluginBase
      * Post initialization of the template engine.
      *
      */
-    protected function postInitializeTemplateEngine($template)
+    protected function postInitializeTemplateEngine(Template $template)
     {
         $template->addVariable('tx_solr', $this->getSolrVariables());
 


### PR DESCRIPTION
This pull request backports the runtime notice fixes for Search.php and FrequentSearches.php

The php-cs-fixer was pinned to 1.11.6 since the release was build with this version.