### PR TITLE
[TASK] Pin php-cs-fixer version to v1.11.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
 before_install:
   - composer self-update
   - composer --version
-  - composer global require fabpot/php-cs-fixer
+  - composer global require friendsofphp/php-cs-fixer:v1.11.7
   - composer global require namelesscoder/typo3-repository-client
 
 install:

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -14,10 +14,11 @@ ls -l .Build/bin/
 echo "Run PHP Lint"
 find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
 
-.Build/bin/php-cs-fixer --version > /dev/null 2>&1
+# use from vendor dir
+php-cs-fixer --version > /dev/null 2>&1
 if [ $? -eq "0" ]; then
     echo "Check PSR-2 compliance"
-    .Build/bin/php-cs-fixer fix -v --level=psr2 --dry-run Classes
+    php-cs-fixer fix -v --level=psr2 --dry-run Classes
 
     if [ $? -ne "0" ]; then
         echo "Some files are not PSR-2 compliant"

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "typo3/cms": ">=7.6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=4.8.0 <6.0.0",
-    "fabpot/php-cs-fixer": "~1.11"
+    "phpunit/phpunit": ">=4.8.0 <6.0.0"
   },
   "replace": {
     "solr": "self.version",


### PR DESCRIPTION
* Pinned version to 1.11.7
* Make sure to use php-cs-fixer NOT as require dev dependency an do a global install in .travis.yml
* Use new vendor namespace php php-cs-fixer (friendsofphp)

Fixes: #612