### PR TITLE
[TASK] Removed pin to revision of php-cs-fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
 before_install:
   - composer self-update
   - composer --version
-  - composer global require friendsofphp/php-cs-fixer:v1.11.7
+  - composer global require friendsofphp/php-cs-fixer
   - composer global require namelesscoder/typo3-repository-client
   - sudo update-java-alternatives -s java-8-oracle
 


### PR DESCRIPTION
The PSR-2 violations have allready been fixed by @irnnr in this commit: 

https://github.com/TYPO3-Solr/ext-solr/commit/043dac2862578931727f9b26d98028a63eeab0bd

So we can use the latest version of php-cs-fixer again.

Fixes: #611 