### PR TITLE
[FIX] Check if a solr connection for a found page overlay exists.

### DIFF
--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -133,7 +133,9 @@ class PageIndexer extends Indexer
 
             foreach ($translationOverlays as $overlay) {
                 $languageId = $overlay['sys_language_uid'];
-                $accessibleSolrConnections[$languageId] = $solrConnections[$languageId];
+                if (array_key_exists($languageId, $solrConnections)) {
+                    $accessibleSolrConnections[$languageId] = $solrConnections[$languageId];
+                }
             }
 
             $solrConnections = $accessibleSolrConnections;


### PR DESCRIPTION
getSolrConnectionsByItem tried to add a solr connection for every page
overlay found as an accessible solr connection, even non-existing ones.
This patch checks, if a solr connection for a language id actually exists
before adding it to the accessible connections array.

Fixes ext-solr issue #233.