### PR TITLE
[TASK] Replace usages of deprecated method cObj->fileResource

### DIFF
--- a/Classes/Plugin/Results/PageBrowser.php
+++ b/Classes/Plugin/Results/PageBrowser.php
@@ -67,7 +67,10 @@ class PageBrowser
         $this->pagesBefore = (int)$configuration['pagesBefore'];
         $this->pagesAfter = (int)$configuration['pagesAfter'];
 
-        $this->template = $this->contentObject->fileResource($configuration['templateFile']);
+        $path = $GLOBALS['TSFE']->tmpl->getFileName($configuration['templateFile']);
+        if ($path !== null && file_exists($path)) {
+            $this->template = file_get_contents($path);
+        }
     }
 
     /**

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -101,8 +101,10 @@ class Template
      */
     public function loadHtmlFile($htmlFile)
     {
-        $this->template = $this->cObj->fileResource($htmlFile);
-
+        $path = $GLOBALS['TSFE']->tmpl->getFileName($htmlFile);
+        if ($path !== null && file_exists($path)) {
+            $this->template = file_get_contents($path);
+        }
         if (empty($this->template)) {
             throw new \RuntimeException(
                 'Could not load template file "' . htmlspecialchars($htmlFile) . '"',


### PR DESCRIPTION
The method ContentObjectRenderer::fileResource has been marked
as deprecated and should not be used anymore.

Resolves: https://github.com/TYPO3-Solr/ext-solr/issues/665