### PR TITLE
[TASK] Clear the sitePagesCache

### DIFF
--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -182,6 +182,15 @@ class Site
     }
 
     /**
+     * Clears the $sitePagesCache
+     *
+     */
+    public static function clearSitePagesCache()
+    {
+        self::$sitePagesCache = array();
+    }
+
+    /**
      * Gets the site's root page ID (uid).
      *
      * @return int The site's root page ID.


### PR DESCRIPTION
When processing multisites - you need to be able to clear the sitePagesCache - between each iterations or else the pages to be indexed will be mixed up