### PR TITLE
[FEATURE] Add updateConnections available through CommandController

### DIFF
--- a/Classes/Command/SolrCommandController.php
+++ b/Classes/Command/SolrCommandController.php
@@ -1,0 +1,33 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Command;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
+
+/**
+ * Controller to run solr specific tasks via CLI
+ */
+class SolrCommandController extends CommandController
+{
+    /**
+     * Update EXT:solr connections
+     */
+    public function updateConnectionsCommand()
+    {
+        $connectionManager = GeneralUtility::makeInstance(\ApacheSolrForTypo3\Solr\ConnectionManager::class);
+        $connectionManager->updateConnections();
+        $this->outputLine('<info>EXT:solr connections are updated in the registry.</info>');
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -313,6 +313,8 @@ if (TYPO3_MODE == 'BE') {
     );
 }
 
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \ApacheSolrForTypo3\Solr\Command\SolrCommandController::class;
+
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '])) {


### PR DESCRIPTION
Make updateConnections task available through the Extbase CommandController
without adding a "_cli_solr" TYPO3 backend user.

This is useful e.g. as a task after syncing database from production to stage/dev
environment where the solr connections are different (TYPO3_CONTEXT).