### PR TITLE
Make rendering errors better readable in the backend

### DIFF
--- a/Resources/Private/Templates/IndexQueueModule/ShowError.html
+++ b/Resources/Private/Templates/IndexQueueModule/ShowError.html
@@ -4,9 +4,9 @@
 
 <f:if condition="{indexQueueItem.errors}">
     <p><f:translate key="solr.backend.index_queue_module.error_details"/> (uid: {indexQueueItem.uid}, type: {indexQueueItem.item_type}):</p>
-    <div class="alert alert-danger">
+    <pre class="alert alert-danger">
         {indexQueueItem.errors}
-    </div>
+    </pre>
 
     <f:link.action arguments="{module: 'IndexQueue'}" controller="Administration">
         <f:translate key="solr.backend.index_queue_module.back"/>


### PR DESCRIPTION
Render indexing errors in a pre tag to make them better readable as
linebreaks and whitespaces are interpreted.