### PR TITLE
[BUGFIX] use TypoScript configuration object for plugin baseWrap

### DIFF
--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -158,9 +158,10 @@ abstract class PluginBase extends AbstractPlugin
      */
     protected function baseWrap($content)
     {
-        if (isset($this->conf['general.']['baseWrap.'])) {
+        $baseWrap = $this->typoScriptConfiguration->getObjectByPath('plugin.tx_solr.general.baseWrap.');
+        if (isset($baseWrap)) {
             return $this->cObj->stdWrap($content,
-                $this->conf['general.']['baseWrap.']);
+                $baseWrap);
         } else {
             return $this->pi_wrapInBaseClass($content);
         }


### PR DESCRIPTION
The baseWrap function still used the old way to access the TypoScript configuration. This patch makes use of the TypoScript configuration object to make the baseWrap functional again.