### PR TITLE
[TASK] Refactor usage of getMonitoredTables in TypoScriptConfiguration

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -389,6 +389,40 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Gets an array of tables configured for indexing by the Index Queue. Since the
+     * record monitor must watch these tables for manipulation.
+     *
+     * @return array Array of table names to be watched by the record monitor.
+     */
+    public function getIndexQueueMonitoredTables()
+    {
+        $monitoredTables = [];
+
+        $indexingConfigurations =  $this->getEnabledIndexQueueConfigurationNames();
+        foreach ($indexingConfigurations as $indexingConfigurationName) {
+            $monitoredTable = $this->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
+            $monitoredTables[] = $monitoredTable;
+            if ($monitoredTable == 'pages') {
+                // when monitoring pages, also monitor creation of translations
+                $monitoredTables[] = 'pages_language_overlay';
+            }
+        }
+
+        return array_values(array_unique($monitoredTables));
+    }
+
+    /**
+     * This method can be used to check if a table is configured to be monitored by the record monitor.
+     *
+     * @param string $tableName
+     * @return boolean
+     */
+    public function getIndexQueueIsMonitoredTable($tableName)
+    {
+        return in_array($tableName, $this->getIndexQueueMonitoredTables(), true);
+    }
+
+    /**
      * Returns the configured indexer class that should be used for a certain indexingConfiguration.
      * By default "ApacheSolrForTypo3\\Solr\\IndexQueue\\Indexer" will be returned.
      *
@@ -1839,28 +1873,5 @@ class TypoScriptConfiguration
     {
         $sortingViewHelperConfiguration = $this->getObjectByPathOrDefault('plugin.tx_solr.viewHelpers.sortIndicator.', $defaultIfEmpty);
         return $sortingViewHelperConfiguration;
-    }
-
-    /**
-     * Gets an array of tables configured for indexing by the Index Queue. Since the
-     * record monitor must watch these tables for manipulation.
-     *
-     * @return array Array of table names to be watched by the record monitor.
-     */
-    public function getMonitoredTables()
-    {
-        $monitoredTables = array();
-
-        $indexingConfigurations =  $this->getEnabledIndexQueueConfigurationNames();
-        foreach ($indexingConfigurations as $indexingConfigurationName) {
-            $monitoredTable = $this->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
-            $monitoredTables[] = $monitoredTable;
-            if ($monitoredTable == 'pages') {
-                // when monitoring pages, also monitor creation of translations
-                $monitoredTables[] = 'pages_language_overlay';
-            }
-        }
-
-        return array_unique($monitoredTables);
     }
 }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -278,6 +278,73 @@ class TypoScriptConfigurationTest extends UnitTest
     /**
      * @test
      */
+    public function canGetIndexQueueMonitoredTables()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'tx_model_news' => 1,
+                    'tx_model_news.' => array(
+                    ),
+                    'custom_one' => 1,
+                    'custom_one.' => array(
+                        'table' => 'tx_model_bar'
+                    ),
+
+                    'custom_two' => 1,
+                    'custom_two.' => array(
+                        'table' => 'tx_model_news'
+                    ),
+                    'pages' => 1,
+                    'pages.' => array()
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $monitoredTables =  $configuration->getIndexQueueMonitoredTables();
+        $this->assertEquals(array('tx_model_news', 'tx_model_bar', 'pages', 'pages_language_overlay'), $monitoredTables);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueueIsMonitoredTable()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = array(
+            'index.' => array(
+                'queue.' => array(
+                    'tx_model_news' => 1,
+                    'tx_model_news.' => array(
+                    ),
+                    'custom_one' => 1,
+                    'custom_one.' => array(
+                        'table' => 'tx_model_bar'
+                    ),
+
+                    'custom_two' => 1,
+                    'custom_two.' => array(
+                        'table' => 'tx_model_news'
+                    ),
+                    'pages' => 1,
+                    'pages.' => array()
+                )
+            )
+        );
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $this->assertFalse($configuration->getIndexQueueIsMonitoredTable('tx_mycustom_table2'), 'tx_mycustom_table2 was not expected to be monitored');
+
+        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('pages'), 'pages was expected to be monitored');
+        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('pages_language_overlay'), 'pages_language_overlay was expected to be monitored');
+        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_bar'), 'tx_model_bar was expected to be monitored');
+        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_news'), 'tx_model_news was expected to be monitored');
+    }
+
+    /**
+     * @test
+     */
     public function canGetLoggingEnableStateForIndexQueueByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = array(


### PR DESCRIPTION
* Rename method getMonitoredTables to getIndexQueueMonitoredTables
* Add new method getIndexQueueIsMonitoredTable and use it in the RecordMonitor
* Refactored RecordMonitor to return immediatly when a non monitored record is handled.

Follow up for: #714