### PR TITLE
[FEATURE] Make it possible to define facet.limit

### DIFF
--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -770,6 +770,7 @@ class Query
         if ($faceting) {
             $this->queryParameters['facet'] = 'true';
             $this->queryParameters['facet.mincount'] = $this->solrConfiguration->getSearchFacetingMinimumCount();
+            $this->queryParameters['facet.limit'] = $this->solrConfiguration->getSearchFacetingFacetLimit();
 
             $this->applyConfiguredFacetSorting();
         } else {

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1694,7 +1694,7 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Return the configured limit value for facets.
+     * Return the configured limit value for facets, used for displaying.
      *
      * plugin.tx_solr.search.faceting.limit
      *
@@ -1704,6 +1704,19 @@ class TypoScriptConfiguration
     public function getSearchFacetingLimit($defaultIfEmpty = 10)
     {
         return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.faceting.limit', $defaultIfEmpty);
+    }
+
+    /**
+     * Return the configured limit value for facets, used for the response.
+     *
+     * plugin.tx_solr.search.faceting.facetLimit
+     *
+     * @param int $defaultIfEmpty
+     * @return int
+     */
+    public function getSearchFacetingFacetLimit($defaultIfEmpty = 100)
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.faceting.facetLimit', $defaultIfEmpty);
     }
 
     /**

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -758,6 +758,17 @@ faceting.limit
 
 Number of options to display per facet. If more options are returned by Solr, they are hidden and can be expanded by clicking a "show more" link. This feature uses a small javascript function to collapse/expand the additional options.
 
+faceting.facetLimit
+~~~~~~~~~~~~~~~~~~~
+
+:Type: Integer
+:TS Path: plugin.tx_solr.search.faceting.facetLimit
+:Since: 6.0
+:Default: 100
+
+    Number of options of a facet returned from solr.
+
+
 faceting.singleFacetMode
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Make the number of facet options configurable. Especially if
using a bigger hierarchical facet, the default limit of 100 can
be too low which would lead to an incomplete rendering.

By using plugin.tx_solr.search.faceting.facetLimit, the limit can be
now configured.

Resolves: #724