### PR TITLE
[BUGFIX] Set escapeOutput to false for ViewHelpers in Backend

### DIFF
--- a/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
@@ -35,6 +35,13 @@ class CoreSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
 {
 
     /**
+     * As this ViewHelper renders HTML, the output must not be escaped.
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @var string
      */
     protected $tagName = 'select';
@@ -84,8 +91,8 @@ class CoreSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
                 $selectedAttribute = ' selected="selected"';
             }
 
-            $options .= '<option value="' . $core->getPath() . '"' . $selectedAttribute . '>'
-                . $core->getPath()
+            $options .= '<option value="' . htmlspecialchars($core->getPath()) . '"' . $selectedAttribute . '>'
+                . htmlspecialchars($core->getPath())
                 . '</option>';
         }
 

--- a/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
@@ -35,6 +35,13 @@ class SiteSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
 {
 
     /**
+     * As this ViewHelper renders HTML, the output must not be escaped.
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @var string
      */
     protected $tagName = 'select';
@@ -74,8 +81,8 @@ class SiteSelectorMenuViewHelper extends AbstractSolrTagBasedViewHelper
                 $selectedAttribute = ' selected="selected"';
             }
 
-            $options .= '<option value="' . $site->getRootPageId() . '"' . $selectedAttribute . '>'
-                . $site->getLabel()
+            $options .= '<option value="' . htmlspecialchars($site->getRootPageId()) . '"' . $selectedAttribute . '>'
+                . htmlspecialchars($site->getLabel())
                 . '</option>';
         }
 


### PR DESCRIPTION
As the Backend ViewHelpers outpout HTML, it's content must not be escaped.