### PR TITLE
[TASK] Prevent SQL hammering in getConfigurationFromPageId

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -246,6 +246,13 @@ class Util
         $language = 0,
         $useCache = true
     ) {
+        static $configurationsByCacheKey = array();
+        $cacheId = md5($pageId . '|' . $path . '|' . $language);
+
+        if (isset($configurationsByCacheKey[$cacheId])) {
+            return $configurationsByCacheKey[$cacheId];
+        }
+
         // If we're on UID 0, we cannot retrieve a configuration currently.
         // getRootline() below throws an exception (since #typo3-60 )
         // as UID 0 cannot have any parent rootline by design.
@@ -254,7 +261,6 @@ class Util
         }
 
         if ($useCache) {
-            $cacheId = md5($pageId . '|' . $path . '|' . $language);
             $cache = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache', 'tx_solr_configuration');
             $configurationToUse = $cache->get($cacheId);
         }
@@ -276,7 +282,7 @@ class Util
             $cache->set($cacheId, $configurationToUse);
         }
 
-        return self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
+        return $configurationsByCacheKey[$cacheId] = self::buildTypoScriptConfigurationFromArray($configurationToUse, $pageId, $language, $path);
     }
 
     /**


### PR DESCRIPTION
This change implements a memoizer to remember each resolved
TS configuration array based on input arguments. During certain
RecordMonitor operations the SQL database gets hammered with
repeated requests to retrieve the exact same SQL resource (and
parse the result using semi-expensive logic). E.g. when indexing
multiple records on the same page.

Since TS output is the same for any page ID + language + path,
always, the problem can be solved by remembering the output
in the Util::getConfigurationFromPageId.