### PR TITLE
[TASK] Remove usage of deprecated renderCharset

### DIFF
--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -124,9 +124,8 @@ class Typo3PageIndexer
         }
 
         $this->contentExtractor = GeneralUtility::makeInstance(
-            'ApacheSolrForTypo3\\Solr\\Typo3PageContentExtractor',
-            $this->page->content,
-            $this->page->renderCharset
+            Typo3PageContentExtractor::class,
+            $this->page->content
         );
 
         $this->pageAccessRootline = GeneralUtility::makeInstance(


### PR DESCRIPTION
The code can be cleaned up by removing usage of $this->page->renderCharset.

- The 2nd argument of the constructor has been removed years ago
- The renderCharset has been marked as deprecated

Resolves: #733