### PR TITLE
[TASK] Avoid schema retrieval on every call

### DIFF
--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -186,7 +186,7 @@ class SolrService extends \Apache_Solr_Service
     /**
      * Returns the current time in milliseconds.
      *
-     * @return int
+     * @return double
      */
     protected function getMilliseconds()
     {
@@ -741,7 +741,7 @@ class SolrService extends \Apache_Solr_Service
     /**
      * Add list of synonyms for base word to managed synonyms map
      *
-     * @param $baseWord
+     * @param string $baseWord
      * @param array $synonyms
      *
      * @return \Apache_Solr_Response
@@ -759,7 +759,7 @@ class SolrService extends \Apache_Solr_Service
     /**
      * Remove a synonym from the synonyms map
      *
-     * @param $baseWord
+     * @param string $baseWord
      * @return \Apache_Solr_Response
      * @throws \Apache_Solr_InvalidArgumentException
      */
@@ -776,7 +776,7 @@ class SolrService extends \Apache_Solr_Service
     /**
      * Central method for making a HTTP DELETE operation against the Solr server
      *
-     * @param $url
+     * @param string $url
      * @param bool|float $timeout Read timeout in seconds
      * @return \Apache_Solr_Response
      */

--- a/Classes/System/Solr/Service/StopWordParser.php
+++ b/Classes/System/Solr/Service/StopWordParser.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\System\Solr\Service;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Hund <timo.hund@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+/**
+ * Class to parse the stopwords from a solr response.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class StopWordParser
+{
+
+    /**
+     * Parse the solr stopwords response from an json string to an array.
+     *
+     * @param string $jsonString
+     * @return array
+     */
+    public function parseJson($jsonString)
+    {
+        $stopWords = [];
+
+        $decodedResponse = json_decode($jsonString);
+
+        if (isset($decodedResponse->wordSet->managedList)) {
+            $stopWords = (array)$decodedResponse->wordSet->managedList;
+        }
+
+        return $stopWords;
+    }
+
+    /**
+     * @param string|array $stopWords
+     * @return string
+     * @throws \Apache_Solr_InvalidArgumentException
+     */
+    public function toJson($stopWords)
+    {
+        if (empty($stopWords)) {
+            throw new \Apache_Solr_InvalidArgumentException('Must provide stop word.');
+        }
+
+        if (is_string($stopWords)) {
+            $stopWords = [$stopWords];
+        }
+
+        $stopWords = array_values($stopWords);
+        return json_encode($stopWords);
+    }
+}

--- a/Classes/System/Solr/Service/SynonymParser.php
+++ b/Classes/System/Solr/Service/SynonymParser.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\System\Solr\Service;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Hund <timo.hund@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+
+/**
+ * Class to parse the synonyms from a solr response.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SynonymParser
+{
+
+    /**
+     * Parse the solr synonyms response from an json string to an array.
+     *
+     * @param string $baseWord
+     * @param string $jsonString
+     * @return array
+     */
+    public function parseJson($baseWord, $jsonString)
+    {
+        $decodedResponse = json_decode($jsonString);
+        $synonyms = [];
+        if (!empty($baseWord)) {
+            if (is_array($decodedResponse->{$baseWord})) {
+                $synonyms = $decodedResponse->{$baseWord};
+            }
+        } else {
+            if (isset($decodedResponse->synonymMappings->managedMap)) {
+                $synonyms = (array)$decodedResponse->synonymMappings->managedMap;
+            }
+        }
+
+        return $synonyms;
+    }
+
+    /**
+     * @param string $baseWord
+     * @param array $synonyms
+     * @return string
+     * @throws \Apache_Solr_InvalidArgumentException
+     */
+    public function toJson($baseWord, $synonyms)
+    {
+        if (empty($baseWord) || empty($synonyms)) {
+            throw new \Apache_Solr_InvalidArgumentException('Must provide base word and synonyms.');
+        }
+
+        return json_encode([$baseWord => $synonyms]);
+    }
+}

--- a/Classes/ViewHelpers/AbstractSolrTagBasedViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrTagBasedViewHelper.php
@@ -1,10 +1,11 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Button;
+
+namespace ApacheSolrForTypo3\Solr\ViewHelpers;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -24,34 +25,18 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Button;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrViewHelper;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
-/**
- * View helper to return a help button
- *
- */
-class HelpButtonViewHelper extends AbstractSolrViewHelper
+abstract class AbstractSolrTagBasedViewHelper extends AbstractTagBasedViewHelper
 {
 
     /**
      * @var bool
      */
-    protected $escapeOutput = false;
+    protected $escapeChildren = true;
 
     /**
-     * Render a help button wit the given title and content
-     *
-     * @param string $title Help title
-     * @return mixed
+     * @var bool
      */
-    public function render($title)
-    {
-        $content = $this->renderChildren();
-
-        return BackendUtility::wrapInHelp('', '', '', array(
-            'title' => $title,
-            'description' => $content
-        ));
-    }
+    protected $escapeOutput = true;
 }

--- a/Classes/ViewHelpers/AbstractSolrViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
+namespace ApacheSolrForTypo3\Solr\ViewHelpers;
 
 /***************************************************************
  *  Copyright notice

--- a/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/CoreSelectorMenuViewHelper.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Menu;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrTagBasedViewHelper;
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrTagBasedViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**

--- a/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Menu/SiteSelectorMenuViewHelper.php
@@ -25,7 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Menu;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Site;
-use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrTagBasedViewHelper;
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrTagBasedViewHelper;
 
 /**
  * Site selector menu view helper

--- a/Classes/ViewHelpers/Format/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/ImplodeViewHelper.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\ViewHelpers\Format;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+
+/**
+ * ViewHelper to implode an array with a specific glue value.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ImplodeViewHelper extends AbstractSolrViewHelper implements CompilableInterface
+{
+    /**
+     * This ViewHelper can be used to implode the values of an array into one string.
+     *
+     * @param string $glue The glue value that should be used on implode
+     * @param array $value The array that should be imploded.
+     * @return string
+     */
+    public function render($glue = ',', $value = [])
+    {
+        return static::renderStatic(
+            ['glue' => $glue, 'value' => $value],
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $glue = isset($arguments['glue']) ? $arguments['glue'] : ',';
+        $value = isset($arguments['value']) ? $arguments['value'] : [];
+
+        return implode($glue, $value);
+    }
+}

--- a/Resources/Private/Templates/StopWordsModule/Index.html
+++ b/Resources/Private/Templates/StopWordsModule/Index.html
@@ -25,8 +25,7 @@
 			<f:form actionUri="{f:uri.action(controller:'Administration', arguments:{module:'{module.name}', moduleAction:'saveStopWords'} )}"
 					id="edit-stopwords">
 				<textarea name="tx_solr_tools_solradministration[stopWords]"
-					rows="20" cols="50" style="width: auto;"><f:for each="{stopWords}" as="stopWord">{stopWord}
-		</f:for></textarea>
+					rows="20" cols="50" style="width: auto;"><solr:format.implode glue="&#013;&#010;" value="{stopWords}"/></textarea>
 
 				<div class="submit">
 					<f:form.submit value="Save Stop Word List" class="btn btn-sm btn-default"/>

--- a/Tests/Unit/SolrServiceTest.php
+++ b/Tests/Unit/SolrServiceTest.php
@@ -52,7 +52,7 @@ class SolrServiceTest extends UnitTest
         $transportMock->expects($this->once())->method('performGetRequest')->will($this->returnValue($responseMock));
 
             /** @var $solrService SolrService */
-        $solrService = $this->getMockBuilder(SolrService::class)->setMethods(['getHttpTransport','_initUrls'])->setConstructorArgs([
+        $solrService = $this->getMockBuilder(SolrService::class)->setMethods(['getHttpTransport'])->setConstructorArgs([
             'test',
             8983,
             '/solr/',
@@ -84,7 +84,7 @@ class SolrServiceTest extends UnitTest
         $transportMock->expects($this->exactly(2))->method('performGetRequest')->will($this->returnValue($responseMock));
 
         /** @var $solrService SolrService */
-        $solrService = $this->getMockBuilder(SolrService::class)->setMethods(['getHttpTransport','_initUrls'])->setConstructorArgs([
+        $solrService = $this->getMockBuilder(SolrService::class)->setMethods(['getHttpTransport'])->setConstructorArgs([
             'test',
             8983,
             '/solr/',

--- a/Tests/Unit/ViewHelpers/Format/ImplodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/ImplodeViewHelperTest.php
@@ -1,6 +1,5 @@
 <?php
-
-namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Format;
 
 /***************************************************************
  *  Copyright notice
@@ -25,18 +24,26 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Format\ImplodeViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
-abstract class AbstractSolrTagBasedViewHelper extends AbstractTagBasedViewHelper
+
+/**
+ * Testcase for the ImplodeViewHelper
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ImplodeViewHelperTest extends UnitTest
 {
-
     /**
-     * @var bool
+     * @test
      */
-    protected $escapeChildren = true;
-
-    /**
-     * @var bool
-     */
-    protected $escapeOutput = true;
+    public function canImplode() {
+        $viewHelper = new ImplodeViewHelper();
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $viewHelper->setRenderingContext($renderingContextMock);
+        $result = $viewHelper->render(',', ['one','two','three']);
+        $this->assertSame('one,two,three', $result, 'Implode ViewHelper created unexpected result');
+    }
 }


### PR DESCRIPTION
* This pull request refactors the SolrService to initialize StopWords and Synonyms endpoints only when they are needed.
* The result is, that the schema will only be retrieved when it's needed in the backend.
* Beside that a bug was fixed, that the stopwords in the backend have beend rendered with additional whitespaces

Fixes: #775