### PR TITLE
[BUGFIX] Fix class name error AbstractSolrViewHelper in SitesViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Backend/SitesViewHelper.php
+++ b/Classes/ViewHelpers/Backend/SitesViewHelper.php
@@ -37,7 +37,7 @@ use ApacheSolrForTypo3\Solr\Site;
  *      </f:if>
  * </solr:backend.sites>
  */
-class SitesViewHelper extends AbstractSolrViewHelper
+class SitesViewHelper extends AbstractSolrBackendViewHelper
 {
     /**
      * @var \ApacheSolrForTypo3\Solr\Service\ModuleDataStorageService


### PR DESCRIPTION
Fix: Class 'ApacheSolrForTypo3\Solr\ViewHelpers\Backend\AbstractSolrViewHelper' not found in solr/Classes/ViewHelpers/Backend/SitesViewHelper.php on line 40