### PR TITLE
[BUGFIX] Add missing field facet_counts to faked empty search response

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -379,6 +379,8 @@ class SearchResultSetService implements SingletonInterface
             $response->spellcheck = [];
             $response->debug = [];
             $response->responseHeader = [];
+            $response->facet_counts = [];
+
             $documents = [];
         }
 


### PR DESCRIPTION
* Add the field facet_counts to the empty fake respone

Followup of: #803