### PR TITLE
[TASK] Add renderingInstruction for dates as options

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Hendrik Putzek <hendrik.putzek@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Formats a given date string to another format
+ *
+ * Accepted typoscript parameters:
+ * inputFormat -> The format of the input string
+ * outputFormat -> The format of the processed string (output)
+ *
+ * If the input date can not be processed by the given inputFormat string it is
+ * returned unprocessed.
+ *
+ * @author Hendrik Putzek <hendrik.putzek@dkd.de>
+ */
+class FormatDate
+{
+
+    /**
+     * @var FormatService
+     */
+    protected $formatService = null;
+
+    /**
+     * FormatDate constructor.
+     * @param FormatService|null $formatService
+     */
+    public function __construct(FormatService $formatService = null)
+    {
+        $this->formatService = is_null($formatService) ? GeneralUtility::makeInstance(FormatService::class) : $formatService;
+    }
+
+    /**
+     * Formats a given date string to another format
+     *
+     * @param   string $content the content to process
+     * @param   array $conf typoscript configuration
+     * @return  string formatted  date
+     */
+    public function format($content, $conf)
+    {
+        // set default values
+        $inputFormat = $conf['inputFormat'] ?: 'Y-m-d\TH:i:s\Z';
+        $outputFormat = $conf['outputFormat'] ?: '';
+        return $this->formatService->format($content, $inputFormat, $outputFormat);
+    }
+}

--- a/Classes/System/DateTime/FormatService.php
+++ b/Classes/System/DateTime/FormatService.php
@@ -1,0 +1,78 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\DateTime;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011-2016 Timo Schmidt <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Testcase to check if the configuration object can be used as expected
+ *
+ * @author Hendrik Putzek <hendrik.putzek@dkd.de>
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class FormatService
+{
+
+    /**
+     * @see http://php.net/manual/de/function.date.php for formatting options
+     * @param string $input the passed date string
+     * @param string $inputFormat the input format that should be used for parsing
+     * @param string $outputFormat The output format, when nothing is passed
+     * $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] will be used or Y-m-d when nothing is configured
+     * @param DateTimeZone $timezone
+     * @return \DateTime|string
+     */
+    public function format($input = '', $inputFormat = 'Y-m-d\TH:i:s\Z', $outputFormat = '', $timezone = null)
+    {
+        if ($outputFormat === '') {
+            // when no value was passed we us the TYPO3 configured or fallback to Y-m-d
+            $outputFormat = $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] ?: 'Y-m-d';
+        }
+
+        // try to create DateTime object
+        $timezone = is_null($timezone) ?  new DateTimeZone(date_default_timezone_get()) : $timezone;
+        return $this->getFormattedDate($input, $inputFormat, $outputFormat, $timezone);
+    }
+
+    /**
+     * Applies the formatting using DateTime.
+     *
+     * @param string $input
+     * @param string $inputFormat
+     * @param string $outputFormat
+     * @param DateTimeZone $timezone
+     * @return \DateTime|string
+     */
+    protected function getFormattedDate($input, $inputFormat, $outputFormat, DateTimeZone $timezone)
+    {
+        $formattedDate = DateTime::createFromFormat($inputFormat, $input, $timezone);
+        if ($formattedDate) {
+            return $formattedDate->format($outputFormat);
+        }
+
+        return $input;
+    }
+}

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1208,6 +1208,34 @@ Example: (taken from issue #5920)
         }
     }
 
+
+EXT:solr provides the following renderingInstructions that you can use in your project:
+
+**FormatDate**:
+
+This rendering instruction can be used in combination with a date field or an integer field that hold a timestamp. You can use this rendering instruction to format the facet value on rendering.
+A common usecase for this is, when the datatype in solr needs to be sortable (date or int) but you need to render the date as readable date option in the frontend:
+
+
+|
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.faceting.facets {
+        created {
+            field = created
+            label = Created
+            sortBy = alpha
+            reverseOrder = 1
+            renderingInstruction = TEXT
+            renderingInstruction {
+               field = optionValue
+               postUserFunc = ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate->format
+            }
+        }
+    }
+
+
 faceting.facets.[facetName].facetLinkATagParams
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Releases/solr release 6.0.md
+++ b/Documentation/Releases/solr release 6.0.md
@@ -223,6 +223,28 @@ plugin.tx_solr.solr.timeout = 20
 
 * https://github.com/TYPO3-Solr/ext-solr/pull/798
 
+### Rendering Instruction for DateFormatting
+
+The following rendering instruction can be used, when you want to format a date as option facet and store it as date or timestamp.
+
+```
+plugin.tx_solr.search.faceting.facets.created {
+   field = created
+   label = Created
+   sortBy = alpha
+   reverseOrder = 1
+   renderingInstruction = TEXT
+   renderingInstruction {
+      field = optionValue
+      postUserFunc = ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate->format
+   }
+}
+```
+
+**Related PRs:**
+
+* https://github.com/TYPO3-Solr/ext-solr/pull/829
+
 ## Bugfixes
 
 The following bugs have been fixed in this release.
@@ -262,6 +284,7 @@ awesome community. Here are the contributors for this release.
 * Daniel Siepmann
 * Dominique Kreemers
 * Georg Ringer
+* Hendrik Putzek
 * Ingo Renner
 * Josef Glatz
 * Markus Friedrich

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class FormatDateTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canFormatUsingDefaultFormat()
+    {
+        $processingInstruction = new FormatDate();
+        $result = $processingInstruction->format('2015-11-17T17:16:10Z', []);
+        $this->assertSame('17-11-15', $result, 'Could not format date with default format');
+    }
+
+    /**
+     * @test
+     */
+    public function canPassCustomOutputFormat()
+    {
+        $processingInstruction = new FormatDate();
+        $result = $processingInstruction->format('2015-11-17T17:16:10Z', ['outputFormat' => 'd.m.Y']);
+        $this->assertSame('17.11.2015', $result, 'Could not format date with default format');
+    }
+
+    /**
+     * @test
+     */
+    public function canParseTimestampAsInputValue()
+    {
+        $processingInstruction = new FormatDate();
+        $fiveDays = (60 * 60 * 24 * 5) - 1;
+        $result = $processingInstruction->format((string) $fiveDays, ['inputFormat' => 'U', 'outputFormat' => 'd.m.Y']);
+        $this->assertSame('05.01.1970', $result, 'Could not format date from timestamp');
+    }
+}


### PR DESCRIPTION
This PR adds a rendering instruction, that can be used to format dates when they are used in option facets.

Fixes: #828