### PR TITLE
[BUGFIX] Allow custom fields for own page index configuration.

### DIFF
--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_custom_pagetype_into_solr.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_custom_pagetype_into_solr.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text
+                                }
+                            }
+
+                            mytype < pages
+                            mytype {
+                                allowedPageTypes = 130
+                                additionalWhereClause = doktype = 130
+                                fields {
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text from custom page type
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello solr</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>mytype</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -67,6 +67,24 @@ class PageIndexerTest extends IntegrationTest
     /**
      * @test
      */
+    public function canIndexPageWithCustomPageTypeIntoSolr()
+    {
+        $this->importDataSetFromFixture('can_index_custom_pagetype_into_solr.xml');
+
+        $this->executePageIndexer();
+
+        // we wait to make sure the document will be available in solr
+        $this->waitToBeVisibleInSolr();
+
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+        $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"custom_stringS":"my text from custom page type"', $solrContent, 'Document does not contains value build with typoscript');
+    }
+
+    /**
+     * @test
+     */
     public function canIndexPageIntoSolrWithAdditionalFields()
     {
         //@todo additional fields indexer requires the hook to be activated which is normally done in ext_localconf.php


### PR DESCRIPTION
When a custom page index configuration is used, that defines custom fields that differ from the pages configuration they have not been recognized because the default configuration of pages was used.
This PR fixes this and adds an integration test for the PageIndexer.

Fixes: #842