### PR TITLE
[BUGFIX] hierarchical fields need to add trailing slash

### DIFF
--- a/Classes/Facet/HierarchicalFacetHelper.php
+++ b/Classes/Facet/HierarchicalFacetHelper.php
@@ -120,7 +120,7 @@ class HierarchicalFacetHelper
     {
         $menu = array();
 
-        $subMenuEntryPrefix = $level . '-' . $menuName . '/';
+        $subMenuEntryPrefix = $level . '-' . $menuName;
 
         foreach ($facetOptions as $facetOptionKey => $facetOption) {
             // find the sub menu items for the current menu
@@ -142,7 +142,7 @@ class HierarchicalFacetHelper
                 // move one level down (recursion)
                 $subMenu = $this->getSubMenu(
                     $facetOptions,
-                    $menuName . '/' . $lastPathSegment,
+                    $menuName . $lastPathSegment . '/',
                     $level + 1
                 );
                 if (!empty($subMenu)) {

--- a/Classes/Facet/HierarchicalFacetRenderer.php
+++ b/Classes/Facet/HierarchicalFacetRenderer.php
@@ -159,7 +159,7 @@ class HierarchicalFacetRenderer extends AbstractFacetRenderer
         $facetOptionKey = trim($facetOptionKey, '"');
         list(, $path) = explode('-', $facetOptionKey, 2);
 
-        $explodedPath = explode('/', $path);
+        $explodedPath = explode('/', rtrim($path, '/'));
         $lastPathSegment = $explodedPath[count($explodedPath) - 1];
 
         return $lastPathSegment;

--- a/Classes/FieldProcessor/AbstractHierarchyProcessor.php
+++ b/Classes/FieldProcessor/AbstractHierarchyProcessor.php
@@ -50,12 +50,12 @@ abstract class AbstractHierarchyProcessor
         }
 
         foreach ($idRootline as $uid) {
-            $hierarchy[] = $depth . '-' . $currentPath;
+            $hierarchy[] = $depth . '-' . $currentPath . '/';
 
             $depth++;
             $currentPath .= '/' . $uid;
         }
-        $hierarchy[] = $depth . '-' . $currentPath;
+        $hierarchy[] = $depth . '-' . $currentPath . '/';
 
         return $hierarchy;
     }

--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -43,10 +43,10 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
  *
  * In Solr hierarchy notation, we get
  *
- * 0-1
- * 1-1/10
- * 2-1/10/100
- * 3-1/10/100/11
+ * 0-1/
+ * 1-1/10/
+ * 2-1/10/100/
+ * 3-1/10/100/11/
  *
  * which is finally saved in a multi-value field.
  *

--- a/Classes/FieldProcessor/PathToHierarchy.php
+++ b/Classes/FieldProcessor/PathToHierarchy.php
@@ -69,7 +69,7 @@ class PathToHierarchy implements FieldProcessor
         foreach ($treeParts as $i => $part) {
             $currentTreeParts[] = $part;
 
-            $hierarchy[] = $i . '-' . implode('/', $currentTreeParts);
+            $hierarchy[] = $i . '-' . implode('/', $currentTreeParts) . '/';
         }
 
         return $hierarchy;

--- a/Classes/Query/FilterEncoder/Hierarchy.php
+++ b/Classes/Query/FilterEncoder/Hierarchy.php
@@ -64,9 +64,10 @@ class Hierarchy implements FilterEncoder
     public function decodeFilter($hierarchy, array $configuration = array())
     {
         $hierarchy = substr($hierarchy, 1);
+        $hierarchy = rtrim($hierarchy, '/');
         $hierarchyItems = explode(self::DELIMITER, $hierarchy);
 
-        $hierarchyFilter = '"' . (count($hierarchyItems) - 1) . '-' . $hierarchy . '"';
+        $hierarchyFilter = '"' . (count($hierarchyItems) - 1) . '-' . $hierarchy . '/"';
 
         return $hierarchyFilter;
     }

--- a/Tests/Integration/Plugin/Results/ResultsTest.php
+++ b/Tests/Integration/Plugin/Results/ResultsTest.php
@@ -253,7 +253,7 @@ class ResultsTest extends AbstractPluginTest
 
         $this->assertContains('facet-type-hierarchy', $resultPage, 'Did not render hierarchy facet in the response');
         $this->assertContains('class="rootlinefacet-item"', $resultPage, 'Hierarchy facet items did not contain expected class from TypoScript');
-        $this->assertContains('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
+        $this->assertContains('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%253A%252F1%252F2%252F&amp;', $resultPage, 'Result page did not contain hierarchical facet link');
     }
 
     /**

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -49,20 +49,20 @@ class PathToHierarchyTest extends UnitTest
     public function canBuildSolrHierarchyString()
     {
         $this->assertEquals($this->processor->process(array('sport/cricket')),
-            array('0-sport', '1-sport/cricket'));
+            array('0-sport/', '1-sport/cricket/'));
         $this->assertEquals($this->processor->process(array('sport/skateboarding')),
-            array('0-sport', '1-sport/skateboarding'));
+            array('0-sport/', '1-sport/skateboarding/'));
         $this->assertEquals($this->processor->process(array('sport/skateboarding/street')),
             array(
-                '0-sport',
-                '1-sport/skateboarding',
-                '2-sport/skateboarding/street'
+                '0-sport/',
+                '1-sport/skateboarding/',
+                '2-sport/skateboarding/street/'
             ));
         $this->assertEquals($this->processor->process(array('/sport/skateboarding/street//')),
             array(
-                '0-sport',
-                '1-sport/skateboarding',
-                '2-sport/skateboarding/street'
+                '0-sport/',
+                '1-sport/skateboarding/',
+                '2-sport/skateboarding/street/'
             ));
     }
 }

--- a/Tests/Unit/Query/FilterEncoder/HierarchyTest.php
+++ b/Tests/Unit/Query/FilterEncoder/HierarchyTest.php
@@ -50,8 +50,8 @@ class HierarchyTest extends UnitTest
      */
     public function canParseHierarchy3LevelQuery()
     {
-        $expected = '"2-sport/skateboarding/street"';
-        $actual = $this->parser->decodeFilter('/sport/skateboarding/street');
+        $expected = '"2-sport/skateboarding/street/"';
+        $actual = $this->parser->decodeFilter('/sport/skateboarding/street/');
 
         $this->assertEquals($expected, $actual);
     }
@@ -61,8 +61,8 @@ class HierarchyTest extends UnitTest
      */
     public function canParseHierarchy2LevelQuery()
     {
-        $expected = '"1-sport/skateboarding"';
-        $actual = $this->parser->decodeFilter('/sport/skateboarding');
+        $expected = '"1-sport/skateboarding/"';
+        $actual = $this->parser->decodeFilter('/sport/skateboarding/');
 
         $this->assertEquals($expected, $actual);
     }
@@ -72,8 +72,8 @@ class HierarchyTest extends UnitTest
      */
     public function canParseHierarchy1LevelQuery()
     {
-        $expected = '"0-sport"';
-        $actual = $this->parser->decodeFilter('/sport');
+        $expected = '"0-sport/"';
+        $actual = $this->parser->decodeFilter('/sport/');
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
In order to be able to differentiate between 0-foo and 0-foobar
when using facet.prefix it is necessary to use a trailing slash
that way when using facet.prefix 0-foo/ only the 0-foo/ will
be found and not also 0-foobar/

Resolves: #683