### PR TITLE
Do not issue commits before deletes

### DIFF
--- a/Classes/Backend/SolrModule/IndexMaintenanceModuleController.php
+++ b/Classes/Backend/SolrModule/IndexMaintenanceModuleController.php
@@ -73,8 +73,6 @@ class IndexMaintenanceModuleController extends AbstractModuleController
             $solrServers = $this->connectionManager->getConnectionsBySite($this->site);
             foreach ($solrServers as $solrServer) {
                 /* @var $solrServer SolrService */
-                // make sure maybe not-yet committed documents are committed
-                $solrServer->commit();
                 $solrServer->deleteByQuery('siteHash:' . $siteHash);
                 $solrServer->commit(false, false, false);
             }

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -94,9 +94,6 @@ class ReIndexTask extends AbstractTask
         }
 
         foreach ($solrServers as $solrServer) {
-            // make sure not-yet committed documents are removed, too
-            $solrServer->commit();
-
             $deleteQuery = 'type:(' . implode(' OR ', $typesToCleanUp) . ')'
                 . ' AND siteHash:' . $this->site->getSiteHash();
             $solrServer->deleteByQuery($deleteQuery);


### PR DESCRIPTION
We're currently doing work on reducing the number of commits against our solr installation to improve scalability and cache efficiency.

Looking through the typo3 extension these two particular cases struck me as particularly bad. Essentially it seems the author was unsure of whether his deleteByQuery would delete non-committed documents and so issues an extra commit first, which is completely unnecessary since solr by default will delete both committed and pending documents.

I'm unsure of whether this may have been necessary at some point, but in 4.10+ it is not.