### PR TITLE
[FEATURE] Adding plugin.tx_solr.statistics.addDebugData

### DIFF
--- a/Classes/Response/Processor/StatisticsWriter.php
+++ b/Classes/Response/Processor/StatisticsWriter.php
@@ -79,9 +79,9 @@ class StatisticsWriter implements ResponseProcessor
 
             'num_found' => $response->response->numFound,
             'suggestions_shown' => is_object($response->spellcheck->suggestions) ? (int)get_object_vars($response->spellcheck->suggestions) : 0,
-            'time_total' => $response->debug->timing->time,
-            'time_preparation' => $response->debug->timing->prepare->time,
-            'time_processing' => $response->debug->timing->process->time,
+            'time_total' => isset($response->debug->timing->time) ? $response->debug->timing->time : 0,
+            'time_preparation' => isset($response->debug->timing->prepare->time) ? $response->debug->timing->prepare->time : 0,
+            'time_processing' => isset($response->debug->timing->process->time) ? $response->debug->timing->process->time : 0,
 
             'feuser_id' => (int)$GLOBALS['TSFE']->fe_user->user['uid'],
             'cookie' => $GLOBALS['TSFE']->fe_user->id,

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -43,8 +43,11 @@ class StatisticsComponent extends AbstractComponent
         $solrConfiguration = Util::getSolrConfiguration();
 
         if ($solrConfiguration->getStatistics()) {
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery']['statistics'] = 'ApacheSolrForTypo3\\Solr\\Query\\Modifier\\Statistics';
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processSearchResponse']['statistics'] = 'ApacheSolrForTypo3\\Solr\\Response\\Processor\\StatisticsWriter';
+            // Only if AdvancedStatistics is enabled add Query modifier
+            if ($solrConfiguration->getAdvancedStatistics()) {
+                $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery']['statistics'] = 'ApacheSolrForTypo3\\Solr\\Query\\Modifier\\Statistics';
+            }
         }
     }
 }

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -44,8 +44,8 @@ class StatisticsComponent extends AbstractComponent
 
         if ($solrConfiguration->getStatistics()) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processSearchResponse']['statistics'] = 'ApacheSolrForTypo3\\Solr\\Response\\Processor\\StatisticsWriter';
-            // Only if AdvancedStatistics is enabled add Query modifier
-            if ($solrConfiguration->getAdvancedStatistics()) {
+            // Only if addDebugData is enabled add Query modifier
+            if ($solrConfiguration->getStatisticsAddDebugData()) {
                 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery']['statistics'] = 'ApacheSolrForTypo3\\Solr\\Query\\Modifier\\Statistics';
             }
         }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1856,22 +1856,22 @@ class TypoScriptConfiguration
      */
     public function getStatisticsAnonymizeIP($defaultIfEmpty = 0)
     {
-        $anomizeToLength = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics.anonymizeIP', $defaultIfEmpty);
-        return (int)$anomizeToLength;
+        $anonymizeToLength = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics.anonymizeIP', $defaultIfEmpty);
+        return (int)$anonymizeToLength;
     }
 
     /**
-     * Indicates if advancedStatistics is enabled or not.
+     * Indicates if additional debug Data should be added to the statistics
      *
-     * plugin.tx_solr.advancedStatistics
+     * plugin.tx_solr.statistics.addDebugData
      *
      * @param bool $defaultIfEmpty
      * @return bool
      */
-    public function getAdvancedStatistics($defaultIfEmpty = false)
+    public function getStatisticsAddDebugData($defaultIfEmpty = false)
     {
-        $isAdvancedStatisticsEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.advancedStatistics', $defaultIfEmpty);
-        return $this->getBool($isAdvancedStatisticsEnabled);
+        $statisticsAddDebugDataEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics.addDebugData', $defaultIfEmpty);
+        return $this->getBool($statisticsAddDebugDataEnabled);
     }
 
     /**

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1842,8 +1842,8 @@ class TypoScriptConfiguration
      */
     public function getStatistics($defaultIfEmpty = false)
     {
-        $isFacetingEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics', $defaultIfEmpty);
-        return $this->getBool($isFacetingEnabled);
+        $isStatisticsEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics', $defaultIfEmpty);
+        return $this->getBool($isStatisticsEnabled);
     }
 
     /**
@@ -1858,6 +1858,20 @@ class TypoScriptConfiguration
     {
         $anomizeToLength = $this->getValueByPathOrDefaultValue('plugin.tx_solr.statistics.anonymizeIP', $defaultIfEmpty);
         return (int)$anomizeToLength;
+    }
+
+    /**
+     * Indicates if advancedStatistics is enabled or not.
+     *
+     * plugin.tx_solr.advancedStatistics
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getAdvancedStatistics($defaultIfEmpty = false)
+    {
+        $isAdvancedStatisticsEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.advancedStatistics', $defaultIfEmpty);
+        return $this->getBool($isAdvancedStatisticsEnabled);
     }
 
     /**

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -43,21 +43,15 @@ statistics.anonymizeIP
 
 Anonymizes the ip address in the logging records.
 
-tx_solr.advancedStatistics
-===================
-
-This section allows you to configure the logging for advancedStatistics. It fills the columns `time_total`, `time_preparation` and `time_processing`
-in the table `tx_solr_statistics` with values returned from the search query.
-
-**Note**: Enabling advancedStatistics can have performance impact since debugMode is appended to queries - requires that
-`plugin.tx_solr.statistics = 1` has been set.
-
-advancedStatistics
-----------
+statistics.addDebugData
+-----------------------
 
 :Type: Boolean
-:TS Path: plugin.tx_solr.advancedStatistics
+:TS Path: plugin.tx_solr.statistics.addDebugData
 :Since: 6.1
 :Default: 0
 
-Set `plugin.tx_solr.advancedStatistics = 1` to enable advanced statistics
+Adds debug data to the columns `time_total`, `time_preparation` and `time_processing` in the table `tx_solr_statistics`
+from the result of the search query.
+
+**Note**: Enabling addDebugData can have performance impact since debugMode is appended to queries.

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -42,3 +42,22 @@ statistics.anonymizeIP
 :Default: 0
 
 Anonymizes the ip address in the logging records.
+
+tx_solr.advancedStatistics
+===================
+
+This section allows you to configure the logging for advancedStatistics. It fills the columns `time_total`, `time_preparation` and `time_processing`
+in the table `tx_solr_statistics` with values returned from the search query.
+
+**Note**: Enabling advancedStatistics can have performance impact since debugMode is appended to queries - requires that
+`plugin.tx_solr.statistics = 1` has been set.
+
+advancedStatistics
+----------
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.advancedStatistics
+:Since: 6.1
+:Default: 0
+
+Set `plugin.tx_solr.advancedStatistics = 1` to enable advanced statistics


### PR DESCRIPTION
Only if advancedStatistics is set the debugModes is appended to the search query. Since there is a performance issue it makes sense to split it into 2 configurations.