### PR TITLE
[FEATURE] Add plugin.tx_solr.index.enableCommits option.

### DIFF
--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -201,7 +201,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         $indexQueueItems = $this->getIndexQueue()->getItems($table, $uid);
         foreach ($indexQueueItems as $indexQueueItem) {
             $site = $indexQueueItem->getSite();
-            $solrConfiguration = $this->site->getSolrConfiguration();
+            $solrConfiguration = $site->getSolrConfiguration();
 
             // a site can have multiple connections (cores / languages)
             $solrConnections = $connectionManager->getConnectionsBySite($site);

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -202,12 +202,13 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         foreach ($indexQueueItems as $indexQueueItem) {
             $site = $indexQueueItem->getSite();
             $solrConfiguration = $site->getSolrConfiguration();
+            $enableCommitsSetting = $solrConfiguration->getEnableCommits();
 
             // a site can have multiple connections (cores / languages)
             $solrConnections = $connectionManager->getConnectionsBySite($site);
             foreach ($solrConnections as $solr) {
                 $solr->deleteByQuery('type:' . $table . ' AND uid:' . intval($uid));
-                if ($solrConfiguration->getEnableCommits()) {
+                if ($enableCommitsSetting) {
                     $solr->commit(false, false, false);
                 }
             }

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -207,7 +207,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
             $solrConnections = $connectionManager->getConnectionsBySite($site);
             foreach ($solrConnections as $solr) {
                 $solr->deleteByQuery('type:' . $table . ' AND uid:' . intval($uid));
-                if($solrConfiguration->getEnableCommits()) {
+                if ($solrConfiguration->getEnableCommits()) {
                     $solr->commit(false, false, false);
                 }
             }

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -201,12 +201,15 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         $indexQueueItems = $this->getIndexQueue()->getItems($table, $uid);
         foreach ($indexQueueItems as $indexQueueItem) {
             $site = $indexQueueItem->getSite();
+            $solrConfiguration = $this->site->getSolrConfiguration();
 
             // a site can have multiple connections (cores / languages)
             $solrConnections = $connectionManager->getConnectionsBySite($site);
             foreach ($solrConnections as $solr) {
                 $solr->deleteByQuery('type:' . $table . ' AND uid:' . intval($uid));
-                $solr->commit(false, false, false);
+                if($solrConfiguration->getEnableCommits()) {
+                    $solr->commit(false, false, false);
+                }
             }
         }
     }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1946,8 +1946,7 @@ class TypoScriptConfiguration
      */
     public function getEnableCommits($defaultIfEmpty = true)
     {
-	$enableCommits = $this->getValueByPathOrDefaultValue('plugin.tx_solr.index.enableCommits', $defaultIfEmpty);
-	$this->getBool($enableCommits);
+        $enableCommits = $this->getValueByPathOrDefaultValue('plugin.tx_solr.index.enableCommits', $defaultIfEmpty);
+        $this->getBool($enableCommits);
     }
-
 }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1930,4 +1930,24 @@ class TypoScriptConfiguration
         $sortingViewHelperConfiguration = $this->getObjectByPathOrDefault('plugin.tx_solr.viewHelpers.sortIndicator.', $defaultIfEmpty);
         return $sortingViewHelperConfiguration;
     }
+
+    /**
+     * Controls whether ext-solr will send commits to solr.
+     * Beware: If you disable this, you need to ensure
+     * that some other mechanism will commit your changes
+     * otherwise they will never be searchable.
+     * A good way to achieve this is enabling the solr
+     * daemons autoCommit feature.
+     *
+     * plugin.tx_solr.index.enableCommits
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getEnableCommits($defaultIfEmpty = true)
+    {
+	$enableCommits = $this->getValueByPathOrDefaultValue('plugin.tx_solr.index.enableCommits', $defaultIfEmpty);
+	$this->getBool($enableCommits);
+    }
+
 }

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -87,6 +87,7 @@ class ReIndexTask extends AbstractTask
         $solrConfiguration = $this->site->getSolrConfiguration();
         $solrServers = GeneralUtility::makeInstance('ApacheSolrForTypo3\\Solr\\ConnectionManager')->getConnectionsBySite($this->site);
         $typesToCleanUp = array();
+        $enableCommitsSetting = $solrConfiguration->getEnableCommits();
 
         foreach ($this->indexingConfigurationsToReIndex as $indexingConfigurationName) {
             $type = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
@@ -98,7 +99,7 @@ class ReIndexTask extends AbstractTask
                 . ' AND siteHash:' . $this->site->getSiteHash();
             $solrServer->deleteByQuery($deleteQuery);
 
-            if (!$solrConfiguration->getEnableCommits()) {
+            if (!$enableCommitsSetting) {
                 # Do not commit
                 continue;
             }

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -98,6 +98,11 @@ class ReIndexTask extends AbstractTask
                 . ' AND siteHash:' . $this->site->getSiteHash();
             $solrServer->deleteByQuery($deleteQuery);
 
+            if(!$solrConfiguration->getEnableCommits()) {
+                # Do not commit
+                continue;
+            }
+
             $response = $solrServer->commit(false, false, false);
             if ($response->getHttpStatus() != 200) {
                 $cleanUpResult = false;

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -98,7 +98,7 @@ class ReIndexTask extends AbstractTask
                 . ' AND siteHash:' . $this->site->getSiteHash();
             $solrServer->deleteByQuery($deleteQuery);
 
-            if(!$solrConfiguration->getEnableCommits()) {
+            if (!$solrConfiguration->getEnableCommits()) {
                 # Do not commit
                 continue;
             }

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -686,4 +686,19 @@ Example:
         additionalWhereClause = pid=2
     }
 
+enableCommits
+-----------------------------
 
+:Type: Boolean
+:TS Path: plugin.tx_solr.index.enableCommits
+:Since: 6.1
+:Default: true
+
+This setting controls whether ext-solr will implicitly cause solr commits as part of its operation.
+
+If this settings is set to false, you need to ensure that something else will periodically call
+commits. The solr daemons AutoCommit feature would be a natural choice.
+
+This feature is mainly useful, when you have many installations in the same solr core.
+
+**Note**: Calling some APIs may still cause commits, but these can always be explicitly disabled.


### PR DESCRIPTION
The option makes it possible to disable implicit solr commits, which
can improve scalability and performance when a solr core is shared
between many installations.

This affects the garbageCollector (used by the indexQueue) and the special reIndexTask.

This doesn't preclude manually triggering commits and the deleteByType function will still issue commits by default, but that can be explicitly disabled, and changing that would cause unnecessary API breakage.

I still need to test this a bit more, so please don't merge it yet.

Fixes: #870 