### PR TITLE
[TASK] Allow to use new testing framework of TYPO3 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TYPO3_VERSION="dev-master"
-      php: 7.0
-    - env: TYPO3_VERSION="dev-master"
       php: 7.1
     - env: TYPO3_VERSION="~8.5.0"
       php: 7.1

--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -1,7 +1,6 @@
 <phpunit
 	backupGlobals="false"
 	backupStaticAttributes="false"
-	bootstrap="../../.Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTestsBootstrap.php"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertWarningsToExceptions="true"

--- a/Build/Test/UnitTests.xml
+++ b/Build/Test/UnitTests.xml
@@ -1,8 +1,6 @@
 <phpunit
 	backupGlobals="false"
 	backupStaticAttributes="false"
-	bootstrap="../../.Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTestsBootstrap.php"
-
 	colors="true"
 	convertErrorsToExceptions="false"
 	convertWarningsToExceptions="false"

--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -39,11 +39,18 @@ fi
 
 composer require --dev --prefer-source typo3/cms="$TYPO3_VERSION"
 
+if [[ $TYPO3_VERSION == "dev-master" ]]; then
+    # For dev-master we need to use the new testing framework
+    # after dropping 7.x support we need to change this in the patched files
+    sed  -i 's/Core\Tests\FunctionalTestCase as TYPO3IntegrationTest/Components\TestingFramework\Core\FunctionalTestCase as TYPO3IntegrationTest/g' Tests/Integration/IntegrationTest.php
+    sed  -i 's/Core\Tests\UnitTestCase as TYPO3UnitTest/Components\TestingFramework\Core\UnitTestCase as TYPO3UnitTest/g' Tests/Unit/UnitTest.php
+    ln -s  ../vendor/typo3/cms/components .Build/Web/components
+fi
+
 # Restore composer.json
 git checkout composer.json
 
 export TYPO3_PATH_WEB=$SCRIPTPATH/.Build/Web
-
 mkdir -p $TYPO3_PATH_WEB/uploads $TYPO3_PATH_WEB/typo3temp
 
 # Setup Solr Using our install script

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -27,8 +27,13 @@ if [ $? -eq "0" ]; then
     fi
 fi
 
+UNIT_BOOTSTRAP=".Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTestsBootstrap.php"
+if [[ $TYPO3_VERSION == "dev-master" ]]; then
+    UNIT_BOOTSTRAP=".Build/vendor/typo3/cms/components/testing_framework/core/Build/UnitTestsBootstrap.php"
+fi
+
 echo "Run unit tests"
-.Build/bin/phpunit --colors -c Build/Test/UnitTests.xml --coverage-clover=coverage.unit.clover
+.Build/bin/phpunit --colors -c Build/Test/UnitTests.xml --coverage-clover=coverage.unit.clover --bootstrap=$UNIT_BOOTSTRAP
 
 echo "Run integration tests"
 
@@ -64,4 +69,9 @@ else
 	exit 1
 fi
 
-.Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --coverage-clover=coverage.integration.clover
+INTEGRATION_BOOTSTRAP=".Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTestsBootstrap.php"
+if [[ $TYPO3_VERSION == "dev-master" ]]; then
+    INTEGRATION_BOOTSTRAP=".Build/vendor/typo3/cms/components/testing_framework/core/Build/FunctionalTestsBootstrap.php"
+fi
+
+.Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --coverage-clover=coverage.integration.clover --bootstrap=$INTEGRATION_BOOTSTRAP

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,9 @@
   "autoload-dev": {
     "psr-4": {
       "ApacheSolrForTypo3\\Solr\\Tests\\": "Tests/",
-      "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
+      "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/",
+      "TYPO3\\CMS\\Components\\TestingFramework\\Core\\": ".Build/vendor/typo3/cms/components/testing_framework/core/",
+      "TYPO3\\CMS\\Components\\TestingFramework\\Fluid\\": ".Build/vendor/typo3/cms/components/testing_framework/fluid/"
     }
   },
   "config": {


### PR DESCRIPTION
This pull request allows to run all tests against the current TYPO3 dev-master (8.6-dev) and applies the required changes that are needed for the moved testing framework.