### PR TITLE
[TASK] Add cObject support for solr settings

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -2,6 +2,7 @@
 
 namespace ApacheSolrForTypo3\Solr\System\Configuration;
 
+use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -46,13 +47,20 @@ class TypoScriptConfiguration
     protected $contextPageId = 0;
 
     /**
+     * @var ContentObjectService
+     */
+    protected $contentObjectService;
+
+    /**
      * @param array $configuration
      * @param int $contextPageId
+     * @param ContentObjectService $contentObjectService
      */
-    public function __construct(array $configuration, $contextPageId = 0)
+    public function __construct(array $configuration, $contextPageId = 0, ContentObjectService $contentObjectService = null)
     {
         $this->configurationAccess = new ArrayAccessor($configuration, '.', true);
         $this->contextPageId = $contextPageId;
+        $this->contentObjectService = is_null($contentObjectService) ? GeneralUtility::makeInstance(ContentObjectService::class) : $contentObjectService;
     }
 
     /**
@@ -231,6 +239,19 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns true when ext_solr is enabled
+     *
+     * @param boolean $defaultIfEmpty
+     * @return boolean
+     */
+    public function getEnabled($defaultIfEmpty = false)
+    {
+        $path = 'plugin.tx_solr.enabled';
+        $result = $this->getValueByPathOrDefaultValue($path, $defaultIfEmpty);
+        return $this->getBool($result);
+    }
+
+    /**
      * Returns the configured css file for a specific fileKey.
      *
      * plugin.tx_solr.cssFiles.<fileKey>
@@ -406,7 +427,7 @@ class TypoScriptConfiguration
     {
         $monitoredTables = [];
 
-        $indexingConfigurations =  $this->getEnabledIndexQueueConfigurationNames();
+        $indexingConfigurations = $this->getEnabledIndexQueueConfigurationNames();
         foreach ($indexingConfigurations as $indexingConfigurationName) {
             $monitoredTable = $this->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
             $monitoredTables[] = $monitoredTable;
@@ -532,13 +553,13 @@ class TypoScriptConfiguration
     public function getInitialPagesAdditionalWhereClause($defaultIfEmpty = ' AND 1=1')
     {
         $path = 'plugin.tx_solr.index.queue.pages' . '.initialPagesAdditionalWhereClause';
-        $initialPagesAdditionalWhereClause =  $this->getValueByPathOrDefaultValue($path, '');
+        $initialPagesAdditionalWhereClause = $this->getValueByPathOrDefaultValue($path, '');
 
         if (trim($initialPagesAdditionalWhereClause) === '') {
             return $defaultIfEmpty;
         }
 
-        return ' AND ' .  $initialPagesAdditionalWhereClause;
+        return ' AND ' . $initialPagesAdditionalWhereClause;
     }
 
     /**
@@ -880,9 +901,23 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns true or false if something is configured below plugin.tx_solr.solr.
+     *
+     * plugin.tx_solr.solr.
+     *
+     * @param boolean $defaultIfEmpty
+     * @return boolean
+     */
+    public function getSolrHasConnectionConfiguration($defaultIfEmpty = false)
+    {
+        $configuration = $this->getObjectByPathOrDefault('plugin.tx_solr.solr.', []);
+        return $configuration !== [] ? true : $defaultIfEmpty;
+    }
+
+    /**
      * Returns the defaultTimeout used for requests to the Solr server
      *
-     * plugin.tx_solr.solr.defaultTimeout
+     * plugin.tx_solr.solr.timeout
      *
      * @param float $defaultIfEmpty
      * @return float
@@ -890,6 +925,113 @@ class TypoScriptConfiguration
     public function getSolrTimeout($defaultIfEmpty = 0.0)
     {
         return (float)$this->getValueByPathOrDefaultValue('plugin.tx_solr.solr.timeout', $defaultIfEmpty);
+    }
+
+    /**
+     * Returns the scheme used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.scheme
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSolrScheme($defaultIfEmpty = 'http')
+    {
+        $valuePath = 'plugin.tx_solr.solr.scheme';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        return $this->renderContentElementOfConfigured($valuePath, $value);
+    }
+
+    /**
+     * Returns the hostname used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.host
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSolrHost($defaultIfEmpty = 'localhost')
+    {
+        $valuePath = 'plugin.tx_solr.solr.host';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        return $this->renderContentElementOfConfigured($valuePath, $value);
+    }
+
+    /**
+     * Returns the port used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.port
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param int $defaultIfEmpty
+     * @return int
+     */
+    public function getSolrPort($defaultIfEmpty = 8983)
+    {
+        $valuePath = 'plugin.tx_solr.solr.port';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        return $this->renderContentElementOfConfigured($valuePath, $value);
+    }
+
+    /**
+     * Returns the path used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.path
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSolrPath($defaultIfEmpty = '/solr/core_en/')
+    {
+        $valuePath = 'plugin.tx_solr.solr.path';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        $solrPath = $this->renderContentElementOfConfigured($valuePath, $value);
+
+        $solrPath = trim($solrPath, '/');
+        $solrPath = '/' . $solrPath . '/';
+
+        return $solrPath;
+    }
+
+    /**
+     * Returns the username used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.username
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSolrUsername($defaultIfEmpty = '')
+    {
+        $valuePath = 'plugin.tx_solr.solr.username';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        return $this->renderContentElementOfConfigured($valuePath, $value);
+    }
+
+    /**
+     * Returns the password used for requests to the Solr server
+     *
+     * plugin.tx_solr.solr.password
+     *
+     * Applies stdWrap on the configured setting
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSolrPassword($defaultIfEmpty = '')
+    {
+        $valuePath = 'plugin.tx_solr.solr.password';
+        $value = (string)$this->getValueByPathOrDefaultValue($valuePath, $defaultIfEmpty);
+        return $this->renderContentElementOfConfigured($valuePath, $value);
     }
 
     /**
@@ -1962,5 +2104,24 @@ class TypoScriptConfiguration
     {
         $enableCommits = $this->getValueByPathOrDefaultValue('plugin.tx_solr.index.enableCommits', $defaultIfEmpty);
         $this->getBool($enableCommits);
+    }
+
+    /*
+     * Applies the stdWrap if it is configured for the path, otherwise the unprocessed value will be returned.
+     *
+     * @param string $valuePath
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function renderContentElementOfConfigured($valuePath, $value)
+    {
+        $configurationPath = $valuePath . '.';
+        $configuration = $this->getObjectByPath($configurationPath);
+
+        if ($configuration == null) {
+            return $value;
+        }
+
+        return $this->contentObjectService->renderSingleContentObject($value, $configuration);
     }
 }

--- a/Classes/System/ContentObject/ContentObjectService.php
+++ b/Classes/System/ContentObject/ContentObjectService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\System\ContentObject;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.hund@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * StdWrap Service that can be used to apply the ContentObjectRenderer stdWrap functionality on data.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ContentObjectService
+{
+
+    /**
+     * @var ContentObjectRenderer
+     */
+    protected $contentObjectRenderer;
+
+    /**
+     * StdWrapService constructor.
+     * @param ContentObjectRenderer|null $contentObject
+     */
+    public function __construct(ContentObjectRenderer $contentObject = null)
+    {
+        $this->contentObjectRenderer = is_null($contentObject) ? GeneralUtility::makeInstance(ContentObjectRenderer::class) : $contentObject;
+    }
+
+    /**
+     * This method use $content and $conf and passes it directly to stdWrap.
+     *
+     * @param string $content
+     * @param array $conf
+     * @return string
+     */
+    public function renderSingleContentObject($content = '', $conf = [])
+    {
+        return $this->contentObjectRenderer->cObjGetSingle($content, $conf);
+    }
+
+    /**
+     * Very object stdWrap is used with 'field' as $content and 'field.' as $conf with this
+     * method you can pass the array and the $key that is used to access $conant and $conf from $array.
+     *
+     * @param array $array
+     * @param string $key
+     * @return string
+     */
+    public function renderSingleContentObjectByArrayAndKey($array = [], $key = '')
+    {
+        $content = isset($array[$key]) ? $array[$key] : [];
+        $conf = isset($array[$key . '.']) ? $array[$key . '.'] : '';
+        return $this->renderSingleContentObject($content, $conf);
+    }
+}

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -32,3 +32,6 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/IntroPackageSearchBox/',
     'Search - (Example) Replace Introduction Package search box');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/ConnectionFromConfVars/',
+    'Search - (Example) Use connection settings from TYPO3_CONF_VARS');

--- a/Configuration/TypoScript/Examples/ConnectionFromConfVars/setup.txt
+++ b/Configuration/TypoScript/Examples/ConnectionFromConfVars/setup.txt
@@ -1,0 +1,24 @@
+plugin.tx_solr {
+	solr {
+		scheme = TEXT
+		scheme {
+			value = {$plugin.tx_solr.solr.scheme}
+			override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|scheme
+		}
+		host = TEXT
+		host {
+			value = {$plugin.tx_solr.solr.host}
+			override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|host
+		}
+		port = TEXT
+		port {
+			value = {$plugin.tx_solr.solr.port}
+			override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|port
+		}
+		path = TEXT
+		path {
+			value = {$plugin.tx_solr.solr.path}
+			override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|path
+		}
+	}
+}

--- a/Documentation/Configuration/Reference/TxSolrSolr.rst
+++ b/Documentation/Configuration/Reference/TxSolrSolr.rst
@@ -35,6 +35,7 @@ scheme
 :TS Path: plugin.tx_solr.solr.scheme
 :Default: http
 :Options: http, https
+:cObject supported: yes
 :Since: 1.2 2.0
 
 Allows to set the connection scheme to "https" instead of the default "http".
@@ -45,6 +46,7 @@ host
 :Type: String
 :TS Path: plugin.tx_solr.solr.host
 :Default: localhost
+:cObject supported: yes
 :Since: 1.0
 
 Sets the host portion of the URL.
@@ -55,6 +57,7 @@ port
 :Type: Integer
 :TS Path: plugin.tx_solr.solr.port
 :Default: 8983
+:cObject supported: yes
 :Since: 1.0
 
 Sets the port portion of the URL.
@@ -65,6 +68,7 @@ path
 :Type: String
 :TS Path: plugin.tx_solr.solr.path
 :Default: /
+:cObject supported: yes
 :Since: 1.0
 
 Sets the path portion of the URL. Make sure to have the path end with a slash (/).
@@ -75,6 +79,7 @@ username
 :Type: String
 :TS Path: plugin.tx_solr.solr.username
 :Since: 6.0
+:cObject supported: yes
 
 Sets the username required to access the solr server.
 
@@ -84,6 +89,7 @@ password
 :Type: String
 :TS Path: plugin.tx_solr.solr.password
 :Since: 6.0
+:cObject supported: yes
 
 Sets the password required to access the solr server.
 
@@ -94,5 +100,6 @@ timeout
 :TS Path: plugin.tx_solr.solr.timeout
 :Default: 0.0
 :Since: 1.0
+:cObject supported: no
 
 Can be used to configure a connection timeout.

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -269,3 +269,33 @@ You can do that, by using SOLR_MULTIVALUE
     }
 
 |
+
+**How can i use a configuration from AdditionalConfiguration.php when i deploy my application on several instances?**
+
+The configuration of the connection is done with typoscript. When you want to use a configuration from TYPO3_CONF_VARS or from the system environment,
+you can apply an stdWrap on the configuration that reads from these configurations.
+
+The following example shows how a host can be configured in the AdditionalConfiguration.php and used in your typoscript to connect to solr:
+
+The following line is added to AdditionalConfiguration.php
+
+::
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['host'] = 'mysolrserver.de';
+
+|
+
+To use this configuration for the host, you can use a TEXT element in the configuration and use override.data to use the
+value from the AdditionalConfiguration.php
+
+::
+
+    plugin.tx_solr.solr {
+       host = TEXT
+       host {
+         value = localhost
+         override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|host
+       }
+    }
+
+|

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -1,0 +1,160 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class TypoScriptConfigurationTest extends IntegrationTest
+{
+
+    /**
+     * @return void
+     */
+    public function setUp() {
+        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $tsfe->cObjectDepthCounter = 50;
+        $GLOBALS['TSFE'] = $tsfe;
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function testCanRenderCObjectInConfiguration() {
+
+        // we fake some deployment settings
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['host'] = 'mydeployhostname';
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['path'] = '/deploy/core_en/';
+
+        $configuration = [
+            'plugin.' => [
+                'tx_solr.' => [
+                    'solr.' => [
+                        'host' => 'TEXT',
+                        'host.' => [
+                            'value' => 'mydefaulthostname',
+                            'override.' => [
+                                'data' => 'global:TYPO3_CONF_VARS|EXTCONF|solr|host'
+                            ]
+                        ],
+                        'path' => 'TEXT',
+                        'path.' => [
+                            'value' => '/mydefaultpath/',
+                            'override.' => [
+                                'data' => 'global:TYPO3_CONF_VARS|EXTCONF|solr|path'
+                            ]
+                        ]
+
+                    ]
+                ]
+            ]
+        ];
+
+            /** @var $typoScriptConfiguration TypoScriptConfiguration */
+        $typoScriptConfiguration = GeneralUtility::makeInstance(TypoScriptConfiguration::class, $configuration, 0);
+
+        $hostname = $typoScriptConfiguration->getSolrHost();
+        $this->assertSame('mydeployhostname', $hostname, 'Could not apply cObject with configuration from TYPO3_CONF_VARS for host');
+
+        $path = $typoScriptConfiguration->getSolrPath();
+        $this->assertSame('/deploy/core_en/', $path, 'Could not apply cObject with configuration from TYPO3_CONF_VARS for path');
+
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['host']);
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['path']);
+    }
+
+
+    /**
+     * @test
+     */
+    public function testValueOfCObjectIsUsedWhenNoTYPO3ConfVarIsPresent() {
+        // no configuration in TYPO3_CONF_VARS done we expect that the fallback configuration in value will be used
+
+        $configuration = [
+            'plugin.' => [
+                'tx_solr.' => [
+                    'solr.' => [
+                        'host' => 'TEXT',
+                        'host.' => [
+                            'value' => 'mydefaulthostname',
+                            'override.' => [
+                                'data' => 'global:TYPO3_CONF_VARS|EXTCONF|solr|host'
+                            ]
+                        ],
+                        'path' => 'TEXT',
+                        'path.' => [
+                            'value' => '/mydefaultpath/',
+                            'override.' => [
+                                'data' => 'global:TYPO3_CONF_VARS|EXTCONF|solr|path'
+                            ]
+                        ]
+
+                    ]
+                ]
+            ]
+        ];
+
+        /** @var $typoScriptConfiguration TypoScriptConfiguration */
+        $typoScriptConfiguration = GeneralUtility::makeInstance(TypoScriptConfiguration::class, $configuration, 0);
+
+        $hostname = $typoScriptConfiguration->getSolrHost();
+        $this->assertSame('mydefaulthostname', $hostname, 'cObject does not fallback to value when TYPO3_CONF_VARS value is missing');
+
+        $path = $typoScriptConfiguration->getSolrPath();
+        $this->assertSame('/mydefaultpath/', $path, 'cObject does not fallback to value when TYPO3_CONF_VARS value is missing');
+    }
+
+    /**
+     * @test
+     */
+    public function testCanUsePlainValuesFromConfiguration() {
+        $configuration = [
+            'plugin.' => [
+                'tx_solr.' => [
+                    'solr.' => [
+                        'host' => 'plainhost',
+                        'path' => '/plainpath/',
+                    ]
+                ]
+            ]
+        ];
+
+        /** @var $typoScriptConfiguration TypoScriptConfiguration */
+        $typoScriptConfiguration = GeneralUtility::makeInstance(TypoScriptConfiguration::class, $configuration, 0);
+
+        $hostname = $typoScriptConfiguration->getSolrHost();
+        $this->assertSame('plainhost', $hostname, 'Can not use configured plain value as host');
+
+        $path = $typoScriptConfiguration->getSolrPath();
+        $this->assertSame('/plainpath/', $path, 'Can not use configured plain value as path');
+    }
+}

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+namespace  ApacheSolrForTypo3\Solr\Test\System\ContentObject;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Testcase for ContentObjectService
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ContentObjectServiceTest extends UnitTest
+{
+
+    /**
+     * @var ContentObjectRenderer
+     */
+    protected $contentObjectRendererMock;
+
+    /**
+     * @var ContentObjectService
+     */
+    protected $contentObjectService;
+
+    public function setUp() {
+        $this->contentObjectRendererMock = $this->getDumbMock(ContentObjectRenderer::class);
+        $this->contentObjectService = new ContentObjectService($this->contentObjectRendererMock);
+    }
+
+    /**
+     * @test
+     */
+    public function canRenderSingleContentObjectByArrayAndKey()
+    {
+        $fakeStdWrapConfiguration = [
+            'field' => 'TEXT',
+            'field.' => ['value' => 'test']
+        ];
+
+        $this->contentObjectRendererMock->expects($this->once())->method('cObjGetSingle')->with('TEXT',  ['value' => 'test']);
+        $this->contentObjectService->renderSingleContentObjectByArrayAndKey($fakeStdWrapConfiguration, 'field');
+    }
+}


### PR DESCRIPTION
This feature allows you use cObjects in the solr typoscript configuration. This enables you to read the configuration
e.g. from the AdditionConfiguration.php, which is most likely the place to put environment specific settings in deployment scenarios.

The following example shows the usage:

Addition to AdditionalConfiguration.php:

```
   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['host'] = 'mysolrserver.de';
```

Usage in typoscript:

```
    plugin.tx_solr.solr {
       host = TEXT
       host {
         value = localhost
         override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|host
       }
    }
```

Fixes: #868