### PR TITLE
[TASK] Scrolling bar in backend not visible

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -47,7 +47,7 @@
 
 
 		<div class="module-body t3js-module-body">
-			<div id="typo3-inner-docbody" class="container-fluid">
+			<div class="container-fluid">
 				<div class="row">
 					<solr:backend.sites>
 						<f:if condition="{hasSites}">


### PR DESCRIPTION
* The id="typo3-inner-docbody" was removed since this is not required

Fixes: #883