### PR TITLE
[BUG] In TYPO3 8.x it's need to set escapeOutput to false in order to…

### DIFF
--- a/Classes/ViewHelpers/Format/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/ImplodeViewHelper.php
@@ -36,6 +36,9 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
  */
 class ImplodeViewHelper extends AbstractSolrViewHelper implements CompilableInterface
 {
+    // Set $escapeOutput to false in order to ensure that "newline" is handled correctly
+    protected $escapeOutput = false;
+
     /**
      * This ViewHelper can be used to implode the values of an array into one string.
      *


### PR DESCRIPTION
… ensure that new-line is handled correctly