### PR TITLE
[TASK] Streamline Backend Summary

### DIFF
--- a/Resources/Private/Templates/Backend/PageModule/Summary.html
+++ b/Resources/Private/Templates/Backend/PageModule/Summary.html
@@ -1,0 +1,9 @@
+<table class="typo3-dblist" style="width:100%; {f:if(condition: hidden, then: 'hidden')}">
+	<f:for each="{settings}" as="settingValue" key="settingName" iteration="current">
+		<tr class="{f:if(condition: current.isOdd, then: 'bgColor4', else: 'bgColor3')}">
+			<td style="font-weight:bold; width:40%; padding-right: 3px;">{settingName}</td>
+			<td>{settingValue}</td>
+		</tr>
+	</f:for>
+</table>
+

--- a/Tests/Integration/Controller/Backend/Fixtures/fakeFlexform.xml
+++ b/Tests/Integration/Controller/Backend/Fixtures/fakeFlexform.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3FlexForms>
+    <data>
+        <sheet index="sDEF">
+            <language index="lDEF">
+                <field index="targetPage">
+                    <value index="vDEF"></value>
+                </field>
+            </language>
+        </sheet>
+        <sheet index="sQuery">
+            <language index="lDEF">
+                <field index="initializeWithEmptyQuery">
+                    <value index="vDEF">1</value>
+                </field>
+                <field index="showResultsOfInitialEmptyQuery">
+                    <value index="vDEF">1</value>
+                </field>
+                <field index="initializeWithQuery">
+                    <value index="vDEF">foobar</value>
+                </field>
+                <field index="showResultsOfInitialQuery">
+                    <value index="vDEF">1</value>
+                </field>
+                <field index="filter">
+                    <value index="vDEF">filter:filter</value>
+                </field>
+                <field index="sortBy">
+                    <value index="vDEF">sorting</value>
+                </field>
+                <field index="resultsPerPage">
+                    <value index="vDEF">10</value>
+                </field>
+                <field index="boostFunction">
+                    <value index="vDEF">boostFunction</value>
+                </field>
+                <field index="boostQuery">
+                    <value index="vDEF">boostQuery</value>
+                </field>
+            </language>
+        </sheet>
+        <sheet index="sOptions">
+            <language index="lDEF">
+                <field index="templateFile">
+                    <value index="vDEF"></value>
+                </field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>

--- a/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
+++ b/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Backend;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Controller\Backend\PageModuleSummary;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+
+/**
+ * EXT:solr offers a summary in the backend module that summarizes the extension
+ * configuration. This testcase checks if the SummaryController produces the expected output.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class PageModuleSummaryTest extends IntegrationTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetSummary() {
+        $flexFormData = $this->getFixtureContent('fakeFlexform.xml');
+
+        $fakeRow = ['pi_flexform' => $flexFormData];
+        $data = ['row' => $fakeRow];
+        $summary = new PageModuleSummary();
+        $result = $summary->getSummary($data);
+
+        $this->assertContains('<td>filter:filter</td>', $result, 'Summary did not contain filter');
+        $this->assertContains('<td>sorting</td>', $result, 'Summary did not contain sorting');
+        $this->assertContains('<td>boostFunction</td>', $result, 'Summary did not contain boostFunction');
+        $this->assertContains('<td>boostQuery</td>', $result, 'Summary did not contain boostQuery');
+        $this->assertContains('<td>10</td>', $result, 'Summary did not contain resultsPerPage');
+    }
+
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,7 +45,7 @@ if (TYPO3_MODE == 'FE' && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])) {
 
 // page module plugin settings summary
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info'][$_EXTKEY . '_pi_results'][$_EXTKEY] = 'ApacheSolrForTypo3\\Solr\\Plugin\\BackendSummary->getSummary';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info'][$_EXTKEY . '_pi_results'][$_EXTKEY] = \ApacheSolrForTypo3\Solr\Controller\Backend\PageModuleSummary::class . '->getSummary';
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 


### PR DESCRIPTION
This PR:

* Uses the FluidStandaloneView to render the backend summary
* Adds an integration test for the summary
* Move the class to Classes/Controller/Backend/PageModuleSummary.php

Fixes: #731