### PR TITLE
[FEATURE] Recursive update of pages

### DIFF
--- a/Classes/AbstractDataHandlerListener.php
+++ b/Classes/AbstractDataHandlerListener.php
@@ -84,6 +84,41 @@ abstract class AbstractDataHandlerListener
     }
 
     /**
+     * Checks if a page update will trigger a recursive update of pages
+     *
+     * This can either be the case if some $changedFields are part of the TriggerConfiguration or
+     * columns have explicit been configured via plugin.tx_solr.index.queue.recursiveUpdateFields
+     *
+     * @param int $pageId
+     * @param array $changedFields
+     * @return bool
+     */
+    protected function isRecursivePageUpdateRequired($pageId, $changedFields)
+    {
+        // First check TriggerConfiguration
+        $isRecursiveUpdateRequiredTriggerConfiguration = $this->isRecursiveUpdateRequired($pageId, $changedFields);
+        // If TriggerConfiguration is false => check if changeFields are part of recursiveUpdateFields
+        if ($isRecursiveUpdateRequiredTriggerConfiguration === false) {
+            $solrConfiguration = Util::getSolrConfigurationFromPageId($pageId);
+            // @TODO This should be fetched via configuration - however that requires
+            // that we move some methods from RecordMonitor into this class and
+            // handles the issue involved with $solrConfiguration
+            $indexQueueConfigurationName = 'pages';
+            $updateFields = $solrConfiguration->getIndexQueueConfigurationRecursiveUpdateFields($indexQueueConfigurationName);
+
+            // Check if no additional fields have been defined and then skip recursive update
+            if (count($updateFields) === 0) {
+                return false;
+            }
+            // If the recursiveUpdateFields configuration is not part of the $changedFields skip recursive update
+            if (!array_intersect_key($changedFields, $updateFields)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * @param int $pageId
      * @param array $changedFields
      * @return bool

--- a/Classes/AbstractDataHandlerListener.php
+++ b/Classes/AbstractDataHandlerListener.php
@@ -179,8 +179,11 @@ abstract class AbstractDataHandlerListener
      * @param TypoScriptConfiguration $solrConfiguration
      * @return string Name of indexing configuration
      */
-    protected function getIndexingConfigurationName($recordTable, $recordUid,TypoScriptConfiguration $solrConfiguration)
-    {
+    protected function getIndexingConfigurationName(
+        $recordTable,
+        $recordUid,
+        TypoScriptConfiguration $solrConfiguration
+    ) {
         $name = $recordTable;
         $indexingConfigurations = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
         foreach ($indexingConfigurations as $indexingConfigurationName) {
@@ -189,7 +192,8 @@ abstract class AbstractDataHandlerListener
                 continue;
             }
 
-            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName, $solrConfiguration);
+            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid,
+                $indexingConfigurationName, $solrConfiguration);
             if (!empty($record)) {
                 $name = $indexingConfigurationName;
                 // FIXME currently returns after the first configuration match
@@ -215,7 +219,8 @@ abstract class AbstractDataHandlerListener
         $indexingConfigurations = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
 
         foreach ($indexingConfigurations as $indexingConfigurationName) {
-            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName, $solrConfiguration);
+            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid,
+                $indexingConfigurationName, $solrConfiguration);
             if (!empty($record)) {
                 // if we found a record which matches the conditions, we can continue
                 break;
@@ -235,9 +240,15 @@ abstract class AbstractDataHandlerListener
      * @param TypoScriptConfiguration $solrConfiguration
      * @return array
      */
-    private function getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName, TypoScriptConfiguration $solrConfiguration)
-    {
-        if (!$this->isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName, $solrConfiguration)) {
+    private function getRecordWhenIndexConfigurationIsValid(
+        $recordTable,
+        $recordUid,
+        $indexingConfigurationName,
+        TypoScriptConfiguration $solrConfiguration
+    ) {
+        if (!$this->isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName,
+            $solrConfiguration)
+        ) {
             return [];
         }
 
@@ -258,8 +269,11 @@ abstract class AbstractDataHandlerListener
      * @param TypoScriptConfiguration $solrConfiguration
      * @return boolean
      */
-    private function isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName, TypoScriptConfiguration $solrConfiguration)
-    {
+    private function isValidTableForIndexConfigurationName(
+        $recordTable,
+        $indexingConfigurationName,
+        TypoScriptConfiguration $solrConfiguration
+    ) {
         $tableToIndex = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
 
         $isMatchingTable = $tableToIndex === $recordTable;

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -190,7 +190,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      */
     protected function deleteSubpagesWhenExtendToSubpagesIsSet($table, $uid, $changedFields)
     {
-        if (!$this->isRecursiveUpdateRequired($uid, $changedFields)) {
+        if (!$this->isRecursivePageUpdateRequired($uid, $changedFields)) {
             return;
         }
 

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -401,6 +401,8 @@ class RecordMonitor extends AbstractDataHandlerListener
         $garbageCollector->collectGarbage($recordTable, $recordUid);
     }
 
+    // Handle pages showing content from another page
+
     /**
      * Triggers Index Queue updates for other pages showing content from the
      * page currently being updated.

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -355,7 +355,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         $this->updateCanonicalPages($recordUid);
         $this->mountPageUpdater->update($recordUid);
 
-        if ($this->isRecursiveUpdateRequired($recordUid, $fields)) {
+        if ($this->isRecursivePageUpdateRequired($recordUid, $fields)) {
             $treePageIds = $this->getSubPageIds($recordUid);
             $this->updatePageIdItems($treePageIds);
         }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -315,7 +315,6 @@ class RecordMonitor extends AbstractDataHandlerListener
             $this->indexQueue->updateItem($recordTable, $recordUid, $configurationName);
         }
 
-
         if ($recordTable == 'pages') {
             $this->doPagesPostUpdateOperations($fields, $recordUid);
         }
@@ -441,5 +440,4 @@ class RecordMonitor extends AbstractDataHandlerListener
         $pid = intval($pid);
         return $pid;
     }
-
 }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -27,8 +27,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 use ApacheSolrForTypo3\Solr\AbstractDataHandlerListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -43,13 +41,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RecordMonitor extends AbstractDataHandlerListener
 {
-
-    /**
-     * Solr TypoScript configuration
-     *
-     * @var TypoScriptConfiguration
-     */
-    protected $solrConfiguration;
 
     /**
      * Index Queue
@@ -412,32 +403,6 @@ class RecordMonitor extends AbstractDataHandlerListener
     }
 
     /**
-     * Retrieves a record, taking into account the additionalWhereClauses of the
-     * Indexing Queue configurations.
-     *
-     * @param string $recordTable Table to read from
-     * @param int $recordUid Id of the record
-     * @return array Record if found, otherwise empty array
-     */
-    protected function getRecord($recordTable, $recordUid)
-    {
-        $record = [];
-        $indexingConfigurations = $this->solrConfiguration->getEnabledIndexQueueConfigurationNames();
-
-        foreach ($indexingConfigurations as $indexingConfigurationName) {
-            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName);
-            if (!empty($record)) {
-                // if we found a record which matches the conditions, we can continue
-                break;
-            }
-        }
-
-        return $record;
-    }
-
-    // Handle pages showing content from another page
-
-    /**
      * Triggers Index Queue updates for other pages showing content from the
      * page currently being updated.
      *
@@ -477,96 +442,4 @@ class RecordMonitor extends AbstractDataHandlerListener
         return $pid;
     }
 
-    /**
-     * Retrieves the name of the  Indexing Queue Configuration for a record
-     *
-     * @param string $recordTable Table to read from
-     * @param int $recordUid Id of the record
-     * @return string Name of indexing configuration
-     */
-    protected function getIndexingConfigurationName($recordTable, $recordUid)
-    {
-        $name = $recordTable;
-        $indexingConfigurations = $this->solrConfiguration->getEnabledIndexQueueConfigurationNames();
-        foreach ($indexingConfigurations as $indexingConfigurationName) {
-            if (!$this->solrConfiguration->getIndexQueueConfigurationIsEnabled($indexingConfigurationName)) {
-                // ignore disabled indexing configurations
-                continue;
-            }
-
-            $record = $this->getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName);
-            if (!empty($record)) {
-                $name = $indexingConfigurationName;
-                // FIXME currently returns after the first configuration match
-                break;
-            }
-        }
-
-        return $name;
-    }
-
-    /**
-     * This method return the record array if the table is valid for this indexingConfiguration.
-     * Otherwise an empty array will be returned.
-     *
-     * @param string $recordTable
-     * @param integer $recordUid
-     * @param string $indexingConfigurationName
-     * @return array
-     */
-    protected function getRecordWhenIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName)
-    {
-        if (!$this->isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName)) {
-            return [];
-        }
-
-        $recordWhereClause = $this->solrConfiguration->getIndexQueueAdditionalWhereClauseByConfigurationName($indexingConfigurationName);
-
-        if ($recordTable === 'pages_language_overlay') {
-            return $this->getPageOverlayRecordWhenParentIsAccessible($recordUid, $recordWhereClause);
-        }
-
-        return (array)BackendUtility::getRecord($recordTable, $recordUid, '*', $recordWhereClause);
-    }
-
-    /**
-     * This method retrieves the pages_language_overlay record when the parent record is accessible
-     * through the recordWhereClause
-     *
-     * @param int $recordUid
-     * @param string $parentWhereClause
-     * @return array
-     */
-    protected function getPageOverlayRecordWhenParentIsAccessible($recordUid, $parentWhereClause)
-    {
-        $overlayRecord = (array)BackendUtility::getRecord('pages_language_overlay', $recordUid, '*');
-        $pageRecord = (array)BackendUtility::getRecord('pages', $overlayRecord['pid'], '*', $parentWhereClause);
-
-        if (empty($pageRecord)) {
-            return [];
-        }
-
-        return $overlayRecord;
-    }
-
-    /**
-     * This method is used to check if a table is an allowed table for an index configuration.
-     *
-     * @param string $recordTable
-     * @param string $indexingConfigurationName
-     * @return boolean
-     */
-    protected function isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName)
-    {
-        $tableToIndex = $this->solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
-
-        $isMatchingTable = $tableToIndex === $recordTable;
-        $isPagesPassedAndOverlayRequested = $tableToIndex === 'pages' && $recordTable === 'pages_language_overlay';
-
-        if ($isMatchingTable || $isPagesPassedAndOverlayRequested) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -568,8 +568,8 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Retrieves an array of additional Fields that will trigger an
-     * recursive of pages when some of the fields on that page are modified
+     * Retrieves an array of additional fields that will trigger an recursive update of pages
+     * when some of the fields on that page are modified.
      *
      * plugin.tx_solr.index.queue.recursiveUpdateFields
      *

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -568,6 +568,29 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Retrieves an array of additional Fields that will trigger an
+     * recursive of pages when some of the fields on that page are modified
+     *
+     * plugin.tx_solr.index.queue.recursiveUpdateFields
+     *
+     * @param string $configurationName
+     * @param array $defaultIfEmpty
+     * @return array
+     */
+    public function getIndexQueueConfigurationRecursiveUpdateFields($configurationName, $defaultIfEmpty = [])
+    {
+        $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.recursiveUpdateFields';
+        $recursiveUpdateFieldsString = $this->getValueByPathOrDefaultValue($path, '');
+        if (trim($recursiveUpdateFieldsString) === '') {
+            return $defaultIfEmpty;
+        }
+        $recursiveUpdateFields = GeneralUtility::trimExplode(',', $recursiveUpdateFieldsString);
+        // For easier check later on we return an array by combining $recursiveUpdateFields
+        return array_combine($recursiveUpdateFields, $recursiveUpdateFields);
+    }
+
+
+    /**
      * Retrieves and initialPagesAdditionalWhereClause where clause when configured or an empty string.
      *
      * plugin.tx_solr.index.queue.pages.initialPagesAdditionalWhereClause

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -380,6 +380,25 @@ Example:
 
     plugin.tx_solr.index.queue.tt_news.attachments.fields = news_files
 
+queue.[indexConfig].recursiveUpdateFields
+-----------------------------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].recursiveUpdateFields
+:Since: 6.1
+:Default: Empty
+
+Allows to define a list of additional fields from the pages table that will trigger an recursive update of
+pages.
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.index.queue.pages.recursiveUpdateFields = title
+
+The example above will trigger an recursive update of pages if the title is changed.
+
+Please not that the following columns should NOT be configured hidden and extendToSubpages since
+they are covered internally by solr and thus they will have not effect.
 
 queue.pages.excludeContentByClass
 ---------------------------------

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -388,17 +388,16 @@ queue.[indexConfig].recursiveUpdateFields
 :Since: 6.1
 :Default: Empty
 
-Allows to define a list of additional fields from the pages table that will trigger an recursive update of
-pages.
+Allows to define a list of additional fields from the pages table that will trigger an recursive update.
 
 .. code-block:: typoscript
 
     plugin.tx_solr.index.queue.pages.recursiveUpdateFields = title
 
-The example above will trigger an recursive update of pages if the title is changed.
+The example above will trigger a recursive update of pages if the title is changed.
 
-Please not that the following columns should NOT be configured hidden and extendToSubpages since
-they are covered internally by solr and thus they will have not effect.
+Please note that the following columns should NOT be configured as recursive update fields: "hidden" and "extendToSubpages".
+These fields are handled by EXT:solr already internally and thus they will have not effect.
 
 queue.pages.excludeContentByClass
 ---------------------------------

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -388,7 +388,7 @@ queue.[indexConfig].recursiveUpdateFields
 :Since: 6.1
 :Default: Empty
 
-Allows to define a list of additional fields from the pages table that will trigger an recursive update.
+Allows to define a list of additional fields from the pages table that will trigger a recursive update.
 
 .. code-block:: typoscript
 

--- a/Tests/Integration/IndexQueue/Fixtures/update_page_with_recursive_update_fields_configured.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_page_with_recursive_update_fields_configured.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+                        queue {
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+                                recursiveUpdateFields = title, doktype
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Root page</title>
+        <subtitle>Root page subtitle</subtitle>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page one</title>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page 2</title>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page 3</title>
+    </pages>
+    <pages>
+        <uid>5</uid>
+        <pid>3</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level two page 1</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/update_page_without_recursive_update_fields_configured.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_page_without_recursive_update_fields_configured.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+                        queue {
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Root page</title>
+        <subtitle>Root page subtitle</subtitle>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page one</title>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page 2</title>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level one page 3</title>
+    </pages>
+    <pages>
+        <uid>5</uid>
+        <pid>3</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sub page level two page 1</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -254,7 +254,7 @@ class RecordMonitorTest extends IntegrationTest
     public function exceptionIsThrowsWhenRecordWithoutPidIsCreated()
     {
         // we expect that this exception is getting thrown, because a record without pid was updated
-        $this->setExpectedExceptio(NoPidException::class);
+        $this->setExpectedException(NoPidException::class);
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension_table.sql');

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -254,7 +254,7 @@ class RecordMonitorTest extends IntegrationTest
     public function exceptionIsThrowsWhenRecordWithoutPidIsCreated()
     {
         // we expect that this exception is getting thrown, because a record without pid was updated
-        $this->expectException(NoPidException::class);
+        $this->setExpectedExceptio(NoPidException::class);
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension_table.sql');

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -86,7 +86,7 @@ class RecordMonitorTest extends IntegrationTest
     protected function assertIndexQueueContainsItemAmount($amount)
     {
         $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to contain ' . (int) $amount . ' items.');
+            'Index queue is empty and was expected to contain ' . (int)$amount . ' items.');
     }
 
     /**
@@ -254,7 +254,7 @@ class RecordMonitorTest extends IntegrationTest
     public function exceptionIsThrowsWhenRecordWithoutPidIsCreated()
     {
         // we expect that this exception is getting thrown, because a record without pid was updated
-        $this->setExpectedException(NoPidException::class);
+        $this->expectException(NoPidException::class);
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension_table.sql');
@@ -275,7 +275,8 @@ class RecordMonitorTest extends IntegrationTest
 
         // we expect that the index queue is empty before we start
         $this->assertEmptyIndexQueue();
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
     }
 
     /**
@@ -290,19 +291,26 @@ class RecordMonitorTest extends IntegrationTest
         $table = 'pages';
         // unexisting uid
         $uid = 2;
-        $fields = ['title' => 'testpage', 'starttime' => 1000000, 'endtime' => 1100000, 'tsstamp' => 1000000, 'pid' => 1];
+        $fields = [
+            'title' => 'testpage',
+            'starttime' => 1000000,
+            'endtime' => 1100000,
+            'tsstamp' => 1000000,
+            'pid' => 1
+        ];
 
         $this->importDataSetFromFixture('update_unexisting_item_will_remove_queue_entry.xml');
 
         // there should be one item in the queue.
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
 
         // the queue entry should be removed since the record itself does not exist
         $this->assertEmptyIndexQueue();
     }
 
-     /**
+    /**
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/639
      * @test
      */
@@ -400,9 +408,11 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 4
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
@@ -422,12 +432,14 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 1
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
         $this->assertIndexQueueContainsItemAmount(1);
 
         $firstQueueItem = $this->indexQueue->getItem(1);
         $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
-        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(), 'First queue item has unexpected indexingConfigurationName');
+        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
+            'First queue item has unexpected indexingConfigurationName');
     }
 
 
@@ -448,13 +460,15 @@ class RecordMonitorTest extends IntegrationTest
             'hidden' => 1
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
         $this->assertIndexQueueContainsItemAmount(1);
 
         $firstQueueItem = $this->indexQueue->getItem(1);
         $this->assertInstanceOf(Item::class, $firstQueueItem, 'Expect to get a queue item');
         $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
-        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(), 'First queue item has unexpected indexingConfigurationName');
+        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
+            'First queue item has unexpected indexingConfigurationName');
     }
 
     /**
@@ -473,7 +487,8 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 1
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
         $this->assertEmptyIndexQueue();
     }
 
@@ -493,7 +508,8 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 1
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
 
         $firstQueueItem = $this->indexQueue->getItem(1);
         $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
@@ -515,9 +531,199 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 1
         ];
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
 
         $firstQueueItem = $this->indexQueue->getItem(1);
         $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
+    }
+
+    /**
+     * @test
+     */
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 1;
+        $fields = [
+            'title' => 'Update updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(5);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 3;
+        $fields = [
+            'title' => 'Update updateSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 5;
+        $fields = [
+            'title' => 'Update updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 1;
+        $fields = [
+            'subtitle' => 'Update updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 3;
+        $fields = [
+            'subtitle' => 'Update updateSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    {
+        $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 5;
+        $fields = [
+            'subtitle' => 'Update updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRootPageWithoutRecursiveUpdateFieldsConfigured()
+    {
+        $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 1;
+        $fields = [
+            'title' => 'Update updateRootPageWithoutRecursiveUpdateFieldsConfigured'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubChildPageWithoutRecursiveUpdateFieldsConfigured()
+    {
+        $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 3;
+        $fields = [
+            'title' => 'Update updateSubChildPageWithoutRecursiveUpdateFieldsConfigured'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubSubChildPageWithoutRecursiveUpdateFieldsConfigured()
+    {
+        $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
+        $this->assertEmptyIndexQueue();
+
+        $status = 'update';
+        $table = 'pages';
+        $uid = 5;
+        $fields = [
+            'title' => 'Update updateSubSubChildPageWithoutRecursiveUpdateFieldsConfigured'
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+            $this->dataHandler);
+
+        $this->assertIndexQueueContainsItemAmount(1);
     }
 }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -225,6 +225,61 @@ class TypoScriptConfigurationTest extends UnitTest
     /**
      * @test
      */
+    public function canGetIndexQueueConfigurationRecursiveUpdateFields()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'index.' => [
+                'queue.' => [
+                    'pages' => 1,
+                    'pages.' => [
+                        'recursiveUpdateFields' => ''
+                    ],
+                    'custom.' => [
+                        'recursiveUpdateFields' => ''
+                    ]
+                ]
+            ]
+        ];
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'index.' => [
+                'queue.' => [
+                    'pages' => 1,
+                    'pages.' => [
+                    ],
+                    'custom.' => [
+                    ]
+                ]
+            ]
+        ];
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'index.' => [
+                'queue.' => [
+                    'pages' => 1,
+                    'pages.' => [
+                        'recursiveUpdateFields' => 'title, subtitle'
+                    ],
+                    'custom.' => [
+                        'recursiveUpdateFields' => 'title, subtitle'
+                    ]
+                ]
+            ]
+        ];
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $this->assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        $this->assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+    }
+
+    /**
+     * @test
+     */
     public function canGetAdditionalWhereClause()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [


### PR DESCRIPTION
Add new constant plugin.tx_solr.index.queue.pages.recursiveUpdateFields to ensure that recursive update of pages can be done - there remains two TODO's use of queue configuration and functional test.

Solves solve the issue #355