### PR TITLE
Fix allowEmptyQuery option

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -441,7 +441,7 @@ class SearchResultSetService implements SingletonInterface
      */
     protected function shouldHideResultsFromInitialSearch($rawQuery)
     {
-        return ($this->typoScriptConfiguration->getSearchInitializeWithEmptyQuery() || $this->typoScriptConfiguration->getSearchInitializeWithQuery()) && !$this->typoScriptConfiguration->getSearchShowResultsOfInitialEmptyQuery() && !$this->typoScriptConfiguration->getSearchShowResultsOfInitialQuery() && empty($rawQuery);
+        return ($this->typoScriptConfiguration->getSearchInitializeWithEmptyQuery() || $this->typoScriptConfiguration->getSearchInitializeWithQuery()) && !$this->typoScriptConfiguration->getSearchShowResultsOfInitialEmptyQuery() && !$this->typoScriptConfiguration->getSearchShowResultsOfInitialQuery() && $rawQuery === null;
     }
 
     /**


### PR DESCRIPTION
The option `search.query.allowEmptyQuery` does not work due to a `empty()` check against the query parameter.
It must not be checked if the query paremter is `empty()` but if it is `null` to not get a false positive for an empty string.

Fixes #918