### PR TITLE
[BUGFIX] Use static instead of self

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -83,7 +83,7 @@ abstract class AbstractIndexer
                 continue;
             }
 
-            if (!self::isAllowedToOverrideField($solrFieldName)) {
+            if (!static::isAllowedToOverrideField($solrFieldName)) {
                 throw new InvalidFieldNameException(
                     'Must not overwrite field .' . $solrFieldName,
                     1435441863

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -59,7 +59,7 @@ abstract class AbstractIndexer
      */
     public static function isAllowedToOverrideField($solrFieldName)
     {
-        return !in_array($solrFieldName, self::$unAllowedOverrideFields);
+        return !in_array($solrFieldName, static::$unAllowedOverrideFields);
     }
 
     /**


### PR DESCRIPTION
At the moment it is not possible to override the unAllowedOverrideFields array.
This change allows to override / modify the array in an own Indexer class.