### PR TITLE
[!!!][TASK] Allow to disable siteHash check by setting query.allowedSites to *

### DIFF
--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Site;
+
+/**
+ * SiteHashService
+ *
+ * Responsible to provide sitehash related service methods.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SiteHashService
+{
+
+    /**
+     * Resolves magic keywords in allowed sites configuration.
+     * Supported keywords:
+     *   __solr_current_site - The domain of the site the query has been started from
+     *   __current_site - Same as __solr_current_site
+     *   __all - Adds all domains as allowed sites
+     *   * - Means all sites are allowed, same as no siteHash
+     *
+     * @param integer $pageId A page ID that is then resolved to the site it belongs to
+     * @param string $allowedSitesConfiguration TypoScript setting for allowed sites
+     * @return string List of allowed sites/domains, magic keywords resolved
+     */
+    public function getAllowedSitesForPageIdAndAllowedSitesConfiguration($pageId, $allowedSitesConfiguration)
+    {
+        if ($allowedSitesConfiguration === '__all') {
+            return  $this->getDomainListOfAllSites();
+        } elseif ($allowedSitesConfiguration === '*') {
+            return '*';
+        } else {
+            return $this->getDomainByPageIdAndReplaceMarkers($pageId, $allowedSitesConfiguration);
+        }
+    }
+
+    /**
+     * Gets the site hash for a domain
+     *
+     * @param string $domain Domain to calculate the site hash for.
+     * @return string site hash for $domain
+     */
+    public function getSiteHashForDomain($domain)
+    {
+        static $siteHashes = [];
+        if (isset($siteHashes[$domain])) {
+            return $siteHashes[$domain];
+        }
+
+        $siteHashes[$domain] = sha1($domain . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] . 'tx_solr');
+        return $siteHashes[$domain];
+    }
+
+
+    /**
+     * Returns a comma separated list of all domains from all sites.
+     *
+     * @return string
+     */
+    protected function getDomainListOfAllSites()
+    {
+        $sites = $this->getAvailableSites();
+        $domains = [];
+        foreach ($sites as $site) {
+            $domains[] = $site->getDomain();
+        }
+
+        $allowedSites = implode(',', $domains);
+        return $allowedSites;
+    }
+
+    /**
+     * Retrieves the domain of the site that belongs to the passed pageId and replaces their markers __solr_current_site
+     * and __current_site.
+     *
+     * @param integer $pageId
+     * @param string $allowedSitesConfiguration
+     * @return string
+     */
+    protected function getDomainByPageIdAndReplaceMarkers($pageId, $allowedSitesConfiguration)
+    {
+        $domainOfPage = $this->getSiteByPageId($pageId)->getDomain();
+        $allowedSites = str_replace(['__solr_current_site', '__current_site'], $domainOfPage, $allowedSitesConfiguration);
+        return (string)$allowedSites;
+    }
+
+    /**
+     * @return Site[]
+     */
+    protected function getAvailableSites()
+    {
+        return Site::getAvailableSites();
+    }
+
+    /**
+     * @param $pageId
+     * @return Site
+     */
+    protected function getSiteByPageId($pageId)
+    {
+        return Site::getSiteByPageId($pageId);
+    }
+}

--- a/Classes/Domain/Variants/IdBuilder.php
+++ b/Classes/Domain/Variants/IdBuilder.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Variants;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The variantId can be used to group documents by a variantId. This variantId is by default unique per system,
+ * and has the following syntax:
+ *
+ * <SystemHash>/type/uid
+ *
+ * A file from one system will get the same variantId, which could be useful for de-duplication.
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class IdBuilder
+{
+
+    /**
+     * This method is used to build a variantId.
+     *
+     * By default the variantId is used
+     * @param string $type
+     * @param integer $uid
+     * @return string
+     */
+    public function buildFromTypeAndUid($type, $uid)
+    {
+        $systemHash = $this->getSystemHash();
+        $variantId = $systemHash . '/' . $type . '/' . $uid;
+
+        $variantId = $this->applyHook($variantId, $systemHash, $type, $uid);
+        return $variantId;
+    }
+
+    /**
+     * Applies configured postProcessing hooks to build a custom variantId.
+     *
+     * @param string $variantId
+     * @param string $systemHash
+     * @param string $type
+     * @param integer $uid
+     * @return string
+     */
+    protected function applyHook($variantId, $systemHash, $type, $uid)
+    {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId'])) {
+            return $variantId;
+        }
+
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId'] as $classReference) {
+            $variantIdModifier = GeneralUtility::getUserObj($classReference);
+            if ($variantIdModifier instanceof IdModifier) {
+                $variantId = $variantIdModifier->modifyVariantId($variantId, $systemHash, $type, $uid);
+            }
+        }
+
+        return $variantId;
+    }
+
+    /**
+     * Returns a system unique hash.
+     *
+     * @return string
+     */
+    protected function getSystemHash()
+    {
+        if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'])) {
+            throw new \InvalidArgumentException("No sitename set in TYPO3_CONF_VARS|SYS|sitename");
+        }
+
+        $siteName = $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'];
+        $systemKey = 'tx_solr' . $siteName;
+        return GeneralUtility::hmac($systemKey);
+    }
+}

--- a/Classes/Domain/Variants/IdModifier.php
+++ b/Classes/Domain/Variants/IdModifier.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Variants;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+/**
+ * An implementation of this class can be used to modify the variantId.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+interface IdModifier
+{
+
+    /**
+     * @param string $variantId
+     * @param string $systemHash
+     * @param string $type
+     * @param integer $uid
+     * @return string
+     */
+    public function modifyVariantId($variantId, $systemHash, $type, $uid);
+}

--- a/Classes/Eid/SiteHash.php
+++ b/Classes/Eid/SiteHash.php
@@ -32,6 +32,7 @@
 
 */
 
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -40,7 +41,9 @@ $domain = GeneralUtility::_GP('domain');
 $returnData = '';
 
 if (!empty($domain)) {
-    $siteHash = Util::getSiteHashForDomain($domain);
+    /** @var $siteHashService SiteHashService */
+    $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+    $siteHash = $siteHashService->getSiteHashForDomain($domain);
     $returnData = json_encode(['sitehash' => $siteHash]);
 } else {
     header(HttpUtility::HTTP_STATUS_400);

--- a/Classes/Eid/Suggest.php
+++ b/Classes/Eid/Suggest.php
@@ -23,6 +23,7 @@
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\SuggestQuery;
 use ApacheSolrForTypo3\Solr\Util;
@@ -69,10 +70,8 @@ if ('OpenSearch' == GeneralUtility::_GET('format')) {
     $q = GeneralUtility::_GET('q');
 }
 $allowedSitesConfig = $solrConfiguration->getObjectByPathOrDefault('plugin.tx_solr.search.query.', []);
-$allowedSites = Util::resolveSiteHashAllowedSites(
-    $pageId,
-    $allowedSitesConfig['allowedSites']
-);
+$siteService = GeneralUtility::makeInstance(SiteHashService::class);
+$allowedSites = $siteService->getAllowedSitesForPageIdAndAllowedSitesConfiguration($pageId, $allowedSitesConfig['allowedSites']);
 
 $suggestQuery = GeneralUtility::makeInstance(SuggestQuery::class, $q);
 $suggestQuery->setUserAccessGroups(explode(',', $GLOBALS['TSFE']->gr_list));

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\FieldProcessor\PageUidToHierarchy;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -151,17 +152,22 @@ class Query
     protected $variantField = 'variantId';
 
     /**
+     * @var SiteHashService
+     */
+    protected $siteHashService = null;
+
+    /**
+     * Query constructor.
      * @param string $keywords
      * @param TypoScriptConfiguration $solrConfiguration
+     * @param SiteHashService|null $siteHashService
      */
-    public function __construct($keywords, $solrConfiguration = null)
+    public function __construct($keywords, $solrConfiguration = null, SiteHashService $siteHashService = null)
     {
         $keywords = (string) $keywords;
-        if ($solrConfiguration == null) {
-            $this->solrConfiguration = Util::getSolrConfiguration();
-        } else {
-            $this->solrConfiguration = $solrConfiguration;
-        }
+
+        $this->solrConfiguration = is_null($solrConfiguration) ? Util::getSolrConfiguration() : $solrConfiguration;
+        $this->siteHashService = is_null($siteHashService) ? GeneralUtility::makeInstance(SiteHashService::class) : $siteHashService;
 
         $this->setKeywords($keywords);
         $this->sorting = '';
@@ -949,12 +955,15 @@ class Query
      */
     public function setSiteHashFilter($allowedSites)
     {
+        if (trim($allowedSites) === '*') {
+            return;
+        }
+
         $allowedSites = GeneralUtility::trimExplode(',', $allowedSites);
         $filters = [];
 
         foreach ($allowedSites as $site) {
-            $siteHash = Util::getSiteHashForDomain($site);
-
+            $siteHash = $this->siteHashService->getSiteHashForDomain($site);
             $filters[] = 'siteHash:"' . $siteHash . '"';
         }
 

--- a/Classes/Search/AccessComponent.php
+++ b/Classes/Search/AccessComponent.php
@@ -24,8 +24,9 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Query;
-use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Access search component
@@ -43,17 +44,31 @@ class AccessComponent extends AbstractComponent implements QueryAware
     protected $query;
 
     /**
+     * @var SiteHashService
+     */
+    protected $siteHashService;
+
+    /**
+     * AccessComponent constructor.
+     * @param SiteHashService|null $siteService
+     */
+    public function __construct(SiteHashService $siteService = null)
+    {
+        $this->siteHashService = is_null($siteService) ? GeneralUtility::makeInstance(SiteHashService::class) : $siteService;
+    }
+
+    /**
      * Initializes the search component.
      */
     public function initializeSearchComponent()
     {
-        $allowedSites = Util::resolveSiteHashAllowedSites(
+        $allowedSites = $this->siteHashService->getAllowedSitesForPageIdAndAllowedSitesConfiguration(
             $GLOBALS['TSFE']->id,
             $this->searchConfiguration['query.']['allowedSites']
         );
+
         $this->query->setSiteHashFilter($allowedSites);
-        $this->query->setUserAccessGroups(explode(',',
-            $GLOBALS['TSFE']->gr_list));
+        $this->query->setUserAccessGroups(explode(',', $GLOBALS['TSFE']->gr_list));
     }
 
     /**

--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -399,7 +400,9 @@ class Site
      */
     public function getSiteHash()
     {
-        return Util::getSiteHashForDomain($this->getDomain());
+        /** @var $siteHashService SiteHashService */
+        $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+        return $siteHashService->getSiteHashForDomain($this->getDomain());
     }
 
     /**

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -512,23 +512,16 @@ class Util
     /**
      * Gets the site hash for a domain
      *
+     * @deprecated since 6.1 will be removed in 7.0. use SiteHashService->getSiteHashForDomain now.
      * @param string $domain Domain to calculate the site hash for.
      * @return string site hash for $domain
      */
     public static function getSiteHashForDomain($domain)
     {
-        static $siteHashes = [];
-        if (isset($siteHashes[$domain])) {
-            return $siteHashes[$domain];
-        }
-
-        $siteHashes[$domain] = sha1(
-            $domain .
-            $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] .
-            'tx_solr'
-        );
-
-        return $siteHashes[$domain];
+        GeneralUtility::logDeprecatedFunction();
+            /** @var $siteHashService SiteHashService */
+        $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+        return $siteHashService->getSiteHashForDomain($domain);
     }
 
     /**
@@ -537,33 +530,19 @@ class Util
      *   __solr_current_site - The domain of the site the query has been started from
      *   __current_site - Same as __solr_current_site
      *   __all - Adds all domains as allowed sites
-     *   * - Same as __all
+     *   * - Means all sites are allowed, same as no siteHash
      *
+     * @deprecated since 6.1 will be removed in 7.0. use SiteHashService->getAllowedSitesForPageIdAndAllowedSitesConfiguration now.
      * @param int $pageId A page ID that is then resolved to the site it belongs to
      * @param string $allowedSitesConfiguration TypoScript setting for allowed sites
      * @return string List of allowed sites/domains, magic keywords resolved
      */
-    public static function resolveSiteHashAllowedSites(
-        $pageId,
-        $allowedSitesConfiguration
-    ) {
-        if ($allowedSitesConfiguration == '*' || $allowedSitesConfiguration == '__all') {
-            $sites = Site::getAvailableSites();
-            $domains = [];
-            foreach ($sites as $site) {
-                $domains[] = $site->getDomain();
-            }
-
-            $allowedSites = implode(',', $domains);
-        } else {
-            $allowedSites = str_replace(
-                ['__solr_current_site', '__current_site'],
-                Site::getSiteByPageId($pageId)->getDomain(),
-                $allowedSitesConfiguration
-            );
-        }
-
-        return $allowedSites;
+    public static function resolveSiteHashAllowedSites($pageId, $allowedSitesConfiguration)
+    {
+        /** @var $siteHashService SiteHashService */
+        GeneralUtility::logDeprecatedFunction();
+        $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+        return $siteHashService->getAllowedSitesForPageIdAndAllowedSitesConfiguration($pageId, $allowedSitesConfiguration);
     }
 
     /**

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -100,7 +100,7 @@ Version 3.0 introduced a couple more magic keywords that get replaced:
 
 - **__current_site** same as **__solr_current_site**
 - **__all** Adds all domains as allowed sites
-- \* (asterisk character) Same as **__all**
+- \* (asterisk character) Everything is allowed as siteHash (same as no siteHash check). This option should only be used when you need a search across multiple system and you know the impact of turning of the siteHash check.
 
 query.getParameter
 ~~~~~~~~~~~~~~~~~~

--- a/Tests/Integration/Domain/Site/Fixtures/can_resolve_site_hash.xml
+++ b/Tests/Integration/Domain/Site/Fixtures/can_resolve_site_hash.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_domain>
+        <pid>1</pid>
+        <domainName>solrtesta.local</domainName>
+    </sys_domain>
+
+    <sys_domain>
+        <pid>2</pid>
+        <domainName>solrtestb.local</domainName>
+    </sys_domain>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Site A</title>
+    </pages>
+
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Site B</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Integration/Domain/Site/SiteHashServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase to check if the SiteHashService class works as expected.
+ *
+ * The integration test is used to check if we get the expected results with a defined database state.
+ *
+ * @author Timo Hund <timo.hund.de>
+ */
+class SiteHashServiceTest extends IntegrationTest
+{
+
+    /**
+     * @return array
+     */
+    public function canResolveSiteHashAllowedSitesDataProvider() {
+        return [
+            'siteHashDisabled' => ['*', '*'],
+            'allSitesInSystem' => ['__all', 'solrtesta.local,solrtestb.local'],
+            'currentSiteOnly' => ['__current_site', 'solrtesta.local']
+        ];
+    }
+
+    /**
+     * @dataProvider canResolveSiteHashAllowedSitesDataProvider
+     * @test
+     */
+    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration , $expectedAllowedSites)
+    {
+        $this->importDataSetFromFixture('can_resolve_site_hash.xml');
+        $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+        $allowedSites = $siteHashService->getAllowedSitesForPageIdAndAllowedSitesConfiguration(1, $allowedSitesConfiguration);
+        $this->assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
+    }
+}

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase to check if the SiteHashService class works as expected.
+ *
+ * The unit test is used to make sure that the SiteHashService works as expected when the calls to Site:: are mocked
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SiteHashServiceTest extends UnitTest
+{
+
+    /**
+     * @return array
+     */
+    public function canResolveSiteHashAllowedSitesDataProvider() {
+        return [
+            'siteHashDisabled' => ['*', '*'],
+            'allSitesInSystem' => ['__all', 'solrtesta.local,solrtestb.local'],
+            'currentSiteOnly' => ['__current_site', 'solrtesta.local']
+        ];
+    }
+
+    /**
+     * @dataProvider canResolveSiteHashAllowedSitesDataProvider
+     * @test
+     */
+    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration , $expectedAllowedSites)
+    {
+        $siteA = $this->getDumbMock(Site::class);
+        $siteA->expects($this->any())->method('getDomain')->will($this->returnValue('solrtesta.local'));
+        $siteB = $this->getDumbMock(Site::class);
+        $siteB->expects($this->any())->method('getDomain')->will($this->returnValue('solrtestb.local'));
+        $allSites = [$siteA, $siteB];
+
+            /** @var $siteHashServiceMock SiteHashService */
+        $siteHashServiceMock = $this->getMockBuilder(SiteHashService::class)->setMethods(['getAvailableSites','getSiteByPageId'])->getMock();
+        $siteHashServiceMock->expects($this->any())->method('getAvailableSites')->will($this->returnValue($allSites));
+        $siteHashServiceMock->expects($this->any())->method('getSiteByPageId')->will($this->returnValue($siteA));
+
+        $allowedSites = $siteHashServiceMock->getAllowedSitesForPageIdAndAllowedSitesConfiguration(1, $allowedSitesConfiguration);
+        $this->assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
+    }
+
+    /**
+     * @test
+     */
+    public function getSiteHashForDomain()
+    {
+        $oldKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'testKey';
+
+        $service = new SiteHashService();
+        $hash1 = $service->getSiteHashForDomain('www.example.com');
+        $hash2 = $service->getSiteHashForDomain('www.example.com');
+
+        $this->assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash1);
+        $this->assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash2);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $oldKey;
+    }
+}

--- a/Tests/Unit/Domain/Variants/CustomIdModifier.php
+++ b/Tests/Unit/Domain/Variants/CustomIdModifier.php
@@ -1,0 +1,42 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Variants;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Variants\IdModifier;
+
+class CustomIdModifier implements IdModifier {
+
+    /**
+     * @param string $variantId
+     * @param string $systemHash
+     * @param string $type
+     * @param integer $uid
+     * @return string
+     */
+    public function modifyVariantId($variantId, $systemHash, $type, $uid)
+    {
+        return 'mycustomid';
+    }
+}

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Variants;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase to check if the IdBuilder can be used to build proper variantIds.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class IdBuilderTest extends UnitTest
+{
+
+    /**
+     * @var string
+     */
+    protected $oldEncryptionKey;
+
+    public function setUp() {
+        $this->oldEncryptionKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'testkey';
+        parent::setUp();
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] =  $this->oldEncryptionKey;
+    }
+
+    /**
+     * @test
+     */
+    public function canBuildVariantId()
+    {
+        $build = new IdBuilder();
+        $variantId = $build->buildFromTypeAndUid('pages', 4711);
+        $this->assertSame('e99b3552a0451f1a2e7aca4ac06ccaba063393de/pages/4711', $variantId);
+    }
+
+    /**
+     * @test
+     */
+    public function canRegisterCustomHook()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId']['test'] = CustomIdModifier::class;
+
+        $build = new IdBuilder();
+        $variantId = $build->buildFromTypeAndUid('pages', 4711);
+
+        // the variantId should be overwritten by the custom modifier
+        $this->assertSame('mycustomid', $variantId);
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId'] = [];
+    }
+}

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -711,6 +711,34 @@ class QueryTest extends UnitTest
     /**
      * @test
      */
+    public function noSiteHashFilterIsSetWhenWildcardIsPassed()
+    {
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = $this->getInitializedTestQuery();
+        $query->setSiteHashFilter('*');
+        $filters = $query->getFilters();
+        $this->assertEmpty($filters, 'The filters should be empty when a wildcard sitehash was passed');
+    }
+
+    /**
+     * @test
+     */
+    public function filterIsAddedWhenAllowedSiteIsPassed()
+    {
+        /** @var $query \ApacheSolrForTypo3\Solr\Query */
+        $query = $this->getInitializedTestQuery();
+        $query->setSiteHashFilter('solrtest.local');
+        $filters = $query->getFilters();
+
+        $this->assertCount(1, $filters, 'We expected that one filter was added');
+
+        $firstFilter= $filters[0];
+        $this->assertContains('siteHash:', $firstFilter, 'The filter was expected to start with siteHash*');
+    }
+
+    /**
+     * @test
+     */
     public function canTestNumberOfSuggestionsToTryFromConfiguration()
     {
         $input = 9;

--- a/Tests/Unit/UtilTest.php
+++ b/Tests/Unit/UtilTest.php
@@ -15,20 +15,4 @@ class UtilTest extends UnitTest
         $configuration = Util::getConfigurationFromPageId(0, 'plugin.tx_solr', false, 0, false);
         $this->assertInstanceOf('ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration', $configuration);
     }
-
-    /**
-     * @test
-     */
-    public function getSiteHashForDomain()
-    {
-        $oldKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'testKey';
-
-        $hash1 = Util::getSiteHashForDomain('www.test.de');
-        $hash2 = Util::getSiteHashForDomain('www.test.de');
-
-        $this->assertEquals('b17ca8164881e80e96a96529c16b19cc405c9bd0', $hash1);
-        $this->assertEquals('b17ca8164881e80e96a96529c16b19cc405c9bd0', $hash2);
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $oldKey;
-    }
 }


### PR DESCRIPTION
This PR changes the behaviour of `query.allowedSites`; the behavior `*` has been changed:

* Before: `*` was the same as `__all`, which means all sites in the system
* After: `__all` is still handled as `__all` sites in the system, but `*` now means every site (same as no check at all)

## Implementation Details

During the implementation the following things have been done

* Move SiteHash related logic from Util* to SiteHashService* and make them non static (See: http://wiki.c2.com/?AbuseOfUtilityClasses)
* Mark SiteHash related method in Util deprecated and announce removal
* Added Tests for Query and SiteHashService modifications
* If variants should be used across multiple instances the `variantId` needs to be unique by system (not by site!). As of now the `variantId` only contains (type/uid), to have a unique `variantId` across multiple systems, a system hash was added.

## Impact & Migration

* If you use `*` for query.allowedSites please use `__all` now unless you want to disable the siteHash check
* If you use variants, it is recommended to reindex your pages, since the hash was changed.

Fixes: #862