### PR TITLE
[TASK] Check performance of IndexQueueWorkTask::getProgress

### DIFF
--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -203,11 +203,7 @@ class IndexQueueModuleController extends AbstractModuleController
 
         $messagesForConfigurations = [];
         foreach (array_keys($initializedIndexingConfigurations) as $indexingConfigurationName) {
-            $itemCount = $itemIndexQueue->getItemsCountBySite($this->site,
-                $indexingConfigurationName);
-            if (!is_int($itemCount)) {
-                $itemCount = 0;
-            }
+            $itemCount = $itemIndexQueue->getItemsCountBySite($this->site, $indexingConfigurationName);
             $messagesForConfigurations[] = $indexingConfigurationName . ' (' . $itemCount . ' records)';
         }
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_get_item_count_by_site.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_get_item_count_by_site.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -186,4 +186,35 @@ class QueueTest extends IntegrationTest
             'Item was queued with unexpected configuration'
         );
     }
+
+    /**
+     * @test
+     */
+    public function canGetItemCountBySite()
+    {
+        $this->importDataSetFromFixture('can_get_item_count_by_site.xml');
+        $site = Site::getFirstAvailableSite();
+        $itemCount = $this->indexQueue->getItemsCountBySite($site);
+
+            // there are two items in the queue but only one for the site
+        $this->assertSame(1, $itemCount, 'Unexpected item count for the first site');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetRemainingItemCountBySite()
+    {
+        $this->importDataSetFromFixture('can_get_item_count_by_site.xml');
+        $site = Site::getFirstAvailableSite();
+
+        $itemCount = $this->indexQueue->getRemainingItemsCountBySite($site);
+        $this->assertSame(1, $itemCount, 'Unexpected remaining item count for the first site');
+
+            // when we update the item, no remaining item should be left
+        $this->indexQueue->updateItem('pages', 1);
+        $itemCount = $this->indexQueue->getRemainingItemsCountBySite($site);
+        $this->assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
+    }
+
 }


### PR DESCRIPTION
This PR resolve performance issues in the IndexQueueWorkerTask.

The reason was:

* The configuration is fetched in the constructor of IndexService but only needed when items get really processed.

The solution is:

* Fetch the configuration indexItems, then it will not be fetched when just the progress is calculated

Beside that:

* The database logic was move to the IndexQueue because this class should be responsible to do database operations on 'tx_solr_indexqueue_item' (Related issue: #904)
* Tests have been added for the IndexQueue methods
* It is tested that the configuration is only fetched when records get indexed

Fixes: #928