### PR TITLE
[BUG] Wrapped CliEnvironment to be used only in cli-mode

### DIFF
--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -65,6 +65,7 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
     public function execute()
     {
         $cliEnvironment = null;
+
         // Wrapped the CliEnvironment to avoid defining TYPO3_PATH_WEB since this
         // should only be done in the case when running it from outside TYPO3 BE
         // @see #921 and #934 on https://github.com/TYPO3-Solr
@@ -73,6 +74,7 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
             $cliEnvironment->backup();
             $cliEnvironment->initialize($this->getWebRoot());
         }
+
         $indexService = GeneralUtility::makeInstance(IndexService::class, $this->site);
         $indexService->setContextTask($this);
         $indexService->indexItems($this->documentsToIndexLimit);

--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -64,10 +64,11 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
      */
     public function execute()
     {
+        $cliEnvironment = null;
         // Wrapped the CliEnvironment to avoid defining TYPO3_PATH_WEB since this
         // should only be done in the case when running it from outside TYPO3 BE
         // @see #921 and #934 on https://github.com/TYPO3-Solr
-        if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) {
+        if (TYPO3_REQUESTTYPE && TYPO3_REQUESTTYPE_CLI) {
             $cliEnvironment = GeneralUtility::makeInstance(CliEnvironment::class);
             $cliEnvironment->backup();
             $cliEnvironment->initialize($this->getWebRoot());
@@ -76,7 +77,7 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
         $indexService->setContextTask($this);
         $indexService->indexItems($this->documentsToIndexLimit);
 
-        if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) {
+        if (TYPO3_REQUESTTYPE && TYPO3_REQUESTTYPE_CLI) {
             $cliEnvironment->restore();
         }
 


### PR DESCRIPTION
Solves #921 - I have tested it and links still seem to be generated properly both from cli and BE.
In addition a have created a patch for the dev-branch of SolrFal