### PR TITLE
[TASK] RecordMonitor does not track records outside the siteroot.

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -44,11 +44,8 @@ class ConfigurationAwareRecordService
      * @param TypoScriptConfiguration $solrConfiguration
      * @return string Name of indexing configuration
      */
-    public function getIndexingConfigurationName(
-        $recordTable,
-        $recordUid,
-        TypoScriptConfiguration $solrConfiguration
-    ) {
+    public function getIndexingConfigurationName($recordTable, $recordUid, TypoScriptConfiguration $solrConfiguration)
+    {
         $name = $recordTable;
         $indexingConfigurations = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
         foreach ($indexingConfigurations as $indexingConfigurationName) {
@@ -103,15 +100,9 @@ class ConfigurationAwareRecordService
      * @param TypoScriptConfiguration $solrConfiguration
      * @return array
      */
-    protected function getRecordIfIndexConfigurationIsValid(
-        $recordTable,
-        $recordUid,
-        $indexingConfigurationName,
-        TypoScriptConfiguration $solrConfiguration
-    ) {
-        if (!$this->isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName,
-            $solrConfiguration)
-        ) {
+    protected function getRecordIfIndexConfigurationIsValid($recordTable, $recordUid, $indexingConfigurationName, TypoScriptConfiguration $solrConfiguration)
+    {
+        if (!$this->isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName, $solrConfiguration)) {
             return [];
         }
 
@@ -132,11 +123,8 @@ class ConfigurationAwareRecordService
      * @param TypoScriptConfiguration $solrConfiguration
      * @return boolean
      */
-    protected function isValidTableForIndexConfigurationName(
-        $recordTable,
-        $indexingConfigurationName,
-        TypoScriptConfiguration $solrConfiguration
-    ) {
+    protected function isValidTableForIndexConfigurationName($recordTable, $indexingConfigurationName, TypoScriptConfiguration $solrConfiguration)
+    {
         $tableToIndex = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
 
         $isMatchingTable = ($tableToIndex === $recordTable);

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * RootPageResolver.
+ *
+ * Responsibility: The RootPageResolver is responsible to determine all relevant site root page id's
+ * for a certain records, by table and uid.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class RootPageResolver implements SingletonInterface
+{
+
+    /**
+     * @var ConfigurationAwareRecordService
+     */
+    protected $recordService;
+
+    /**
+     * @var TwoLevelCache
+     */
+    protected $siteRootsCache;
+
+    /**
+     * RootPageResolver constructor.
+     * @param ConfigurationAwareRecordService|null $recordService
+     * @param TwoLevelCache|null $twoLevelCache
+     */
+    public function __construct(ConfigurationAwareRecordService $recordService = null, TwoLevelCache $twoLevelCache = null)
+    {
+        $this->recordService = isset($recordService) ? $recordService : GeneralUtility::makeInstance(ConfigurationAwareRecordService::class);
+        $this->siteRootsCache = isset($twoLevelCache) ? $twoLevelCache : GeneralUtility::makeInstance(TwoLevelCache::class, 'tx_solr_siteroots');
+    }
+
+    /**
+     * This method determines the responsible site roots for a record by getting the rootPage of the record and checking
+     * if the pid is references in another site with additionalPageIds and returning those rootPageIds as well.
+     * The result is cached by the caching framework.
+     *
+     * @param string $table
+     * @param int $uid
+     * @return array
+     */
+    public function getResponsibleRootPageIds($table, $uid)
+    {
+        $cacheKey = 'rootpageids-' . $table . '-'.$uid;
+        $cacheResult = $this->siteRootsCache->get($cacheKey);
+        if ($cacheResult !== false) {
+            return $cacheResult;
+        }
+
+        $methodResult = $this->buildResponsibleRootPageIds($table, $uid);
+        $this->siteRootsCache->set($cacheKey, $methodResult);
+        return $methodResult;
+    }
+
+
+    /**
+     * This method determines the responsible site roots for a record by getting the rootPage of the record and checking
+     * if the pid is references in another site with additionalPageIds and returning those rootPageIds as well.
+     *
+     * @param string $table
+     * @param integer $uid
+     * @return array
+     */
+    protected function buildResponsibleRootPageIds($table, $uid)
+    {
+        $rootPages = [];
+        $rootPageId = $this->getRootPageIdByTableAndUid($table, $uid);
+        if ($this->getIsRootPageId($rootPageId)) {
+            $rootPages[] = $rootPageId;
+        }
+
+        $alternativeSiteRoots = $this->getAlternativeSiteRootPagesIds($table, $uid, $rootPageId);
+        $rootPages = array_merge($rootPages, $alternativeSiteRoots);
+        return $rootPages;
+    }
+
+    /**
+     * This method checks if the record is a pages record or another one and determines the rootPageId from the records
+     * rootline.
+     *
+     * @param string $table
+     * @param int $uid
+     * @return int
+     */
+    protected function getRootPageIdByTableAndUid($table, $uid)
+    {
+        if ($table === 'pages') {
+            $rootPageId = Util::getRootPageId($uid);
+            return $rootPageId;
+        } else {
+            $record = BackendUtility::getRecord($table, $uid);
+            $rootPageId = Util::getRootPageId($record['pid'], true);
+            return $rootPageId;
+        }
+    }
+
+    /**
+     * Checks if the passed pageId is a root page.
+     *
+     * @param integer $pageId
+     * @return bool
+     */
+    protected function getIsRootPageId($pageId)
+    {
+        return Util::isRootPage($pageId);
+    }
+
+    /**
+     * When no root page can be determined we check if the pageIdOf the record is configured as additionalPageId in the index
+     * configuration of another site, if so we return the rootPageId of this site.
+     * The result is cached by the caching framework.
+     *
+     * @param string $table
+     * @param int $uid
+     * @param int $recordPageId
+     * @return array
+     */
+    public function getAlternativeSiteRootPagesIds($table, $uid, $recordPageId)
+    {
+        $siteRootsByObservedPageIds = $this->getSiteRootsByObservedPageIds($table, $uid);
+        if (!isset($siteRootsByObservedPageIds[$recordPageId])) {
+            return [];
+        }
+
+        return $siteRootsByObservedPageIds[$recordPageId];
+    }
+
+    /**
+     * Retrieves an optimized array structure we the monitored pageId as key and the relevant site rootIds as value.
+     *
+     * @param string $table
+     * @param integer $uid
+     * @return array
+     */
+    protected function getSiteRootsByObservedPageIds($table, $uid)
+    {
+        $cacheKey = 'alternativesiteroots-' . $table . '-' . $uid;
+        $cacheResult = $this->siteRootsCache->get($cacheKey);
+        if ($cacheResult !== false) {
+            return $cacheResult;
+        }
+
+        $methodResult = $this->buildSiteRootsByObservedPageIds($table, $uid);
+        $this->siteRootsCache->set($cacheKey, $methodResult);
+        return $methodResult;
+    }
+
+    /**
+     * This methods build an array with observer page id as key and rootPageIds as values to determine which root pages
+     * are responsible for this record by referencing the pageId in additionalPageIds configuration.
+     *
+     * @param string $table
+     * @param integer $uid
+     * @return array
+     */
+    protected function buildSiteRootsByObservedPageIds($table, $uid)
+    {
+        $siteRootByObservedPageIds = [];
+        $allSites = Site::getAvailableSites();
+        foreach ($allSites as $site) {
+            $solrConfiguration = $site->getSolrConfiguration();
+            $indexingConfigurationName = $this->recordService->getIndexingConfigurationName($table, $uid, $solrConfiguration);
+            $observedPageIdsOfSiteRoot = $solrConfiguration->getIndexQueueAdditionalPageIdsByConfigurationName($indexingConfigurationName);
+            foreach ($observedPageIdsOfSiteRoot as $observedPageIdOfSiteRoot) {
+                $siteRootByObservedPageIds[$observedPageIdOfSiteRoot][] = $site->getRootPageId();
+            }
+        }
+
+        return $siteRootByObservedPageIds;
+    }
+}

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -53,7 +53,6 @@ class Page extends AbstractInitializer
         parent::__construct();
 
         $this->type = 'pages';
-        $this->indexingConfigurationName = 'pages';
     }
 
     /**
@@ -127,7 +126,7 @@ class Page extends AbstractInitializer
                 // Add page like a regular page, as only the sub tree is
                 // mounted. The page itself has its own content.
                 $indexQueue = GeneralUtility::makeInstance(Queue::class);
-                $indexQueue->updateItem($this->type, $mountPage['uid'], $this->indexingConfigurationName);
+                $indexQueue->updateItem($this->type, $mountPage['uid']);
             }
 
             // This can happen when the mount point does not show the content of the

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -354,6 +354,26 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns an array of all additionalPageIds by index configuration name.
+     *
+     * plugin.tx_solr.index.queue.pages.additionalPageIds
+     *
+     * @param string $configurationName
+     * @param array $defaultIfEmpty
+     * @return array
+     */
+    public function getIndexQueueAdditionalPageIdsByConfigurationName($configurationName = 'pages', $defaultIfEmpty = [])
+    {
+        $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.additionalPageIds';
+        $result = $this->getValueByPathOrDefaultValue($path, '');
+        if (trim($result) == '') {
+            return $defaultIfEmpty;
+        }
+
+        return GeneralUtility::trimExplode(',', $result);
+    }
+
+    /**
      * Returns an array of all allowedPageTypes.
      *
      * plugin.tx_solr.index.queue.pages.allowedPageTypes
@@ -896,7 +916,7 @@ class TypoScriptConfiguration
      * Returns if a log message should be written when a page was indexed.
      *
      * plugin.tx_solr.logging.indexing.pageIndexed
-
+     *
      * @param bool $defaultIfEmpty
      * @return bool
      */
@@ -910,7 +930,7 @@ class TypoScriptConfiguration
      * Returns if a log message should be written when the TYPO3 search markers are missing in the page.
      *
      * plugin.tx_solr.logging.indexing.missingTypo3SearchMarkers
-
+     *
      * @param bool $defaultIfEmpty
      * @return bool
      */
@@ -938,7 +958,7 @@ class TypoScriptConfiguration
      * Indicates if the debug mode is enabled or not.
      *
      * plugin.tx_solr.enableDebugMode
-
+     *
      * @param bool $defaultIfEmpty
      * @return bool
      */

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -74,7 +74,7 @@ class IndexServiceTest extends IntegrationTest
     protected function addToIndexQueue($table, $uid)
     {
         // write an index queue item
-        $this->indexQueue->updateItem($table, $uid, null, time());
+        $this->indexQueue->updateItem($table, $uid, time());
     }
 
     public function canResolveAbsRefPrefixDataProvider()

--- a/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 2
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <!-- sysfolder in other site -->
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <doktype>254</doktype>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_foo>
+        <uid>8</uid>
+        <title>testnews</title>
+        <pid>2</pid>
+    </tx_fakeextension_domain_model_foo>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_from_two_sites.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_from_two_sites.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 3
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>2</uid>
+        <pid>2</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_de/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 3
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <!-- sysfolder in other site -->
+    <pages>
+        <uid>3</uid>
+        <pid>0</pid>
+        <doktype>254</doktype>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_foo>
+        <uid>8</uid>
+        <title>testnews</title>
+        <pid>3</pid>
+    </tx_fakeextension_domain_model_foo>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -726,4 +726,60 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->assertIndexQueueContainsItemAmount(1);
     }
+
+    /**
+     * @test
+     */
+    public function updateRecordOutsideSiteRoot()
+    {
+        $this->importDumpFromFixture('fake_extension_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+
+        $this->importDataSetFromFixture('update_record_outside_siteroot.xml');
+
+        $this->assertEmptyIndexQueue();
+
+        // create faked tce main call data
+        $status = 'update';
+        $table = 'tx_fakeextension_domain_model_foo';
+        $uid = 8;
+        $fields = [
+            'title' => 'i am outside the site root',
+            'starttime' => 1000000,
+            'endtime' => 1100000,
+            'tsstamp' => 1000000,
+            'pid' => 2
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRecordOutsideSiteRootReferencedInTwoSites()
+    {
+        $this->importDumpFromFixture('fake_extension_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+
+        $this->importDataSetFromFixture('update_record_outside_siteroot_from_two_sites.xml');
+
+        $this->assertEmptyIndexQueue();
+
+        // create faked tce main call data
+        $status = 'update';
+        $table = 'tx_fakeextension_domain_model_foo';
+        $uid = 8;
+        $fields = [
+            'title' => 'i am outside the site root and referenced in two sites',
+            'starttime' => 1000000,
+            'endtime' => 1100000,
+            'tsstamp' => 1000000,
+            'pid' => 3
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
 }

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class RootPageResolverTest extends UnitTest
+{
+    /**
+     * @var TwoLevelCache
+     */
+    protected $cacheMock;
+
+    /**
+     * @var ConfigurationAwareRecordService
+     */
+    protected $recordServiceMock;
+
+    /**
+     * @var RootPageResolver
+     */
+    protected $rootPageResolver;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->fakeDisabledCache();
+
+        $this->recordServiceMock = $this->getDumbMock(ConfigurationAwareRecordService::class);
+
+        /** @var $rootPageResolver RootPageResolver */
+        $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
+            ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
+            ->setMethods(['getIsRootPageId','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid'])->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences()
+    {
+        $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
+        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(true));
+        $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
+
+        $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
+
+        $message = 'Root page resolver did not retrieve and merge root page ids from root line and typoscript references';
+        $this->assertEquals([222,333,444], $resolvedRootPages, $message);
+    }
+
+    /**
+     * @test
+     */
+    public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot()
+    {
+        $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
+        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(false));
+        $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
+
+        $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
+
+        $message = 'Root page resolver should only return rootPageIds from references';
+        $this->assertEquals([333,444], $resolvedRootPages, $message);
+    }
+
+    /**
+     * @return void
+     */
+    protected function fakeDisabledCache()
+    {
+        $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
+        $this->cacheMock->method('get')->will($this->returnValue(false));
+    }
+
+
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -291,8 +291,16 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration'] = [];
 }
 
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots'] = [];
+}
+
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['backend'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['backend'] = \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class;
+}
+
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['backend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['backend'] = \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class;
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['options'])) {
@@ -300,8 +308,17 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['options'] = ['defaultLifetime' => 60 * 60 * 24];
 }
 
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['options'])) {
+    // default life time one day
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['options'] = ['defaultLifetime' => 60 * 60 * 24];
+}
+
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'] = ['all'];
+}
+
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['groups'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['groups'] = ['all'];
 }
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #


### PR DESCRIPTION
With the configuration "additionalPageIds" it was possible to add additional page ids to an indexing configuration.
When these external records have been updated in the backend by now the RecordMonitor does not recognize these updates.

This PR allows the RecordMonitor to determine all responsible site roots and add the entry to the queue when the queue get's intialized.

Fixes: #485