### PR TITLE
[TASK] Fix deprecations with TYPO3 8.x

### DIFF
--- a/Classes/Backend/IndexInspector/IndexInspector.php
+++ b/Classes/Backend/IndexInspector/IndexInspector.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use TYPO3\CMS\Backend\Module\AbstractFunctionModule;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Index Inspector to see what documents have been indexed for a selected page.
@@ -111,9 +112,17 @@ class IndexInspector extends AbstractFunctionModule
         );
 
         $pageRenderer->addExtDirectCode(['TYPO3.tx_solr.IndexInspector.Remote']);
-        $pageRenderer->addJsFile('sysext/backend/Resources/Public/JavaScript/extjs/ux/Ext.grid.RowExpander.js');
-        $pageRenderer->addJsFile($this->document->backPath . $GLOBALS['PATHrel_solr'] . 'Resources/JavaScript/ExtJs/override/gridpanel.js');
-        $pageRenderer->addJsFile($this->document->backPath . $GLOBALS['PATHrel_solr'] . 'Resources/JavaScript/ModIndex/index_inspector.js');
+
+        // @Todo This should be solved otherwise see #948 - for now a copy of
+        // Ext.grid.RowExpander.js from 7.6.x has been included
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= VersionNumberUtility::convertVersionNumberToInteger('8.0')) {
+            $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ExtJs/Ext.grid.RowExpander.js');
+        } else {
+            $pageRenderer->addJsFile('sysext/backend/Resources/Public/JavaScript/extjs/ux/Ext.grid.RowExpander.js');
+        }
+
+        $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ExtJs/override/gridpanel.js');
+        $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ModIndex/index_inspector.js');
 
         $pageRenderer->addCssInlineBlock('grid-selection-enabler', '
 			.x-selectable, .x-selectable * {

--- a/Classes/Backend/IndexInspector/IndexInspector.php
+++ b/Classes/Backend/IndexInspector/IndexInspector.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use TYPO3\CMS\Backend\Module\AbstractFunctionModule;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
@@ -117,12 +118,13 @@ class IndexInspector extends AbstractFunctionModule
         // Ext.grid.RowExpander.js from 7.6.x has been included
         if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= VersionNumberUtility::convertVersionNumberToInteger('8.0')) {
             $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ExtJs/Ext.grid.RowExpander.js');
+            $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ExtJs/override/gridpanel.js');
+            $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ModIndex/index_inspector.js');
         } else {
-            $pageRenderer->addJsFile('sysext/backend/Resources/Public/JavaScript/extjs/ux/Ext.grid.RowExpander.js');
+            $pageRenderer->addJsFile(ExtensionManagementUtility::extRelPath('backend') . 'Resources/Public/JavaScript/extjs/ux/Ext.grid.RowExpander.js');
+            $pageRenderer->addJsFile(ExtensionManagementUtility::extRelPath('solr') . 'Resources/JavaScript/ExtJs/override/gridpanel.js');
+            $pageRenderer->addJsFile(ExtensionManagementUtility::extRelPath('solr') . 'Resources/JavaScript/ModIndex/index_inspector.js');
         }
-
-        $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ExtJs/override/gridpanel.js');
-        $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ModIndex/index_inspector.js');
 
         $pageRenderer->addCssInlineBlock('grid-selection-enabler', '
 			.x-selectable, .x-selectable * {

--- a/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
+++ b/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
@@ -7,6 +7,5 @@ if (is_object($TYPO3backend)) {
     /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
     $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
 
-    $javascriptPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('solr') . 'Resources/JavaScript/ContextMenu/';
-    $pageRenderer->addJsFile($javascriptPath . 'initializesolrconnectionsclickmenuaction.js');
+    $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ContextMenu/initializesolrconnectionsclickmenuaction.js');
 }

--- a/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
+++ b/Classes/BackendItem/ContextMenuActionJavascriptRegistration.php
@@ -7,5 +7,10 @@ if (is_object($TYPO3backend)) {
     /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
     $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
 
-    $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ContextMenu/initializesolrconnectionsclickmenuaction.js');
+    // @Todo This should be removed when we don't support 7.6 LTS anymore
+    if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('8.0')) {
+        $pageRenderer->addJsFile('EXT:solr/Resources/JavaScript/ContextMenu/initializesolrconnectionsclickmenuaction.js');
+    } else {
+        $pageRenderer->addJsFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('solr') . 'Resources/JavaScript/ContextMenu/initializesolrconnectionsclickmenuaction.js');
+    }
 }

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -186,7 +186,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
                 'os' => '',
                 'exec' => '',
 
-                'classFile' => $GLOBALS['PATH_solr'] . 'Classes/IndexQueue/FrontendHelper/AuthorizationService.php',
+                'classFile' => ExtensionManagementUtility::extPath('solr') . 'Classes/IndexQueue/FrontendHelper/AuthorizationService.php',
                 'className' => AuthorizationService::class,
             ]
         );

--- a/Resources/JavaScript/ExtJs/Ext.grid.RowExpander.js
+++ b/Resources/JavaScript/ExtJs/Ext.grid.RowExpander.js
@@ -1,0 +1,193 @@
+/*
+ * Ext JS Library 2.0
+ * Copyright(c) 2006-2007, Ext JS, LLC.
+ * licensing@extjs.com
+ *
+ * http://extjs.com/license
+ *
+ * MODIFIED: SGB [12.12.07]
+ * Added support for a new config option, remoteDataMethod,
+ * including getter and setter functions, and minor mods
+ * to the beforeExpand and expandRow functions
+ */
+
+Ext.grid.RowExpander = function(config) {
+	Ext.apply(this, config);
+	Ext.grid.RowExpander.superclass.constructor.call(this);
+
+	if (this.tpl) {
+		if (typeof this.tpl == 'string') {
+			this.tpl = new Ext.Template(this.tpl);
+		}
+		this.tpl.compile();
+	}
+
+	this.state = {};
+	this.bodyContent = {};
+
+	this.addEvents({
+		beforeexpand : true,
+		expand: true,
+		beforecollapse: true,
+		collapse: true
+	});
+};
+
+Ext.extend(Ext.grid.RowExpander, Ext.util.Observable, {
+	header: "",
+	width: 20,
+	sortable: false,
+	fixed:true,
+	dataIndex: '',
+	id: 'expander',
+	lazyRender : true,
+	enableCaching: true,
+
+	getRowClass : function(record, rowIndex, p, ds) {
+		p.cols = p.cols-1;
+		var content = this.bodyContent[record.id];
+		if (!content && !this.lazyRender) {
+			content = this.getBodyContent(record, rowIndex);
+		}
+		if (content) {
+			p.body = content;
+		}
+		return this.state[record.id] ? 'x-grid3-row-expanded' : 'x-grid3-row-collapsed';
+	},
+
+	init : function(grid) {
+		this.grid = grid;
+
+		var view = grid.getView();
+		view.getRowClass = this.getRowClass.createDelegate(this);
+
+		view.enableRowBody = true;
+
+		grid.on('render', function() {
+			view.mainBody.on('mousedown', this.onMouseDown, this);
+		}, this);
+
+		grid.store.on('load', this.onStoreLoaded, this);
+		grid.on("beforestaterestore", this.applyState, this);
+		grid.on("beforestatesave", this.saveState, this);
+	},
+
+	/** @private */
+	onStoreLoaded: function(store, records, options) {
+		var index = -1;
+		for(var key in this.state){
+			if (this.state[key] === true) {
+				index = store.indexOfId(key);
+				if (index > -1) {
+					this.expandRow(index);
+				}
+			}
+		}
+	},
+
+	/** @private */
+	applyState: function(grid, state){
+		this.suspendStateStore = true;
+		if(state.expander) {
+			this.state = state.expander;
+		}
+		this.suspendStateStore = false;
+	},
+
+	/** @private */
+	saveState: function(grid, state){
+		return state.expander = this.state;
+	},
+
+	getBodyContent : function(record, index) {
+		if (!this.enableCaching) {
+			return this.tpl.apply(record.data);
+		}
+		var content = this.bodyContent[record.id];
+		if (!content) {
+			content = this.tpl.apply(record.data);
+			this.bodyContent[record.id] = content;
+		}
+		return content;
+	},
+	// Setter and Getter methods for the remoteDataMethod property
+	setRemoteDataMethod : function (fn) {
+		this.remoteDataMethod = fn;
+	},
+
+	getRemoteDataMethod : function (record, index) {
+		if (!this.remoteDataMethod) {
+			return;
+		}
+			return this.remoteDataMethod.call(this,record,index);
+	},
+
+	onMouseDown : function(e, t) {
+		if (t.className == 'x-grid3-row-expander') {
+			e.stopEvent();
+			var row = e.getTarget('.x-grid3-row');
+			this.toggleRow(row);
+		}
+	},
+
+	renderer : function(v, p, record) {
+		p.cellAttr = 'rowspan="2"';
+		return '<div class="x-grid3-row-expander">&#160;</div>';
+	},
+
+	beforeExpand : function(record, body, rowIndex) {
+		if (this.fireEvent('beforexpand', this, record, body, rowIndex) !== false) {
+			// If remoteDataMethod is defined then we'll need a div, with a unique ID,
+			//  to place the content
+			if (this.remoteDataMethod) {
+				this.tpl = new Ext.Template("<div id=\"remData" + rowIndex + "\" class=\"rem-data-expand\"><\div>");
+			}
+			if (this.tpl && this.lazyRender) {
+				body.innerHTML = this.getBodyContent(record, rowIndex);
+			}
+
+			return true;
+		}else{
+			return false;
+		}
+	},
+
+	toggleRow : function(row) {
+		if (typeof row == 'number') {
+			row = this.grid.view.getRow(row);
+		}
+		this[Ext.fly(row).hasClass('x-grid3-row-collapsed') ? 'expandRow' : 'collapseRow'](row);
+		this.grid.saveState();
+	},
+
+	expandRow : function(row) {
+		if (typeof row == 'number') {
+			row = this.grid.view.getRow(row);
+		}
+		var record = this.grid.store.getAt(row.rowIndex);
+		var body = Ext.DomQuery.selectNode('tr:nth(2) div.x-grid3-row-body', row);
+		if (this.beforeExpand(record, body, row.rowIndex)) {
+			this.state[record.id] = true;
+			Ext.fly(row).replaceClass('x-grid3-row-collapsed', 'x-grid3-row-expanded');
+			this.grid.saveState();
+		   	if (this.fireEvent('expand', this, record, body, row.rowIndex) !== false) {
+				//  If the expand event is successful then get the remoteDataMethod
+				this.getRemoteDataMethod(record,row.rowIndex);
+			}
+		}
+	},
+
+	collapseRow : function(row) {
+		if (typeof row == 'number') {
+			row = this.grid.view.getRow(row);
+		}
+		var record = this.grid.store.getAt(row.rowIndex);
+		var body = Ext.fly(row).child('tr:nth(1) div.x-grid3-row-body', true);
+		if (this.fireEvent('beforcollapse', this, record, body, row.rowIndex) !== false) {
+			this.state[record.id] = false;
+			Ext.fly(row).replaceClass('x-grid3-row-expanded', 'x-grid3-row-collapsed');
+			this.grid.saveState();
+			this.fireEvent('collapse', this, record, body, row.rowIndex);
+		}
+	}
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,14 +3,12 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-$GLOBALS['PATH_solr'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('solr');
-
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 // Windows compatibility
 
 if (!function_exists('strptime')) {
-    require_once($GLOBALS['PATH_solr'] . 'Resources/Private/Php/strptime/strptime.php');
+    require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('solr') . 'Resources/Private/Php/strptime/strptime.php');
 }
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,10 +3,6 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-// TODO change to a constant, so that it can't get manipulated
-$GLOBALS['PATH_solr'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('solr');
-$GLOBALS['PATHrel_solr'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('solr');
-
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 // add search plugin to content element wizard
@@ -170,7 +166,7 @@ options.contextMenu.table.pages.items.851 = DIVIDER
 );
 
 // include JS in backend
-$GLOBALS['TYPO3_CONF_VARS']['typo3/backend.php']['additionalBackendItems']['Solr.ContextMenuInitializeSolrConnectionsAction'] = $GLOBALS['PATH_solr'] . 'Classes/BackendItem/ContextMenuActionJavascriptRegistration.php';
+$GLOBALS['TYPO3_CONF_VARS']['typo3/backend.php']['additionalBackendItems']['Solr.ContextMenuInitializeSolrConnectionsAction'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('solr') . 'Classes/BackendItem/ContextMenuActionJavascriptRegistration.php';
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 


### PR DESCRIPTION
Removed $GLOBALS['PATH_solr'] , $GLOBALS['PATHrel_solr'], ExtensionManagementUtility::extRelPath('solr') and temp fix for #948 