### PR TITLE
[TASK] Added runtime cache to RecordMonitor

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -243,18 +243,9 @@ class RecordMonitor extends AbstractDataHandlerListener
         $recordTable = $table;
         $recordUid = $uid;
 
-        // Check if record has already been processed since DataHandler sends processDatamap_afterDatabaseOperations
-        // more than one time per table with nearly identical $fields array - but we only use the pid
-        // @see https://forge.typo3.org/issues/79635
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
-        $cacheId = 'RecordMonitor' . '_' . 'processDatamap_afterDatabaseOperations' . '_' . $table . '_' . $uid . '_' . $status;
-
-        $isProcessed = $cache->get($cacheId);
-        if (!empty($isProcessed)) {
-            // item already processed in this request
+        if ($this->hasRecordBeenProcessed($table, $uid, $status)) {
             return;
         }
-        $cache->set($cacheId, true);
 
         if ($status == 'new') {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];
@@ -273,6 +264,33 @@ class RecordMonitor extends AbstractDataHandlerListener
         }
 
         $this->processRecord($recordTable, $recordPageId, $recordUid, $fields);
+    }
+
+    /**
+     * Checks if the record has already been processed by the processDatamap_afterDatabaseOperations hook
+     *
+     * @param string $status Status of the current operation, 'new' or 'update'
+     * @param string $table The table the record belongs to
+     * @param mixed $uid The record's uid, [integer] or [string] (like 'NEW...')
+     *
+     * @return bool
+     */
+    protected function hasRecordBeenProcessed($table, $uid, $status)
+    {
+        // Check if record has already been processed since DataHandler sends processDatamap_afterDatabaseOperations
+        // more than one time per table with nearly identical $fields array - but we only use the pid
+        // @see https://forge.typo3.org/issues/79635
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
+        $cacheId = 'RecordMonitor' . '_' . 'processDatamap_afterDatabaseOperations' . '_' . $table . '_' . $uid . '_' . $status;
+
+        $isProcessed = $cache->get($cacheId);
+        if (!empty($isProcessed)) {
+            // item already processed in this request
+            return true;
+        }
+        $cache->set($cacheId, true);
+
+        return false;
     }
 
     /**

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -280,7 +280,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         // more than one time per table with nearly identical $fields array - but we only use the pid
         // @see https://forge.typo3.org/issues/79635
         $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
-        $cacheId = 'RecordMonitor' . '_' . 'processDatamap_afterDatabaseOperations' . '_' . $table . '_' . $uid . '_' . $status;
+        $cacheId = 'RecordMonitor' . '_' . 'hasRecordBeenProcessed' . '_' . $table . '_' . $uid . '_' . $status;
 
         $isProcessed = $cache->get($cacheId);
         if (!empty($isProcessed)) {

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\AbstractDataHandlerListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -241,6 +242,19 @@ class RecordMonitor extends AbstractDataHandlerListener
     ) {
         $recordTable = $table;
         $recordUid = $uid;
+
+        // Check if record has already been processed since DataHandler sends processDatamap_afterDatabaseOperations
+        // more than one time per table with nearly identical $fields array - but we only use the pid
+        // @see https://forge.typo3.org/issues/79635
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
+        $cacheId = 'RecordMonitor' . '_' . 'processDatamap_afterDatabaseOperations' . '_' . $table . '_' . $uid . '_' . $status;
+
+        $isProcessed = $cache->get($cacheId);
+        if (!empty($isProcessed)) {
+            // item already processed in this request
+            return;
+        }
+        $cache->set($cacheId, true);
 
         if ($status == 'new') {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -243,7 +243,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         $recordTable = $table;
         $recordUid = $uid;
 
-        if ($this->hasRecordBeenProcessed($table, $uid, $status)) {
+        if ($this->hasRecordBeenProcessed($status, $table, $uid)) {
             return;
         }
 
@@ -272,10 +272,9 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param string $status Status of the current operation, 'new' or 'update'
      * @param string $table The table the record belongs to
      * @param mixed $uid The record's uid, [integer] or [string] (like 'NEW...')
-     *
      * @return bool
      */
-    protected function hasRecordBeenProcessed($table, $uid, $status)
+    protected function hasRecordBeenProcessed($status, $table, $uid)
     {
         // Check if record has already been processed since DataHandler sends processDatamap_afterDatabaseOperations
         // more than one time per table with nearly identical $fields array - but we only use the pid


### PR DESCRIPTION
The method processDatamap_afterDatabaseOperations in RecordMonitor needs a to filter multiple processings of identical record to a a "bug" in TYPO3 core
This also gains some performance when copying trees performance when copying trees - should solve #943 