### PR TITLE
[BUG] Fixed that checks uses single & and NOT &&

### DIFF
--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -69,7 +69,7 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
         // Wrapped the CliEnvironment to avoid defining TYPO3_PATH_WEB since this
         // should only be done in the case when running it from outside TYPO3 BE
         // @see #921 and #934 on https://github.com/TYPO3-Solr
-        if (TYPO3_REQUESTTYPE && TYPO3_REQUESTTYPE_CLI) {
+        if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) {
             $cliEnvironment = GeneralUtility::makeInstance(CliEnvironment::class);
             $cliEnvironment->backup();
             $cliEnvironment->initialize($this->getWebRoot());
@@ -79,7 +79,7 @@ class IndexQueueWorkerTask extends AbstractTask implements ProgressProviderInter
         $indexService->setContextTask($this);
         $indexService->indexItems($this->documentsToIndexLimit);
 
-        if (TYPO3_REQUESTTYPE && TYPO3_REQUESTTYPE_CLI) {
+        if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) {
             $cliEnvironment->restore();
         }
 


### PR DESCRIPTION
In the check for enabling CliEnvironment - the check needs to use single & and NOT && in order to work. Should fix #968