### PR TITLE
[TASK] Deprecate Util::isRootPage - moved to RootPageResolver 

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -88,14 +88,14 @@ class RootPageResolver implements SingletonInterface
     }
 
     /**
-     * Takes a page Id and checks whether the page is marked as root page.
+     * Checks if the passed pageId is a root page.
      *
      * @param int $pageId Page ID
      * @return bool TRUE if the page is marked as root page, FALSE otherwise
      */
-    public function isRootPage($pageId)
+    public function getIsRootPageId($pageId)
     {
-        $cacheId = 'RootPageResolver' . '_' . 'isRootPage' . '_' . $pageId;
+        $cacheId = 'RootPageResolver' . '_' . 'getIsRootPageId' . '_' . $pageId;
         $isSiteRoot = $this->runtimeCache->get($cacheId);
         if (!empty($isSiteRoot)) {
             return $isSiteRoot;
@@ -129,7 +129,7 @@ class RootPageResolver implements SingletonInterface
     {
         $rootPages = [];
         $rootPageId = $this->getRootPageIdByTableAndUid($table, $uid);
-        if ($this->isRootPage($rootPageId)) {
+        if ($this->getIsRootPageId($rootPageId)) {
             $rootPages[] = $rootPageId;
         }
 

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -340,7 +340,7 @@ class RecordMonitor extends AbstractDataHandlerListener
     protected function getConfigurationPageId($recordTable, $recordPageId, $recordUid)
     {
         $rootPageId = Util::getRootPageId($recordPageId);
-        if ($this->rootPageResolver->isRootPage($rootPageId)) {
+        if ($this->rootPageResolver->getIsRootPageId($rootPageId)) {
             return $recordPageId;
         }
 
@@ -396,7 +396,7 @@ class RecordMonitor extends AbstractDataHandlerListener
     {
         if ($status == 'update' && !isset($fields['pid'])) {
             $recordPageId = $this->getValidatedPid($tceMain, $recordTable, $recordUid);
-            if (($recordTable == 'pages') && ($this->rootPageResolver->isRootPage($recordUid))) {
+            if (($recordTable == 'pages') && ($this->rootPageResolver->getIsRootPageId($recordUid))) {
                 $recordPageId = $originalUid;
             }
 

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -340,7 +340,7 @@ class RecordMonitor extends AbstractDataHandlerListener
     protected function getConfigurationPageId($recordTable, $recordPageId, $recordUid)
     {
         $rootPageId = Util::getRootPageId($recordPageId);
-        if (Util::isRootPage($rootPageId)) {
+        if ($this->rootPageResolver->isRootPage($rootPageId)) {
             return $recordPageId;
         }
 
@@ -396,7 +396,7 @@ class RecordMonitor extends AbstractDataHandlerListener
     {
         if ($status == 'update' && !isset($fields['pid'])) {
             $recordPageId = $this->getValidatedPid($tceMain, $recordTable, $recordUid);
-            if ($recordTable == 'pages' && Util::isRootPage($recordUid)) {
+            if (($recordTable == 'pages') && ($this->rootPageResolver->isRootPage($recordUid))) {
                 $recordPageId = $originalUid;
             }
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -509,7 +509,7 @@ class Util
         GeneralUtility::logDeprecatedFunction();
         $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
 
-        return $rootPageResolver->isRootPage($pageId);
+        return $rootPageResolver->getIsRootPageId($pageId);
     }
 
     /**

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -510,7 +510,6 @@ class Util
         $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
 
         return $rootPageResolver->isRootPage($pageId);
-
     }
 
     /**

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
@@ -501,31 +502,15 @@ class Util
      *
      * @param int $pageId Page ID
      * @return bool TRUE if the page is marked as root page, FALSE otherwise
+     * @deprecated since 6.1 will be removed in 7.0
      */
     public static function isRootPage($pageId)
     {
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
-        $cacheId = 'Util' . '_' . 'isRootPage' . '_' . $pageId;
+        GeneralUtility::logDeprecatedFunction();
+        $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
 
-        $isSiteRoot = $cache->get($cacheId);
-        if (!empty($isSiteRoot)) {
-            return $isSiteRoot;
-        }
+        return $rootPageResolver->isRootPage($pageId);
 
-        $page = (array)BackendUtility::getRecord('pages', $pageId, 'is_siteroot');
-
-        if (empty($page)) {
-            throw new \InvalidArgumentException(
-                'The page for the given page ID \'' . $pageId
-                . '\' could not be found in the database and can therefore not be used as site root page.',
-                1487171426
-            );
-        }
-
-        $isSiteRoot = Site::isRootPage($page);
-        $cache->set($cacheId, $isSiteRoot);
-
-        return $isSiteRoot;
     }
 
     /**

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -62,7 +62,7 @@ class RootPageResolverTest extends UnitTest
         /** @var $rootPageResolver RootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
-            ->setMethods(['getIsRootPageId','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid'])->getMock();
+            ->setMethods(['isRootPage','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid'])->getMock();
     }
 
     /**
@@ -71,7 +71,7 @@ class RootPageResolverTest extends UnitTest
     public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences()
     {
         $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(true));
+        $this->rootPageResolver->expects($this->once())->method('isRootPage')->will($this->returnValue(true));
         $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
@@ -86,7 +86,7 @@ class RootPageResolverTest extends UnitTest
     public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot()
     {
         $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(false));
+        $this->rootPageResolver->expects($this->once())->method('isRootPage')->will($this->returnValue(false));
         $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -62,7 +62,7 @@ class RootPageResolverTest extends UnitTest
         /** @var $rootPageResolver RootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
-            ->setMethods(['isRootPage','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid'])->getMock();
+            ->setMethods(['getIsRootPageId','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid'])->getMock();
     }
 
     /**
@@ -71,7 +71,7 @@ class RootPageResolverTest extends UnitTest
     public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences()
     {
         $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('isRootPage')->will($this->returnValue(true));
+        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(true));
         $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
@@ -86,7 +86,7 @@ class RootPageResolverTest extends UnitTest
     public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot()
     {
         $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('isRootPage')->will($this->returnValue(false));
+        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(false));
         $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -289,16 +289,8 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration'] = [];
 }
 
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots'] = [];
-}
-
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['backend'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['backend'] = \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class;
-}
-
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['backend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['backend'] = \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class;
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['options'])) {
@@ -306,17 +298,8 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['options'] = ['defaultLifetime' => 60 * 60 * 24];
 }
 
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['options'])) {
-    // default life time one day
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['options'] = ['defaultLifetime' => 60 * 60 * 24];
-}
-
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_configuration']['groups'] = ['all'];
-}
-
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['groups'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr_siteroots']['groups'] = ['all'];
 }
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #


### PR DESCRIPTION
Use cache_runtime instead in RootPageResolver instead of "own" cache. In addition made some cleanup and fixed tests. 

Fixes: #970