### PR TITLE
[BUG] getIsRootPageId must handle 0 

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -134,7 +134,7 @@ class RootPageResolver implements SingletonInterface
     {
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
-        $rootPageId = intval($pageId) ? intval($pageId) : intval($GLOBALS['TSFE']->id);
+        $rootPageId = intval($pageId) ?: intval($GLOBALS['TSFE']->id);
 
         // frontend
         if (!empty($GLOBALS['TSFE']->rootLine)) {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -96,6 +96,11 @@ class RootPageResolver implements SingletonInterface
      */
     public function getIsRootPageId($pageId)
     {
+        // Page 0 can never be a root page
+        if ($pageId === 0) {
+            return false;
+        }
+
         $cacheId = 'RootPageResolver' . '_' . 'getIsRootPageId' . '_' . $pageId;
         $isSiteRoot = $this->runtimeCache->get($cacheId);
         if (!empty($isSiteRoot)) {
@@ -129,7 +134,7 @@ class RootPageResolver implements SingletonInterface
     {
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
-        $rootPageId = intval($pageId) ? intval($pageId) : $GLOBALS['TSFE']->id;
+        $rootPageId = intval($pageId) ? intval($pageId) : intval($GLOBALS['TSFE']->id);
 
         // frontend
         if (!empty($GLOBALS['TSFE']->rootLine)) {

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -93,6 +94,26 @@ class RootPageResolverTest extends UnitTest
 
         $message = 'Root page resolver should only return rootPageIds from references';
         $this->assertEquals([333,444], $resolvedRootPages, $message);
+    }
+
+    /**
+     * @test
+     */
+    public function getIsRootPageIdWithPageIdZero() {
+        $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
+        $rootPage = $rootPageResolver->getIsRootPageId(0);
+
+        $this->assertEquals(false, $rootPage);
+    }
+
+    /**
+     * @test
+     */
+    public function getIsRootPageIdWithUnknownPageId() {
+        $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
+
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $rootPageResolver->getIsRootPageId(42);
     }
 
     /**


### PR DESCRIPTION
The method getRootPageId should always return an int

Fixes:  #1077 