### PR TITLE
[!!!][TASK] Use new logging API instead of deprecated devLog

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Page\Rootline;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Toolbar\ClearCacheActionsHookInterface;
@@ -52,6 +53,11 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
     protected static $connections = [];
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * Gets a Solr connection.
      *
      * Instead of generating a new connection with each call, connections are
@@ -70,13 +76,10 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
     public function getConnection($host = '', $port = 8983, $path = '/solr/', $scheme = 'http', $username = '', $password = '')
     {
         if (empty($host)) {
-            GeneralUtility::devLog(
-                'ApacheSolrForTypo3\Solr\ConnectionManager::getConnection() called with empty
-                host parameter. Using configuration from TSFE, might be
-                inaccurate. Always provide a host or use the getConnectionBy*
-                methods.',
-                'solr',
-                2
+            $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+            $this->logger->log(
+                SolrLogManager::WARNING,
+                'ApacheSolrForTypo3\Solr\ConnectionManager::getConnection() called with empty host parameter. Using configuration from TSFE, might be inaccurate. Always provide a host or use the getConnectionBy* methods.'
             );
 
             $configuration = Util::getSolrConfiguration();

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -68,6 +69,11 @@ class IndexService
     protected $signalSlotDispatcher;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * IndexService constructor.
      * @param Site $site
      * @param Queue|null $queue
@@ -75,6 +81,7 @@ class IndexService
      */
     public function __construct(Site $site, Queue $queue = null, Dispatcher $dispatcher = null)
     {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->site = $site;
         $this->indexQueue = is_null($queue) ? GeneralUtility::makeInstance(Queue::class) : $queue;
         $this->signalSlotDispatcher = is_null($dispatcher) ? GeneralUtility::makeInstance(Dispatcher::class) : $dispatcher;
@@ -141,7 +148,12 @@ class IndexService
     {
         $message = 'Failed indexing Index Queue item ' . $itemToIndex->getIndexQueueUid();
         $data = ['code' => $e->getCode(), 'message' => $e->getMessage(), 'trace' => $e->getTrace(), 'item' => (array)$itemToIndex];
-        GeneralUtility::devLog($message, 'solr', 3, $data);
+
+        $this->logger->log(
+            SolrLogManager::ERROR,
+            $message,
+            $data
+        );
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -33,6 +33,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Search\QueryAware;
 use ApacheSolrForTypo3\Solr\Search\SearchComponentManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -98,12 +99,18 @@ class SearchResultSetService implements SingletonInterface
     protected $typoScriptConfiguration;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+     */
+    protected $logger = null;
+
+    /**
      * @param TypoScriptConfiguration $configuration
      * @param Search $search
      * @param AbstractPlugin $parentPlugin (optional parent plugin, needed for plugin aware components)
      */
     public function __construct(TypoScriptConfiguration $configuration, Search $search, AbstractPlugin $parentPlugin = null)
     {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
         $this->parentPlugin = $parentPlugin;
@@ -193,7 +200,13 @@ class SearchResultSetService implements SingletonInterface
         $this->applyPageSectionsRootLineFilter($query);
 
         if ($this->typoScriptConfiguration->getLoggingQuerySearchWords()) {
-            GeneralUtility::devLog('received search query', 'solr', 0, [$rawQuery]);
+            $this->logger->log(
+                SolrLogManager::INFO,
+                'Received search query',
+                [
+                    $rawQuery
+                ]
+            );
         }
 
         $query->setResultsPerPage($resultsPerPage);

--- a/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -56,6 +57,11 @@ abstract class AbstractFrontendHelper implements FrontendHelper
      * The action a frontend helper executes.
      */
     protected $action = null;
+
+    /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
 
     /**
      * Disables the frontend output for index queue requests.
@@ -90,12 +96,16 @@ abstract class AbstractFrontendHelper implements FrontendHelper
     ) {
         $this->request = $request;
         $this->response = $response;
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 
         if ($request->getParameter('loggingEnabled')) {
-            GeneralUtility::devLog('Page indexer request received', 'solr', 0,
+            $this->logger->log(
+                SolrLogManager::INFO,
+                'Page indexer request received',
                 [
                     'request' => (array)$request,
-                ]);
+                ]
+            );
         }
     }
 

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectPostInitHookInterface;
@@ -64,6 +65,11 @@ class UserGroupDetector extends AbstractFrontendHelper implements
      * @var array
      */
     protected $frontendGroups = [];
+
+    /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
 
     // activation
 
@@ -191,12 +197,15 @@ class UserGroupDetector extends AbstractFrontendHelper implements
                 $frontendGroups = 0;
             } else {
                 if ($this->request->getParameter('loggingEnabled')) {
-                    GeneralUtility::devLog('Access restriction found', 'solr',
-                        0, [
+                    $this->logger->log(
+                        SolrLogManager::INFO,
+                        'Access restriction found',
+                        [
                             'groups' => $frontendGroups,
                             'record' => $record,
                             'record type' => $table,
-                        ]);
+                        ]
+                    );
                 }
             }
 

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -90,7 +90,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     public function __construct()
     {
-        $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
     }

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -28,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Initializer;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -76,6 +77,11 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     protected $flashMessageQueue;
 
+    /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
     // Object initialization
 
     /**
@@ -84,6 +90,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     public function __construct()
     {
+        $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
     }
@@ -362,7 +369,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
     {
         $solrConfiguration = $this->site->getSolrConfiguration();
 
-        $logSeverity = -1;
+        $logSeverity = SolrLogManager::NOTICE;
         $logData = [
             'site' => $this->site->getLabel(),
             'indexing configuration name' => $this->indexingConfigurationName,
@@ -372,15 +379,14 @@ abstract class AbstractInitializer implements IndexQueueInitializer
         ];
 
         if ($GLOBALS['TYPO3_DB']->sql_errno()) {
-            $logSeverity = 3;
+            $logSeverity = SolrLogManager::ERROR;
             $logData['error'] = $GLOBALS['TYPO3_DB']->sql_errno() . ': ' . $GLOBALS['TYPO3_DB']->sql_error();
         }
 
         if ($solrConfiguration->getLoggingIndexingIndexQueueInitialization()) {
-            GeneralUtility::devLog(
-                'Index Queue initialized for indexing configuration ' . $this->indexingConfigurationName,
-                'solr',
+            $this->logger->log(
                 $logSeverity,
+                'Index Queue initialized for indexing configuration ' . $this->indexingConfigurationName,
                 $logData
             );
         }

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -30,6 +30,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Initializer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Utility\DatabaseUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -43,6 +44,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Page extends AbstractInitializer
 {
+    /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
 
     /**
      * Constructor, sets type and indexingConfigurationName to "pages".
@@ -53,6 +58,7 @@ class Page extends AbstractInitializer
         parent::__construct();
 
         $this->type = 'pages';
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     /**
@@ -145,11 +151,12 @@ class Page extends AbstractInitializer
             } catch (\Exception $e) {
                 DatabaseUtility::transactionRollback();
 
-                GeneralUtility::devLog(
+                $this->logger->log(
+                    SolrLogManager::ERROR,
                     'Index Queue initialization failed for mount pages',
-                    'solr',
-                    3,
-                    [$e->__toString()]
+                    [
+                        $e->__toString()
+                    ]
                 );
                 break;
             }

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -92,12 +92,18 @@ class PageIndexerRequest
     protected $timeout;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * PageIndexerRequest constructor.
      *
      * @param string $jsonEncodedParameters json encoded header
      */
     public function __construct($jsonEncodedParameters = null)
     {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->requestId = uniqid();
         $this->timeout = (float)ini_get('default_socket_timeout');
 
@@ -177,10 +183,9 @@ class PageIndexerRequest
         $decodedResponse = $response->getResultsFromJson($rawResponse);
 
         if ($rawResponse === false || $decodedResponse === false) {
-            GeneralUtility::devLog(
+            $this->logger->log(
+                SolrLogManager::ERROR,
                 'Failed to execute Page Indexer Request. Request ID: ' . $this->requestId,
-                'solr',
-                3,
                 [
                     'request ID' => $this->requestId,
                     'request url' => $url,

--- a/Classes/IndexQueue/PageIndexerRequestHandler.php
+++ b/Classes/IndexQueue/PageIndexerRequestHandler.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Dispatcher;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -59,12 +60,18 @@ class PageIndexerRequestHandler implements SingletonInterface
     protected $dispatcher;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * Constructor.
      *
      * Initializes request, response, and dispatcher.
      */
     public function __construct()
     {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->dispatcher = GeneralUtility::makeInstance(Dispatcher::class);
         $this->request = GeneralUtility::makeInstance(PageIndexerRequest::class, $_SERVER['HTTP_X_TX_SOLR_IQ']);
         $this->response = GeneralUtility::makeInstance(PageIndexerResponse::class);
@@ -81,10 +88,9 @@ class PageIndexerRequestHandler implements SingletonInterface
     public function run()
     {
         if (!$this->request->isAuthenticated()) {
-            GeneralUtility::devLog(
+            $this->logger->log(
+                SolrLogManager::ERROR,
                 'Invalid Index Queue Frontend Request detected!',
-                'solr',
-                3,
                 [
                     'page indexer request' => (array)$this->request,
                     'index queue header' => $_SERVER['HTTP_X_TX_SOLR_IQ']

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -33,6 +33,7 @@ use ApacheSolrForTypo3\Solr\Query\LinkBuilder;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Template;
 use ApacheSolrForTypo3\Solr\ViewHelper\ViewHelperProvider;
 use TYPO3\CMS\Core\Localization\LocalizationFactory;
@@ -104,6 +105,11 @@ abstract class PluginBase extends AbstractPlugin
     private $searchResultsSetService;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * The main method of the plugin
      *
      * @param string $content The plugin content
@@ -114,6 +120,8 @@ abstract class PluginBase extends AbstractPlugin
     {
         /** @noinspection PhpUnusedLocalVariableInspection */
         $content = '';
+
+        $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 
         try {
             $this->initialize($configuration);
@@ -130,10 +138,9 @@ abstract class PluginBase extends AbstractPlugin
             $content = $this->postRender($content);
         } catch (\Exception $e) {
             if ($this->typoScriptConfiguration->getLoggingExceptions()) {
-                GeneralUtility::devLog(
+                $this->logger->log(
+                    SolrLogManager::ERROR,
                     $e->getCode() . ': ' . $e->__toString(),
-                    'solr',
-                    3,
                     (array)$e
                 );
             }

--- a/Classes/Plugin/PluginBase.php
+++ b/Classes/Plugin/PluginBase.php
@@ -121,7 +121,7 @@ abstract class PluginBase extends AbstractPlugin
         /** @noinspection PhpUnusedLocalVariableInspection */
         $content = '';
 
-        $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 
         try {
             $this->initialize($configuration);

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\FieldProcessor\PageUidToHierarchy;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -158,6 +159,11 @@ class Query
     protected $siteHashService = null;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * Query constructor.
      * @param string $keywords
      * @param TypoScriptConfiguration $solrConfiguration
@@ -167,6 +173,7 @@ class Query
     {
         $keywords = (string) $keywords;
 
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->solrConfiguration = is_null($solrConfiguration) ? Util::getSolrConfiguration() : $solrConfiguration;
         $this->siteHashService = is_null($siteHashService) ? GeneralUtility::makeInstance(SiteHashService::class) : $siteHashService;
 
@@ -194,18 +201,6 @@ class Query
     protected function initializeQuery()
     {
         $this->initializeCollapsingFromConfiguration();
-    }
-
-    /**
-     * Writes a message to the devLog.
-     *
-     * @param string $msg
-     * @param int $severity
-     * @param mixed $dataVar
-     */
-    protected function writeDevLog($msg, $severity = 0, $dataVar = false)
-    {
-        GeneralUtility::devLog($msg, 'solr', $severity, $dataVar);
     }
 
     /**
@@ -940,7 +935,13 @@ class Query
     {
         // TODO refactor to split filter field and filter value, @see Drupal
         if ($this->solrConfiguration->getLoggingQueryFilters()) {
-            $this->writeDevLog('adding filter', 0, [$filterString]);
+            $this->logger->log(
+                SolrLogManager::INFO,
+                'Adding filter',
+                [
+                    $filterString
+                ]
+            );
         }
 
         $this->filters[] = $filterString;

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -751,9 +751,9 @@ class TypoScriptConfiguration
      * @param bool $defaultIfEmpty
      * @return bool
      */
-    public function getLoggingDebugOutputDevlog($defaultIfEmpty = false)
+    public function getLoggingDebugOutput($defaultIfEmpty = false)
     {
-        $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.logging.debugDevlogOutput', $defaultIfEmpty);
+        $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.logging.debugOutput', $defaultIfEmpty);
         return $this->getBool($result);
     }
 

--- a/Classes/System/Logging/DevLogDebugWriter.php
+++ b/Classes/System/Logging/DevLogDebugWriter.php
@@ -40,7 +40,7 @@ class DevLogDebugWriter
 {
 
     /**
-     * When the feature is enabled with: plugin.tx_solr.logging.debugDevlogOutput the log writer uses the extbase
+     * When the feature is enabled with: plugin.tx_solr.logging.debugOutput the log writer uses the extbase
      * debug functionality in the frontend, or the console in the backend to display the devlog messages.
      *
      * @param array $parameters
@@ -59,7 +59,7 @@ class DevLogDebugWriter
             return;
         }
 
-        $isDebugOutputEnabled = $this->getIsDevLogDebugOutputEnabled();
+        $isDebugOutputEnabled = $this->getIsdebugOutputEnabled();
         if (!$isDebugOutputEnabled) {
             return;
         }
@@ -76,11 +76,14 @@ class DevLogDebugWriter
     }
 
     /**
+     * Check if Logging via debugOutput has been configured
+     *
      * @return bool
      */
-    protected function getIsDevLogDebugOutputEnabled()
+    protected function getIsdebugOutputEnabled()
     {
-        return Util::getSolrConfiguration()->getLoggingDebugOutputDevlog();
+        $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+        return $logger->isDebugOutputEnabled();
     }
 
     /**

--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\System\Logging;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Log\LogLevel;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -68,5 +69,16 @@ class SolrLogManager
     public function log($level, $message, array $data = [])
     {
         $this->logger->log($level, $message, $data);
+    }
+
+
+    /**
+     * Check if Logging via debugOutput has been configured
+     *
+     * @return bool
+     */
+    public function isDebugOutputEnabled()
+    {
+        return Util::getSolrConfiguration()->getLoggingDebugOutput();
     }
 }

--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\System\Logging;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 - Thomas Hohn <tho@systime.dk>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Log\LogLevel;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Wrapper to for the TYPO3 Logging Framework
+ *
+ * @author Thomas Hohn <tho@systime.dk>
+ */
+class SolrLogManager
+{
+    const WARNING = LogLevel::WARNING;
+    const ERROR = LogLevel::ERROR;
+    const INFO = LogLevel::INFO;
+    const NOTICE = LogLevel::NOTICE;
+
+    /**
+     * @var \TYPO3\CMS\Core\Log\Logger
+     */
+    protected $logger = null;
+
+    function __construct($className)
+    {
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger($className);
+    }
+
+    /**
+     * Adds an entry to the LogManager
+     *
+     * @param int|string $level Log level. Value according to \TYPO3\CMS\Core\Log\LogLevel. Alternatively accepts a string.
+     * @param string $message Log message.
+     * @param array $data Additional data to log
+     *
+     * @return mixed
+     */
+    public function log($level, $message, array $data = [])
+    {
+        $this->logger->log($level, $message, $data);
+    }
+}

--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -46,7 +46,12 @@ class SolrLogManager
      */
     protected $logger = null;
 
-    function __construct($className)
+    /**
+     * SolrLogManager constructor.
+     *
+     * @param $className
+     */
+    public function __construct($className)
     {
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger($className);
     }

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\ViewHelper\SubpartViewHelper;
 use ApacheSolrForTypo3\Solr\ViewHelper\ViewHelper;
 use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
@@ -58,6 +59,11 @@ class Template
     protected $debugMode = false;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * Constructor for the html marker template engine.
      *
      * @param ContentObjectRenderer $contentObject content object
@@ -69,6 +75,8 @@ class Template
         $templateFile,
         $subpart
     ) {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+
         $this->cObj = $contentObject;
         $this->templateFile = $templateFile;
 
@@ -185,10 +193,13 @@ class Template
                 } catch (\Exception $e) {
                     $configuration = Util::getSolrConfiguration();
                     if ($configuration->getLoggingExceptions()) {
-                        GeneralUtility::devLog('exception while adding a viewhelper',
-                            'solr', 3, [
+                        $this->logger->log(
+                            SolrLogManager::ERROR,
+                            'Exception while adding a viewhelper',
+                            [
                                 $e->__toString()
-                            ]);
+                            ]
+                        );
                     }
                 }
             }
@@ -490,10 +501,13 @@ class Template
             } catch (\UnexpectedValueException $e) {
                 $configuration = Util::getSolrConfiguration();
                 if ($configuration->getLoggingExceptions()) {
-                    GeneralUtility::devLog('Exception while rendering a viewhelper',
-                        'solr', 3, [
+                    $this->logger->log(
+                        SolrLogManager::ERROR,
+                        'Exception while rendering a viewhelper',
+                        [
                             $e->__toString()
-                        ]);
+                        ]
+                    );
                 }
 
                 $viewHelperContent = '';

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -33,6 +34,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Typo3PageContentExtractor extends HtmlContentExtractor
 {
+
+    /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
 
     /**
      * Shortcut method to retrieve the raw content marked for indexing.
@@ -59,7 +65,11 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
 
         $indexableContent = $this->excludeContentByClass($indexableContent);
         if (empty($indexableContent) && $this->getConfiguration()->getLoggingIndexingMissingTypo3SearchMarkers()) {
-            GeneralUtility::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
+            $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+            $this->logger->log(
+                SolrLogManager::WARNING,
+                'No TYPO3SEARCH markers found.'
+            );
         }
 
         return $indexableContent;

--- a/Classes/ViewHelper/Relevance.php
+++ b/Classes/ViewHelper/Relevance.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -54,12 +55,18 @@ class Relevance implements ViewHelper
     protected $maxScore = 0.0;
 
     /**
+     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
      * Constructor
      *
      * @param array $arguments
      */
     public function __construct(array $arguments = [])
     {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         if (is_null($this->search)) {
             $this->search = GeneralUtility::makeInstance(Search::class);
             $this->maxScore = $this->search->getMaximumResultScore();
@@ -126,11 +133,14 @@ class Relevance implements ViewHelper
             } else {
                 $solrConfiguration = Util::getSolrConfiguration();
                 if ($solrConfiguration->getValueByPathOrDefaultValue('plugin.tx_solr.logging.exceptions', false)) {
-                    GeneralUtility::devLog('Could not resolve document score for relevance calculation',
-                        'solr', 3, [
+                    $this->logger->log(
+                        SolrLogManager::ERROR,
+                        'Could not resolve document score for relevance calculation',
+                        [
                             'rawDocument' => $rawDocument,
                             'unserializedDocument' => $document
-                        ]);
+                        ]
+                    );
                 }
 
                 throw new \RuntimeException(

--- a/Configuration/TypoScript/Examples/EverythingOn/setup.txt
+++ b/Configuration/TypoScript/Examples/EverythingOn/setup.txt
@@ -30,7 +30,7 @@ plugin.tx_solr {
 
 	logging {
 		exceptions = 1
-		debugDevlogOutput = 1
+		debugOutput = 1
 
 		indexing {
 			indexQueueInitialization = 1

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -362,7 +362,7 @@ plugin.tx_solr {
 
 	logging {
 		exceptions = 1
-		debugDevlogOutput = 0
+		debugOutput = 0
 
 		indexing {
 			indexQueueInitialization = 0

--- a/Documentation/Configuration/Reference/TxSolrLogging.rst
+++ b/Documentation/Configuration/Reference/TxSolrLogging.rst
@@ -23,14 +23,14 @@ This section defines logging options. All loggings will be available in the devl
 .. contents::
    :local:
 
-debugDevlogOutput
------------------
+debugOutput
+-----------
 
 :Type: Boolean
-:TS Path: plugin.tx_solr.logging.debugDevlogOutput
+:TS Path: plugin.tx_solr.logging.debugOutput
 :Default: 0
 :Options: 0,1
-:Since: 5.0
+:Since: 6.1
 
 If enabled the written log entries will be printed out as debug message in the frontend or to the TYPO3 debug console in the backend.
 

--- a/Documentation/Logging/ShowOutput.rst
+++ b/Documentation/Logging/ShowOutput.rst
@@ -23,7 +23,7 @@ To enable this features you need to:
 
 .. code-block:: typoscript
 
-    plugin.tx_solr.logging.debugDevlogOutput = 1
+    plugin.tx_solr.logging.debugOutput = 1
 
 
 You can now see the written log in the frontend:

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -754,24 +754,6 @@ class QueryTest extends UnitTest
     }
 
     /**
-     * @test
-     */
-    public function canWriteALogForAFilterWhenLoggingIsEnabled()
-    {
-        $fakeConfigurationArray = [];
-        $fakeConfigurationArray['plugin.']['tx_solr.']['logging.']['query.']['filters'] = true;
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
-        /** @var $query \ApacheSolrForTypo3\Solr\Query */
-        $query = $this->getMockBuilder(Query::class)
-            ->setMethods(['writeDevLog'])
-            ->setConstructorArgs(['test', $fakeConfiguration])
-            ->getMock();
-        $query->expects($this->once())->method('writeDevLog');
-        $query->addFilter('foo');
-    }
-
-    /**
      * @return array
      */
     public function escapeQueryDataProvider()

--- a/Tests/Unit/System/Logging/DevLogDebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DevLogDebugWriterTest.php
@@ -39,9 +39,9 @@ class DevLogDebugWriterTest extends UnitTest
     public function testDebugMessageIsWrittenForMessageFromSolr()
     {
         /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsDevLogDebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsDevLogDebugOutputEnabled')->will($this->returnValue(true));
+        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
 
             //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->once())->method('writeDebugMessage');
@@ -54,9 +54,9 @@ class DevLogDebugWriterTest extends UnitTest
     public function testDebugMessageIsNotWrittenForOtherExtensions()
     {
         /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsDevLogDebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsDevLogDebugOutputEnabled')->will($this->returnValue(true));
+        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->never())->method('writeDebugMessage');
@@ -69,9 +69,9 @@ class DevLogDebugWriterTest extends UnitTest
     public function testDebugMessageIsNotWrittenWhenDevIpMaskIsNotMatching()
     {
         /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsDevLogDebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(false));
-        $logWriter->expects($this->any())->method('getIsDevLogDebugOutputEnabled')->will($this->returnValue(true));
+        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->never())->method('writeDebugMessage');
@@ -84,9 +84,9 @@ class DevLogDebugWriterTest extends UnitTest
     public function testDebugMessageIsNotWrittenWhenDebugOutputIsDisabled()
     {
         /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsDevLogDebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsDevLogDebugOutputEnabled')->will($this->returnValue(false));
+        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(false));
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->never())->method('writeDebugMessage');

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -318,3 +318,20 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassN
 
 // Log devLog entries to console and files
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_div.php']['devLog']['extsolr-debug-writer'] = \ApacheSolrForTypo3\Solr\System\Logging\DevLogDebugWriter::class . '->log';
+
+$context = \TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext();
+if ($context->isProduction()) {
+    $logLevel = \TYPO3\CMS\Core\Log\LogLevel::ERROR;
+} elseif ($context->isDevelopment()) {
+    $logLevel = \TYPO3\CMS\Core\Log\LogLevel::DEBUG;
+} else {
+    $logLevel = \TYPO3\CMS\Core\Log\LogLevel::INFO;
+}
+
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['ApacheSolrForTypo3']['Solr']['writerConfiguration'] = array(
+    $logLevel => array(
+        'TYPO3\\CMS\\Core\\Log\\Writer\\FileWriter' => array(
+            'logFile' => 'typo3temp/var/logs/solr.log'
+        )
+    ),
+);


### PR DESCRIPTION
This PR introduces a new SolrLogManager which uses the logger framework to write logs.

Since the devLog usage does not make any sence anymore the typoscript setting

plugin.tx_solr.logging.debugDevLogOutput 

was renamed to

plugin.tx_solr.logging.debugOutput

Fixes: #490 