### PR TITLE
[BUGFIX] Change name of getFixturePath and getFixtureContent

### DIFF
--- a/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
+++ b/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
@@ -40,7 +40,7 @@ class PageModuleSummaryTest extends IntegrationTest
      * @test
      */
     public function canGetSummary() {
-        $flexFormData = $this->getFixtureContent('fakeFlexform.xml');
+        $flexFormData = $this->getFixtureContentByName('fakeFlexform.xml');
 
         $fakeRow = ['pi_flexform' => $flexFormData];
         $data = ['row' => $fakeRow];

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -111,8 +111,8 @@ class IndexServiceTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePath('fake_extension2_directrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
 
         $this->importDataSetFromFixture('can_index_custom_record_absRefPrefix_' . $absRefPrefix . '.xml');
 

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -80,8 +80,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePath('fake_extension2_mmrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_mm_relation.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
@@ -109,8 +109,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePath('fake_extension2_mmrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_translated_record_with_mm_relation.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
@@ -137,8 +137,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePath('fake_extension2_mmrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_mm_relationAndAdditionalWhere.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
@@ -165,8 +165,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePath('fake_extension2_directrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relation.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
@@ -197,8 +197,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePath('fake_extension2_directrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relationAndAdditionalWhere.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
@@ -223,8 +223,8 @@ class IndexerTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePath('fake_extension2_bar_tca.php'));
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePath('fake_extension2_directrelated_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_configuration_in_rootline.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -140,7 +140,7 @@ class RecordMonitorTest extends IntegrationTest
     {
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         // create faked tce main call data
         $status = 'new';
@@ -258,7 +258,7 @@ class RecordMonitorTest extends IntegrationTest
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         // create faked tce main call data
         $status = 'update';
@@ -733,7 +733,7 @@ class RecordMonitorTest extends IntegrationTest
     public function updateRecordOutsideSiteRoot()
     {
         $this->importDumpFromFixture('fake_extension_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         $this->importDataSetFromFixture('update_record_outside_siteroot.xml');
 
@@ -761,7 +761,7 @@ class RecordMonitorTest extends IntegrationTest
     public function updateRecordOutsideSiteRootReferencedInTwoSites()
     {
         $this->importDumpFromFixture('fake_extension_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePath('fake_extension_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         $this->importDataSetFromFixture('update_record_outside_siteroot_from_two_sites.xml');
 

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -102,7 +102,7 @@ abstract class IntegrationTest extends TYPO3IntegrationTest
      * @param $fixtureName
      * @return string
      */
-    protected function getFixturePath($fixtureName)
+    protected function getFixturePathByName($fixtureName)
     {
         return $this->getFixtureRootPath() . $fixtureName;
     }
@@ -113,9 +113,9 @@ abstract class IntegrationTest extends TYPO3IntegrationTest
      * @param string $fixtureName
      * @return string
      */
-    protected function getFixtureContent($fixtureName)
+    protected function getFixtureContentByName($fixtureName)
     {
-        return file_get_contents($this->getFixturePath($fixtureName));
+        return file_get_contents($this->getFixturePathByName($fixtureName));
     }
 
     /**
@@ -127,7 +127,7 @@ abstract class IntegrationTest extends TYPO3IntegrationTest
         $database = $GLOBALS['TYPO3_DB'];
         $database->debugOutput = true;
 
-        $dumpContent = $this->getFixtureContent($fixtureName);
+        $dumpContent = $this->getFixtureContentByName($fixtureName);
         $dumpContent = str_replace(["\r", "\n"], '', $dumpContent);
 
         $queries = GeneralUtility::trimExplode(';', $dumpContent, true);

--- a/Tests/Integration/SolrServiceTest.php
+++ b/Tests/Integration/SolrServiceTest.php
@@ -55,7 +55,7 @@ class SolrServiceTest extends IntegrationTest
      */
     public function canExtractByQuery()
     {
-        $testFilePath = $this->getFixturePath('testpdf.pdf');
+        $testFilePath = $this->getFixturePathByName('testpdf.pdf');
             /** @var $extractQuery \ApacheSolrForTypo3\Solr\ExtractingQuery */
         $extractQuery = GeneralUtility::makeInstance(ExtractingQuery::class, $testFilePath);
         $extractQuery->setExtractOnly();


### PR DESCRIPTION
Since the core introduced a method getFixturePath with another meaning,
we should rename two methods in the base class for integration tests:

* getFixturePath => getFixturePathByName
* getFixtureContent => getFixtureContentByName

Fixes: #1087