### PR TITLE
[TASK] Refactor DevLogDebugWriter to work with SolrLogManager

### DIFF
--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -48,13 +48,20 @@ class SolrLogManager
     protected $logger = null;
 
     /**
+     * @var DebugWriter
+     */
+    protected $debugWriter = null;
+
+    /**
      * SolrLogManager constructor.
      *
      * @param $className
+     * @param DebugWriter $debugWriter
      */
-    public function __construct($className)
+    public function __construct($className, DebugWriter $debugWriter = null)
     {
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger($className);
+        $this->debugWriter = isset($debugWriter) ? $debugWriter : GeneralUtility::makeInstance(DebugWriter::class);
     }
 
     /**
@@ -69,16 +76,6 @@ class SolrLogManager
     public function log($level, $message, array $data = [])
     {
         $this->logger->log($level, $message, $data);
-    }
-
-
-    /**
-     * Check if Logging via debugOutput has been configured
-     *
-     * @return bool
-     */
-    public function isDebugOutputEnabled()
-    {
-        return Util::getSolrConfiguration()->getLoggingDebugOutput();
+        $this->debugWriter->write($level, $message, $data);
     }
 }

--- a/Documentation/Configuration/Reference/TxSolrLogging.rst
+++ b/Documentation/Configuration/Reference/TxSolrLogging.rst
@@ -33,6 +33,7 @@ debugOutput
 :Since: 6.1
 
 If enabled the written log entries will be printed out as debug message in the frontend or to the TYPO3 debug console in the backend.
+This setting replaces the previous setting `plugin.tx_solr.logging.debugDevLogOutput` which was needed, when the devLog was used.
 
 exceptions
 ----------

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Logging;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2011-2016 Timo Hund <timo.hund@dkd.de>
+ *  (c) 2011-2017 Timo Hund <timo.hund@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -24,13 +24,15 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Logging\DebugWriter;
 use ApacheSolrForTypo3\Solr\System\Logging\DevLogDebugWriter;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class DevLogDebugWriterTest extends UnitTest
+class DebugWriterTest extends UnitTest
 {
 
     /**
@@ -38,29 +40,14 @@ class DevLogDebugWriterTest extends UnitTest
      */
     public function testDebugMessageIsWrittenForMessageFromSolr()
     {
-        /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        /** @var $logWriter DebugWriter */
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
         $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
 
             //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->once())->method('writeDebugMessage');
-        $logWriter->log(['extKey' => 'solr', 'message' => 'test']);
-    }
-
-    /**
-     * @test
-     */
-    public function testDebugMessageIsNotWrittenForOtherExtensions()
-    {
-        /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
-        $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
-
-        //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
-        $logWriter->expects($this->never())->method('writeDebugMessage');
-        $logWriter->log(['extKey' => 'news', 'message' => 'test']);
+        $logWriter->write(SolrLogManager::INFO, 'test');
     }
 
     /**
@@ -68,14 +55,14 @@ class DevLogDebugWriterTest extends UnitTest
      */
     public function testDebugMessageIsNotWrittenWhenDevIpMaskIsNotMatching()
     {
-        /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        /** @var $logWriter DebugWriter */
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(false));
         $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->never())->method('writeDebugMessage');
-        $logWriter->log(['extKey' => 'solr', 'message' => 'test']);
+        $logWriter->write(SolrLogManager::INFO, 'test');
     }
 
     /**
@@ -83,13 +70,13 @@ class DevLogDebugWriterTest extends UnitTest
      */
     public function testDebugMessageIsNotWrittenWhenDebugOutputIsDisabled()
     {
-        /** @var $logWriter DevLogDebugWriter */
-        $logWriter = $this->getMockBuilder(DevLogDebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        /** @var $logWriter DebugWriter */
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
         $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(false));
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
         $logWriter->expects($this->never())->method('writeDebugMessage');
-        $logWriter->log(['extKey' => 'solr', 'message' => 'test']);
+        $logWriter->write(SolrLogManager::INFO, 'test');
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -316,9 +316,6 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassN
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassName '] = \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet::class;
 }
 
-// Log devLog entries to console and files
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_div.php']['devLog']['extsolr-debug-writer'] = \ApacheSolrForTypo3\Solr\System\Logging\DevLogDebugWriter::class . '->log';
-
 $context = \TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext();
 if ($context->isProduction()) {
     $logLevel = \TYPO3\CMS\Core\Log\LogLevel::ERROR;


### PR DESCRIPTION
In #1086 the usage of devLog was replaced with the SolrLogManager that
uses the TYPO3 logging framework.

Since the setting tx_solr.plugin.logging.debugDevLogOutput does not make any sence
without the devLog it was renamed to tx_solr.plugin.logging.debugOutput.

To still output the log messages to the console (in the backend) or in the frontend when
tx_solr.plugin.logging.debugOutput is set to 1 the SolrLogManager needs to use the DebugWriter
to do that.

This PR:

* Renames the DevLogDebugWriter to DebugWriter
* Refactors the SolrLogManager to use the DebugWriter
* Adapts the existing tests

Impact:

When you set `tx_solr.plugin.logging.debugOutput = 1` the log messages in the frontend are
shown as debug message and in the backend in the TYPO3 console. When the setting is disabled
you do not see the log messages.

Fixes: #1090