### PR TITLE
[TASK] Allow to use closest typoscript template to retrieve configuration

### DIFF
--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -1,0 +1,137 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Schmidt <timo.schmidt@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use \TYPO3\CMS\Frontend\Page\PageRepository;
+
+/**
+ * This class is responsible to find the closest page id from the rootline where
+ * a typoscript template is stored on.
+ *
+ * @package ApacheSolrForTypo3\Solr\System\Configuration
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ConfigurationPageResolver
+{
+    /**
+     * @var PageRepository
+     */
+    protected $pageRepository;
+
+    /**
+     * @var TwoLevelCache
+     */
+    protected $twoLevelCache;
+
+    /**
+     * ConfigurationPageResolver constructor.
+     * @param PageRepository|null $pageRepository
+     * @param TwoLevelCache|null $twoLevelCache
+     */
+    public function __construct(PageRepository $pageRepository = null, TwoLevelCache $twoLevelCache = null)
+    {
+        $this->pageRepository = isset($pageRepository) ? $pageRepository : GeneralUtility::makeInstance(PageRepository::class);
+        $this->runtimeCache = isset($twoLevelCache) ? $twoLevelCache : GeneralUtility::makeInstance(TwoLevelCache::class, 'cache_runtime');
+    }
+
+    /**
+     * This method fetches the rootLine and calculates the id of the closest template in the rootLine.
+     * The result is stored in the runtime cache.
+     *
+     * @param integer $startPageId
+     * @return integer
+     */
+    public function getClosestPageIdWithActiveTemplate($startPageId)
+    {
+        if ($startPageId === 0) {
+            return 0;
+        }
+
+        $cacheId = 'ConfigurationPageResolver' . '_' . 'getClosestPageIdWithActiveTemplate' . '_' . $startPageId;
+        $methodResult = $this->runtimeCache->get($cacheId);
+        if (!empty($methodResult)) {
+            return $methodResult;
+        }
+
+        $methodResult = $this->calculateClosestPageIdWithActiveTemplate($startPageId);
+        $this->runtimeCache->set($cacheId, $methodResult);
+
+        return $methodResult;
+    }
+
+    /**
+     * This method fetches the rootLine and calculates the id of the closest template in the rootLine.
+     *
+     * @param integer $startPageId
+     * @return int
+     */
+    protected function calculateClosestPageIdWithActiveTemplate($startPageId)
+    {
+        $rootLine = $this->pageRepository->getRootLine($startPageId);
+        // when no rootline is present the startpage it's self is the closest page
+        if (!is_array($rootLine)) {
+            return $startPageId;
+        }
+
+        $closestPageIdWithTemplate = $this->getPageIdsWithTemplateInRootLineOrderedByDepth($rootLine);
+        if ($closestPageIdWithTemplate === 0) {
+            return $startPageId;
+        }
+
+        return (int)$closestPageIdWithTemplate;
+    }
+
+    /**
+     * Retrieves the closest pageId with a template on and 0 when non is found.
+     *
+     * @param array $rootLine
+     * @return int
+     */
+    protected function getPageIdsWithTemplateInRootLineOrderedByDepth($rootLine)
+    {
+        $rootLinePageIds = [0];
+        foreach ($rootLine as $rootLineItem) {
+            $rootLinePageIds[] = (int)$rootLineItem['uid'];
+        }
+
+        $pageIdsClause = implode(",", $rootLinePageIds);
+        $where = 'pid IN (' . $pageIdsClause . ') AND deleted = 0 AND hidden = 0';
+        $res = $this->getDatabaseConnection()->exec_SELECTgetRows('uid,pid', 'sys_template', $where);
+
+        $firstTemplateRow = $res[0];
+        return isset($firstTemplateRow['pid']) ? $firstTemplateRow['pid'] : 0;
+    }
+
+    /**
+     * @return DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+}

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -1,0 +1,66 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Schmidt <timo.schmidt@dkd.de
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * This class encapsulates the access to the extension configuration.
+ *
+ * @package ApacheSolrForTypo3\Solr\System\Configuration
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ExtensionConfiguration
+{
+
+    /**
+     * ExtensionConfiguration constructor.
+     * @param array $configurationToUse
+     */
+    public function __construct($configurationToUse = [])
+    {
+        if (empty($configurationToUse)) {
+            $this->configuration =  unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['solr']);
+        } else {
+            $this->configuration = $configurationToUse;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsUseConfigurationFromClosestTemplateEnabled()
+    {
+        return (bool) $this->getConfigurationOrDefaultValue('useConfigurationFromClosestTemplate', false);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $defaultValue
+     * @return mixed
+     */
+    protected function getConfigurationOrDefaultValue($key, $defaultValue)
+    {
+        return isset($this->configuration[$key]) ? $this->configuration[$key] : $defaultValue;
+    }
+}

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -50,4 +50,4 @@ Configuration Reference
 	Reference/TxSolrStatistics
 	Reference/TxSolrViewHelpers
 	Reference/TxSolrLogging
-
+    Reference/ExtensionSettings

--- a/Documentation/Configuration/Reference/ExtensionSettings.rst
+++ b/Documentation/Configuration/Reference/ExtensionSettings.rst
@@ -1,0 +1,32 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
+.. include:: ../../Includes.txt
+
+
+.. raw:: latex
+
+    \newpage
+
+.. raw:: pdf
+
+   PageBreak
+
+.. _conf-tx-solr-settings:
+
+Extension Configuration
+=======================
+
+The following settings can be defined in the extension manager
+
+useConfigurationFromClosestTemplate
+-----------------------------------
+
+:Type: Boolean
+:Since: 6.1
+:Default: 0
+
+When this setting is active the closest page with a typoscript template will be used to fetch the configuration.
+This improves the performance but limits also the possibilities. E.g. conditions can not be used that are related to a certain page.

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ConfigurationPageResolverTest extends IntegrationTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetClosestPageIdWithActiveTemplate()
+    {
+        $this->importDataSetFromFixture('can_get_closest_template_page_id.xml');
+
+            /** @var $configurationPageIdResolver ConfigurationPageResolver */
+        $configurationPageIdResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
+
+        $pageIdWithActiveTypoScriptConfiguration = $configurationPageIdResolver->getClosestPageIdWithActiveTemplate(4);
+        $this->assertSame(2, $pageIdWithActiveTypoScriptConfiguration, 'Could not resolve expected page id with active typoscript configuration');
+    }
+}

--- a/Tests/Integration/System/Configuration/Fixtures/can_get_closest_template_page_id.xml
+++ b/Tests/Integration/System/Configuration/Fixtures/can_get_closest_template_page_id.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"2";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>2</uid>
+        <pid>2</pid>
+        <root>0</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>3</uid>
+        <pid>3</pid>
+        <root>0</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+            ]]>
+        </config>
+        <sorting>100</sorting>
+        <deleted>1</deleted>
+    </sys_template>
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <pid>0</pid>
+        <title>Rootpage</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <pid>1</pid>
+        <title>Subpage with template</title>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <pid>2</pid>
+        <title>Subsubpage with deleted template</title>
+    </pages>
+
+    <pages>
+        <uid>4</uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <pid>3</pid>
+        <title>Subsubsubpage</title>
+    </pages>
+</dataset>

--- a/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase to test the functionallity of the extension configuration that comes from
+ *
+ * ext_conf_template.txt
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ExtensionConfigurationTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function testGetIsUseConfigurationFromClosestTemplateEnabled()
+    {
+        $defaultConfiguration = new ExtensionConfiguration();
+        $this->assertFalse($defaultConfiguration->getIsUseConfigurationFromClosestTemplateEnabled());
+        $configurationWithClosestTemplateEnabled = new ExtensionConfiguration(
+            ['useConfigurationFromClosestTemplate' => 1]
+        );
+        $this->assertTrue($configurationWithClosestTemplateEnabled->getIsUseConfigurationFromClosestTemplateEnabled());
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/enable/10; type=boolean; label=Use closest rootpage for configuration (Performance improvement)
+useConfigurationFromClosestTemplate = 0


### PR DESCRIPTION
By now, when the configuration is fetched the real pageId is used to retrieve it.
The drawback of this approach is, that in many systems this is an overhead,
because the configuration is only set on the rootlevel or some subpages
(except when e.g. conditions are used).

This pull request introduces an ext_conf_template setting that forces ext_solr
to use the closest page id with a typoscript configuration to retrieve the
configuration. The result is, that the configuration cache has more hits and
the performance in the backend is better

Fixes: #937