### PR TITLE
[TASK] Add regression for #488

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_initialize_multiple_sites.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_initialize_multiple_sites.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            pages = 1
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>2</uid>
+        <pid>2</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_de/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            pages = 1
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Rootpage en</title>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>Subpage en</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Rootpage de</title>
+    </pages>
+    <pages>
+        <uid>20</uid>
+        <pid>2</pid>
+        <doktype>1</doktype>
+        <title>Subpage de</title>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -218,4 +218,39 @@ class QueueTest extends IntegrationTest
         $this->assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
     }
 
+    /**
+     * @test
+     */
+    public function canInitializeMultipleSites()
+    {
+        $this->importDataSetFromFixture('can_initialize_multiple_sites.xml');
+        $this->assertEmptyQueue();
+
+        $availableSites = Site::getAvailableSites();
+        $this->indexQueue->deleteAllItems();
+
+        if (is_array($availableSites)) {
+            foreach ($availableSites as $site) {
+                if ($site instanceof Site) {
+                    $this->indexQueue->initialize($site);
+                }
+            }
+        }
+
+
+        $firstRootPage = $this->indexQueue->getItems('pages',1);
+        $secondRootPage = $this->indexQueue->getItems('pages',2);
+
+        $this->assertCount(1, $firstRootPage);
+        $this->assertCount(1, $secondRootPage);
+
+        $firstSubPage = $this->indexQueue->getItems('pages',10);
+        $secondSubPage = $this->indexQueue->getItems('pages',20);
+
+        $this->assertCount(1, $firstSubPage);
+        $this->assertCount(1, $secondSubPage);
+
+        $this->assertItemsInQueue(4);
+    }
+
 }


### PR DESCRIPTION
This is a followup for the fix of #488 and adds a regression test that makes sure
that the index queue contains the expected items when multiple sites get initialized
in on process.

Related: #488