### PR TITLE
[FEATURE] Add TypoScript TEXT object support for plugin.tx_solr.solr.values

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -753,7 +753,6 @@ class Util
      */
     public static function getSolrServerConfigurationByRootPageIdAndLanguage($rootPage, $languageId = 0)
     {
-
         $contentObject = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
 
         $languageId = intval($languageId);

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -814,12 +814,12 @@ class Util
             $host = $username . ':' . $password . '@' . $host;
         }
 
-        return [
+        return array(
             'host' => $host,
             'port' => $port,
             'path' => $path,
             'scheme' => $scheme,
             'enabled' => $solrEnabled
-        ];
+        );
     }
 }

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -744,7 +744,8 @@ class Util
 
     /**
      * Gets solr configuration from TypoScript.
-     * If there is configuration in $GLOBALS['TYPO3_CONF_VARS']['SOLR'], this configuration will be overwritten
+     * If there is configuration in e.g. $GLOBALS['TYPO3_CONF_VARS']['SOLR'],
+     * this configuration will be overwritten
      *
      * @param array $rootPage
      * @param int $languageId
@@ -753,7 +754,7 @@ class Util
     public static function getSolrServerConfigurationByRootPageIdAndLanguage($rootPage, $languageId = 0)
     {
 
-        $contentObject = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+        $contentObject = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
 
         $languageId = intval($languageId);
         GeneralUtility::_GETset($languageId, 'L');
@@ -762,9 +763,11 @@ class Util
         $rootLine = $pageSelect->getRootLine($rootPage['uid']);
 
         $tmpl = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService');
-        $tmpl->tt_track = false; // Do not log time-performance information
+        // Do not log time-performance information
+        $tmpl->tt_track = false;
         $tmpl->init();
-        $tmpl->runThroughTemplates($rootLine); // This generates the constants/config + hierarchy info for the template.
+        // This generates the constants/config + hierarchy info for the template.
+        $tmpl->runThroughTemplates($rootLine);
 
         // fake micro TSFE to get correct condition parsing
         $GLOBALS['TSFE'] = new \stdClass();

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -741,4 +741,82 @@ class Util
 
         return $absRefPrefix;
     }
+
+    /**
+     * Gets solr configuration from TypoScript.
+     * If there is configuration in $GLOBALS['TYPO3_CONF_VARS']['SOLR'], this configuration will be overwritten
+     *
+     * @param array $rootPage
+     * @param int $languageId
+     * @return array
+     */
+    public static function getSolrServerConfigurationByRootPageIdAndLanguage($rootPage, $languageId = 0)
+    {
+
+        $contentObject = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+
+        $languageId = intval($languageId);
+        GeneralUtility::_GETset($languageId, 'L');
+
+        $pageSelect = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+        $rootLine = $pageSelect->getRootLine($rootPage['uid']);
+
+        $tmpl = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService');
+        $tmpl->tt_track = false; // Do not log time-performance information
+        $tmpl->init();
+        $tmpl->runThroughTemplates($rootLine); // This generates the constants/config + hierarchy info for the template.
+
+        // fake micro TSFE to get correct condition parsing
+        $GLOBALS['TSFE'] = new \stdClass();
+        $GLOBALS['TSFE']->tmpl = new \stdClass();
+        $GLOBALS['TSFE']->tmpl->rootLine = $rootLine;
+        $GLOBALS['TSFE']->sys_page = $pageSelect;
+        $GLOBALS['TSFE']->id = $rootPage['uid'];
+        $GLOBALS['TSFE']->page = $rootPage;
+
+        $tmpl->generateConfig();
+
+        list($solrConfiguration) = $tmpl->ext_getSetup($tmpl->setup, 'plugin.tx_solr.solr');
+        list(, $solrEnabled) = $tmpl->ext_getSetup($tmpl->setup, 'plugin.tx_solr.enabled');
+        $solrEnabled = !empty($solrEnabled) ? true : false;
+
+        $host = $solrConfiguration['host'];
+        $port = $solrConfiguration['port'];
+        $path = $solrConfiguration['path'];
+        $scheme = $solrConfiguration['scheme'];
+        $username = $solrConfiguration['username'];
+        $password = $solrConfiguration['password'];
+
+        if (!empty($solrConfiguration['host.'])) {
+            $host = $contentObject->TEXT($solrConfiguration['host.']);
+        }
+        if (!empty($solrConfiguration['port.'])) {
+            $port = $contentObject->TEXT($solrConfiguration['port.']);
+        }
+        if (!empty($solrConfiguration['path.'])) {
+            $path = $contentObject->TEXT($solrConfiguration['path.']);
+        }
+        if (!empty($solrConfiguration['scheme.'])) {
+            $scheme = $contentObject->TEXT($solrConfiguration['scheme.']);
+        }
+        if (!empty($solrConfiguration['username.'])) {
+            $username = $contentObject->TEXT($solrConfiguration['username.']);
+        }
+        if (!empty($solrConfiguration['password.'])) {
+            $password = $contentObject->TEXT($solrConfiguration['password.']);
+        }
+
+        // we include username and password in host
+        if (!empty($username) && !empty($password)) {
+            $host = $username . ':' . $password . '@' . $host;
+        }
+
+        return [
+            'host' => $host,
+            'port' => $port,
+            'path' => $path,
+            'scheme' => $scheme,
+            'enabled' => $solrEnabled
+        ];
+    }
 }

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -25,17 +25,17 @@ plugin.tx_solr {
 		scheme = TEXT
 		scheme {
 			value = {$plugin.tx_solr.solr.scheme}
-			override.data = global:TYPO3_CONF_VARS|SOLR|scheme
+			value.override.data = global:TYPO3_CONF_VARS|SOLR|scheme
 		}
 		host = TEXT
 		host {
 			value = {$plugin.tx_solr.solr.host}
-			override.data = global:TYPO3_CONF_VARS|SOLR|host
+			value.override.data = global:TYPO3_CONF_VARS|SOLR|host
 		}
 		port = TEXT
 		port {
 			value = {$plugin.tx_solr.solr.port}
-			override.data = global:TYPO3_CONF_VARS|SOLR|port
+			value.override.data = global:TYPO3_CONF_VARS|SOLR|port
 		}
 		path = TEXT
 		path {


### PR DESCRIPTION
Using TEXT objects for configuration, can be overwritten by e.g. $TYPO3_CONF_VARS['SOLR']

Relates: #868
Releases: master