### PR TITLE
[TASK] Move access to IndexQueue from IndexQueueModuleController to IndexQueue

### DIFF
--- a/Classes/Domain/Index/Queue/Statistic/QueueStatistic.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatistic.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class QueueStatistic
+{
+
+    /**
+     * @var int
+     */
+    protected $failedCount = 0;
+
+    /**
+     * @var int
+     */
+    protected $pendingCount = 0;
+
+    /**
+     * @var int
+     */
+    protected $successCount = 0;
+
+    /**
+     * @param int $failedCount
+     */
+    public function setFailedCount($failedCount)
+    {
+        $this->failedCount = $failedCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFailedCount()
+    {
+        return $this->failedCount;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getFailedPercentage()
+    {
+        return $this->getPercentage($this->getFailedCount());
+    }
+
+    /**
+     * @param int $pendingCount
+     */
+    public function setPendingCount($pendingCount)
+    {
+        $this->pendingCount = $pendingCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPendingCount()
+    {
+        return $this->pendingCount;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getPendingPercentage()
+    {
+        return $this->getPercentage($this->getPendingCount());
+    }
+
+    /**
+     * @param int $successCount
+     */
+    public function setSuccessCount($successCount)
+    {
+        $this->successCount = $successCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSuccessCount()
+    {
+        return $this->successCount;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getSuccessPercentage()
+    {
+        return $this->getPercentage($this->getSuccessCount());
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        return $this->pendingCount + $this->failedCount + $this->successCount;
+    }
+
+    /**
+     * @param integer $count
+     * @return float|int
+     */
+    protected function getPercentage($count)
+    {
+        return round((100 / $this->getTotalCount()) * $count, 2);
+    }
+}

--- a/Classes/IndexQueue/Item.php
+++ b/Classes/IndexQueue/Item.php
@@ -110,6 +110,11 @@ class Item
     protected $record;
 
     /**
+     * @var string
+     */
+    protected $errors = '';
+
+    /**
      * Constructor, takes item meta data information and resolves that to the full record.
      *
      * @param array $itemMetaData Metadata describing the item to index using the index queue. Is expected to contain a record from table tx_solr_indexqueue_item
@@ -124,6 +129,7 @@ class Item
         $this->type = $itemMetaData['item_type'];
         $this->recordUid = $itemMetaData['item_uid'];
         $this->changed = $itemMetaData['changed'];
+        $this->errors = (string) empty($itemMetaData['errors']) ? '' : $itemMetaData['errors'];
 
         $this->indexingConfigurationName = $itemMetaData['indexing_configuration'];
         $this->hasIndexingProperties = (boolean)$itemMetaData['has_indexing_properties'];
@@ -133,6 +139,9 @@ class Item
         }
     }
 
+    /**
+     * @return int|mixed
+     */
     public function getIndexQueueUid()
     {
         return $this->indexQueueUid;
@@ -148,9 +157,20 @@ class Item
         return $this->rootPageUid;
     }
 
+    /**
+     * @param integer $uid
+     */
     public function setRootPageUid($uid)
     {
         $this->rootPageUid = intval($uid);
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrors()
+    {
+        return $this->errors;
     }
 
     /**

--- a/Resources/Private/Templates/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/IndexQueueModule/Index.html
@@ -12,7 +12,7 @@
 
 <hr class="section-divider" />
 
-<f:if condition="{indexqueue_statistics_counts.total} > 0">
+<f:if condition="{indexqueue_statistics.totalCount} > 0">
 	<div class="row section-with-header">
 		<div class="col-md-12">
 			<h2>
@@ -22,28 +22,28 @@
 			<div class="row">
 				<div class="col-md-12">
 					<div class="progress">
-						<f:if condition="{indexqueue_statistics_counts.indexed} > 0">
+						<f:if condition="{indexqueue_statistics.successCount} > 0">
 							<div class="progress-bar progress-bar-success"
-								 style="width: {indexqueue_statistics_percentages.indexed}%"
-								 title="{f:translate(key:'solr.backend.index_queue_module.status.indexed')}: {indexqueue_statistics_counts.indexed}/{indexqueue_statistics_counts.total} ({indexqueue_statistics_percentages.indexed}%)">
+								 style="width: {indexqueue_statistics.successPercentage}%"
+								 title="{f:translate(key:'solr.backend.index_queue_module.status.indexed')}: {indexqueue_statistics.successCount}/{indexqueue_statistics.totalCount} ({indexqueue_statistics.successPercentage}%)">
 								<f:translate
 										key="solr.backend.index_queue_module.status.indexed"/>
 							</div>
 						</f:if>
 
-						<f:if condition="{indexqueue_statistics_counts.pending} > 0">
+						<f:if condition="{indexqueue_statistics.pendingCount} > 0">
 							<div class="progress-bar progress-bar-warning"
-								 style="width: {indexqueue_statistics_percentages.pending}%"
-								 title="{f:translate(key:'solr.backend.index_queue_module.status.pending')}: {indexqueue_statistics_counts.pending}/{indexqueue_statistics_counts.total} ({indexqueue_statistics_percentages.pending}%)">
+								 style="width: {indexqueue_statistics.pendingPercentage}%"
+								 title="{f:translate(key:'solr.backend.index_queue_module.status.pending')}: {indexqueue_statistics.pendingCount}/{indexqueue_statistics.totalCount} ({indexqueue_statistics.pendingPercentage}%)">
 								<f:translate
 										key="solr.backend.index_queue_module.status.pending"/>
 							</div>
 						</f:if>
 
-						<f:if condition="{indexqueue_statistics_counts.errors} > 0">
+						<f:if condition="{indexqueue_statistics.failedCount} > 0">
 							<div class="progress-bar progress-bar-danger"
-								 style="width: {indexqueue_statistics_percentages.errors}%"
-								 title="{f:translate(key:'solr.backend.index_queue_module.status.errors')}: {indexqueue_statistics_counts.errors}/{indexqueue_statistics_counts.total} ({indexqueue_statistics_percentages.errors}%)">
+								 style="width: {indexqueue_statistics.failedPercentage}%"
+								 title="{f:translate(key:'solr.backend.index_queue_module.status.errors')}: {indexqueue_statistics.failedCount}/{indexqueue_statistics.totalCount} ({indexqueue_statistics.failedPercentage}%)">
 								<f:translate
 										key="solr.backend.index_queue_module.status.errors"/>
 							</div>

--- a/Resources/Private/Templates/IndexQueueModule/ShowError.html
+++ b/Resources/Private/Templates/IndexQueueModule/ShowError.html
@@ -3,7 +3,7 @@
 <solr:backend.style file="{f:uri.resource(path:'StyleSheets/Backend/IndexQueueModule.css')}" />
 
 <f:if condition="{indexQueueItem.errors}">
-    <p><f:translate key="solr.backend.index_queue_module.error_details"/> (uid: {indexQueueItem.uid}, type: {indexQueueItem.item_type}):</p>
+    <p><f:translate key="solr.backend.index_queue_module.error_details"/> (uid: {indexQueueItem.indexQueueUid}, type: {indexQueueItem.type}):</p>
     <pre class="alert alert-danger">
         {indexQueueItem.errors}
     </pre>

--- a/Tests/Integration/IndexQueue/Fixtures/can_get_statistics_by_site.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_get_statistics_by_site.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>3</pid>
+        <doktype>1</doktype>
+    </pages>
+
+    <!-- scheduled site 1 -->
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <!-- scheduled site 2 -->
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+
+    <!-- failed -->
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>3</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors>can not open page</errors>
+    </tx_solr_indexqueue_item>
+
+    <!-- processed -->
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>4</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>1449151778</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -253,4 +253,18 @@ class QueueTest extends IntegrationTest
         $this->assertItemsInQueue(4);
     }
 
+    /**
+     * @test
+     */
+    public function canGetStatistics()
+    {
+        $this->importDataSetFromFixture('can_get_statistics_by_site.xml');
+        $this->assertItemsInQueue(4);
+
+        $statistics = $this->indexQueue->getStatisticsBySite(Site::getSiteByPageId(2));
+        $this->assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed items from queue');
+        $this->assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed items from queue');
+        $this->assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed items from queue');
+    }
+
 }

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\Statistic;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Hund
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class QueueStatisticTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canGetFailedPercentage() {
+            /** @var $statistic QueueStatistic */
+        $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
+        $statistic->setFailedCount(2);
+        $statistic->setSuccessCount(1);
+        $statistic->setPendingCount(1);
+
+        $this->assertSame(50.0, $statistic->getFailedPercentage(), 'Can not calculate failed percentage');
+        $this->assertSame(25.0, $statistic->getSuccessPercentage(), 'Can not calculate success percentage');
+        $this->assertSame(25.0, $statistic->getPendingPercentage(), 'Can not calculate pending percentage');
+    }
+
+}

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @authot Timo Hund <timo.hund@dkd.de>
+ */
+class ItemTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetErrors()
+    {
+        $metaData = ['errors' => 'error during index'];
+        $record = [];
+        $item = new Item($metaData, $record);
+
+        $errors = $item->getErrors();
+        $this->assertSame('error during index', $errors, 'Can not get errors from queue item');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetType()
+    {
+        $metaData = ['item_type' => 'pages'];
+        $record = [];
+        $item = new Item($metaData, $record);
+
+        $type = $item->getType();
+        $this->assertSame('pages', $type, 'Can not get type from queue item');
+    }
+}


### PR DESCRIPTION
To simplify the migration to doctrine in the next release, this pr moves direct access
to the index queue item table from the controller to the IndexQueue class

Fixes: #908