### PR TITLE
[TASK] Remove database access from IndexService

### DIFF
--- a/Classes/Backend/SolrModule/IndexQueueModuleController.php
+++ b/Classes/Backend/SolrModule/IndexQueueModuleController.php
@@ -133,7 +133,7 @@ class IndexQueueModuleController extends AbstractModuleController
 
         $messagesForConfigurations = [];
         foreach (array_keys($initializedIndexingConfigurations) as $indexingConfigurationName) {
-            $itemCount = $this->indexQueue->getItemsCountBySite($this->site, $indexingConfigurationName);
+            $itemCount = $this->indexQueue->getStatisticsBySite($this->site, $indexingConfigurationName)->getTotalCount();
             $messagesForConfigurations[] = $indexingConfigurationName . ' (' . $itemCount . ' records)';
         }
 

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -238,18 +238,7 @@ class IndexService
      */
     public function getProgress()
     {
-        $itemsIndexedPercentage = 0.0;
-
-        $totalItemsCount = $this->indexQueue->getItemsCountBySite($this->site);
-        $remainingItemsCount = $this->indexQueue->getRemainingItemsCountBySite($this->site);
-        $itemsIndexedCount = $totalItemsCount - $remainingItemsCount;
-
-        if ($totalItemsCount > 0) {
-            $itemsIndexedPercentage = $itemsIndexedCount * 100 / $totalItemsCount;
-            $itemsIndexedPercentage = round($itemsIndexedPercentage, 2);
-        }
-
-        return $itemsIndexedPercentage;
+        return $this->indexQueue->getStatisticsBySite($this->site)->getSuccessPercentage();
     }
 
     /**

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -803,13 +803,13 @@ class Queue
      * @param Site $site The site to search for.
      * @param string $indexingConfigurationName name of a specific indexing
      *      configuration
+     * @deprecated since 6.1 will be removed in 7.0 use getStatisticsBySite()->getTotalCount() please
      * @return int Number of items
      */
     public function getItemsCountBySite(Site $site, $indexingConfigurationName = '')
     {
-        $indexingConfigurationConstraint = $this->buildIndexConfigurationConstraint($indexingConfigurationName);
-        $where = 'root = ' . $site->getRootPageId() . $indexingConfigurationConstraint;
-        return (int)$this->getItemCount($where);
+        GeneralUtility::logDeprecatedFunction();
+        return (int) $this->getStatisticsBySite($site, $indexingConfigurationName)->getTotalCount();
     }
 
     /**
@@ -819,13 +819,13 @@ class Queue
      * @param Site $site The site to search for.
      * @param string $indexingConfigurationName name of a specific indexing
      *      configuration
+     * @deprecated since 6.1 will be removed in 7.0 use getStatisticsBySite()->getPendingCount() please
      * @return int Number of items.
      */
     public function getRemainingItemsCountBySite(Site $site, $indexingConfigurationName = '')
     {
-        $indexingConfigurationConstraint = $this->buildIndexConfigurationConstraint($indexingConfigurationName);
-        $where = 'changed > indexed AND root = ' . $site->getRootPageId() . $indexingConfigurationConstraint;
-        return (int)$this->getItemCount($where);
+        GeneralUtility::logDeprecatedFunction();
+        return (int) $this->getStatisticsBySite($site, $indexingConfigurationName)->getPendingCount();
     }
 
     /**
@@ -854,16 +854,22 @@ class Queue
      * Extracts the number of pending, indexed and erroneous items from the
      * Index Queue.
      *
+     * @param Site $site
+     * @param string $indexingConfigurationName
+     *
      * @return QueueStatistic
      */
-    public function getStatisticsBySite(Site $site)
+    public function getStatisticsBySite(Site $site, $indexingConfigurationName = '')
     {
+        $indexingConfigurationConstraint = $this->buildIndexConfigurationConstraint($indexingConfigurationName);
+        $where = 'root = ' . (int)$site->getRootPageId() . $indexingConfigurationConstraint;
+
         $indexQueueStats = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
             'indexed < changed as pending,'
             . '(errors not like "") as failed,'
             . 'COUNT(*) as count',
             'tx_solr_indexqueue_item',
-            'root = ' . (int) $site->getRootPageId(),
+            $where,
             'pending, failed'
         );
             /** @var $statistic QueueStatistic */

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -191,11 +191,11 @@ class QueueTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetItemCountBySite()
+    public function canGetStatisticsWithTotalItemCount()
     {
         $this->importDataSetFromFixture('can_get_item_count_by_site.xml');
         $site = Site::getFirstAvailableSite();
-        $itemCount = $this->indexQueue->getItemsCountBySite($site);
+        $itemCount = $this->indexQueue->getStatisticsBySite($site)->getTotalCount();
 
             // there are two items in the queue but only one for the site
         $this->assertSame(1, $itemCount, 'Unexpected item count for the first site');
@@ -204,17 +204,17 @@ class QueueTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetRemainingItemCountBySite()
+    public function canGetStatisticsBySiteWithPendingItems()
     {
         $this->importDataSetFromFixture('can_get_item_count_by_site.xml');
         $site = Site::getFirstAvailableSite();
 
-        $itemCount = $this->indexQueue->getRemainingItemsCountBySite($site);
+        $itemCount = $this->indexQueue->getStatisticsBySite($site)->getPendingCount();
         $this->assertSame(1, $itemCount, 'Unexpected remaining item count for the first site');
 
             // when we update the item, no remaining item should be left
         $this->indexQueue->updateItem('pages', 1);
-        $itemCount = $this->indexQueue->getRemainingItemsCountBySite($site);
+        $itemCount = $this->indexQueue->getStatisticsBySite($site)->getPendingCount();
         $this->assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
     }
 

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -26,11 +26,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Index\IndexService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Query\Modifier\Statistics;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use Dkd\DkdReports\Reports\Status;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
@@ -99,8 +102,9 @@ class IndexServiceTest extends UnitTest
     {
         $this->siteMock->expects($this->never())->method('getSolrConfiguration');
 
-        $this->queueMock->expects($this->once())->method('getItemsCountBySite')->will($this->returnValue(50));
-        $this->queueMock->expects($this->once())->method('getRemainingItemsCountBySite')->will($this->returnValue(25));
+        $statisticMock = $this->getDumbMock(QueueStatistic::class);
+        $statisticMock->expects($this->once())->method('getSuccessPercentage')->will($this->returnValue(50.0));
+        $this->queueMock->expects($this->once())->method('getStatisticsBySite')->will($this->returnValue($statisticMock));
 
         $indexService = $this->getMockBuilder(IndexService::class)
             ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock])


### PR DESCRIPTION
This pr:

* Removes the direct database access in IndexService
* Uses the method getStatisticsBySite instead
* deprecates Queue::getItemsCountBySite
* deprecates Queue::getRemainingItemsCountBySite
* Adapts the tests

Fixes: #1128