### PR TITLE
[TASK] Remove direct database access in IndexQueueWorkerTask

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -242,6 +242,16 @@ class IndexService
     }
 
     /**
+     * Returns the amount of failed queue items for the current site.
+     *
+     * @return int
+     */
+    public function getFailCount()
+    {
+        return $this->indexQueue->getStatisticsBySite($this->site)->getFailedCount();
+    }
+
+    /**
      * Initializes the $_SERVER['HTTP_HOST'] environment variable in CLI
      * environments dependent on the Index Queue item's root page.
      *

--- a/Classes/Domain/Index/Queue/Statistic/QueueStatistic.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatistic.php
@@ -125,10 +125,14 @@ class QueueStatistic
 
     /**
      * @param integer $count
-     * @return float|int
+     * @return float
      */
     protected function getPercentage($count)
     {
-        return round((100 / $this->getTotalCount()) * $count, 2);
+        $total = $this->getTotalCount();
+        if ($total === 0) {
+            return 0.0;
+        }
+        return (float)round((100 / $total) * $count, 2);
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -49,4 +49,13 @@ class QueueStatisticTest extends UnitTest
         $this->assertSame(25.0, $statistic->getPendingPercentage(), 'Can not calculate pending percentage');
     }
 
+    /**
+     * @test
+     */
+    public function canGetZeroPercentagesWhenEmpty() {
+        /** @var $statistic QueueStatistic */
+        $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
+        $this->assertSame(0.0, $statistic->getFailedPercentage(), 'Can not zero percent for empty');
+    }
+
 }


### PR DESCRIPTION
Currently the IndexQueueWorkerTask does a direct read in the database.
To optimize the code structure and simplify the migration to doctrine, this
pr migrates the IndexQueueWorker task to use the logic from the Queue to retrieve
the count of failed documents.

Fixes: #1129