### PR TITLE
Remove check when overwriting type

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -66,13 +66,6 @@ abstract class AbstractIndexer
                 continue;
             }
 
-            if ($solrFieldName == 'type') {
-                throw new InvalidFieldNameException(
-                    'Must not overwrite field "type".',
-                    1435441863
-                );
-            }
-
             $fieldValue = $this->resolveFieldValue($indexingConfiguration,
                 $solrFieldName, $data);
 


### PR DESCRIPTION
Due to having no clue why this is forbidden the check should be removed.