### PR TITLE
[BUGFIX] Report is broken when invalid solr connection is configured

### DIFF
--- a/Classes/System/Solr/Parser/SchemaParser.php
+++ b/Classes/System/Solr/Parser/SchemaParser.php
@@ -49,6 +49,10 @@ class SchemaParser
 
         $schema = GeneralUtility::makeInstance(Schema::class);
 
+        if ($schemaResponse === null) {
+            return $schema;
+        }
+
         $language = $this->parseLanguage($schemaResponse);
         $schema->setLanguage($language);
 

--- a/Tests/Integration/Report/Fixtures/can_check_status_fail_on_invalid_connection.xml
+++ b/Tests/Integration/Report/Fixtures/can_check_status_fail_on_invalid_connection.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"6548";s:8:"solrPath";s:14:"/solr/core_xx/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:6548/solr/core_xx/";}}</entry_value>
+    </sys_registry>
+
+</dataset>

--- a/Tests/Integration/Report/SolrStatusTest.php
+++ b/Tests/Integration/Report/SolrStatusTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Report\SolrStatus;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Reports\Status;
+
+/**
+ * Integration test for the solr status report
+ *
+ * @author Timo Hund
+ */
+class SolrStatusTest extends IntegrationTest
+{
+    /**
+     * @test
+     */
+    public function allStatusChecksShouldBeOkForValidSolrConnection()
+    {
+        $this->importDataSetFromFixture('can_check_status.xml');
+
+        /** @var $solrStatus  SolrStatus */
+        $solrStatus = GeneralUtility::makeInstance(SolrStatus::class);
+        $statusCollection = $solrStatus->getStatus();
+
+        foreach($statusCollection as $status) {
+            /** @var $status Status */
+            $this->assertSame(Status::OK, $status->getSeverity(), 'Expected that all status objects should be ok');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function allStatusChecksShouldFailForInvalidSolrConnection()
+    {
+        $this->importDataSetFromFixture('can_check_status_fail_on_invalid_connection.xml');
+
+        /** @var $solrStatus  SolrStatus */
+        $solrStatus = GeneralUtility::makeInstance(SolrStatus::class);
+        $statusCollection = $solrStatus->getStatus();
+
+        foreach($statusCollection as $status) {
+            /** @var $status Status */
+            $this->assertSame(Status::ERROR, $status->getSeverity(), 'Expected that all status objects should indicate an error');
+        }
+    }
+}

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Test\System\Solr\Parser;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
+use ApacheSolrForTypo3\Solr\System\Solr\Schema\Schema;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
@@ -53,6 +54,16 @@ class SchemaParserTest extends UnitTest
         $parser = new SchemaParser();
         $schema = $parser->parseJson($this->getFixtureContentByName('schema.json'));
         $this->assertSame('tx_solr-6-0-0--20161122', $schema->getName(), 'Could not parser name from schema response');
+    }
+
+    /**
+     * @test
+     */
+    public function canReturnEmptySchemaWhenNoSchemaPropertyInResponse()
+    {
+        $parser = new SchemaParser();
+        $schema = $parser->parseJson('{}');
+        $this->assertInstanceOf(Schema::class, $schema, 'Can not get schema object from empty response');
     }
 
 }


### PR DESCRIPTION
When the report is checked with an invalid solr connection you get an error in the backend.

This PR:

* Fixes the error
* Adds an integration test for an invalid solr server and checks if a report can be rendered

Fixes: #1152