### PR TITLE
[BUGFIX] Copy context config in getCopyForSubRequest

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -554,7 +554,12 @@ class SearchRequest
         if (!$onlyPersistentArguments) {
             // create a new request with all data
             $argumentsArray = $this->argumentsAccessor->getData();
-            return new SearchRequest($argumentsArray);
+            return new SearchRequest(
+                $argumentsArray,
+                $this->contextPageUid,
+                $this->contextSystemLanguageUid,
+                $this->contextTypoScriptConfiguration
+            );
         }
 
         $arguments = new ArrayAccessor();
@@ -564,7 +569,12 @@ class SearchRequest
             }
         }
 
-        return new SearchRequest($arguments->getData());
+        return new SearchRequest(
+            $arguments->getData(),
+            $this->contextPageUid,
+            $this->contextSystemLanguageUid,
+            $this->contextTypoScriptConfiguration
+        );
     }
 
     /**


### PR DESCRIPTION
Make sure all context aware settings and config is also copied in SearchRequest::getCopyForSubRequest() so target page and language 
are correct for all created urls.