### PR TITLE
[FIX] Deleting stop words with umlauts on ext-solr behind frontend proxies

### DIFF
--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -820,7 +820,7 @@ class SolrService extends \Apache_Solr_Service
             throw new \Apache_Solr_InvalidArgumentException('Must provide stop word.');
         }
 
-        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . $stopWord);
+        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . urlencode($stopWord));
     }
 
     /**

--- a/Tests/Integration/SolrServiceTest.php
+++ b/Tests/Integration/SolrServiceTest.php
@@ -55,10 +55,42 @@ class SolrServiceTest extends IntegrationTest
     public function canExtractByQuery()
     {
         $testFilePath = $this->getFixturePath('testpdf.pdf');
-            /** @var $extractQuery \ApacheSolrForTypo3\Solr\ExtractingQuery */
+        /** @var $extractQuery \ApacheSolrForTypo3\Solr\ExtractingQuery */
         $extractQuery = GeneralUtility::makeInstance('ApacheSolrForTypo3\Solr\ExtractingQuery', $testFilePath);
         $extractQuery->setExtractOnly();
         $response = $this->solrService->extractByQuery($extractQuery);
         $this->assertContains('PDF Test', $response[0], 'Could not extract text');
+    }
+
+    /**
+     * @test
+     */
+    public function canAddAndDeleteStopwords()
+    {
+        $stopWord = 'blabla_word';
+
+        $this->solrService->addStopWords($stopWord);
+        $stopWordsFromSolr = $this->solrService->getStopWords();
+        $this->assertContains($stopWord, $stopWordsFromSolr);
+
+        $this->solrService->deleteStopWord('blabla_word');
+        $stopWordsFromSolr = $this->solrService->getStopWords();
+        $this->assertNotContains($stopWord, $stopWordsFromSolr);
+    }
+
+    /**
+     * @test
+     */
+    public function canAddAndDeleteStopwordsWithUmlauts()
+    {
+        $stopWordWithUmlauts = 'ärger';
+
+        $this->solrService->addStopWords($stopWordWithUmlauts);
+        $stopWordsFromSolr = $this->solrService->getStopWords();
+        $this->assertContains($stopWordWithUmlauts, $stopWordsFromSolr);
+
+        $this->solrService->deleteStopWord($stopWordWithUmlauts);
+        $stopWordsFromSolr = $this->solrService->getStopWords();
+        $this->assertNotContains($stopWordWithUmlauts, $stopWordsFromSolr);
     }
 }


### PR DESCRIPTION
We need to encode the url for deleting stop words on Apache Solr
machines behind frontend proxies.

Fixes: #1206
Needs Up-Merge
