### PR TITLE
[FIX] Deleting synonyms with umlauts behind fronted proxies

### DIFF
--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -714,7 +714,7 @@ class SolrService extends \Apache_Solr_Service
             throw new \Apache_Solr_InvalidArgumentException('Must provide base word.');
         }
 
-        return $this->_sendRawDelete($this->_synonymsUrl . '/' . $baseWord);
+        return $this->_sendRawDelete($this->_synonymsUrl . '/' . urlencode($baseWord));
     }
 
     /**

--- a/Tests/Integration/SolrServiceTest.php
+++ b/Tests/Integration/SolrServiceTest.php
@@ -61,4 +61,47 @@ class SolrServiceTest extends IntegrationTest
         $response = $this->solrService->extractByQuery($extractQuery);
         $this->assertContains('PDF Test', $response[0], 'Could not extract text');
     }
+
+    /**
+     * @test
+     */
+    public function canAddAndDeleteSynonyms()
+    {
+        $baseword = 'base';
+        $synonyms = array(
+            'pad',
+            'underlay',
+            'record'
+        );
+
+        $this->solrService->addSynonym($baseword, $synonyms);
+        $synonymsFromSolr = $this->solrService->getSynonyms();
+        $this->assertArrayHasKey($baseword, $synonymsFromSolr);
+
+        $this->solrService->deleteSynonym($baseword);
+        $synonymsFromSolr = $this->solrService->getSynonyms();
+        $this->assertArrayNotHasKey($baseword, $synonymsFromSolr);
+    }
+
+    /**
+     * @test
+     */
+    public function canAddAndDeleteSynonymsWithUmlauts()
+    {
+        $baseword = 'ärger';
+        $synonyms = array(
+            'kummer',
+            'problem',
+            'unruhe'
+        );
+
+        $this->solrService->addSynonym($baseword, $synonyms);
+        $synonymsFromSolr = $this->solrService->getSynonyms();
+        $this->assertArrayHasKey($baseword, $synonymsFromSolr);
+
+        $this->solrService->deleteSynonym($baseword);
+        $synonymsFromSolr = $this->solrService->getSynonyms();
+        $this->assertArrayNotHasKey($baseword, $synonymsFromSolr);
+    }
+
 }


### PR DESCRIPTION
We need to encode the url for deleting synonyms on Apache Solr
machines behind front-end proxies with default configs.

Closes: #1205