### PR TITLE
[TASK] Use urlencode when deleting synonyms and stopwords

### DIFF
--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -773,7 +773,7 @@ class SolrService extends \Apache_Solr_Service
             throw new \Apache_Solr_InvalidArgumentException('Must provide base word.');
         }
 
-        return $this->_sendRawDelete($this->_synonymsUrl . '/' . $baseWord);
+        return $this->_sendRawDelete($this->_synonymsUrl . '/' . urlencode($baseWord));
     }
 
     /**
@@ -893,7 +893,7 @@ class SolrService extends \Apache_Solr_Service
             throw new \Apache_Solr_InvalidArgumentException('Must provide stop word.');
         }
 
-        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . $stopWord);
+        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . urlencode($stopWord));
     }
 
     /**

--- a/Tests/Integration/SolrServiceTest.php
+++ b/Tests/Integration/SolrServiceTest.php
@@ -64,43 +64,70 @@ class SolrServiceTest extends IntegrationTest
     }
 
     /**
+     * @return array
+     */
+    public function synonymDataProvider()
+    {
+        return [
+            'normal' => ['baseword' => 'homepage', 'synonyms' => ['website']],
+            'umlaut' => ['baseword' => 'früher', 'synonyms' => ['vergangenheit']]
+
+        ];
+    }
+
+    /**
+     * @param string $baseWord
+     * @param array $synonyms
+     * @dataProvider synonymDataProvider
      * @test
      */
-    public function canAddSynonym()
+    public function canAddSynonym($baseWord, $synonyms = [])
     {
         // make sure old synonyms have been deleted
-        $this->solrService->deleteSynonym('homepage');
+        $this->solrService->deleteSynonym($baseWord);
 
-        $synonymsBeforeAdd = $this->solrService->getSynonyms('homepage');
+        $synonymsBeforeAdd = $this->solrService->getSynonyms($baseWord);
         $this->assertEquals([], $synonymsBeforeAdd, 'Synonyms was not empty');
 
-        $this->solrService->addSynonym('homepage', ['website']);
-        $synonymsAfterAdd = $this->solrService->getSynonyms('homepage');
-        $this->assertEquals(['website'], $synonymsAfterAdd, 'Could not retrieve synonym after adding');
+        $this->solrService->addSynonym($baseWord, $synonyms);
+        $synonymsAfterAdd = $this->solrService->getSynonyms($baseWord);
+        $this->assertEquals($synonyms, $synonymsAfterAdd, 'Could not retrieve synonym after adding');
 
-        $this->solrService->deleteSynonym('homepage');
+        $this->solrService->deleteSynonym($baseWord);
 
-        $synonymsAfterRemove = $this->solrService->getSynonyms('homepage');
+        $synonymsAfterRemove = $this->solrService->getSynonyms($baseWord);
         $this->assertEquals([], $synonymsAfterRemove, 'Synonym was not removed');
     }
 
     /**
-     * @test
+     * @return array
      */
-    public function canAddStopWord()
+    public function stopWordDataProvider()
+    {
+        return [
+            'normal' => ['stopword' => 'badword'],
+            'umlaut' => ['stopword' => 'frühaufsteher']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider stopwordDataProvider
+     */
+    public function canAddStopWord($stopWord)
     {
         // make sure old stopwords are deleted
-        $this->solrService->deleteStopWord('badword');
+        $this->solrService->deleteStopWord($stopWord);
         $stopWords = $this->solrService->getStopWords();
-        $this->assertNotContains('badword', $stopWords, 'Stopwords are not empty after initializing');
+        $this->assertNotContains($stopWord, $stopWords, 'Stopwords are not empty after initializing');
 
-        $this->solrService->addStopWords('badword');
+        $this->solrService->addStopWords($stopWord);
         $stopWordsAfterAdd = $this->solrService->getStopWords();
-        $this->assertContains('badword', $stopWordsAfterAdd, 'Stopword was not added');
+        $this->assertContains($stopWord, $stopWordsAfterAdd, 'Stopword was not added');
 
-        $this->solrService->deleteStopWord('badword');
+        $this->solrService->deleteStopWord($stopWord);
         $stopWordsAfterDelete = $this->solrService->getStopWords();
-        $this->assertNotContains('badword', $stopWordsAfterDelete, 'Stopwords are not empty after removing');
+        $this->assertNotContains($stopWord, $stopWordsAfterDelete, 'Stopwords are not empty after removing');
     }
 
     /**


### PR DESCRIPTION
This pr makes sure that urlencode is used when synonyms and stopwords are deleted.

This is not a problem with a default solr installation, but when you have a proxy before the solr server that does not allow utf8 urls.

Related:

#1205 
#1206 