### PR TITLE
[BUGFIX] Core reload fails when core path consists of more then two segments - release 6.0.x

### DIFF
--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -887,6 +887,30 @@ class SolrService extends \Apache_Solr_Service
     }
 
     /**
+     * Returns the core name from the configured path.
+     *
+     * @return string
+     */
+    public function getCoreName()
+    {
+        $paths = explode('/', trim($this->_path, '/'));
+
+        return (string)array_pop($paths);
+    }
+
+    /**
+     * Returns the core name from the configured path without the core name.
+     *
+     * @return string
+     */
+    public function getCoreBasePath()
+    {
+        $pathWithoutLeadingAndTrailingSlashes = trim(trim($this->_path), "/");
+        $pathWithoutLastSegment = substr($pathWithoutLeadingAndTrailingSlashes, 0, strrpos($pathWithoutLeadingAndTrailingSlashes, "/"));
+        return '/' . $pathWithoutLastSegment . '/';
+    }
+
+    /**
      * Reloads the current core
      *
      * @return \Apache_Solr_Response
@@ -921,12 +945,11 @@ class SolrService extends \Apache_Solr_Service
             array('wt' => self::SOLR_WRITER)
         );
 
-        $pathElements = explode('/', trim($this->_path, '/'));
         $this->_coresUrl =
             $this->_scheme . '://' .
             $this->_host . ':' .
-            $this->_port . '/' .
-            $pathElements[0] . '/' .
+            $this->_port .
+            $this->getCoreBasePath() .
             self::CORES_SERVLET;
 
         $this->_schemaUrl = $this->_constructUrl(self::SCHEMA_SERVLET);

--- a/Tests/Unit/SolrServiceTest.php
+++ b/Tests/Unit/SolrServiceTest.php
@@ -149,4 +149,48 @@ class SolrServiceTest extends UnitTest
         $solrService->setScheme('invalidscheme');
     }
 
+    /**
+     * @return array
+     */
+    public function coreNameDataProvider()
+    {
+        return [
+            ['path' => '/solr/bla', 'expectedName' => 'bla'],
+            ['path' => '/somewherelese/solr/corename', 'expectedName' => 'corename']
+
+        ];
+    }
+
+    /**
+     * @dataProvider coreNameDataProvider
+     * @test
+     */
+    public function canGetCoreName($path, $expectedCoreName)
+    {
+        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $solrService = new SolrService('localhost','8080', $path,'http', $fakeConfiguration);
+        $this->assertSame($expectedCoreName, $solrService->getCoreName());
+    }
+
+    /**
+     * @return array
+     */
+    public function coreBasePathDataProvider()
+    {
+        return [
+            ['path' => '/solr/bla', 'expectedPath' => '/solr/'],
+            ['path' => '/somewherelese/solr/corename', 'expectedCoreBasePath' => '/somewherelese/solr/']
+        ];
+    }
+
+    /**
+     * @dataProvider coreBasePathDataProvider
+     * @test
+     */
+    public function canGetCoreBasePath($path, $expectedCoreBasePath)
+    {
+        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $solrService = new SolrService('localhost','8080', $path,'http', $fakeConfiguration);
+        $this->assertSame($expectedCoreBasePath, $solrService->getCoreBasePath());
+    }
 }


### PR DESCRIPTION
This PR:

* Extracts the logic into the method getCoreBasePath
* Adds unit tests for getCoreBasePath and getCoreName

Fixes: #1209