### PR TITLE
[TASK] Add tests for #1213 GarbageCollector check on endtime=0

### DIFF
--- a/Tests/Integration/Fixtures/does_not_remove_updated_content_element_with_not_set_endtime.xml
+++ b/Tests/Integration/Fixtures/does_not_remove_updated_content_element_with_not_set_endtime.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.disableAllHeaderCode = 1
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                page.10.wrap = <!--TYPO3SEARCH_begin--><html><body>|</body></html><!--TYPO3SEARCH_end-->
+
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <title>Testpage</title>
+    </pages>
+
+    <tt_content>
+        <uid>88</uid>
+        <pid>1</pid>
+        <bodytext>Will stay after update!</bodytext>
+        <colPos>0</colPos>
+        <endtime>0</endtime>
+    </tt_content>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>1</indexed>
+        <errors/>
+        <pages_mountidentifier/>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -181,6 +181,31 @@ class TCAServiceTest extends UnitTest
     /**
      * @test
      */
+    public function isEndTimeInPastCanDetectedEndtimeIsEmpty(){
+        $fakeTCA = [
+            'pages' => [
+                'ctrl' => [
+                    'enablecolumns' => [
+                        'endtime' => 'end'
+                    ]
+                ]
+            ]
+        ];
+
+        $GLOBALS['EXEC_TIME'] = 1000;
+        $fakePageRecord = [
+            'end' => 0
+        ];
+
+        $tcaService = new TCAService($fakeTCA);
+        $isEndTimeInPast = $tcaService->isEndTimeInPast('pages', $fakePageRecord);
+
+        $this->assertFalse($isEndTimeInPast, 'Not set endtime(default 0), was detected as endtime in past.');
+    }
+
+    /**
+     * @test
+     */
     public function isStartTimeInFutureCanDetectedStartTimeInFuture() {
         $fakeTCA = [
             'pages' => [


### PR DESCRIPTION
As followup of #1213 added tests that makes sure that a solr document still exists, when a custom record was updates.

Closes #1214