### PR TITLE
[BUGFIX] Change type to 254 in fixture

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_configuration_in_rootline.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_configuration_in_rootline.xml
@@ -116,7 +116,7 @@
         <title>storage folder</title>
         <uid>3</uid>
         <is_siteroot>1</is_siteroot>
-        <doktype>1</doktype>
+        <doktype>254</doktype>
         <pid>2</pid>
     </pages>
 


### PR DESCRIPTION
This PR changes the dokytpe to 254 in the fixture file to make sure the storage behaves like a sysfolder.

Fixes: #1266