### PR TITLE
[BUGFIX] Load default configuration for DB records outside site root

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -276,7 +276,7 @@ class Indexer extends AbstractIndexer
         $indexConfigurationName = $item->getIndexingConfigurationName();
         $fields = $solrConfiguration->getIndexQueueFieldsConfigurationByConfigurationName($indexConfigurationName, []);
 
-	if (count($fields) === 0) {
+        if (count($fields) === 0) {
             $solrConfiguration = Util::getSolrConfigurationFromPageId($item->getRootPageUid(), true, $language);
             if (!empty($solrConfiguration->getIndexQueueAdditionalPageIdsByConfigurationName($indexConfigurationName))) {
                 $fields = $solrConfiguration->getIndexQueueFieldsConfigurationByConfigurationName($indexConfigurationName, []);

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -276,11 +276,17 @@ class Indexer extends AbstractIndexer
         $indexConfigurationName = $item->getIndexingConfigurationName();
         $fields = $solrConfiguration->getIndexQueueFieldsConfigurationByConfigurationName($indexConfigurationName, []);
 
-        if (count($fields) === 0) {
-            throw new \RuntimeException('The item indexing configuration "' . $item->getIndexingConfigurationName() .
-                '" on root page uid ' . $item->getRootPageUid() . ' could not be found!', 1455530112);
-        }
+	if (count($fields) === 0) {
+            $solrConfiguration = Util::getSolrConfigurationFromPageId($item->getRootPageUid(), true, $language);
+            if (!empty($solrConfiguration->getIndexQueueAdditionalPageIdsByConfigurationName($indexConfigurationName))) {
+                $fields = $solrConfiguration->getIndexQueueFieldsConfigurationByConfigurationName($indexConfigurationName, []);
+            }
 
+            if (count($fields) === 0) {
+                throw new \RuntimeException('The item indexing configuration "' . $item->getIndexingConfigurationName() .
+                    '" on root page uid ' . $item->getRootPageUid() . ' could not be found!', 1455530112);
+            }
+        }
         return $fields;
     }
 


### PR DESCRIPTION
If a custom DB record is outside of the site root and should be
indexed (via `additioanlpageIds` configuration) the configuration
of the site root is loaded if there is no configuration present in
the rootline of the cusomt DB record.