### PR TITLE
[BUGFIX] Remove unused use statement in DebugWriterTest

### DIFF
--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -25,7 +25,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Logging;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Logging\DebugWriter;
-use ApacheSolrForTypo3\Solr\System\Logging\DevLogDebugWriter;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 


### PR DESCRIPTION
This pr:

* Removes an unused use statement of the Class DevLogDebugWriter

Fixes:

#1285