### PR TITLE
[BUGFIX] Mounted pages from outside of the page tree lead to index queue errors

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -136,9 +136,10 @@ class RootPageResolver implements SingletonInterface
      *
      * @param int $pageId A page ID somewhere in a tree.
      * @param bool $forceFallback Force the explicit detection and do not use the current frontend root line
+     * @param string $mountPointIdentifier
      * @return int The page's tree branch's root page ID
      */
-    public function getRootPageId($pageId = 0, $forceFallback = false)
+    public function getRootPageId($pageId = 0, $forceFallback = false, $mountPointIdentifier = '')
     {
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
@@ -151,8 +152,10 @@ class RootPageResolver implements SingletonInterface
 
         // fallback, backend
         if ($pageId != 0 && ($forceFallback || !$rootLine->getHasRootPage())) {
+            /* @var $pageSelect PageRepository */
             $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-            $rootLineArray = $pageSelect->getRootLine($pageId, '', true);
+
+            $rootLineArray = $pageSelect->getRootLine($pageId, $mountPointIdentifier, true);
             $rootLine->setRootLineArray($rootLineArray);
         }
 

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -75,11 +75,12 @@ class SiteRepository
      * Gets the Site for a specific page Id.
      *
      * @param int $pageId The page Id to get a Site object for.
+     * @param string $mountPointIdentifier
      * @return Site Site for the given page Id.
      */
-    public function getSiteByPageId($pageId)
+    public function getSiteByPageId($pageId, $mountPointIdentifier = '')
     {
-        $rootPageId = $this->rootPageResolver->getRootPageId($pageId);
+        $rootPageId = $this->rootPageResolver->getRootPageId($pageId, false, $mountPointIdentifier);
         return $this->getSiteByRootPageId($rootPageId);
     }
 

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -530,7 +530,7 @@ class Indexer extends AbstractIndexer
             }
         }
 
-        $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId);
+        $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId, 0, $item->getMountPointIdentifier());
         $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays);
 
         $solrConnections[0] = $defaultConnection;

--- a/Classes/IndexQueue/Item.php
+++ b/Classes/IndexQueue/Item.php
@@ -111,6 +111,13 @@ class Item
     protected $record;
 
     /**
+     * Moint point identifier.
+     *
+     * @var string
+     */
+    protected $mountPointIdentifier;
+
+    /**
      * @var string
      */
     protected $errors = '';
@@ -129,6 +136,7 @@ class Item
         $this->rootPageUid = $itemMetaData['root'];
         $this->type = $itemMetaData['item_type'];
         $this->recordUid = $itemMetaData['item_uid'];
+        $this->mountPointIdentifier = (string) empty($itemMetaData['pages_mountidentifier']) ? '' : $itemMetaData['pages_mountidentifier'];
         $this->changed = $itemMetaData['changed'];
         $this->errors = (string) empty($itemMetaData['errors']) ? '' : $itemMetaData['errors'];
 
@@ -156,6 +164,16 @@ class Item
     public function getRootPageUid()
     {
         return $this->rootPageUid;
+    }
+
+    /**
+     * Returns mount point identifier
+     *
+     * @return string
+     */
+    public function getMountPointIdentifier()
+    {
+        return $this->mountPointIdentifier;
     }
 
     /**

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -730,12 +730,33 @@ class Queue
      */
     public function getItems($itemType, $itemUid)
     {
+        $whereClause = 'item_type = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($itemType, 'tx_solr_indexqueue_item') . ' AND item_uid = ' . intval($itemUid);
+        return $this->getItemsByWhereClause($whereClause);
+    }
+
+    /**
+     * Returns all items in the queue.
+     *
+     * @return Item[] An array of items matching $itemType and $itemUid
+     */
+    public function getAllItems()
+    {
+        return $this->getItemsByWhereClause('1 = 1');
+    }
+
+    /**
+     * Returns a collection of items by whereClause.
+     *
+     * @param string $whereClause
+     * @return array
+     */
+    protected function getItemsByWhereClause($whereClause = '1=1')
+    {
         $indexQueueItemRecords = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
             '*',
             'tx_solr_indexqueue_item',
-            'item_type = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($itemType,
-                'tx_solr_indexqueue_item') .
-            ' AND item_uid = ' . intval($itemUid)
+            $whereClause
+
         );
 
         return $this->getIndexQueueItemObjectsFromRecords($indexQueueItemRecords);

--- a/Tests/Integration/Fixtures/can_find_connection_for_mouted_page.xml
+++ b/Tests/Integration/Fixtures/can_find_connection_for_mouted_page.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+ [0]
+  |
+  ——[20] Shared-Pages (Folder: Not root)
+  |   |
+  |   ——[24] FirstShared
+  |       |
+  |       ——[25] first sub page from FirstShared
+  |       |
+  |       ——[26] second sub page from FirstShared
+  |
+  ——[ 1] Page (Root)
+  |   |
+  |   ——[14] Mount Point 1 (to [24] to show contents from)
+  |
+  ——[ 2] Page2 (Root)
+      |
+      ——[34] Mount Point 2 (to [24] to show contents from)
+
+-->
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+        <pages>
+            <uid>24</uid>
+            <pid>20</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>1</doktype>
+            <mount_pid>0</mount_pid>
+            <mount_pid_ol>0</mount_pid_ol>
+            <title>FirstShared (Not root)</title>
+            <TSconfig></TSconfig>
+            <tsconfig_includes/>
+        </pages>
+            <pages>
+                <uid>25</uid>
+                <pid>24</pid>
+                <is_siteroot>0</is_siteroot>
+                <doktype>1</doktype>
+                <mount_pid>0</mount_pid>
+                <mount_pid_ol>0</mount_pid_ol>
+                <title>first sub page from FirstShared (Not root)</title>
+                <TSconfig></TSconfig>
+                <tsconfig_includes/>
+            </pages>
+            <pages>
+                <uid>26</uid>
+                <pid>24</pid>
+                <is_siteroot>0</is_siteroot>
+                <doktype>1</doktype>
+                <mount_pid>0</mount_pid>
+                <mount_pid_ol>0</mount_pid_ol>
+                <title>second sub page from FirstShared (Not root)</title>
+                <TSconfig></TSconfig>
+                <tsconfig_includes/>
+            </pages>
+
+
+    <!-- Site tree -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root)</title>
+    </pages>
+        <pages>
+            <uid>14</uid>
+            <pid>1</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Mount Point 1</title>
+            <TSconfig/>
+            <urltype>1</urltype>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+
+    <!-- Second Site tree -->
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Second Site (Root)</title>
+    </pages>
+        <pages>
+            <uid>34</uid>
+            <pid>2</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Mount Point 2</title>
+            <TSconfig/>
+            <urltype>1</urltype>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+  [0]
+   |
+   ——[20] Shared-Pages (Not root)
+   |   |
+   |   ——[24] FirstShared (Not root)
+   |
+   ——[ 1] Page (Root)
+       |
+       ——[14] Mount Point (to [24] to show contents from)
+-->
+
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>solrtesta.local</domainName>
+    </sys_domain>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+        <pages>
+            <uid>24</uid>
+            <pid>20</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>1</doktype>
+            <mount_pid>0</mount_pid>
+            <mount_pid_ol>0</mount_pid_ol>
+            <title>FirstShared (Not root)</title>
+            <TSconfig></TSconfig>
+            <tsconfig_includes/>
+        </pages>
+            <tt_content>
+                <uid>99</uid>
+                <pid>24</pid>
+                <bodytext>Some Lorem Ipsum conteint!</bodytext>
+                <colPos>0</colPos>
+            </tt_content>
+
+    <!-- Site tree -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root)</title>
+    </pages>
+        <pages>
+            <uid>14</uid>
+            <pid>1</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Mount Point</title>
+            <TSconfig/>
+            <urltype>1</urltype>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>24</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+  [0]
+   |
+   ——[20] Shared-Pages (Not root)
+   |   |
+   |   ——[44] FirstShared (Not root)
+   |
+   ——[ 1] Page (Root)
+       |
+       ——[14] Mount Point (to [44] to show contents from)
+   |
+   ——[ 2] Page (Root)
+       |
+       ——[24] Mount Point (to [44] to show contents from)
+-->
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection b";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>2</uid>
+        <pid>2</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>solrtesta.local</domainName>
+    </sys_domain>
+    <sys_domain>
+        <uid>2</uid>
+        <pid>2</pid>
+        <domainName>solrtestb.local</domainName>
+    </sys_domain>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+        <pages>
+            <uid>44</uid>
+            <pid>20</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>1</doktype>
+            <mount_pid>0</mount_pid>
+            <mount_pid_ol>0</mount_pid_ol>
+            <title>FirstShared (Not root)</title>
+            <TSconfig></TSconfig>
+            <tsconfig_includes/>
+        </pages>
+            <tt_content>
+                <uid>99</uid>
+                <pid>44</pid>
+                <bodytext>Some Lorem Ipsum conteint!</bodytext>
+                <colPos>0</colPos>
+            </tt_content>
+
+    <!-- Site tree a -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root a)</title>
+    </pages>
+        <pages>
+            <uid>14</uid>
+            <pid>1</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>44</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Mount Point</title>
+            <TSconfig/>
+            <urltype>1</urltype>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root b)</title>
+    </pages>
+        <pages>
+            <uid>24</uid>
+            <pid>1</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>44</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Mount Point</title>
+            <TSconfig/>
+            <urltype>1</urltype>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>44</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>44</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_non_root_page_from_different_tree_can_be_indexed.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_non_root_page_from_different_tree_can_be_indexed.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+  [0]
+   |
+   ——[20] Shared-Pages (Not root)
+   |   |
+   |   ——[24] FirstShared (Not root)
+   |
+   ——[ 1] Page (Root)
+       |
+       ——[14] Mount Point (to [24] to show contents from)
+-->
+
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+    <pages>
+        <uid>24</uid>
+        <pid>20</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>FirstShared (Not root)</title>
+        <TSconfig></TSconfig>
+        <tsconfig_includes/>
+    </pages>
+
+    <!-- Site tree -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root)</title>
+    </pages>
+    <pages>
+        <uid>14</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>24</mount_pid>
+        <mount_pid_ol>1</mount_pid_ol>
+        <title>Mount Point</title>
+        <TSconfig/>
+        <urltype>1</urltype>
+        <content_from_pid>0</content_from_pid>
+        <tsconfig_includes/>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+ [0]
+  |
+  ——[20] Shared-Pages (Folder: Not root)
+  |   |
+  |   ——[24] FirstShared
+  |
+  ——[ 1] Page (Root)
+  |   |
+  |   ——[14] Mount Point 1 (to [24] to show contents from)
+  |
+  ——[ 2] Page2 (Root)
+      |
+      ——[34] Mount Point 2 (to [24] to show contents from)
+
+-->
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+    <pages>
+        <uid>24</uid>
+        <pid>20</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>FirstShared (Not root)</title>
+        <TSconfig></TSconfig>
+        <tsconfig_includes/>
+    </pages>
+
+    <!-- Site tree -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root)</title>
+    </pages>
+    <pages>
+        <uid>14</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>24</mount_pid>
+        <mount_pid_ol>1</mount_pid_ol>
+        <title>Mount Point 1</title>
+        <TSconfig/>
+        <urltype>1</urltype>
+        <content_from_pid>0</content_from_pid>
+        <tsconfig_includes/>
+    </pages>
+
+    <!-- Second Site tree -->
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Second Site (Root)</title>
+    </pages>
+    <pages>
+        <uid>34</uid>
+        <pid>2</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>24</mount_pid>
+        <mount_pid_ol>1</mount_pid_ol>
+        <title>Mount Point 2</title>
+        <TSconfig/>
+        <urltype>1</urltype>
+        <content_from_pid>0</content_from_pid>
+        <tsconfig_includes/>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_root_page_from_different_tree_can_be_indexed.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_root_page_from_different_tree_can_be_indexed.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+  There is following scenario:
+
+    [0]
+     |
+     ——[20] Shared-Pages (Folder Not root)
+     |   |
+     |   ——[24] FirstShared (marked as root)
+     |
+     ——[ 1] Page (Root)
+         |
+         ——[14] Mount Point (to [24] to show contents from)
+-->
+
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <!-- Shared Pages tree -->
+    <pages>
+        <uid>20</uid>
+        <pid>0</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>Shared-Pages</title>
+        <TSconfig/>
+        <tsconfig_includes/>
+    </pages>
+    <pages>
+        <uid>24</uid>
+        <pid>20</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <mount_pid>0</mount_pid>
+        <mount_pid_ol>0</mount_pid_ol>
+        <title>FirstShared (marked as root)</title>
+        <TSconfig></TSconfig>
+        <tsconfig_includes/>
+    </pages>
+
+    <!-- Site tree -->
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Page (Root)</title>
+    </pages>
+    <pages>
+        <uid>14</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>7</doktype>
+        <mount_pid>24</mount_pid>
+        <mount_pid_ol>1</mount_pid_ol>
+        <title>Mount Point</title>
+        <TSconfig/>
+        <urltype>1</urltype>
+        <content_from_pid>0</content_from_pid>
+        <tsconfig_includes/>
+    </pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -390,9 +390,11 @@ class RecordMonitorTest extends IntegrationTest
     }
 
     /**
+     *
+     *
      * @test
      */
-    public function mountPointIsOnlyAddedOnceOnUpdate()
+    public function mountPointIsOnlyAddedOnceForEachTree()
     {
         $this->importDataSetFromFixture('mount_pages_are_added_once.xml');
         $this->assertEmptyIndexQueue();
@@ -410,10 +412,14 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-        $this->assertIndexQueueContainsItemAmount(1);
+
+        // we assert that the page is added twice, once for the original tree and once for the mounted tree
+        $this->assertIndexQueueContainsItemAmount(2);
+        /* @var $indexQueue Queue */
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-        $this->assertIndexQueueContainsItemAmount(1);
+        // we assert that the page is added twice, once for the original tree and once for the mounted tree
+        $this->assertIndexQueueContainsItemAmount(2);
     }
 
     /**

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -160,18 +160,21 @@ abstract class IntegrationTest extends TYPO3IntegrationTest
     /**
      * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
      */
-    protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0)
+    protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '')
     {
         /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
         $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
-            $TYPO3_CONF_VARS, $id, $type);
+            $TYPO3_CONF_VARS, $id, $type, $no_cache, $cHash, $_2, $MP, $RDCT);
         EidUtility::initLanguage();
+
         $TSFE->initFEuser();
         $TSFE->set_no_cache();
         $TSFE->checkAlternativeIdMethods();
+        $TSFE->clear_preview();
         $TSFE->determineId();
         $TSFE->initTemplate();
         $TSFE->getConfigArray();
+
         Bootstrap::getInstance();
         $TSFE->settingLanguage();
         $TSFE->settingLocale();


### PR DESCRIPTION
Fixed Indexer mounted page resolving stack.
Incomplete testcase added for PageIndexer, which ends with:
  `Failed to execute Page Indexer Request.`

This fixes #953 