### PR TITLE
[BUGFIX] Indexing record outside siteroot throws exception - release-6.1.x

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -86,19 +86,19 @@ class Util
      * Generates a document id in the form $siteHash/$type/$uid.
      *
      * @param string $table The records table name
-     * @param int $pid The record's pid
+     * @param int $rootPageId The record's site root id
      * @param int $uid The record's uid
      * @param string $additionalIdParameters Additional ID parameters
      * @return string A document id
      */
     public static function getDocumentId(
         $table,
-        $pid,
+        $rootPageId,
         $uid,
         $additionalIdParameters = ''
     ) {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        $site = $siteRepository->getSiteByPageId($pid);
+        $site = $siteRepository->getSiteByPageId($rootPageId);
         $siteHash = $site->getSiteHash();
 
         $documentId = $siteHash . '/' . $table . '/' . $uid;

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                additionalPageIds = 111
+
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <title>storage folder outside siteroot</title>
+        <uid>111</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <pid>0</pid>
+    </pages>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>111</uid>
+        <pid>111</pid>
+        <title>external testnews</title>
+        <category>4711</category>
+    </tx_fakeextension_domain_model_bar>
+
+</dataset>


### PR DESCRIPTION
When a record outside the siteroot was indexed the following exception was thrown:

* TYPO3\CMS\Core\Error\Http\ServiceUnavailableException: No TypoScript template found! in TypoScriptFrontendController.php:2554

This PR:

* Uses the configuration of the siteroot when no configuration is present
* Uses the root page id of the site to generate the document id of the record

Fixes: #1291