### PR TITLE
[FEATURE] Add a --rootpageid parameter to the CLI command solr:update…

### DIFF
--- a/Classes/Command/SolrCommandController.php
+++ b/Classes/Command/SolrCommandController.php
@@ -24,11 +24,18 @@ class SolrCommandController extends CommandController
 {
     /**
      * Update EXT:solr connections
+     *
+     * @param int $rootPageId A site root page id
      */
-    public function updateConnectionsCommand()
+    public function updateConnectionsCommand($rootPageId = null)
     {
+        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
-        $connectionManager->updateConnections();
+        if ($rootPageId !== null) {
+            $connectionManager->updateConnectionByRootPageId($rootPageId);
+        } else {
+            $connectionManager->updateConnections();
+        }
         $this->outputLine('<info>EXT:solr connections are updated in the registry.</info>');
     }
 }


### PR DESCRIPTION
…connections

This parameter allows to initialize the connections for a particular rootpage.
This parameter is optional: if it is not passed, the connections for all the rootpages
will be initialized.

Usage:
`php ./typo3/cli_dispatch.phpsh extbase solr:updateconnections --rootpageid 121`

Fixes #1288