### PR TITLE
Preserve sort order when fetching related records

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -412,7 +412,9 @@ class Relation
             '*',
             $foreignTable,
             'uid IN (' . implode(',', $uids) . ')'
-            . $whereClause
+            . $whereClause,
+            '',
+            'FIELD(uid, ' . implode(',', $uids) . ')'
         );
     }
 }


### PR DESCRIPTION
This fixes the order in which related items are returned.

`RelationHandler` makes sure to sort items using the appropriate `sorting` key, but when the list of ids is fed to a query which only uses an `IN(a,b,...)` condition, the order is lost.

Cf. #1322 