### PR TITLE
[TASK] Remove uneeded code

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -278,21 +278,6 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Returns the configured css file for a specific fileKey.
-     *
-     * plugin.tx_solr.cssFiles.<fileKey>
-     *
-     * @param string $fileKey
-     * @param string $defaultIfEmpty
-     * @return string
-     */
-    public function getCssFileByFileKey($fileKey, $defaultIfEmpty = '')
-    {
-        $cssFileName = $this->getValueByPathOrDefaultValue('plugin.tx_solr.cssFiles.' . $fileKey, $defaultIfEmpty);
-        return (string)$cssFileName;
-    }
-
-    /**
      * Returns the configured additionalFields configured for the indexing.
      *
      * plugin.tx_solr.index.additionalFields.
@@ -682,35 +667,6 @@ class TypoScriptConfiguration
         $className = $this->getValueByPathOrDefaultValue($path, $defaultIfEmpty);
 
         return $className;
-    }
-
-    /**
-     * Returns the configured javascript file for a specific fileKey.
-     *
-     * plugin.tx_solr.javascriptFiles.<fileKey>
-     *
-     * @param string $fileKey
-     * @param string $defaultIfEmpty
-     * @return string
-     */
-    public function getJavaScriptFileByFileKey($fileKey, $defaultIfEmpty = '')
-    {
-        $javaScriptFileName = $this->getValueByPathOrDefaultValue('plugin.tx_solr.javascriptFiles.' . $fileKey, $defaultIfEmpty);
-        return (string)$javaScriptFileName;
-    }
-
-    /**
-     * Returns the configuration where to load the javascript
-     *
-     * plugin.tx_solr.javascriptFiles.loadIn
-     *
-     * @param string $defaultIfEmpty
-     * @return string
-     */
-    public function getJavaScriptLoadIn($defaultIfEmpty = 'footer')
-    {
-        $loadIn = $this->getValueByPathOrDefaultValue('plugin.tx_solr.javascriptFiles.loadIn', $defaultIfEmpty);
-        return (string)$loadIn;
     }
 
     /**
@@ -1349,20 +1305,6 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Returns the search results fieldRenderingInstructions configuration array
-     *
-     * plugin.tx_solr.search.results.fieldRenderingInstructions.
-     *
-     * @param array $defaultIfEmpty
-     * @return array
-     */
-    public function getSearchResultsFieldRenderingInstructionsConfiguration(array $defaultIfEmpty = [])
-    {
-        $result = $this->getObjectByPathOrDefault('plugin.tx_solr.search.results.fieldRenderingInstructions.', $defaultIfEmpty);
-        return $result;
-    }
-
-    /**
      * Indicates if the results of an initial empty query should be shown or not.
      *
      * plugin.tx_solr.search.showResultsOfInitialEmptyQuery
@@ -1605,20 +1547,6 @@ class TypoScriptConfiguration
     public function getSearchTargetPageConfiguration(array $defaultIfEmpty = [])
     {
         $result = $this->getObjectByPathOrDefault('plugin.tx_solr.search.targetPage.', $defaultIfEmpty);
-        return $result;
-    }
-
-    /**
-     * Retrieves the pagebrowser configuration.
-     *
-     * plugin.tx_solr.search.results.pagebrowser.
-     *
-     * @param array $defaultIfEmpty
-     * @return array
-     */
-    public function getSearchResultsPageBrowserConfiguration(array $defaultIfEmpty = [])
-    {
-        $result = $this->getObjectByPathOrDefault('plugin.tx_solr.search.results.pagebrowser.', $defaultIfEmpty);
         return $result;
     }
 

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -128,45 +128,6 @@ plugin.tx_solr {
 				spell = skip
 			}
 
-			fieldRenderingInstructions {
-
-				url = CASE
-				url {
-					key.field = type
-
-					default = TEXT
-					default {
-						field = url
-						htmlSpecialChars = 1
-						htmlSpecialChars.preserveEntities = 1
-					}
-				}
-
-				link = CASE
-				link {
-					key.field = type
-
-					pages  = TEXT
-					pages {
-						field = title
-
-						typolink {
-							parameter.field = uid
-						}
-					}
-
-					default  = TEXT
-					default {
-						field = title
-
-						typolink {
-							parameter.field = url
-							extTarget =
-						}
-					}
-				}
-			}
-
 			showDocumentScoreAnalysis = 0
 		}
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -374,15 +374,6 @@ Mapping of fieldname to processing instructions. Available instructions: timesta
 
 The utf8Decode option has been removed in version 2.8.
 
-results.fieldRenderingInstructions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Type: cObject
-:TS Path: plugin.tx_solr.search.results.fieldRenderingInstructions
-:Since: 1.0
-
-Additional rendering instructions for specified fields.
-
 results.pagebrowser
 ~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Frontend/Concepts.rst
+++ b/Documentation/Frontend/Concepts.rst
@@ -7,3 +7,5 @@ Since EXT:solr 7.0.0 the old templating of EXT:solr was droppend and rendering w
 Along with this change some concepts have changed:
 
 * Until EXT:solr 7.0.0 EXT:solr css and javascript was loaded by EXT:solr automatically. In most cases you want to use custom css or you have custom javascript and the integrator want to decide which css or javascript to use. Therefore EXT:solr does not load it by default anymore and the integrator can load it with typoscript. EXT:solr provides a lot of example typoscript templates that load the default css or load the javascript that is needed to use a specific feature. Maybe take the time to explore the typoscript templates that are shipped with the extension to see how they are implemented.
+* The old concept of fieldRenderingInstructions modified the content of a result document by loosing the original value. Since manipulating the value of the field is something very view related, this can be done with TYPO3 core ViewHelpers or with a custom ViewHelper.
+

--- a/Tests/Integration/Controller/Frontend/Fixtures/can_render_search_controller.xml
+++ b/Tests/Integration/Controller/Frontend/Fixtures/can_render_search_controller.xml
@@ -197,45 +197,6 @@
                                 spell = skip
                             }
 
-                            fieldRenderingInstructions {
-
-                                url = CASE
-                                url {
-                                    key.field = type
-
-                                    default = TEXT
-                                    default {
-                                        field = url
-                                        htmlSpecialChars = 1
-                                        htmlSpecialChars.preserveEntities = 1
-                                    }
-                                }
-
-                                link = CASE
-                                link {
-                                    key.field = type
-
-                                    pages  = TEXT
-                                    pages {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = uid
-                                        }
-                                    }
-
-                                    default  = TEXT
-                                    default {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = url
-                                            extTarget =
-                                        }
-                                    }
-                                }
-                            }
-
                             showDocumentScoreAnalysis = 1
                         }
 

--- a/Tests/Integration/Controller/Frontend/Fixtures/can_render_search_customTemplate.xml
+++ b/Tests/Integration/Controller/Frontend/Fixtures/can_render_search_customTemplate.xml
@@ -225,45 +225,6 @@
                                 spell = skip
                             }
 
-                            fieldRenderingInstructions {
-
-                                url = CASE
-                                url {
-                                    key.field = type
-
-                                    default = TEXT
-                                    default {
-                                        field = url
-                                        htmlSpecialChars = 1
-                                        htmlSpecialChars.preserveEntities = 1
-                                    }
-                                }
-
-                                link = CASE
-                                link {
-                                    key.field = type
-
-                                    pages  = TEXT
-                                    pages {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = uid
-                                        }
-                                    }
-
-                                    default  = TEXT
-                                    default {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = url
-                                            extTarget =
-                                        }
-                                    }
-                                }
-                            }
-
                             showDocumentScoreAnalysis = 1
                         }
 

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/Fixtures/can_get_apacheSolrDocuments.xml
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/Fixtures/can_get_apacheSolrDocuments.xml
@@ -221,44 +221,6 @@
                                 spell = skip
                             }
 
-                            fieldRenderingInstructions {
-
-                                url = CASE
-                                url {
-                                    key.field = type
-
-                                    default = TEXT
-                                    default {
-                                        field = url
-                                        htmlSpecialChars = 1
-                                        htmlSpecialChars.preserveEntities = 1
-                                    }
-                                }
-
-                                link = CASE
-                                link {
-                                    key.field = type
-
-                                    pages  = TEXT
-                                    pages {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = uid
-                                        }
-                                    }
-
-                                    default  = TEXT
-                                    default {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = url
-                                            extTarget =
-                                        }
-                                    }
-                                }
-                            }
                             showDocumentScoreAnalysis = 0
                         }
                     }

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
@@ -221,44 +221,6 @@
                                 spell = skip
                             }
 
-                            fieldRenderingInstructions {
-
-                                url = CASE
-                                url {
-                                    key.field = type
-
-                                    default = TEXT
-                                    default {
-                                        field = url
-                                        htmlSpecialChars = 1
-                                        htmlSpecialChars.preserveEntities = 1
-                                    }
-                                }
-
-                                link = CASE
-                                link {
-                                    key.field = type
-
-                                    pages  = TEXT
-                                    pages {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = uid
-                                        }
-                                    }
-
-                                    default  = TEXT
-                                    default {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = url
-                                            extTarget =
-                                        }
-                                    }
-                                }
-                            }
                             showDocumentScoreAnalysis = 0
                         }
                     }

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/fe_user_page.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/fe_user_page.xml
@@ -221,44 +221,6 @@
                                 spell = skip
                             }
 
-                            fieldRenderingInstructions {
-
-                                url = CASE
-                                url {
-                                    key.field = type
-
-                                    default = TEXT
-                                    default {
-                                        field = url
-                                        htmlSpecialChars = 1
-                                        htmlSpecialChars.preserveEntities = 1
-                                    }
-                                }
-
-                                link = CASE
-                                link {
-                                    key.field = type
-
-                                    pages  = TEXT
-                                    pages {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = uid
-                                        }
-                                    }
-
-                                    default  = TEXT
-                                    default {
-                                        field = title
-
-                                        typolink {
-                                            parameter.field = url
-                                            extTarget =
-                                        }
-                                    }
-                                }
-                            }
                             showDocumentScoreAnalysis = 0
                         }
                     }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -152,21 +152,6 @@ class TypoScriptConfigurationTest extends UnitTest
     /**
      * @test
      */
-    public function canGetJavaScriptFileByName()
-    {
-        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
-            'javascriptFiles.' => [
-                'ui' => 'ui.js'
-            ]
-        ];
-
-        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertSame('ui.js', $configuration->getJavaScriptFileByFileKey('ui'), 'Could get configured javascript file');
-    }
-
-    /**
-     * @test
-     */
     public function canGetIndexQueueTableOrFallbackToConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [


### PR DESCRIPTION
This pr:

* Removes uneeded methods from TypoScriptConfiguration (not needed anymore because of switch to fluid)
* Removes the rendering instructions from the documentation and the fixtures since they are not supported anymore.