### PR TITLE
Fix logging of error when devlog is enabled

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -115,7 +115,7 @@ class IndexService
                     array(
                         'code' => $e->getCode(),
                         'message' => $e->getMessage(),
-                        'trace' => $e->getTrace(),
+                        'trace' => $e->getTraceAsString(),
                         'item' => (array)$itemToIndex
                     )
                 );


### PR DESCRIPTION
`getTrace()` returns references to the functions called which is a problem, because devlog calls `serialize()` on the data, leading to a `Serialization of 'Closure' is not allowed` exception.

With the typo3 logging system (so tx_solr 6.1+) this is apparently not a problem, because it uses `json_encode` which just produces `{}` for closures.

Fixes: #1342 