### PR TITLE
Log trace as string

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -156,7 +156,7 @@ class IndexService
     protected function generateIndexingErrorLog(Item $itemToIndex, \Exception $e)
     {
         $message = 'Failed indexing Index Queue item ' . $itemToIndex->getIndexQueueUid();
-        $data = ['code' => $e->getCode(), 'message' => $e->getMessage(), 'trace' => $e->getTrace(), 'item' => (array)$itemToIndex];
+        $data = ['code' => $e->getCode(), 'message' => $e->getMessage(), 'trace' => $e->getTraceAsString(), 'item' => (array)$itemToIndex];
 
         $this->logger->log(
             SolrLogManager::ERROR,


### PR DESCRIPTION
As requested in #1341 

This is not a bugfix per se, because Typo3's log writers currently use `json_encode` to store the data which falls back to `{}` for closures.

However, `getTrace()` output has caused problems in the past (with `serialize()`).