### PR TITLE
[BUGFIX] Tracking changes in record from other siteroot is not working as expected

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -186,7 +186,11 @@ class RootPageResolver implements SingletonInterface
             $rootPages[] = $rootPageId;
         }
         if ($this->extensionConfiguration->getIsUseConfigurationTrackRecordsOutsideSiteroot()) {
-            $alternativeSiteRoots = $this->getAlternativeSiteRootPagesIds($table, $uid, $rootPageId);
+            $recordPageId = $this->getRecordPageId($table, $uid);
+            if($recordPageId === 0) {
+                return $rootPages;
+            }
+            $alternativeSiteRoots = $this->getAlternativeSiteRootPagesIds($table, $uid, $recordPageId);
             $rootPages = array_merge($rootPages, $alternativeSiteRoots);
         }
 
@@ -207,10 +211,23 @@ class RootPageResolver implements SingletonInterface
             $rootPageId = $this->getRootPageId($uid);
             return $rootPageId;
         } else {
-            $record = BackendUtility::getRecord($table, $uid, 'pid');
-            $rootPageId = $this->getRootPageId($record['pid'], true);
+            $recordPageId = $this->getRecordPageId($table, $uid);
+            $rootPageId = $this->getRootPageId($recordPageId, true);
             return $rootPageId;
         }
+    }
+
+    /**
+     * Returns the pageId of the record or 0 when no valid record was given.
+     *
+     * @param string $table
+     * @param integer $uid
+     * @return mixed
+     */
+    protected function getRecordPageId($table, $uid)
+    {
+        $record = BackendUtility::getRecord($table, $uid, 'pid');
+        return !empty($record['pid']) ? (int)$record['pid'] : 0;
     }
 
     /**

--- a/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_from_other_siteroot.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_from_other_siteroot.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:1;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8999;s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}s:3:"2|0";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:0:"";s:11:"rootPageUid";i:2;s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";i:8998;s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:0;s:5:"label";s:16:"testconnection a";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 3
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <sys_template>
+        <uid>2</uid>
+        <pid>2</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_de/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 3
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <!-- sysfolder below site 2 -->
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <doktype>254</doktype>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_foo>
+        <uid>8</uid>
+        <title>testnews</title>
+        <pid>3</pid>
+    </tx_fakeextension_domain_model_foo>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -792,6 +792,34 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
+    public function updateRecordOutsideSiteRootLocatedInOtherSite()
+    {
+        $this->importDumpFromFixture('fake_extension_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
+
+        $this->importDataSetFromFixture('update_record_outside_siteroot_from_other_siteroot.xml');
+
+        $this->assertEmptyIndexQueue();
+
+        // create faked tce main call data
+        $status = 'update';
+        $table = 'tx_fakeextension_domain_model_foo';
+        $uid = 8;
+        $fields = [
+            'title' => 'i am in siteroot b but references also in siteroot a',
+            'starttime' => 1000000,
+            'endtime' => 1100000,
+            'tsstamp' => 1000000,
+            'pid' => 3
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
+
+    /**
+     * @test
+     */
     public function updateRecordMonitoringTablesConfiguredDefault()
     {
         $this->importDataSetFromFixture('update_page_use_configuration_monitor_tables.xml');


### PR DESCRIPTION
This PR:

* Fixes the bug (uses the recordPageId instead of the rootPageId to resolve the relevant rootPages)
* Adds an integration test

Fixes: #1347