### PR TITLE
[TASK] Remove selectingSelectedFacetOptionsRemovesFilter and document alternatives

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -42,6 +42,10 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Suggest/',
     'Search - (Example) Suggest/autocomplete with jquery ui');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/Facets/OptionsToggle/',
+    'Search - (Example) Options with on/off toggle');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Facets/QueryGroup/',
     'Search - (Example) QueryGroup facet on the created field');

--- a/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.txt
@@ -1,0 +1,8 @@
+plugin.tx_solr.search.faceting = 1
+plugin.tx_solr.search.faceting.facets {
+    typeToggle {
+        label = Type Toggle
+        field = type
+        partialName = OptionsToggle
+    }
+}

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -819,19 +819,6 @@ faceting.facets.[facetName].label
 
 Used as a headline or title to describe the options of a facet.
 
-faceting.facets.[facetName]. selectingSelectedFacetOptionRemovesFilter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Type: Boolean
-:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].selectingSelectedFacetOptionRemovesFilter
-:Since: 1.2, 2.0
-:Default: 0
-:Options: 0, 1
-
-Activating this option for a facet makes the facets option links behave like on/off switches: You click them once to activate a facet, you click them a second time to deactivate the facet again.
-
-Feel free to suggest a better name for this option.
-
 faceting.facets.[facetName].keepAllOptionsOnSelection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -400,3 +400,39 @@ The following example shows, how to fill the field "mytype_stringS" and build a 
     }
 
 |
+
+
+**I want to implement a toggle functionality for facet options as previously possible with selectingSelectedFacetOptionRemovesFilter. How can i do that?**
+
+This is completely possible with Fluid core ViewHelpers and the domain model. The following steps are required.
+
+Register a custom partial to render the facet:
+
+::
+
+    plugin.tx_solr.search.faceting.facets.<facetName>.partialName = OptionsToggle
+
+This is the content of the OptionsToggle Partial (Feel free to adapt it to your needs):
+
+::
+
+    <h5 class="facet-label">{facet.label}</h5>
+    <ul class="facet-option-list facet-type-options fluidfacet" data-facet-name="{facet.name}" data-facet-label="{facet.label}">
+        <f:for each="{facet.options}" as="option" iteration="iteration">
+            <li class="facet-option{f:if(condition:'{iteration.index} > 9', then:' tx-solr-facet-hidden')}" data-facet-item-value="{option.value}">
+                <f:if condition="{option.selected}">
+                    <f:then><a class="facet solr-ajaxified" href="{s:uri.facet.removeFacetItem(facet: facet, facetItem: option)}">{option.label}</a></f:then>
+                    <f:else><a class="facet solr-ajaxified" href="{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}">{option.label}</a></f:else>
+                </f:if>
+                <span class="facet-result-count">({option.documentCount})</span>
+            </li>
+        </f:for>
+        <f:if condition="{facet.options -> f:count()} > 10">
+            <li>
+                <a href="#" class="tx-solr-facet-show-all" data-label-more="{s:translate(key:'faceting_showMore', extensionName:'solr')}"
+                    data-label-less="{s:translate(key:'faceting_showFewer', extensionName:'solr')}">
+                    <s:translate key="faceting_showMore" extensionName="solr">Show more</s:translate>
+                </a>
+            </li>
+        </f:if>
+    </ul>

--- a/Documentation/Frontend/Concepts.rst
+++ b/Documentation/Frontend/Concepts.rst
@@ -8,4 +8,5 @@ Along with this change some concepts have changed:
 
 * Until EXT:solr 7.0.0 EXT:solr css and javascript was loaded by EXT:solr automatically. In most cases you want to use custom css or you have custom javascript and the integrator want to decide which css or javascript to use. Therefore EXT:solr does not load it by default anymore and the integrator can load it with typoscript. EXT:solr provides a lot of example typoscript templates that load the default css or load the javascript that is needed to use a specific feature. Maybe take the time to explore the typoscript templates that are shipped with the extension to see how they are implemented.
 * The old concept of fieldRenderingInstructions modified the content of a result document by loosing the original value. Since manipulating the value of the field is something very view related, this can be done with TYPO3 core ViewHelpers or with a custom ViewHelper.
-
+* The setting faceting.facets.[facetName].selectingSelectedFacetOptionRemovesFilter has been removed, since it is possible to build this functionality just with Fluid ViewHelpers. The file "EXT:solr/Resources/Private/Templates/Partials/Facets/OptionsToggle.html" shows
+how f:if together with option.selected can be used to have this behaviour.

--- a/Documentation/Frontend/Facets.rst
+++ b/Documentation/Frontend/Facets.rst
@@ -208,7 +208,7 @@ With the following typoscript you create a date range facet:
 
     plugin.tx_solr.search {
         faceting = 1
-        faceting {
+        faceting.facets {
             creationDateRange {
                 label = Created Between
                 field = created
@@ -256,7 +256,7 @@ The following example configures a **numericRange** facet for the field **"pid"*
 
     plugin.tx_solr.search {
         faceting = 1
-        faceting {
+        faceting.facets {
             pidRangeRange {
                 field = pid
                 label = Pid Range
@@ -330,7 +330,7 @@ When you now want to render the facet at another place you can change the group 
 
     plugin.tx_solr.search {
         faceting = 1
-        faceting {
+        faceting.facets {
             contentType {
                 field = type
                 label = Content Type
@@ -353,7 +353,7 @@ If you need another rendering for one facet you can overwrite the used partial w
 
     plugin.tx_solr.search {
         faceting = 1
-        faceting {
+        faceting.facets {
             contentType {
                 field = type
                 label = Content Type

--- a/Resources/Private/Partials/Facets/OptionsToggle.html
+++ b/Resources/Private/Partials/Facets/OptionsToggle.html
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+      xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+      xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
+    <h5 class="facet-label">{facet.label}</h5>
+    <ul class="facet-option-list facet-type-options fluidfacet" data-facet-name="{facet.name}" data-facet-label="{facet.label}">
+        <f:for each="{facet.options}" as="option" iteration="iteration">
+            <li class="facet-option{f:if(condition:'{iteration.index} > 9', then:' tx-solr-facet-hidden')}" data-facet-item-value="{option.value}">
+                <f:if condition="{option.selected}">
+                    <f:then><a class="facet solr-ajaxified" href="{s:uri.facet.removeFacetItem(facet: facet, facetItem: option)}">(x) {option.label}</a></f:then>
+                    <f:else><a class="facet solr-ajaxified" href="{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}">{option.label}</a></f:else>
+                </f:if>
+                <span class="facet-result-count">({option.documentCount})</span>
+            </li>
+        </f:for>
+        <f:if condition="{facet.options -> f:count()} > 10">
+            <li>
+                <a href="#" class="tx-solr-facet-show-all" data-label-more="{s:translate(key:'faceting_showMore', extensionName:'solr')}" data-label-less="{s:translate(key:'faceting_showFewer', extensionName:'solr')}">
+                    <s:translate key="faceting_showMore" extensionName="solr">Show more</s:translate>
+                </a>
+            </li>
+        </f:if>
+    </ul>
+
+</html>


### PR DESCRIPTION
This PR:

* Remove the setting selectingSelectedFacetOptionsRemovesFilter from the documentation
* Documents how this can be done with Fluid core features
* Adds an example and faq entry
* Fixes wrong ts path in documentation

Fixes: #1351