### PR TITLE
[BUGFIX] Little documentation error sorting default order

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1381,13 +1381,13 @@ class TypoScriptConfiguration
 
         // if we have a concrete setting, use it
         if ($specificSortOrder !== null) {
-            return $specificSortOrder;
+            return strtolower($specificSortOrder);
         }
 
         // no specific setting, check common setting
         $commonPath = 'plugin.tx_solr.search.sorting.defaultOrder';
         $commonATagParamOrDefaultValue = $this->getValueByPathOrDefaultValue($commonPath, $defaultIfEmpty);
-        return $commonATagParamOrDefaultValue;
+        return strtolower($commonATagParamOrDefaultValue);
     }
 
     /**
@@ -1402,7 +1402,7 @@ class TypoScriptConfiguration
     public function getSearchSortingFixedOrderBySortOptionName($sortOptionName = '', $defaultIfEmpty = '')
     {
         $fixedOrder = 'plugin.tx_solr.search.sorting.options.' . $sortOptionName . '.fixedOrder';
-        return $this->getValueByPathOrDefaultValue($fixedOrder, $defaultIfEmpty);
+        return strtolower($this->getValueByPathOrDefaultValue($fixedOrder, $defaultIfEmpty));
     }
 
     /**

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -543,8 +543,8 @@ sorting.defaultOrder
 :Type: String
 :TS Path: plugin.tx_solr.search.sorting.defaultOrder
 :Since: 1.0
-:Default: ASC
-:Options: ASC, DESC
+:Default: asc
+:Options: asc, desc
 
 Sets the default sort order for all sort options.
 
@@ -600,8 +600,8 @@ sorting.options.[optionName].defaultOrder
 :Type: String
 :TS Path: plugin.tx_solr.search.sorting.options.[optionName].defaultOrder
 :Since: 2.2
-:Default: ASC
-:Options: ASC, DESC
+:Default: asc
+:Options: asc, desc
 
 Sets the default sort order for a particular sort option.
 
@@ -611,8 +611,8 @@ sorting.options.[optionName].fixedOrder
 :Type: String
 :TS Path: plugin.tx_solr.search.sorting.options.[optionName].fixedOrder
 :Since: 2.2
-:Default: ASC
-:Options: ASC, DESC
+:Default: asc
+:Options: asc, desc
 
 Sets a fixed sort order for a particular sort option that can not be changed.
 

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -684,4 +684,79 @@ class TypoScriptConfigurationTest extends UnitTest
         $this->assertEquals(['foo', 'bar'], $configuration->GetSearchQueryReturnFieldsAsArray());
     }
 
+    /**
+     * @test
+     */
+    public function canGetSearchSortingDefaultOrderBySortOptionNameIsFallingBackToDefaultSortOrder()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'sorting.' => [
+                    'defaultOrder' => 'desc',
+                    'options.' => [
+                        'title.' => [
+                            'field' => 'title',
+                            'label' => 'Titel'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
+        $this->assertEquals('desc', $retrievedSorting);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSearchSortingDefaultOrderBySortOptionName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'sorting.' => [
+                    'defaultOrder' => 'desc',
+                    'options.' => [
+                        'title.' => [
+                            'defaultOrder' => 'asc',
+                            'field' => 'title',
+                            'label' => 'Titel'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
+        $this->assertEquals('asc', $retrievedSorting);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSearchSortingDefaultOrderBySortOptionNameInLowerCase()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'sorting.' => [
+                    'options.' => [
+                        'title.' => [
+                            'defaultOrder' => 'DESC',
+                            'field' => 'title',
+                            'label' => 'Titel'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
+        $this->assertEquals('desc', $retrievedSorting);
+    }
 }


### PR DESCRIPTION
This pr:

* Updates the documentation to use lowercase asc / desc
* Makes the TyposcriptConfiguration object more robust, by lowercasing the setting before
* Adds unit tests for the method

Fixes: #1375