### PR TITLE
[!!!][TASK] Decouple code from tx_solr url namespace - a.k.a multiple plugin instances

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\SolrService;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -93,7 +94,7 @@ class Repository implements SingletonInterface
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $solrConnection = $connectionManager->getConnectionByPageId($pageId, $languageId);
 
-        $this->search = GeneralUtility::makeInstance(Search::class, $solrConnection);
+        $this->search = $this->getSearch($solrConnection);
     }
 
     /**
@@ -117,5 +118,16 @@ class Repository implements SingletonInterface
         $query->setSorting('type asc, title asc');
 
         return $query;
+    }
+
+    /**
+     * Retrieves an instance of the Search object.
+     *
+     * @param SolrService $solrConnection
+     * @return Search
+     */
+    protected function getSearch($solrConnection)
+    {
+        return  GeneralUtility::makeInstance(Search::class, $solrConnection);
     }
 }

--- a/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
+++ b/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
@@ -1,0 +1,61 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Highlight;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+
+
+/**
+ * Provides highlighting of the search words on the document's actual page by
+ * adding parameters to a document's URL property.
+ *
+ * Initial code from ApacheSolrForTypo3\Solr\ResultDocumentModifier\SiteHighlighter
+ *
+ * @author Stefan Sprenger <stefan.sprenger@dkd.de>
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+
+use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class SiteHighlighterUrlModifier
+ * @package ApacheSolrForTypo3\Solr\System\Service
+ */
+class SiteHighlighterUrlModifier {
+
+    /**
+     * @param string $url
+     * @param string $searchWords
+     * @param boolean $addNoCache
+     * @param boolean $keepCHash
+     * @return string
+     */
+    public function modify($url, $searchWords, $addNoCache = true, $keepCHash = false) {
+        $searchWords = str_replace('&quot;', '', $searchWords);
+        $searchWords = GeneralUtility::trimExplode(' ', $searchWords, true);
+
+            /** @var UrlHelper $urlHelper */
+        $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $url);
+        $urlHelper->addQueryParameter('sword_list', $searchWords);
+
+        if ($addNoCache) {
+            $urlHelper->addQueryParameter('no_cache', '1');
+        }
+
+        if (!$keepCHash) {
+            $urlHelper->removeQueryParameter('cHash');
+        }
+
+        return $urlHelper->getUrl();
+    }
+}

--- a/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Statistics;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Writes the last searches
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class LastSearchesWriterProcessor implements SearchResultSetProcessor
+{
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return SearchResultSet
+     */
+    public function process(SearchResultSet $resultSet) {
+
+        if ($resultSet->getAllResultCount() === 0) {
+            // when the search does not produce a result we do not store the last searches
+            return $resultSet;
+        }
+
+        if (!isset($GLOBALS['TSFE']) || !isset($GLOBALS['TYPO3_DB'])) {
+            return $resultSet;
+        }
+
+        $lastSearchesService = $this->getLastSearchesService($resultSet);
+        $lastSearchesService->addToLastSearches($resultSet->getUsedSearchRequest()->getRawUserQuery());
+
+        return $resultSet;
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return LastSearchesService
+     */
+    protected function getLastSearchesService(SearchResultSet $resultSet) {
+        return GeneralUtility::makeInstance(LastSearchesService::class,
+            $resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration(),
+            $GLOBALS['TSFE'],
+            $GLOBALS['TYPO3_DB']);
+    }
+}

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -14,7 +14,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\Sorting;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking\Suggestion;
@@ -84,8 +83,6 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
 
         // here we can reconstitute other domain objects from the solr response
         $resultSet = $this->parseFacetsIntoObjects($resultSet);
-
-        $this->storeLastSearches($resultSet);
 
         return $resultSet;
     }
@@ -239,29 +236,5 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
         }
 
         return $resultSet;
-    }
-
-    /**
-     * @param SearchResultSet $resultSet
-     */
-    protected function storeLastSearches(SearchResultSet $resultSet)
-    {
-        if ($resultSet->getAllResultCount() === 0) {
-            // when the search does not produce a result we do not store the last searches
-            return;
-        }
-
-        if (!isset($GLOBALS['TSFE']) || !isset($GLOBALS['TYPO3_DB'])) {
-            return;
-        }
-
-        /** @var $lastSearchesService \ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService */
-        $lastSearchesService = GeneralUtility::makeInstance(LastSearchesService::class,
-            $resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration(),
-            $GLOBALS['TSFE'],
-            $GLOBALS['TYPO3_DB']);
-
-
-        $lastSearchesService->addToLastSearches($resultSet->getUsedSearchRequest()->getRawUserQuery());
     }
 }

--- a/Classes/Domain/Search/SearchRequestAware.php
+++ b/Classes/Domain/Search/SearchRequestAware.php
@@ -1,10 +1,10 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Search;
+namespace ApacheSolrForTypo3\Solr\Domain\Search;
 
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -15,6 +15,9 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *
  *  The GNU General Public License can be found at
  *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
  *
  *  This script is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -24,42 +27,18 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Query;
-
 /**
- * Highlighting search component
+ * SearchRequest awareness interface for extension components.
  *
- * @author Ingo Renner <ingo@typo3.org>
+ * @author Timo Hund <timo.hund@dkd.de>
  */
-class HighlightingComponent extends AbstractComponent implements QueryAware
+interface SearchRequestAware
 {
 
     /**
-     * Solr query
+     * Provides a component that is aware of the current SearchRequest
      *
-     * @var Query
+     * @param SearchRequest $searchRequest
      */
-    protected $query;
-
-    /**
-     * Initializes the search component.
-     *
-     *
-     */
-    public function initializeSearchComponent()
-    {
-        if ($this->searchConfiguration['results.']['resultsHighlighting']) {
-            $this->query->setHighlighting(true, $this->searchConfiguration['results.']['resultsHighlighting.']['fragmentSize']);
-        }
-    }
-
-    /**
-     * Provides the extension component with an instance of the current query.
-     *
-     * @param Query $query Current query
-     */
-    public function setQuery(Query $query)
-    {
-        $this->query = $query;
-    }
+    public function setSearchRequest(SearchRequest $searchRequest);
 }

--- a/Classes/Search/AnalysisComponent.php
+++ b/Classes/Search/AnalysisComponent.php
@@ -24,8 +24,6 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Plugin\Results\QueryAnalyzerFormModifier;
-use ApacheSolrForTypo3\Solr\ResultDocumentModifier\ScoreAnalyzer;
 use ApacheSolrForTypo3\Solr\Query;
 
 /**
@@ -52,8 +50,6 @@ class AnalysisComponent extends AbstractComponent implements QueryAware
     {
         if ($this->searchConfiguration['results.']['showDocumentScoreAnalysis']) {
             $this->query->setDebugMode();
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyResultDocument']['scoreAnalysis'] = ScoreAnalyzer::class;
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchForm']['queryAnalysis'] = QueryAnalyzerFormModifier::class;
         }
     }
 

--- a/Classes/Search/LastSearchesComponent.php
+++ b/Classes/Search/LastSearchesComponent.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\ResultsetModifier\LastSearches;
+use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\LastSearchesWriterProcessor;
 
 /**
  * Last searches search component
@@ -41,7 +41,7 @@ class LastSearchesComponent extends AbstractComponent
     public function initializeSearchComponent()
     {
         if ($this->searchConfiguration['lastSearches']) {
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyResultSet']['lastSearches'] = LastSearches::class;
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['lastSearches'] = LastSearchesWriterProcessor::class;
         }
     }
 }

--- a/Classes/Search/SortingComponent.php
+++ b/Classes/Search/SortingComponent.php
@@ -24,6 +24,8 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Sorting;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -35,7 +37,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class SortingComponent extends AbstractComponent implements QueryAware
+class SortingComponent extends AbstractComponent implements QueryAware, SearchRequestAware
 {
 
     /**
@@ -44,6 +46,11 @@ class SortingComponent extends AbstractComponent implements QueryAware
      * @var Query
      */
     protected $query;
+
+    /**
+     * @var SearchRequest
+     */
+    protected $searchRequest;
 
     /**
      * Initializes the search component.
@@ -58,18 +65,18 @@ class SortingComponent extends AbstractComponent implements QueryAware
                 $this->searchConfiguration['query.']['sortBy']);
         }
 
-        $solrGetParameters = GeneralUtility::_GET('tx_solr');
+        $arguments = $this->searchRequest->getArguments();
 
         if (!empty($this->searchConfiguration['sorting'])
-            && !empty($solrGetParameters['sort'])
+            && !empty($arguments['sort'])
             && preg_match('/^([a-z0-9_]+ (asc|desc)[, ]*)*([a-z0-9_]+ (asc|desc))+$/i',
-                $solrGetParameters['sort'])
+                $arguments['sort'])
         ) {
             $sortHelper = GeneralUtility::makeInstance(
                 Sorting::class,
                 $this->searchConfiguration['sorting.']['options.']
             );
-            $sortField = $sortHelper->getSortFieldFromUrlParameter($solrGetParameters['sort']);
+            $sortField = $sortHelper->getSortFieldFromUrlParameter($arguments['sort']);
 
             $this->query->setSorting($sortField);
         }
@@ -84,4 +91,13 @@ class SortingComponent extends AbstractComponent implements QueryAware
     {
         $this->query = $query;
     }
+
+    /**
+     * @param SearchRequest $searchRequest
+     */
+    public function setSearchRequest(SearchRequest $searchRequest)
+    {
+        $this->searchRequest = $searchRequest;
+    }
+
 }

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Response\Processor\StatisticsWriter;
+use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Statistics;
 use ApacheSolrForTypo3\Solr\Util;
 
@@ -45,7 +45,7 @@ class StatisticsComponent extends AbstractComponent
         $solrConfiguration = Util::getSolrConfiguration();
 
         if ($solrConfiguration->getStatistics()) {
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processSearchResponse']['statistics'] = StatisticsWriter::class;
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'] = StatisticsWriterProcessor::class;
             // Only if addDebugData is enabled add Query modifier
             if ($solrConfiguration->getStatisticsAddDebugData()) {
                 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery']['statistics'] = Statistics::class;

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1551,6 +1551,21 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Method to check if the site highlighting is enabled. When the siteHighlighting is enabled the
+     * sword_list parameter is added to the results link.
+     *
+     * plugin.tx_solr.searcb.results.siteHighlighting
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getSearchResultsSiteHighlighting($defaultIfEmpty = true)
+    {
+        $isSiteHightlightingEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.results.siteHighlighting', $defaultIfEmpty);
+        return $this->getBool($isSiteHightlightingEnabled);
+    }
+
+    /**
      * Returns the result highlighting fields.
      *
      * plugin.tx_solr.search.results.resultsHighlighting.highlightFields
@@ -2082,6 +2097,35 @@ class TypoScriptConfiguration
     {
         $enableCommits = $this->getValueByPathOrDefaultValue('plugin.tx_solr.index.enableCommits', $defaultIfEmpty);
         return $this->getBool($enableCommits);
+    }
+
+    /**
+     * Returns the url namespace that is used for the arguments.
+     *
+     * plugin.tx_solr.view.pluginNamespace
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSearchPluginNamespace($defaultIfEmpty = 'tx_solr')
+    {
+        return $this->getValueByPathOrDefaultValue('plugin.tx_solr.view.pluginNamespace', $defaultIfEmpty);
+    }
+
+    /**
+     * Returns true if the global url parameter q, that indicates the query should be used.
+     *
+     * Should be set to false, when multiple instance on the same page should have their querystring.
+     *
+     * plugin.tx_solr.search.ignoreGlobalQParameter
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getSearchIgnoreGlobalQParameter($defaultIfEmpty = false)
+    {
+        $enableQParameter = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.ignoreGlobalQParameter', $defaultIfEmpty);
+        return $this->getBool($enableQParameter);
     }
 
     /*

--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -1,0 +1,123 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Url;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+
+/**
+ * Class UrlHelper
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\System\Url
+ */
+class UrlHelper {
+
+    /**
+     * @var string
+     */
+    protected $initialUrl;
+
+    /**
+     * @var array
+     */
+    protected $parts = [];
+
+    /**
+     * @var bool
+     */
+    protected $wasParsed = false;
+
+    /**
+     * UrlHelper constructor.
+     * @param string $url
+     */
+    public function __construct($url)
+    {
+        $this->initialUrl = $url;
+    }
+
+    /**
+     * @return void
+     */
+    protected function parseInitialUrl()
+    {
+        if ($this->wasParsed) {
+            return;
+        }
+        $parts = parse_url($this->initialUrl);
+        if (!is_array($parts)) {
+            throw new \InvalidArgumentException("Non parseable url passed to UrlHelper", 1498751529);
+        }
+        $this->parts = $parts;
+        $this->wasParsed = true;
+    }
+
+    /**
+     * @param string $parameterName
+     * @throws \InvalidArgumentException
+     * @return UrlHelper
+     */
+    public function removeQueryParameter(string $parameterName): UrlHelper
+    {
+        $this->parseInitialUrl();
+        $queryParts = [];
+        parse_str($this->parts['query'], $queryParts);
+        unset($queryParts[$parameterName]);
+        $this->parts['query'] = http_build_query($queryParts);
+
+        return $this;
+    }
+
+    /**
+     * @param string $parameterName
+     * @param mixed $value
+     * @throws \InvalidArgumentException
+     * @return UrlHelper
+     */
+    public function addQueryParameter(string $parameterName, $value): UrlHelper
+    {
+        $this->parseInitialUrl();
+        $queryParts = [];
+        parse_str($this->parts['query'], $queryParts);
+        $queryParts[$parameterName] = $value;
+        $this->parts['query'] = http_build_query($queryParts);
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->unparse_url($this->parts);
+    }
+
+    /**
+     * @param array $parsed_url
+     * @return string
+     */
+    protected function unparse_url(array $parsed_url): string
+    {
+        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+        $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+        $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+        $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+        $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
+        $pass     = ($user || $pass) ? "$pass@" : '';
+        $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+        $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+        return $scheme . $user . $pass . $host . $port . $path . $query . $fragment;
+    }
+
+}

--- a/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
@@ -1,0 +1,76 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Result;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Highlight\SiteHighlighterUrlModifier;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Class AddSearchWordListViewHelper
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\ViewHelpers\Document
+ */
+class AddSearchWordListViewHelper extends AbstractSolrFrontendViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('url', 'string', 'The context searchResultSet', true);
+        $this->registerArgument('searchWords', 'string', 'The document to highlight', true);
+        $this->registerArgument('addNoCache', 'boolean', 'Should no_cache=1 be added or not', false, true);
+        $this->registerArgument('keepCHash', 'boolean', 'Should cHash be kept or not', false, false);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $url = $arguments['url'];
+
+            /** @var $resultSet SearchResultSet */
+        $resultSet = self::getUsedSearchResultSetFromRenderingContext($renderingContext);
+        if (!$resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration()->getSearchResultsSiteHighlighting()) {
+            return $url;
+        }
+
+        $searchWords = $arguments['searchWords'];
+        $addNoCache = $arguments['addNoCache'];
+        $keepCHash = $arguments['keepCHash'];
+
+        /** @var $siteHighlighterUrlModifier SiteHighlighterUrlModifier */
+        $siteHighlighterUrlModifier = GeneralUtility::makeInstance(SiteHighlighterUrlModifier::class);
+
+        return $siteHighlighterUrlModifier->modify($url, $searchWords, $addNoCache, $keepCHash);
+    }
+}

--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>Search</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <search.targetPage>
+                        <TCEforms>
+                            <label>Target Page</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>pages</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
+                                <wizards>
+                                    <suggest>
+                                        <type>suggest</type>
+                                    </suggest>
+                                </wizards>
+                            </config>
+                        </TCEforms>
+                    </search.targetPage>
+                </el>
+            </ROOT>
+        </sDEF>
+        <sOptions>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>Options</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <templateFiles.form>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>Custom Entry Template</label>
+                            <config>
+                                <type>input</type>
+                                <eval>trim</eval>
+                                <size>45</size>
+                            </config>
+                        </TCEforms>
+                    </templateFiles.form>
+                    <view.pluginNamespace>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>Plugin Namespace</label>
+                            <config>
+                                <type>input</type>
+                                <eval>trim</eval>
+                                <default>tx_solr</default>
+                            </config>
+                        </TCEforms>
+                    </view.pluginNamespace>
+                </el>
+            </ROOT>
+        </sOptions>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/FlexForms/Results.xml
+++ b/Configuration/FlexForms/Results.xml
@@ -166,6 +166,28 @@
                             </config>
                         </TCEforms>
                     </templateFiles.results>
+                    <view.pluginNamespace>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>Plugin Namespace</label>
+                            <config>
+                                <type>input</type>
+                                <eval>trim</eval>
+                                <default>tx_solr</default>
+                            </config>
+                        </TCEforms>
+                    </view.pluginNamespace>
+
+                    <search.ignoreGlobalQParameter>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>Ignore the global q parameter</label>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </search.ignoreGlobalQParameter>
                 </el>
             </ROOT>
         </sOptions>

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,7 +5,7 @@ if (!defined ('TYPO3_MODE')) {
 }
 
 // Register the plugins
-$pluginSignature = 'solr_pi_form';
+$pluginSignature = 'solr_pi_search';
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
     'solr',
     'pi_search',
@@ -13,6 +13,12 @@ $pluginSignature = 'solr_pi_form';
 );
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$pluginSignature]
     = 'layout,select_key,pages,recursive';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature]
+    = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    $pluginSignature,
+    'FILE:EXT:solr/Configuration/FlexForms/Form.xml'
+);
 
 
 $pluginSignature = 'solr_pi_frequentlysearched';

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -87,6 +87,8 @@ plugin.tx_solr {
 
 		keepExistingParametersForNewSearches = 0
 
+		ignoreGlobalQParameter = 0
+
 		query {
 			allowEmptyQuery = 0
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -40,6 +40,7 @@ Configuration Reference
 
 	./Reference/TxSolr
 	./Reference/TxSolrGeneral
+	./Reference/TxSolrView
 	./Reference/TxSolrSolr
 	./Reference/TxSolrIndex
 	./Reference/TxSolrSearch

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -84,6 +84,17 @@ keepExistingParametersForNewSearches
 
 When doing a new search, existing parameters like filters will be carried over to the new search. This is useful for a scenario where you want to list all available documents first, then allow the user to filter the documents using facets and finally allow him to specify a search term to refine the search.
 
+ignoreGlobalQParameter
+----------------------
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.ignoreGlobalQParameter
+:Default: 0
+:Options: 0,1
+:Since: 7.0
+
+In some cases you want EXT:solr to react on the parameter "q" in the url. Normally plugins are bounded to a namespace to allow multiple instances of the search on the same page. In this case you might want to disable this and let EXT:solr only react on the namespaced query parameter (tx_solr[q] by default).
+
 query
 -----
 

--- a/Documentation/Configuration/Reference/TxSolrView.rst
+++ b/Documentation/Configuration/Reference/TxSolrView.rst
@@ -1,0 +1,32 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
+.. include:: ../../Includes.txt
+
+
+.. raw:: latex
+
+    \newpage
+
+.. raw:: pdf
+
+   PageBreak
+
+.. _conf-tx-solr-view:
+
+tx_solr.view
+============
+
+All view related settings, these settings might also be relevant for Fluid.
+
+pluginNamespace
+---------------
+
+:Type: String
+:TS Path: plugin.tx_solr.view.pluginNamespace
+:Since: 7.0
+:Default: tx_solr
+
+Plugin namespace. Can be used to change the plugin namespace and can be changed by instance in the flexform.

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -452,3 +452,6 @@ The following example shows how to avoid html in the content field:
 
 Note: When you allow html in the content please make sure that the usage of crop ViewHelpers or a limit of the field length does not break your markup.
 
+**I want to use two instances of the search plugin on the same page, how can i do that?**
+
+If you want to use two search plugins on the same page you can add two instances and assign a different "Plugin Namespace" in the flexform. If you want to avoid, that both plugins react on the global "q" parameter, you can disable this also in the flexform. Each instance is using the querystring from <pluginNamespace>[q] then.

--- a/Resources/Private/Partials/Result/Document.html
+++ b/Resources/Private/Partials/Result/Document.html
@@ -12,7 +12,9 @@
 		<f:if condition="{document.isElevated}">
 			<div class="results-elevated-label"><s:translate key="sponsored"/></div>
 		</f:if>
-		<h5 class="results-topic"><a href="{document.url}">{document.title}</a></h5>
+
+		<h5 class="results-topic"><a href="{s:uri.result.addSearchWordList(url:document.url, searchWords:resultSet.usedQuery.keywords)}">{document.title}</a></h5>
+
 		<div class="results-teaser">
 			<f:render partial="Result/RelevanceBar" section="RelevanceBar" arguments="{resultSet:resultSet, document:document}" />
 

--- a/Resources/Private/Partials/Result/PerPage.html
+++ b/Resources/Private/Partials/Result/PerPage.html
@@ -6,7 +6,7 @@
 	<div id="results-per-page">
 		<form method="post" action="{s:uri.search.currentSearch()}">
 			<s:translate key="results_per_page">Per page:</s:translate>
-			<select name="tx_solr[resultsPerPage]" onchange="this.form.submit()">
+			<select name="{resultSet.usedSearchRequest.argumentNameSpace}[resultsPerPage]" onchange="this.form.submit()">
 				<f:for each="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchResultsPerPageSwitchOptionsAsArray}" as="availablePerPage">
 					<f:if condition="{availablePerPage}=={resultSet.usedResultsPerPage}">
 						<f:then><option selected="selected" value="{availablePerPage}">{availablePerPage}</option></f:then>

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -9,7 +9,7 @@
 	<s:searchForm id="tx-solr-search-form-pi-results" additionalFilters="{additionalFilters}">
 		<input type="hidden" name="L" value="{languageUid}" />
 		<input type="hidden" name="id" value="{pageUid}" />
-		<input type="text" class="tx-solr-q js-solr-q" name="q" value="{q}" />
+		<input type="text" class="tx-solr-q js-solr-q" name="{pluginNamespace}[q]" value="{q}" />
 		<input type="submit" class="tx-solr-submit" value="{s:translate(key:'submit',default:'Search')}" />
 
 	</s:searchForm>

--- a/Resources/Private/Templates/Search/Form.html
+++ b/Resources/Private/Templates/Search/Form.html
@@ -5,5 +5,5 @@
 <f:layout name="Main"/>
 
 <f:section name="main">
-	<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters}" />
+	<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters, pluginNamespace:pluginNamespace}" />
 </f:section>

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -8,7 +8,7 @@
 
 	<div id="tx-solr-search">
 
-		<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters, resultSet: resultSet}" />
+		<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace, resultSet: resultSet}" />
 
 		<f:if condition="{resultSet.usedQuery.keywordsCleaned}">
 			<span class="searched-for">

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -208,7 +208,6 @@ class SearchControllerTest extends IntegrationTest
         $this->searchController->setResetConfigurationBeforeInitialize(false);
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
         $resultPage1 = $this->searchResponse->getContent();
-
         $this->assertContains('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
         $this->assertContains('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
@@ -232,7 +231,6 @@ class SearchControllerTest extends IntegrationTest
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
         $resultPage1 = $this->searchResponse->getContent();
 
-        $this->assertContains('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
         $this->assertContains('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
 

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -118,7 +118,7 @@ class RepositoryTest extends UnitTest
         $mockedSingletons = [ConnectionManager::class => $solrConnectionManager];
 
         $search = $this->getAccessibleMock(Search::class, ['search', 'getResultDocumentsEscaped'], [], '', false);
-        $mockedSingletons[Search::class] = $search;
+
         GeneralUtility::resetSingletonInstances($mockedSingletons);
 
         $expectedApacheSolrDocumentCollection = [new \Apache_Solr_Document(), new \Apache_Solr_Document()];
@@ -126,7 +126,8 @@ class RepositoryTest extends UnitTest
         $search->expects($this->any())->method('getResultDocumentsEscaped')->willReturn($expectedApacheSolrDocumentCollection);
 
         /* @var $apacheSolrDocumentRepository Repository */
-        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage']);
+        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage', 'getSearch']);
+        $apacheSolrDocumentRepository->expects($this->once())->method('getSearch')->willReturn($search);
         $apacheSolrDocumentRepository->expects($this->any())->method('getQueryForPage')->willReturn(GeneralUtility::makeInstance(Query::class, ''));
         $actualApacheSolrDocumentCollection = $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(777, 0);
 

--- a/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
+++ b/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
@@ -1,0 +1,81 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\Highlight;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Highlight\SiteHighlighterUrlModifier;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SiteHighlighterUrlModifierTest extends UnitTest
+{
+
+    public function canModifyDataProvider()
+    {
+        return [
+            'nothingChangedWhenNoSearchWordPresent' => [
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
+                '',
+                false,
+                true,
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar'
+            ],
+            'cHashIsRemoved' => [
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
+                'hello world',
+                true,
+                false,
+                'http://mywebsite.de/home/index.html?foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1'
+            ],
+            'cHashIsKept' => [
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
+                'hello world',
+                true,
+                true,
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1'
+            ],
+            'fragmentIsKept' => [
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar#test',
+                'hello world',
+                true,
+                true,
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1#test'
+            ]
+        ];
+
+    }
+
+    /**
+     * @dataProvider canModifyDataProvider
+     * @test
+     */
+    public function canModify($inputUrl, $keywords, $no_cache, $keepCHash, $expectedResult)
+    {
+        $siteHighlightingModifier = new SiteHighlighterUrlModifier();
+        $result = $siteHighlightingModifier->modify($inputUrl, $keywords, $no_cache, $keepCHash);
+        $this->assertSame($expectedResult, $result);
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -101,7 +101,7 @@ class SearchResultSetTest extends UnitTest
         $fakeResponse = $this->getDumbMock(Apache_Solr_Response::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my search', 0, $fakeResponse);
 
-        $fakeRequest = new SearchRequest(['q' => 'my search']);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my search']]);
 
         $this->assertPerPageInSessionWillNotBeChanged();
         $resultSet = $this->searchResultSetService->search($fakeRequest);
@@ -119,7 +119,7 @@ class SearchResultSetTest extends UnitTest
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 2. search', 50, $fakeResponse);
         $this->configurationMock->expects($this->once())->method('getSearchResultsPerPage')->will($this->returnValue(25));
 
-        $fakeRequest = new SearchRequest(['q' => 'my 2. search', 'tx_solr' => ['page' => 2]]);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 2. search','page' => 2]]);
 
         $this->assertPerPageInSessionWillNotBeChanged();
         $resultSet = $this->searchResultSetService->search($fakeRequest);
@@ -142,7 +142,7 @@ class SearchResultSetTest extends UnitTest
         $fakeResponse = $this->getDumbMock(Apache_Solr_Response::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 3. search', 0, $fakeResponse);
 
-        $fakeRequest = new SearchRequest(['q' => 'my 3. search']);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 3. search']]);
 
         $this->assertPerPageInSessionWillNotBeChanged();
         $resultSet = $this->searchResultSetService->search($fakeRequest);
@@ -167,7 +167,7 @@ class SearchResultSetTest extends UnitTest
         $fakeResponse =new \Apache_Solr_Response($fakeHttpResponse);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 4. search', 0, $fakeResponse);
 
-        $fakeRequest = new SearchRequest(['q' => 'my 4. search']);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 4. search']]);
         $this->assertPerPageInSessionWillNotBeChanged();
         $resultSet  = $this->searchResultSetService->search($fakeRequest);
 
@@ -192,8 +192,7 @@ class SearchResultSetTest extends UnitTest
 
         $fakeRequest = new SearchRequest(
             [
-                'q' => 'test',
-                'tx_solr' => ['page' => 5, 'resultsPerPage' => 25]
+                'tx_solr' => ['q' => 'test', 'page' => 5, 'resultsPerPage' => 25]
             ]
         );
 
@@ -220,7 +219,7 @@ class SearchResultSetTest extends UnitTest
         $this->configurationMock->expects($this->any())->method('getSearchQueryFilterConfiguration')->will(
             $this->returnValue(['type:pages'])
         );
-        $fakeRequest = new SearchRequest(['q' => 'test']);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'test']]);
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
         $this->assertPerPageInSessionWillNotBeChanged();
@@ -250,7 +249,7 @@ class SearchResultSetTest extends UnitTest
         $fakeResponse =new \Apache_Solr_Response($fakeHttpResponse);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('variantsSearch', 0, $fakeResponse);
 
-        $fakeRequest = new SearchRequest(['q' => 'variantsSearch']);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'variantsSearch']]);
 
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         $this->assertSame(1, count($resultSet->getResponse()->response->docs), 'Unexpected amount of document');

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -72,7 +72,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canGetActiveFilterNames()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertEquals(['type'], $request->getActiveFacetNames());
     }
@@ -82,7 +82,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canGetRawQueryString()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertEquals('typo3', $request->getRawUserQuery());
     }
@@ -94,7 +94,7 @@ class SearchRequestTest extends UnitTest
     {
         $request = $this->getSearchRequestFromQueryString('');
         $data  = $request->setRawQueryString('foobar')->getAsArray();
-        $this->assertEquals(['q' => 'foobar'], $data, 'The argument container did not contain the expected argument');
+        $this->assertEquals(['tx_solr' => ['q' => 'foobar']], $data, 'The argument container did not contain the expected argument');
     }
 
     /**
@@ -132,7 +132,7 @@ class SearchRequestTest extends UnitTest
         $arguments  = $request->setRawQueryString('mysearch')->addFacetValue('type', 'tt_content')->getAsArray();
 
         $expectedArguments = [];
-        $expectedArguments['q'] = 'mysearch';
+        $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
         $this->assertSame($arguments, $expectedArguments, 'Could not set a query and add a facet at the same time');
@@ -163,7 +163,7 @@ class SearchRequestTest extends UnitTest
                             ->getAsArray();
 
         $expectedArguments = [];
-        $expectedArguments['q'] = 'mysearch';
+        $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
         $this->assertSame($arguments, $expectedArguments, 'Could not reset arguments');
@@ -183,7 +183,7 @@ class SearchRequestTest extends UnitTest
                                 ->getCopyForSubRequest()->getAsArray();
 
         $expectedArguments = [];
-        $expectedArguments['q'] = 'mysearch';
+        $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
         $this->assertSame($arguments, $expectedArguments);
@@ -212,7 +212,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canRemoveFacetValue()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
 
         $this->assertTrue($request->getHasFacetValue('type', 'pages'), 'Facet was not present');
@@ -225,7 +225,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canGetFacetValues()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Anews';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Anews';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertEquals(['pages', 'news'], $request->getActiveFacetValuesByName('type'));
     }
@@ -235,7 +235,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canRemoveAllFacets()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertSame(2, $request->getActiveFacetCount(), 'Expected to have two active facets');
         $request->removeAllFacets();
@@ -247,7 +247,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canRemoveFacetsByName()
     {
-        $query = 'q=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents&tx_solr%5Bfilter%5D%5B2%5D=created%253A1-4';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents&tx_solr%5Bfilter%5D%5B2%5D=created%253A1-4';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertSame(3, $request->getActiveFacetCount(), 'Expected to have two active facets');
         $request->removeAllFacetValuesByName('type');
@@ -259,7 +259,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canGetSortingField()
     {
-        $query = 'q=typo3&tx_solr%5Bsort%5D=title asc';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
         $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
@@ -271,7 +271,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canRemoveSorting()
     {
-        $query = 'q=typo3&tx_solr%5Bsort%5D=title asc';
+        $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
         $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
@@ -290,7 +290,7 @@ class SearchRequestTest extends UnitTest
      */
     public function canSetSorting()
     {
-        $query = 'q=typo3';
+        $query = 'tx_solr%5Bq%5D=typo3';
         $request = $this->getSearchRequestFromQueryString($query);
         $this->assertFalse($request->getHasSorting(), 'Passed query has no sorting');
 

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\Statistics;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
+use ApacheSolrForTypo3\Solr\Query;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Unit test case for the StatisticsWriterProcessor.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class StatisticsWriterProcessorTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canWritExpectedStatisticData()
+    {
+        $fakeTSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakeTime = 100;
+        $fakeIP = '192.168.2.22';
+
+            /** @var StatisticsWriterProcessor $processor */
+        $processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setMethods(['getTSFE', 'getTime', 'getUserIp', 'saveStatisticDate'])->getMock();
+        $processor->expects($this->once())->method('getTSFE')->will($this->returnValue($fakeTSFE));
+        $processor->expects($this->once())->method('getUserIp')->will($this->returnValue($fakeIP));
+        $processor->expects($this->once())->method('getTime')->will($this->returnValue($fakeTime));
+
+        $typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $typoScriptConfigurationMock->expects($this->once())->method('getStatisticsAnonymizeIP')->will($this->returnValue(0));
+
+        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfigurationMock));
+
+        $queryMock = $this->getDumbMock(Query::class);
+        $queryMock->expects($this->once())->method('getKeywords')->will($this->returnValue('my search'));
+
+        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock->expects($this->once())->method('getUsedQuery')->will($this->returnValue($queryMock));
+        $resultSetMock->expects($this->once())->method('getUsedSearchRequest')->will($this->returnValue($searchRequestMock));
+
+        $self = $this;
+        $processor->expects($this->once())->method('saveStatisticDate')->will($this->returnCallback(function($statisticData) use ($self) {
+            $this->assertSame('my search', $statisticData['keywords'], 'Unexpected keywords given');
+            $this->assertSame('192.168.2.22', $statisticData['ip'], 'Unexpected ip given');
+        }));
+
+        $processor->process($resultSetMock);
+    }
+
+}

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -63,11 +63,15 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function addFacetLinkIsCalledWithSubstitutedArguments()
     {
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
+
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']]];
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
 
-        $previousRequest =  new SearchRequest();
+        $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'foo', 'bar');
     }
 
@@ -84,6 +88,8 @@ class SearchUriBuilderTest extends UnitTest
         $this->extBaseUriBuilderMock->expects($this->once())->method('build')->with()->will($this->returnValue($result));
 
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue(['foo=bar']));
         $previousRequest =  new SearchRequest([], 1, 0, $configurationMock);
         $result = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'option', 'value');
@@ -96,11 +102,16 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered()
     {
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
+
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']]];
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue(urlencode('tx_solr[filter][0]=###tx_solr:filter:0###')));
-        $previousRequest =  new SearchRequest();
+
+        $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
         $previousRequest->removeAllFacets();
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'green');
 
@@ -119,6 +130,8 @@ class SearchUriBuilderTest extends UnitTest
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(4711));
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
 
         $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
@@ -138,6 +151,8 @@ class SearchUriBuilderTest extends UnitTest
     public function canGetRemoveFacetOptionUri()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+
         $previousRequest =  new SearchRequest([
                     'tx_solr' => [
                         'filter' => [
@@ -162,6 +177,8 @@ class SearchUriBuilderTest extends UnitTest
     public function canGetRemoveFacetUri()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+
         $previousRequest =  new SearchRequest([
                     'tx_solr' => [
                         'filter' => [


### PR DESCRIPTION
This PR:

* Refactors the code to allow to configure a different url namespace then tx_solr
* This can be used e.g. to have multiple search instances on the same page (with a different namespace)
* The namespace can be overwritten with "plugin.tx_solr.view.pluginNamespace" or in the flexform
* A new setting "plugin.tx_solr.search.ignoreGlobalQParameter" was added that configures if the "q" parameter of the url should be evaluated or not. This is needed because you might want to disable it, when you use multiple plugin instances.

Along with that:

* It was needed to introduce a SearchRequestAware interface that can be used in SearchComponents and QueryModfiers to get the searchRequest passed.
* $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchResponse'] have been marked as deprecated and will be dropped in 8.0 please use a SearchResultSetProcessor registered in  $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch'] as replacement.
* $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processSearchResponse'] have been marked as deprecated and will be dropped in 8.0 please use a SearchResultSetProcessor registered in  $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch'] as replacement.
* The ViewHelper s:uri.result.addSearchWordList was added since the functionality to add the sword_list parameter in TYPO3 was accidentally removed (can be enabled or disabled with plugin.tx_solr.search.results.siteHighlighting) after merging the Fluid changes.

Fixes: #1314