### PR TITLE
[!!!][TASK] Refactor the Query class

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -105,6 +105,7 @@ class Repository implements SingletonInterface
      */
     protected function getQueryForPage($pageId)
     {
+            /** @var $siteRepository SiteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByPageId($pageId);
         /* @var Query $query */
@@ -112,9 +113,9 @@ class Repository implements SingletonInterface
         $query->setQueryType('standard');
         $query->useRawQueryString(true);
         $query->setQueryString('*:*');
-        $query->addFilter('(type:pages AND uid:' . $pageId . ') OR (*:* AND pid:' . $pageId . ' NOT type:pages)');
-        $query->addFilter('siteHash:' . $site->getSiteHash());
-        $query->setFieldList('*');
+        $query->getFilters()->add('(type:pages AND uid:' . $pageId . ') OR (*:* AND pid:' . $pageId . ' NOT type:pages)');
+        $query->getFilters()->add('siteHash:' . $site->getSiteHash());
+        $query->getReturnFields()->add('*');
         $query->setSorting('type asc, title asc');
 
         return $query;

--- a/Classes/Domain/Search/Query/Helper/EscapeService.php
+++ b/Classes/Domain/Search/Query/Helper/EscapeService.php
@@ -1,0 +1,132 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * The EscpaeService is responsible to escape the querystring as ecpected for Apache Solr.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class EscapeService {
+
+    /**
+     * Quote and escape search strings
+     *
+     * @param string|int|double $string String to escape
+     * @return string|int|double The escaped/quoted string
+     */
+    public function escape($string)
+    {
+        // when we have a numeric string only, nothing needs to be done
+        if (is_numeric($string)) {
+            return $string;
+        }
+
+        // when no whitespaces are in the query we can also just escape the special characters
+        if (preg_match('/\W/', $string) != 1) {
+            return $this->escapeSpecialCharacters($string);
+        }
+
+        // when there are no quotes inside the query string we can also just escape the whole string
+        $hasQuotes = strrpos($string, '"') !== false;
+        if (!$hasQuotes) {
+            return $this->escapeSpecialCharacters($string);
+        }
+
+        $result = $this->tokenizeByQuotesAndEscapeDependingOnContext($string);
+
+        return $result;
+    }
+
+    /**
+     * This method is used to escape the content in the query string surrounded by quotes
+     * different then when it is not in a quoted context.
+     *
+     * @param string $string
+     * @return string
+     */
+    protected function tokenizeByQuotesAndEscapeDependingOnContext($string)
+    {
+        $result = '';
+        $quotesCount = substr_count($string, '"');
+        $isEvenAmountOfQuotes = $quotesCount % 2 === 0;
+
+        // go over all quote segments and apply escapePhrase inside a quoted
+        // context and escapeSpecialCharacters outside the quoted context.
+        $segments = explode('"', $string);
+        $segmentsIndex = 0;
+        foreach ($segments as $segment) {
+            $isInQuote = $segmentsIndex % 2 !== 0;
+            $isLastQuote = $segmentsIndex === $quotesCount;
+
+            if ($isLastQuote && !$isEvenAmountOfQuotes) {
+                $result .= '\"';
+            }
+
+            if ($isInQuote && !$isLastQuote) {
+                $result .= $this->escapePhrase($segment);
+            } else {
+                $result .= $this->escapeSpecialCharacters($segment);
+            }
+
+            $segmentsIndex++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Escapes a value meant to be contained in a phrase with characters with
+     * special meanings in Lucene query syntax.
+     *
+     * @param string $value Unescaped - "dirty" - string
+     * @return string Escaped - "clean" - string
+     */
+    protected function escapePhrase($value)
+    {
+        $pattern = '/("|\\\)/';
+        $replace = '\\\$1';
+
+        return '"' . preg_replace($pattern, $replace, $value) . '"';
+    }
+
+    /**
+     * Escapes characters with special meanings in Lucene query syntax.
+     *
+     * @param string $value Unescaped - "dirty" - string
+     * @return string Escaped - "clean" - string
+     */
+    protected function escapeSpecialCharacters($value)
+    {
+        // list taken from http://lucene.apache.org/core/4_4_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description
+        // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+        // of which we escape: ( ) { } [ ] ^ " ~ : \ /
+        // and explicitly don't escape: + - && || ! * ?
+        $pattern = '/(\\(|\\)|\\{|\\}|\\[|\\]|\\^|"|~|\:|\\\\|\\/)/';
+        $replace = '\\\$1';
+
+        return preg_replace($pattern, $replace, $value);
+    }
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
@@ -1,0 +1,268 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The Faceting ParameterProvider is responsible to build the solr query parameters
+ * that are needed for the highlighting.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class Faceting implements ParameterBuilder
+{
+    /**
+     * @var bool
+     */
+    protected $isEnabled = false;
+
+    /**
+     * @var string
+     */
+    protected $sorting = '';
+
+    /**
+     * @var int
+     */
+    protected $minCount = 1;
+
+    /**
+     * @var
+     */
+    protected $limit = 10;
+
+    /**
+     * @var array
+     */
+    protected $fields = [];
+
+    /**
+     * @var array
+     */
+    protected $additionalParameters = [];
+
+    /**
+     * Faceting constructor.
+     *
+     * private constructor should only be created with the from* methods
+     *
+     * @param bool $isEnabled
+     * @param string $sorting
+     * @param int $minCount
+     * @param int $limit
+     * @param array $fields
+     * @param array $additionalParameters
+     */
+    private function __construct($isEnabled, $sorting = '', $minCount = 1, $limit = 10, $fields = [], $additionalParameters = [])
+    {
+        $this->isEnabled = $isEnabled;
+        $this->sorting = $sorting;
+        $this->minCount = $minCount;
+        $this->limit = $limit;
+        $this->fields = $fields;
+        $this->additionalParameters = $additionalParameters;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsEnabled()
+    {
+        return $this->isEnabled;
+    }
+
+    /**
+     * @param boolean $isEnabled
+     */
+    public function setIsEnabled($isEnabled)
+    {
+        $this->isEnabled = $isEnabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSorting()
+    {
+        return $this->sorting;
+    }
+
+    /**
+     * @param string $sorting
+     */
+    public function setSorting($sorting)
+    {
+        $this->sorting = $sorting;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMinCount()
+    {
+        return $this->minCount;
+    }
+
+    /**
+     * @param int $minCount
+     */
+    public function setMinCount($minCount)
+    {
+        $this->minCount = $minCount;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param mixed $limit
+     */
+    public function setLimit($limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array $fields
+     */
+    public function setFields(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * @param string $fieldName
+     */
+    public function addField($fieldName)
+    {
+        $this->fields[] = $fieldName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalParameters(): array
+    {
+        return $this->additionalParameters;
+    }
+
+    /**
+     * @param array $additionalParameters
+     */
+    public function setAdditionalParameters(array $additionalParameters)
+    {
+        $this->additionalParameters = $additionalParameters;
+    }
+
+    /**
+     * @param array $value
+     */
+    public function addAdditionalParameter($key, $value)
+    {
+        $this->additionalParameters[$key] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        if (!$this->isEnabled) {
+            return [];
+        }
+
+        $facetParameters = [];
+
+        $facetParameters['facet'] = 'true';
+        $facetParameters['facet.mincount'] = $this->minCount;
+        $facetParameters['facet.limit'] = $this->limit;
+        $facetParameters['facet.field'] = $this->fields;
+
+        foreach ($this->additionalParameters as $additionalParameterKey => $additionalParameterValue) {
+            $facetParameters[$additionalParameterKey] = $additionalParameterValue;
+        }
+
+        $facetParameters = $this->applySorting($facetParameters);
+
+        return $facetParameters;
+    }
+
+    /**
+     * Reads the facet sorting configuration and applies it to the queryParameters.
+     *
+     * @return array
+     */
+    protected function applySorting(array $facetParameters)
+    {
+        if (!GeneralUtility::inList('count,index,alpha,lex,1,0,true,false', $this->sorting)) {
+            // when the sorting is not in the list of valid values we do not apply it.
+            return $facetParameters;
+        }
+        $solrSorting = $this->sorting;
+
+        // alpha and lex alias for index
+        if ($this->sorting == 'alpha' || $this->sorting == 'lex') {
+            $solrSorting = 'index';
+        }
+
+        $facetParameters['facet.sort'] = $solrSorting;
+
+        return $facetParameters;
+    }
+
+    /**
+     * @param TypoScriptConfiguration $solrConfiguration
+     * @return Faceting
+     */
+    public static function fromTypoScriptConfiguration(TypoScriptConfiguration $solrConfiguration)
+    {
+        $isEnabled = $solrConfiguration->getSearchFaceting();
+        if (!$isEnabled) {
+            return new Faceting(false);
+        }
+
+        $minCount = $solrConfiguration->getSearchFacetingMinimumCount();
+        $limit = $solrConfiguration->getSearchFacetingFacetLimit();
+        $sorting = $solrConfiguration->getSearchFacetingSortBy();
+
+        return new Faceting($isEnabled, $sorting, $minCount, $limit);
+    }
+
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/Filters.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Filters.php
@@ -1,0 +1,217 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The Filters ParameterProvider is responsible to build the solr query parameters
+ * that are needed for the filtering.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class Filters implements ParameterBuilder, \ArrayAccess, \Countable, \IteratorAggregate
+{
+
+    /**
+     * @var array
+     */
+    protected $filters = [];
+
+    /**
+     * Filters constructor.
+     *
+     * private constructor should only be created with the from* methods
+     */
+    private function __construct() {}
+
+    /**
+     * Removes a filter on a field
+     *
+     * @param string $filterFieldName The field name the filter should be removed for
+     * @return void
+     */
+    public function removeByFieldName($filterFieldName)
+    {
+        $this->removeByPrefix($filterFieldName . ':');
+    }
+
+    /**
+     * @param string $filterFieldName
+     */
+    public function removeByPrefix($filterFieldName)
+    {
+        foreach ($this->filters as $key => $filterString) {
+            if (GeneralUtility::isFirstPartOfStr($filterString, $filterFieldName )) {
+                unset($this->filters[$key]);
+            }
+        }
+    }
+
+    /**
+     * Removes a filter based on name of filter array
+     *
+     * @param string $name name of the filter
+     */
+    public function removeByName($name)
+    {
+        unset($this->filters[$name]);
+    }
+
+
+    /**
+     * @param string $filterString
+     * @param string $name
+     */
+    public function add($filterString, $name = '')
+    {
+        if ($name !== '') {
+            $this->filters[$name] = $filterString;
+        } else {
+            $this->filters[] = $filterString;
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function hasWithName($name)
+    {
+        return array_key_exists($name, $this->filters);
+    }
+
+    /**
+     * Removes a filter by the filter value. The value has the following format:
+     *
+     * "fieldname:value"
+     *
+     * @param string $filterString The filter to remove, in the form of field:value
+     */
+    public function removeByValue($filterString)
+    {
+        $key = array_search($filterString, $this->filters);
+        if ($key === false) {
+            // value not found, nothing to do
+            return;
+        }
+        unset($this->filters[$key]);
+    }
+
+    /**
+     * Gets all currently applied filters.
+     *
+     * @return array Array of filters
+     */
+    public function getValues()
+    {
+        return $this->filters;
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        return ['fq' => array_values($this->filters)];
+    }
+
+    /**
+     * @param TypoScriptConfiguration $solrConfiguration
+     * @return Filters
+     */
+    public static function fromTypoScriptConfiguration(TypoScriptConfiguration $solrConfiguration)
+    {
+        return new Filters();
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        GeneralUtility::logDeprecatedFunction();
+        if (is_null($offset)) {
+            $this->filters[] = $value;
+        } else {
+            $this->filters[$offset] = $value;
+        }
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+        return isset($this->filters[$offset]);
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+        unset($this->filters[$offset]);
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @param mixed $offset
+     * @return mixed|null
+     */
+    public function offsetGet($offset)
+    {
+        GeneralUtility::logDeprecatedFunction();
+        return isset($this->filters[$offset]) ? $this->filters[$offset] : null;
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @return int
+     */
+    public function count()
+    {
+        GeneralUtility::logDeprecatedFunction();
+        return count($this->filters);
+    }
+
+    /**
+     * @deprecated Just for backwards compatibility of the filters array, will be dropped in 8.0.
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        GeneralUtility::logDeprecatedFunction();
+        return new \ArrayIterator($this->filters);
+    }
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
@@ -1,0 +1,275 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+
+/**
+ * The Grouping ParameterProvider is responsible to build the solr query parameters
+ * that are needed for the grouping.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class Grouping implements ParameterBuilder
+{
+
+    /**
+     * @var boolean
+     */
+    protected $isEnabled = false;
+
+    /**
+     * @var array
+     */
+    protected $fields = [];
+
+    /**
+     * @var array
+     */
+    protected $sortings = [];
+
+    /**
+     * @var array
+     */
+    protected $queries = [];
+
+    /**
+     * @var int
+     */
+    protected $numberOfGroups = 5;
+
+    /**
+     * @var int
+     */
+    protected $resultsPerGroup = 1;
+
+    /**
+     * Grouping constructor.
+     *
+     * private constructor should only be created with the from* methods
+     *
+     * @param bool $isEnabled
+     * @param array $fields
+     * @param array $sortings
+     * @param array $queries
+     * @param int $numberOfGroups
+     * @param int $resultsPerGroup
+     */
+    private function __construct($isEnabled, array $fields = [], array $sortings = [], array $queries = [], $numberOfGroups = 5, $resultsPerGroup = 1)
+    {
+        $this->isEnabled = $isEnabled;
+        $this->fields = $fields;
+        $this->sortings = $sortings;
+        $this->queries = $queries;
+        $this->numberOfGroups = $numberOfGroups;
+        $this->resultsPerGroup = $resultsPerGroup;
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        if (!$this->isEnabled) {
+            return [];
+        }
+        $groupingParameter = [];
+        $groupingParameter ['group'] = 'true';
+        $groupingParameter ['group.format'] = 'grouped';
+        $groupingParameter ['group.ngroups'] = 'true';
+
+        if ($this->resultsPerGroup) {
+            $groupingParameter['group.limit'] = $this->resultsPerGroup;
+        }
+
+        if (count($this->queries) > 0) {
+            $groupingParameter['group.query'] = $this->queries;
+        }
+
+        if (count($this->sortings) > 0) {
+            $groupingParameter['group.sort'] = $this->sortings;
+        }
+
+        if (count($this->fields) > 0) {
+            $groupingParameter['group.field'] = $this->sortings;
+        }
+
+        return $groupingParameter;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsEnabled()
+    {
+        return $this->isEnabled;
+    }
+
+    /**
+     * @param boolean $isEnabled
+     */
+    public function setIsEnabled($isEnabled)
+    {
+        $this->isEnabled = $isEnabled;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array $fields
+     */
+    public function setFields(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * @param string $field
+     */
+    public function addField(string $field)
+    {
+        $this->fields[] = $field;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSortings()
+    {
+        return $this->sortings;
+    }
+
+    /**
+     * @param string $sorting
+     */
+    public function addSorting($sorting)
+    {
+        $this->sortings[] = $sorting;
+    }
+
+    /**
+     * @param array $sortings
+     */
+    public function setSortings(array $sortings)
+    {
+        $this->sortings = $sortings;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    /**
+     * @param string $query
+     */
+    public function addQuery($query)
+    {
+        $this->queries[] = $query;
+    }
+
+    /**
+     * @param array $queries
+     */
+    public function setQueries(array $queries)
+    {
+        $this->queries = $queries;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfGroups()
+    {
+        return $this->numberOfGroups;
+    }
+
+    /**
+     * @param int $numberOfGroups
+     */
+    public function setNumberOfGroups($numberOfGroups)
+    {
+        $this->numberOfGroups = $numberOfGroups;
+    }
+
+    /**
+     * @return int
+     */
+    public function getResultsPerGroup()
+    {
+        return $this->resultsPerGroup;
+    }
+
+    /**
+     * @param int $resultsPerGroup
+     */
+    public function setResultsPerGroup($resultsPerGroup)
+    {
+        $resultsPerGroup = max(intval($resultsPerGroup), 0);
+        $this->resultsPerGroup = $resultsPerGroup;
+    }
+
+    /**
+     * @param TypoScriptConfiguration $solrConfiguration
+     * @return Grouping
+     */
+    public static function fromTypoScriptConfiguration(TypoScriptConfiguration $solrConfiguration)
+    {
+        $isEnabled = $solrConfiguration->getSearchGrouping();
+        if (!$isEnabled) {
+            return new Grouping(false);
+        }
+
+        $fields = [];
+        $queries = [];
+        $sortings = [];
+
+        $resultsPerGroup = $solrConfiguration->getSearchGroupingHighestGroupResultsLimit();
+        $configuredGroups = $solrConfiguration->getSearchGroupingGroupsConfiguration();
+        $numberOfGroups = $solrConfiguration->getSearchGroupingNumberOfGroups();
+
+        foreach ($configuredGroups as $groupName => $groupConfiguration) {
+            if (isset($groupConfiguration['field'])) {
+                $fields[] = $groupConfiguration['field'];
+            } elseif (isset($groupConfiguration['query'])) {
+                $queries[] = $groupConfiguration['query'];
+            }
+            if (isset($groupConfiguration['sortBy'])) {
+                $sortings[] = $groupConfiguration['sortBy'];
+            }
+        }
+
+        return new Grouping($isEnabled, $fields, $sortings, $queries, $numberOfGroups, $resultsPerGroup);
+    }
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -1,0 +1,218 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+
+/**
+ * The Highlighting ParameterProvider is responsible to build the solr query parameters
+ * that are needed for the highlighting.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class Highlighting implements ParameterBuilder
+{
+
+    /**
+     * @var bool
+     */
+    protected $isEnabled = false;
+
+    /**
+     * @var int
+     */
+    protected $fragmentSize = 200;
+
+    /**
+     * @var string
+     */
+    protected $highlightingFieldList = '';
+
+    /**
+     * @var string
+     */
+    protected $prefix = '';
+
+    /**
+     * @var string
+     */
+    protected $postfix = '';
+
+    /**
+     * Highlighting constructor.
+     *
+     * private constructor should only be created with the from* methods
+     *
+     * @param bool $isEnabled
+     * @param int $fragmentSize
+     * @param string $highlightingFieldList
+     * @param string $prefix
+     * @param string $postfix
+     */
+    private function __construct($isEnabled = false, $fragmentSize = 200, $highlightingFieldList = '', $prefix = '', $postfix = '')
+    {
+        $this->isEnabled = $isEnabled;
+        $this->fragmentSize = $fragmentSize;
+        $this->highlightingFieldList = $highlightingFieldList;
+        $this->prefix = $prefix;
+        $this->postfix = $postfix;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFragmentSize(): int
+    {
+        return $this->fragmentSize;
+    }
+
+    /**
+     * @param int $fragmentSize
+     */
+    public function setFragmentSize(int $fragmentSize)
+    {
+        $this->fragmentSize = $fragmentSize;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHighlightingFieldList(): string
+    {
+        return $this->highlightingFieldList;
+    }
+
+    /**
+     * @param string $highlightingFieldList
+     */
+    public function setHighlightingFieldList(string $highlightingFieldList)
+    {
+        $this->highlightingFieldList = $highlightingFieldList;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param string $prefix
+     */
+    public function setPrefix(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPostfix(): string
+    {
+        return $this->postfix;
+    }
+
+    /**
+     * @param string $postfix
+     */
+    public function setPostfix(string $postfix)
+    {
+        $this->postfix = $postfix;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsEnabled()
+    {
+        return $this->isEnabled;
+    }
+
+    /**
+     * @param boolean $isEnabled
+     */
+    public function setIsEnabled($isEnabled)
+    {
+        $this->isEnabled = $isEnabled;
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        if (!$this->isEnabled) {
+            return [];
+        }
+
+        $highlightingParameter = [];
+        $highlightingParameter['hl'] = 'true';
+        $highlightingParameter['hl.fragsize'] = (int)$this->fragmentSize;
+
+        if ($this->highlightingFieldList != '') {
+            $highlightingParameter['hl.fl'] = $this->highlightingFieldList;
+        }
+
+        // the fast vector highlighter can only be used, when the fragmentSize is
+        // higher then 17 otherwise solr throws an exception
+        $useFastVectorHighlighter = ($this->fragmentSize >= 18);
+
+        if ($useFastVectorHighlighter) {
+            $highlightingParameter['hl.useFastVectorHighlighter'] = 'true';
+            $highlightingParameter['hl.tag.pre'] = $this->prefix;
+            $highlightingParameter['hl.tag.post'] = $this->postfix;
+        }
+
+        if ($this->prefix !== '' && $this->postfix !== '') {
+            $highlightingParameter['hl.simple.pre'] = $this->prefix;
+            $highlightingParameter['hl.simple.post'] = $this->postfix;
+        }
+
+        return $highlightingParameter;
+    }
+
+    /**
+     * @param TypoScriptConfiguration $solrConfiguration
+     * @return Highlighting
+     */
+    public static function fromTypoScriptConfiguration(TypoScriptConfiguration $solrConfiguration)
+    {
+        $isEnabled = $solrConfiguration->getSearchResultsHighlighting();
+        if (!$isEnabled) {
+            return new Highlighting(false);
+        }
+
+        $fragmentSize = $solrConfiguration->getSearchResultsHighlightingFragmentSize();
+        $highlightingFields = $solrConfiguration->getSearchResultsHighlightingFields();
+        $wrap = explode('|', $solrConfiguration->getSearchResultsHighlightingWrap());
+        $prefix = isset($wrap[0]) ? $wrap[0] : '';
+        $postfix = isset($wrap[1]) ? $wrap[1] : '';
+
+
+        return new Highlighting($isEnabled, $fragmentSize, $highlightingFields, $prefix, $postfix);
+    }
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/ParameterBuilder.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/ParameterBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * The implementation of ParameterBuilder is responsible to build an array with
+ * the query parameter that are needed for solr
+ *
+ * Interface ParameterProvider
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+interface ParameterBuilder {
+
+
+    /**
+     * @return array
+     */
+    public function build();
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
@@ -1,0 +1,120 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The QueryFields class holds all information for the query which fields should be used to query (Solr qf parameter).
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class QueryFields implements ParameterBuilder
+{
+
+    /**
+     * @var array
+     */
+    protected $queryFields = [];
+
+    /**
+     * QueryFields constructor.
+     *
+     * private constructor should only be created with the from* methods
+     *
+     * @param array $queryFields
+     */
+    private function __construct(array $queryFields)
+    {
+        $this->queryFields = $queryFields;
+    }
+
+    /**
+     * @param string $fieldName
+     * @param float $boost
+     */
+    public function set($fieldName, $boost = 1.0)
+    {
+        $this->queryFields[$fieldName] = (float)$boost;
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        $string = $this->toString();
+        // return empty array on empty string
+        return trim($string) === '' ? [] : ['qf' => $string];
+    }
+
+    /**
+     * Creates the string representation
+     *
+     * @param string $delimiter
+     * @return string
+     */
+    public function toString($delimiter = ' ') {
+        $queryFieldString = '';
+
+        foreach ($this->queryFields as $fieldName => $fieldBoost) {
+            $queryFieldString .= $fieldName;
+
+            if ($fieldBoost != 1.0) {
+                $queryFieldString .= '^' . number_format($fieldBoost, 1, '.', '');
+            }
+
+            $queryFieldString .= $delimiter;
+        }
+
+        return rtrim($queryFieldString, $delimiter);
+    }
+
+    /**
+     * Parses the string representation of the queryFields (e.g. content^100, title^10) to the object representation.
+     *
+     * @param string $queryFieldsString
+     * @param string $delimiter
+     * @return QueryFields
+     */
+    public static function fromString($queryFieldsString, $delimiter = ',') {
+        $fields = GeneralUtility::trimExplode($delimiter, $queryFieldsString, true);
+        $queryFields = [];
+
+        foreach ($fields as $field) {
+            $fieldNameAndBoost = explode('^', $field);
+
+            $boost = 1.0;
+            if (isset($fieldNameAndBoost[1])) {
+                $boost = floatval($fieldNameAndBoost[1]);
+            }
+
+            $fieldName = $fieldNameAndBoost[0];
+            $queryFields[$fieldName] = $boost;
+        }
+
+        return new QueryFields($queryFields);
+    }
+}

--- a/Classes/Domain/Search/Query/ParameterBuilder/ReturnFields.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/ReturnFields.php
@@ -1,0 +1,128 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The ReturnFields class is responsible to hold a list of field names that should be returned from
+ * solr.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder
+ */
+class ReturnFields implements ParameterBuilder
+{
+
+    /**
+     * @var array
+     */
+    protected $fieldList = [];
+
+    /**
+     * FieldList constructor.
+     *
+     * private constructor should only be created with the from* methods
+     *
+     * @param array $fieldList
+     */
+    private function __construct(array $fieldList)
+    {
+        $this->fieldList = $fieldList;
+    }
+
+    /**
+     * Adds a field to the list of fields to return. Also checks whether * is
+     * set for the fields, if so it's removed from the field list.
+     *
+     * @param string $fieldName Name of a field to return in the result documents
+     */
+    public function add($fieldName)
+    {
+        if (strpos($fieldName, '[') === false && strpos($fieldName, ']') === false && in_array('*', $this->fieldList)) {
+            $this->fieldList = array_diff($this->fieldList, ['*']);
+        }
+
+        $this->fieldList[] = $fieldName;
+    }
+
+    /**
+     * Removes a field from the list of fields to return (fl parameter).
+     *
+     * @param string $fieldName Field to remove from the list of fields to return
+     */
+    public function remove($fieldName)
+    {
+        $key = array_search($fieldName, $this->fieldList);
+
+        if ($key !== false) {
+            unset($this->fieldList[$key]);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function build()
+    {
+        return ['fl' => $this->toString()];
+    }
+
+    /**
+     * @param string $delimiter
+     * @return string
+     */
+    public function toString($delimiter = ',')
+    {
+        return implode($delimiter, $this->fieldList);
+    }    
+
+    /**
+     * @param string $fieldList
+     * @param string $delimiter
+     * @return ReturnFields
+     */
+    public static function fromString($fieldList, $delimiter = ',')
+    {
+        $fieldListArray = GeneralUtility::trimExplode($delimiter, $fieldList);
+        return static::fromArray($fieldListArray);
+    }
+
+    /**
+     * @param array $fieldListArray
+     * @return ReturnFields
+     */
+    public static function fromArray(array $fieldListArray)
+    {
+        return new ReturnFields($fieldListArray);
+    }
+
+    /**
+     * @return array
+     */
+    public function getValues()
+    {
+        return array_unique(array_values($this->fieldList));
+    }
+}

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\Query;
@@ -187,7 +188,7 @@ class SearchResultSetService
         }
 
         foreach ($this->getAdditionalFilters() as $additionalFilter) {
-            $query->addFilter($additionalFilter);
+            $query->getFilters()->add($additionalFilter);
         }
 
         return $query;
@@ -651,7 +652,7 @@ class SearchResultSetService
     {
         /* @var $query Query */
         $query = GeneralUtility::makeInstance(Query::class, $documentId);
-        $query->setQueryFieldsFromString('id');
+        $query->setQueryFields(QueryFields::fromString('id'));
 
         $response = $this->search->search($query, 0, 1);
         $this->processResponse($documentId, $query, $response);

--- a/Classes/Search/HighlightingComponent.php
+++ b/Classes/Search/HighlightingComponent.php
@@ -24,7 +24,9 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Highlighting;
 use ApacheSolrForTypo3\Solr\Query;
+use ApacheSolrForTypo3\Solr\Util;
 
 /**
  * Highlighting search component
@@ -43,13 +45,13 @@ class HighlightingComponent extends AbstractComponent implements QueryAware
 
     /**
      * Initializes the search component.
-     *
-     *
      */
     public function initializeSearchComponent()
     {
-        if ($this->searchConfiguration['results.']['resultsHighlighting']) {
-            $this->query->setHighlighting(true, $this->searchConfiguration['results.']['resultsHighlighting.']['fragmentSize']);
+        $solrConfiguration = Util::getSolrConfiguration();
+
+        if ($solrConfiguration->getSearchResultsHighlighting()) {
+            $this->query->setHighlighting(Highlighting::fromTypoScriptConfiguration($solrConfiguration));
         }
     }
 

--- a/Classes/SuggestQuery.php
+++ b/Classes/SuggestQuery.php
@@ -60,7 +60,7 @@ class SuggestQuery extends Query
         $this->configuration = $solrConfiguration->getObjectByPathOrDefault('plugin.tx_solr.suggest.', []);
 
         if (!empty($this->configuration['treatMultipleTermsAsSingleTerm'])) {
-            $this->prefix = $this->escape($keywords);
+            $this->prefix = $this->escapeService->escape($keywords);
         } else {
             $matches = [];
             preg_match('/^(:?(.* |))([^ ]+)$/', $keywords, $matches);
@@ -68,7 +68,7 @@ class SuggestQuery extends Query
             $partialKeyword = trim($matches[3]);
 
             $this->setKeywords($fullKeywords);
-            $this->prefix = $this->escape($partialKeyword);
+            $this->prefix = $this->escapeService->escape($partialKeyword);
         }
 
         $this->setAlternativeQuery('*:*');
@@ -79,6 +79,7 @@ class SuggestQuery extends Query
      */
     protected function initializeQuery()
     {
+        $this->initializeFilters();
     }
 
     /**

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1565,6 +1565,21 @@ class TypoScriptConfiguration
         return $this->getBool($isSiteHightlightingEnabled);
     }
 
+
+    /**
+     * Can be used to check if the highlighting is enabled
+     *
+     * plugin.tx_solr.search.results.resultsHighlighting
+     *
+     * @param boolean $defaultIfEmpty
+     * @return string
+     */
+    public function getSearchResultsHighlighting($defaultIfEmpty = false)
+    {
+        $isHighlightingEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.results.resultsHighlighting', $defaultIfEmpty);
+        return $this->getBool($isHighlightingEnabled);
+    }
+
     /**
      * Returns the result highlighting fields.
      *
@@ -1595,6 +1610,19 @@ class TypoScriptConfiguration
         }
 
         return GeneralUtility::trimExplode(',', $highlightingFields, true);
+    }
+
+    /**
+     * Returns the fragmentSize for highlighted segments.
+     *
+     * plugin.tx_solr.search.results.resultsHighlighting.fragmentSize
+     *
+     * @param int $defaultIfEmpty
+     * @return int
+     */
+    public function getSearchResultsHighlightingFragmentSize($defaultIfEmpty = 200)
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.results.resultsHighlighting.fragmentSize', $defaultIfEmpty);
     }
 
     /**
@@ -2126,6 +2154,78 @@ class TypoScriptConfiguration
     {
         $enableQParameter = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.ignoreGlobalQParameter', $defaultIfEmpty);
         return $this->getBool($enableQParameter);
+
+    }
+
+    /**
+     * Method to check if grouping was enabled with typoscript.
+     *
+     * plugin.tx_solr.search.grouping
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getSearchGrouping($defaultIfEmpty = false)
+    {
+        $groupingEnabled = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.grouping', $defaultIfEmpty);
+        return $this->getBool($groupingEnabled);
+    }
+
+    /**
+     * Returns the configured numberOfGroups.
+     *
+     * plugin.tx_solr.search.grouping.numberOfGroups
+     *
+     * @param int $defaultIfEmpty
+     * @return int
+     */
+    public function getSearchGroupingNumberOfGroups($defaultIfEmpty = 5)
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.grouping.numberOfGroups', $defaultIfEmpty);
+    }
+
+    /**
+     * Returns the highestValue of the numberOfResultsPerGroup configuration that is globally configured and
+     * for each group.
+     *
+     * plugin.tx_solr.search.grouping.
+     *
+     * @param int $defaultIfEmpty
+     * @return int
+     */
+    public function getSearchGroupingHighestGroupResultsLimit($defaultIfEmpty = 1)
+    {
+        $groupingConfiguration = $this->getObjectByPathOrDefault('plugin.tx_solr.search.grouping.', []);
+        $highestLimit = $defaultIfEmpty;
+        if (!empty($groupingConfiguration['numberOfResultsPerGroup'])) {
+            $highestLimit = $groupingConfiguration['numberOfResultsPerGroup'];
+        }
+
+        $configuredGroups = $groupingConfiguration['groups.'];
+        if (!is_array($configuredGroups)) {
+            return $highestLimit;
+        }
+
+        foreach ($configuredGroups as $groupName => $groupConfiguration) {
+            if (!empty($groupConfiguration['numberOfResultsPerGroup']) && $groupConfiguration['numberOfResultsPerGroup'] > $highestLimit) {
+                $highestLimit = $groupConfiguration['numberOfResultsPerGroup'];
+            }
+        }
+
+        return $highestLimit;
+    }
+
+    /**
+     * Returns everything that is configured for the groups (plugin.tx_solr.search.grouping.groups.)
+     *
+     * plugin.tx_solr.search.grouping.groups.
+     *
+     * @param array $defaultIfEmpty
+     * @return array
+     */
+    public function getSearchGroupingGroupsConfiguration($defaultIfEmpty = [])
+    {
+        return $this->getObjectByPathOrDefault('plugin.tx_solr.search.grouping.groups.', $defaultIfEmpty);
     }
 
     /*

--- a/Tests/Unit/Domain/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Query/Helper/EscapeHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Helper;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2016 Timo Schmidt
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class EscapeHelperTest extends UnitTest
+{
+
+    /**
+     * @return array
+     */
+    public function escapeQueryDataProvider()
+    {
+        return [
+            'empty' => ['input' => '', 'expectedOutput' => ''],
+            'simple' => ['input' => 'foo', 'expectedOutput' => 'foo'],
+            'single quoted word' => ['input' => '"world"', 'expectedOutput' => '"world"'],
+            'simple quoted phrase' => ['input' => '"hello world"', 'expectedOutput' => '"hello world"'],
+            'simple quoted phrase with ~' => ['input' => '"hello world~"', 'expectedOutput' => '"hello world~"'],
+            'simple phrase with ~' => ['input' => 'hello world~', 'expectedOutput' => 'hello world\~'],
+            'single quote' =>  ['input' => '20" monitor', 'expectedOutput' => '20\" monitor'],
+            'rounded brackets many words' => ['input' => 'hello (world)', 'expectedOutput' => 'hello \(world\)'],
+            'rounded brackets one word' => ['input' => '(world)', 'expectedOutput' => '\(world\)'],
+            'plus character is kept' => ['input' => 'foo +bar -world', 'expectedOutput' => 'foo +bar -world'],
+            '&& character is kept' => ['input' => 'hello && world', 'expectedOutput' => 'hello && world'],
+            '! character is kept' => ['input' => 'hello !world', 'expectedOutput' => 'hello !world'],
+            '* character is kept' => ['input' => 'hello *world', 'expectedOutput' => 'hello *world'],
+            '? character is kept' => ['input' => 'hello ?world', 'expectedOutput' => 'hello ?world'],
+            'ö character is kept' => ['input' => 'schöner tag', 'expectedOutput' => 'schöner tag'],
+            'numeric is kept' => ['input' => 42, 'expectedOutput' => 42],
+            'combined quoted phrase' => ['input' => '"hello world" or planet', 'expectedOutput' => '"hello world" or planet'],
+            'two combined quoted phrases' => ['input' => '"hello world" or "hello planet"', 'expectedOutput' => '"hello world" or "hello planet"'],
+            'combined quoted phrase mixed with escape character' => ['input' => '"hello world" or (planet)', 'expectedOutput' => '"hello world" or \(planet\)']
+        ];
+    }
+
+    /**
+     * @dataProvider escapeQueryDataProvider
+     * @test
+     */
+    public function canEscapeAsExpected($input, $expectedOutput)
+    {
+        $escapeHelper = new EscapeService();
+        $output = $escapeHelper->escape($input);
+        $this->assertSame($expectedOutput, $output, 'Query was not escaped as expected');
+    }
+
+}

--- a/Tests/Unit/Domain/Query/ParameterBuilder/QueryFieldsTest.php
+++ b/Tests/Unit/Domain/Query/ParameterBuilder/QueryFieldsTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class QueryFieldsTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canBuildFromString()
+    {
+        $input = 'one^10.0,two^20.0,three^5.0';
+        $queryFields = QueryFields::fromString($input, ',');
+        $output = $queryFields->toString(',');
+
+        $this->assertSame($input, $output, 'Parsing QueryFields from and to string did not produce the same result');
+    }
+
+}

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -100,6 +100,8 @@ class SearchResultSetTest extends UnitTest
             // later if we retrieve the expected result
         $fakeResponse = $this->getDumbMock(Apache_Solr_Response::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my search', 0, $fakeResponse);
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+
 
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my search']]);
 
@@ -118,6 +120,7 @@ class SearchResultSetTest extends UnitTest
         $fakeResponse = $this->getDumbMock(Apache_Solr_Response::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 2. search', 50, $fakeResponse);
         $this->configurationMock->expects($this->once())->method('getSearchResultsPerPage')->will($this->returnValue(25));
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 2. search','page' => 2]]);
 
@@ -132,6 +135,7 @@ class SearchResultSetTest extends UnitTest
     public function testQueryAwareComponentGetsInitialized()
     {
         $this->configurationMock->expects($this->once())->method('getSearchConfiguration')->will($this->returnValue([]));
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
             // we expect that the initialize method of our component will be called
         $fakeQueryAwareSpellChecker = $this->getDumbMock(SpellcheckingComponent::class);
@@ -154,6 +158,8 @@ class SearchResultSetTest extends UnitTest
      */
     public function canRegisterSearchResponseProcessor()
     {
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+
         $processSearchResponseBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['processSearchResponse'];
 
         $testProcessor = TestSearchResponseProcessor::class;
@@ -189,6 +195,7 @@ class SearchResultSetTest extends UnitTest
         $this->fakeRegisteredSearchComponents([]);
         $this->configurationMock->expects($this->once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
                                 ->will($this->returnValue([10, 25]));
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         $fakeRequest = new SearchRequest(
             [
@@ -216,6 +223,7 @@ class SearchResultSetTest extends UnitTest
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
 
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
         $this->configurationMock->expects($this->any())->method('getSearchQueryFilterConfiguration')->will(
             $this->returnValue(['type:pages'])
         );
@@ -240,6 +248,9 @@ class SearchResultSetTest extends UnitTest
 
             // in this case we collapse on the type field
         $this->configurationMock->expects($this->atLeastOnce())->method('getSearchVariantsField')->will($this->returnValue('type'));
+
+        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+
 
         $this->fakeRegisteredSearchComponents([]);
         $fakedSolrResponse = $this->getFixtureContentByName('fakeCollapsedResponse.json');

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -759,4 +759,87 @@ class TypoScriptConfigurationTest extends UnitTest
         $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
         $this->assertEquals('desc', $retrievedSorting);
     }
+
+    /**
+     * @test
+     */
+    public function canGetSearchGroupingHighestGroupResultsLimit()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'grouping.' => [
+                    'numberOfResultsPerGroup' => 3,
+                    'groups.' => [
+                        'typeGroup.' => [
+                            'field' => 'type',
+                            'numberOfResultsPerGroup' => 5
+                        ],
+                        'priceGroup.' => [
+                            'field' => 'price',
+                            'numberOfResultsPerGroup' => 2
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $highestResultsPerGroup = $configuration->getSearchGroupingHighestGroupResultsLimit();
+        $this->assertEquals(5, $highestResultsPerGroup, 'Can not get highest result per group value');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSearchGroupingHighestGroupResultsLimitAsGlobalFallback()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'grouping.' => [
+                    'numberOfResultsPerGroup' => 8,
+                    'groups.' => [
+                        'typeGroup.' => [
+                            'field' => 'type',
+                            'numberOfResultsPerGroup' => 5
+                        ],
+                        'priceGroup.' => [
+                            'field' => 'price',
+                            'numberOfResultsPerGroup' => 2
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $highestResultsPerGroup = $configuration->getSearchGroupingHighestGroupResultsLimit();
+        $this->assertEquals(8, $highestResultsPerGroup, 'Can not get highest result per group value');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSearchGroupingWhenDisabled()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'search.' => [
+                'grouping' => 0,
+                'grouping.' => [
+                    'numberOfResultsPerGroup' => 8,
+                    'groups.' => [
+                        'typeGroup.' => [
+                            'field' => 'type',
+                            'numberOfResultsPerGroup' => 5
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $this->assertFalse($configuration->getSearchGrouping(), 'Expected grouping to be disabled');
+    }
 }


### PR DESCRIPTION
This PR reduces the amount of methods in the Query class by:

* Remove the usage of escapeMarkers since this was marked to be removed, when the old templating was dropped

* Extracting the escape logic into a seperate EscapeService since this is not directly related to the query itself and more about the formatting of the querystring itself

* Introducing the concept of ParameterBuilders
** ParameterBuilders are able to build the solr query parameters for a certain query part. This helps to split the logic into several components instead of having everything in the query.
** ParameterBuilders are available for "Faceting, Filters, Grouping, Highlighting, QueryFields and ReturnFields"

The following methods have been marked as deprecated:

* Query::setQueryFieldsFromString use setQueryFields(QueryFields::fromString('foo')) with QueryFields instead, will be removed in 8.0
* Query::getQueryFieldsAsString use getQueryFields()->toString() now if needed, will be removed in 8.0
* Query::setQueryField use getQueryFields()->set() now, will be removed in 8.0

* Query::escape Use EscapeService::escape now, when needed

* Query::addReturnField use getReturnFields()->add() now, will be removed in 8.0
* Query::removeReturnField use getReturnFields()->remove() now, will be removed in 8.0
* Query::getFieldList use getReturnFields()->getValues() now, will be removed in 8.0
* Query::setFieldList use setReturnFields() now, will be removed in 8.0

* Query::escapeMarkers not needed anymore, use your own implementation when needed

* Query::setNumberOfGroups use getGrouping()->setNumberOfGroups() instead, will be removed in 8.0
* Query::getNumberOfGroups use getGrouping()->getNumberOfGroups() instead, will be removed in 8.0
* Query::addGroupField use getGrouping()->addField() instead, will be removed in 8.0
* Query::getGroupFields use getGrouping()->getFields() instead, will be removed in 8.0
* Query::addGroupSorting use getGrouping()->addSorting() instead, will be removed in 8.0
* Query::getGroupSortings use getGrouping()->getSortings() instead, will be removed in 8.0
* Query::addGroupQuery use getGrouping()->addQuery() instead, will be removed in 8.0
* Query::getGroupQueries use getGrouping()->getQueries() instead, will be removed in 8.0
* Query::setNumberOfResultsPerGroup use getGrouping()->setResultsPerGroup() instead, will be removed in 8.0
* Query::getNumberOfResultsPerGroup use getGrouping()->getResultsPerGroup() instead, will be removed in 8.0

* Query::setFacetFields use getFaceting()->setFields() instead, will be removed in 8.0
* Query::addFacetField use getFaceting()->addField() instead, will be removed in 8.0

* Query::removeFilter use getFilters()->removeByFieldName() instead, will be removed in 8.0
* Query::removeFilterByKey use getFilters()->removeByName() instead, will be removed in 8.0
* Query::removeFilterByValue use getFilters()->removeByValue() instead, will be removed in 8.0
* Query::addFilter use getFilters()->add() instead, will be removed in 8.0

The following methods will drop support of certain agument types:

* Query::setGrouping now expects the first argument to be a Grouping object, compatibility for the old argument (bool) will be dropped in 8.0
* Query::setHighlighting now expects the first argument to be a Highlighting object, compatibility for the old arguments (bool, int) will be dropped in 8.0
* Query::setFaceting now expects the first argument to be a Faceting object, compatibility for the old arguments (bool) will be dropped in 8.0

Breaking changes:

Most of the changes are tested and backwards compatible but there is one breaking change:

* Query::getFilters now returns a Filters object instead of an array, if you need the values you can user Query::getFilters()->getValues() to have the old behaviour

Related: #685