### PR TITLE
[BUGFIX] Removes the Frontend namespace prefix from the ajaxified search typoscript

### DIFF
--- a/Configuration/TypoScript/Examples/Ajaxify/setup.txt
+++ b/Configuration/TypoScript/Examples/Ajaxify/setup.txt
@@ -20,7 +20,7 @@ tx_solr_ajaxPage {
 		controller = Search
 		action = results
 		switchableControllerActions {
-			Frontend\Search {
+			Search {
 				1 = results
 				2 = form
 			}


### PR DESCRIPTION
Fixes: #1392