### PR TITLE
[TASK] Avoid multiple calls of Util::getSolrConfiguration on frontend requests

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -160,7 +160,7 @@ class SearchResultSetService
     protected function getPreparedQuery($rawQuery, $resultsPerPage)
     {
         /* @var $query Query */
-        $query = GeneralUtility::makeInstance(Query::class, $rawQuery);
+        $query = GeneralUtility::makeInstance(Query::class, $rawQuery, $this->typoScriptConfiguration);
 
         $this->applyPageSectionsRootLineFilter($query);
 

--- a/Classes/Query/Modifier/Elevation.php
+++ b/Classes/Query/Modifier/Elevation.php
@@ -24,6 +24,9 @@ namespace ApacheSolrForTypo3\Solr\Query\Modifier;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
+use ApacheSolrForTypo3\Solr\Plugin\Search\Search;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Util;
 
@@ -32,8 +35,20 @@ use ApacheSolrForTypo3\Solr\Util;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class Elevation implements Modifier
+class Elevation implements Modifier, SearchRequestAware
 {
+
+    /**
+     * @var SearchRequest
+     */
+    protected $searchRequest;
+
+    /**
+     * @param SearchRequest $searchRequest
+     */
+    public function setSearchRequest(SearchRequest $searchRequest) {
+        $this->searchRequest = $searchRequest;
+    }
 
     /**
      * Enables the query's elevation mode.
@@ -43,7 +58,7 @@ class Elevation implements Modifier
      */
     public function modifyQuery(Query $query)
     {
-        $configuration = Util::getSolrConfiguration();
+        $configuration = $this->searchRequest->getContextTypoScriptConfiguration();
         $query->setQueryElevation(
             $configuration->getSearchElevation(),
             $configuration->getSearchElevationForceElevation(),

--- a/Classes/Search/DebugComponent.php
+++ b/Classes/Search/DebugComponent.php
@@ -24,6 +24,8 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Util;
 
@@ -33,7 +35,7 @@ use ApacheSolrForTypo3\Solr\Util;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class DebugComponent extends AbstractComponent implements QueryAware
+class DebugComponent extends AbstractComponent implements QueryAware, SearchRequestAware
 {
 
     /**
@@ -44,6 +46,21 @@ class DebugComponent extends AbstractComponent implements QueryAware
     protected $query;
 
     /**
+     * @var SearchRequest
+     */
+    protected $seachRequest;
+
+    /**
+     * Provides a component that is aware of the current SearchRequest
+     *
+     * @param SearchRequest $searchRequest
+     */
+    public function setSearchRequest(SearchRequest $searchRequest)
+    {
+        $this->seachRequest = $searchRequest;
+    }
+
+    /**
      * Initializes the search component.
      *
      * Sets the debug query parameter
@@ -51,9 +68,7 @@ class DebugComponent extends AbstractComponent implements QueryAware
      */
     public function initializeSearchComponent()
     {
-        $solrConfiguration = Util::getSolrConfiguration();
-
-        if ($solrConfiguration->getEnabledDebugMode()) {
+        if ($this->seachRequest->getContextTypoScriptConfiguration()->getEnabledDebugMode()) {
             $this->query->setDebugMode();
         }
     }

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -24,17 +24,33 @@ namespace ApacheSolrForTypo3\Solr\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Statistics;
-use ApacheSolrForTypo3\Solr\Util;
 
 /**
  * Statistics search component
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class StatisticsComponent extends AbstractComponent
+class StatisticsComponent extends AbstractComponent implements SearchRequestAware
 {
+
+    /**
+     * @var SearchRequest
+     */
+    protected $seachRequest;
+
+    /**
+     * Provides a component that is aware of the current SearchRequest
+     *
+     * @param SearchRequest $searchRequest
+     */
+    public function setSearchRequest(SearchRequest $searchRequest)
+    {
+        $this->seachRequest = $searchRequest;
+    }
 
     /**
      * Initializes the search component.
@@ -42,7 +58,7 @@ class StatisticsComponent extends AbstractComponent
      */
     public function initializeSearchComponent()
     {
-        $solrConfiguration = Util::getSolrConfiguration();
+        $solrConfiguration = $this->seachRequest->getContextTypoScriptConfiguration();
 
         if ($solrConfiguration->getStatistics()) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'] = StatisticsWriterProcessor::class;
@@ -52,4 +68,5 @@ class StatisticsComponent extends AbstractComponent
             }
         }
     }
+
 }

--- a/Tests/Unit/Query/Modifier/ElevationTest.php
+++ b/Tests/Unit/Query/Modifier/ElevationTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetQueryBuilderRegistry;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetUrlDecoderRegistry;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Query;
+use ApacheSolrForTypo3\Solr\Query\Modifier\Faceting;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Elevation class
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ElevationTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canModifiyQuery()
+    {
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchElevation')->willReturn(false);
+        $configurationMock->expects($this->once())->method('getSearchElevationForceElevation')->willReturn(false);
+        $configurationMock->expects($this->once())->method('getSearchElevationMarkElevatedResults')->willReturn(false);
+
+        $requestMock = $this->getDumbMock(SearchRequest::class);
+        $requestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->willReturn($configurationMock);
+
+        $query = $this->getDumbMock(Query::class);
+        $query->expects($this->once())->method('setQueryElevation')->with(false, false, false);
+
+        $modifier = new Query\Modifier\Elevation();
+        $modifier->setSearchRequest($requestMock);
+        $modifier->modifyQuery($query);
+    }
+}

--- a/Tests/Unit/Search/StatisticsComponentTest.php
+++ b/Tests/Unit/Search/StatisticsComponentTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Search\StatisticsComponent;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+
+/**
+ * Testcase for StatisticsComponent
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class StatisticsComponentTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canRegisterStatisticsComponents()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics']  = null;
+        $this->assertEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that no statistic component was registered');
+
+
+        $typoScriptConfiguration = new TypoScriptConfiguration([
+            'plugin.' => [
+                'tx_solr.' => [
+                    'statistics' => 1
+                ]
+            ]
+        ]);
+
+        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+
+        $statisticsComponent = new StatisticsComponent();
+        $statisticsComponent->setSearchRequest($searchRequestMock);
+        $statisticsComponent->initializeSearchComponent();
+        $this->assertNotEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that a statistic component was registered');
+    }
+
+}


### PR DESCRIPTION
This PR:

* Reduces the amount of Util::getSolrConfiguration calls in the frontend to a minimum, by passing a reference when possible or
using SearchRequest::getContextTypoScriptConfiguration when possible.

Fixes: #1389