### PR TITLE
[BUGFIX] Relation handler should handle pages overlays correctly

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -124,12 +124,18 @@ class Relation
         list($localTableName, $localRecordUid) = explode(':',
             $parentContentObject->currentRecord);
 
+        $localTableNameOrg = $localTableName;
+        // pages has a special overlay table constriction
+        if ($GLOBALS['TSFE']->sys_language_uid > 0 && $localTableName === 'pages') {
+            $localTableName = 'pages_language_overlay';
+        }
+
         $localTableTca = $GLOBALS['TCA'][$localTableName];
         $localFieldName = $this->configuration['localField'];
 
         if (isset($localTableTca['columns'][$localFieldName])) {
             $localFieldTca = $localTableTca['columns'][$localFieldName];
-            $localRecordUid = $this->getUidOfRecordOverlay($localTableName, $localRecordUid);
+            $localRecordUid = $this->getUidOfRecordOverlay($localTableNameOrg, $localRecordUid);
             if (isset($localFieldTca['config']['MM']) && trim($localFieldTca['config']['MM']) !== '') {
                 $relatedItems = $this->getRelatedItemsFromMMTable($localTableName,
                     $localRecordUid, $localFieldTca);
@@ -388,8 +394,12 @@ class Relation
         }
 
         $record = $this->getTranslationOverlay($localTableName, $record);
-        // when there is a _LOCALIZED_UID in the overlay, we return it
-        $localRecordUid = $record['_LOCALIZED_UID'] ? $record['_LOCALIZED_UID'] : $localRecordUid;
+        // when there is a _PAGES_OVERLAY_UID | _LOCALIZED_UID in the overlay, we return it
+        if ($localTableName === 'pages') {
+            $localRecordUid = $record['_PAGES_OVERLAY_UID'] ? $record['_PAGES_OVERLAY_UID'] : $localRecordUid;
+        } else {
+            $localRecordUid = $record['_LOCALIZED_UID'] ? $record['_LOCALIZED_UID'] : $localRecordUid;
+        }
         return $localRecordUid;
     }
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -472,6 +472,10 @@ class Queue
     {
         $localizedChangedTime = 0;
 
+        if ($itemType === 'pages') {
+            $itemType = 'pages_language_overlay';
+        }
+
         if (isset($GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'])) {
             // table is localizable
             $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];


### PR DESCRIPTION
Table pages has diferent handling over overlays. Now the
ContantObject/Relation handles these correctly.