### PR TITLE
[TASK] Add support for requirements again

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
@@ -70,6 +70,11 @@ abstract class AbstractFacet
     protected $isUsed = false;
 
     /**
+     * @var bool
+     */
+    protected $allRequirementsMet = true;
+
+    /**
      * AbstractFacet constructor.
      *
      * @param SearchResultSet $resultSet
@@ -164,6 +169,22 @@ abstract class AbstractFacet
     }
 
     /**
+     * @return boolean
+     */
+    public function getAllRequirementsMet()
+    {
+        return $this->allRequirementsMet;
+    }
+
+    /**
+     * @param boolean $allRequirementsMet
+     */
+    public function setAllRequirementsMet($allRequirementsMet)
+    {
+        $this->allRequirementsMet = $allRequirementsMet;
+    }
+
+    /**
      * @return SearchResultSet
      */
     public function getResultSet()
@@ -223,6 +244,16 @@ abstract class AbstractFacet
     }
 
     /**
+     * Returns the configured requirements
+     *
+     * @return array
+     */
+    public function getRequirements()
+    {
+        return $this->getFacetSettingOrDefaultValue('requirements.', []);
+    }
+
+    /**
      * The implementation of this method should return a "flatten" collection of all items.
      *
      * @return AbstractFacetItemCollection
@@ -240,6 +271,6 @@ abstract class AbstractFacet
             return $defaultValue;
         }
 
-        return ((string)$this->configuration[$key]);
+        return ($this->configuration[$key]);
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/FacetCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/FacetCollection.php
@@ -38,7 +38,7 @@ class FacetCollection extends AbstractCollection
     {
         return $this->getFilteredCopy(
             function(AbstractFacet $facet) {
-                return $facet->getIsAvailable() && $facet->getIncludeInAvailableFacets();
+                return $facet->getIsAvailable() && $facet->getIncludeInAvailableFacets() && $facet->getAllRequirementsMet();
             }
         );
     }
@@ -52,6 +52,18 @@ class FacetCollection extends AbstractCollection
         return $this->getFilteredCopy(
             function(AbstractFacet $facet) use ($requiredGroup) {
                 return $facet->getGroupName() == $requiredGroup;
+            }
+        );
+    }
+
+    /**
+     * @param string $requiredName
+     * @return AbstractCollection
+     */
+    public function getByName($requiredName) {
+        return $this->getFilteredCopy(
+            function(AbstractFacet $facet) use ($requiredName) {
+                return $facet->getName() == $requiredName;
             }
         );
     }

--- a/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
@@ -1,0 +1,123 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service class to check for a facet if allRequirements are met for that facet.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facet
+ */
+class RequirementsService
+{
+    /**
+     * Checks if facet meets all requirements.
+     *
+     * Evaluates configuration in "plugin.tx_solr.search.faceting.facets.[facetName].requirements",
+     *
+     * @param AbstractFacet $facet
+     * @return bool true if facet might be rendered
+     */
+    public function getAllRequirementsMet(AbstractFacet $facet)
+    {
+        $requirements = $facet->getRequirements();
+        if (!is_array($requirements) || count($requirements) === 0) {
+            return true;
+        }
+
+        foreach ($requirements as $requirement) {
+            $requirementMet = $this->getRequirementMet($facet, $requirement);
+            $requirementMet = $this->getNegationWhenConfigured($requirementMet, $requirement);
+
+            if ($requirementMet) {
+                // early return
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if a single requirement is met.
+     *
+     * @param AbstractFacet $facet
+     * @param array $requirement
+     * @return bool
+     */
+    protected function getRequirementMet(AbstractFacet $facet, $requirement = []) {
+        $activeFacetItemValues = $this->getActiveItemValues($facet, $requirement['facet']);
+        $csvActiveFacetItemValues = implode(', ', $activeFacetItemValues);
+        $requirementValues = GeneralUtility::trimExplode(',', $requirement['values']);
+
+        foreach ($requirementValues as $value) {
+            $noFacetOptionSelectedRequirementMet = ($value === '__none' && empty($activeFacetItemValues));
+            $anyFacetOptionSelectedRequirementMet = ($value === '__any' && !empty($activeFacetItemValues));
+
+            if ($noFacetOptionSelectedRequirementMet || $anyFacetOptionSelectedRequirementMet || in_array($value, $activeFacetItemValues) || fnmatch($value, $csvActiveFacetItemValues)) {
+                // when we find a single matching requirement we can exit and return true
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the active item values of a facet
+     *
+     * @param string $facetNameToCheckRequirementsOn
+     * @return AbstractFacetItem[]
+     */
+    protected function getActiveItemValues(AbstractFacet $facet, $facetNameToCheckRequirementsOn)
+    {
+        $facetToCheckRequirements = $facet->getResultSet()->getFacets()->getByName($facetNameToCheckRequirementsOn)->getByPosition(0);
+        if (!$facetToCheckRequirements instanceof AbstractFacet) {
+            throw new \InvalidArgumentException('Requirement for unexisting facet configured');
+        }
+
+        if (!$facetToCheckRequirements->getIsUsed()) {
+            // unused facets do not have active values.
+            return [];
+        }
+
+        $itemValues = [];
+        $activeFacetItems = $facetToCheckRequirements->getAllFacetItems();
+        foreach ($activeFacetItems as $item) {
+            /** @var AbstractFacetItem $item */
+            $itemValues[] = $item->getUriValue();
+        }
+
+        return $itemValues;
+    }
+
+    /**
+     * Negates the result when configured.
+     *
+     * @param boolean $value
+     * @param array $configuration
+     * @return boolean
+     */
+    protected function getNegationWhenConfigured($value, $configuration)
+    {
+        if (!is_array($configuration) || empty($configuration['negate']) || (bool)$configuration['negate'] === false) {
+            return $value;
+        }
+
+        return !((bool)$value);
+    }
+}

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -14,7 +14,9 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RequirementsService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\Sorting;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking\Suggestion;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -235,6 +237,30 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             }
         }
 
+        $this->applyRequirements($resultSet);
+
         return $resultSet;
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     */
+    protected function applyRequirements(SearchResultSet $resultSet)
+    {
+        $requirementsService = $this->getRequirementsService();
+        $facets = $resultSet->getFacets();
+        foreach ($facets as $facet) {
+            /** @var $facet AbstractFacet */
+            $requirementsMet = $requirementsService->getAllRequirementsMet($facet);
+            $facet->setAllRequirementsMet($requirementsMet);
+        }
+    }
+
+    /**
+     * @return RequirementsService
+     */
+    protected function getRequirementsService()
+    {
+        return $this->getObjectManager()->get(RequirementsService::class);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RequirementsService;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase to test the RequirementsService
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class RequirementsServiceTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function getRequirementsMetReturnTrueWhenNothingConfigured()
+    {
+        $facet = $this->getDumbMock(OptionsFacet::class);
+        $service = new RequirementsService();
+        $this->assertTrue($service->getAllRequirementsMet($facet), 'Facet without any requirements should met all requirements');
+    }
+
+    /**
+     * @test
+     */
+    public function getAllRequirementsMetIsReturnsFalseWhenARequirementIsNotMet()
+    {
+        $resultSet = new SearchResultSet();
+        $colorConfig = [];
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', $colorConfig);
+        $resultSet->addFacet($colorFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'red'
+                ]
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement is not met');
+    }
+
+    /**
+     * @test
+     */
+    public function getAllRequirementsMetIsReturnsTrueWhenRequirementIsMet()
+    {
+        $resultSet = new SearchResultSet();
+        $colorConfig = [];
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', $colorConfig);
+        $redOption = new Option($colorFacet, 'Red', 'red');
+        $colorFacet->addOption($redOption);
+        $colorFacet->setIsUsed(true);
+
+        $resultSet->addFacet($colorFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'red,green'
+                ]
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color option is present, but is indicated to not be met');
+    }
+
+    /**
+     * @test
+     */
+    public function getAllRequirementsMetIsReturnsFalseWhenRequiredFacetHasADifferentValue()
+    {
+        $resultSet = new SearchResultSet();
+        $colorConfig = [];
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', $colorConfig);
+        $redOption = new Option($colorFacet, 'Red', 'red');
+        $colorFacet->addOption($redOption);
+        $colorFacet->setIsUsed(true);
+
+        $resultSet->addFacet($colorFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'blue,green'
+                ]
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the facet has not the require value');
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionIsThrownForRequirementWithUnexistingFacet()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Requirement for unexisting facet configured');
+        $resultSet = new SearchResultSet();
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'red,green'
+                ]
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $service->getAllRequirementsMet($categoryFacet);
+    }
+
+    /**
+     * @test
+     */
+    public function canNegateRequirementsResult()
+    {
+        $resultSet = new SearchResultSet();
+        $colorConfig = [];
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', $colorConfig);
+        $redOption = new Option($colorFacet, 'Red', 'red');
+        $colorFacet->addOption($redOption);
+        $colorFacet->setIsUsed(true);
+
+        $resultSet->addFacet($colorFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'blue,green',
+                    'negate' => '1'
+                ]
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met because of negate but is not met');
+    }
+
+}


### PR DESCRIPTION
This pr:

* Adds the evaluation for requirements again.
* Requirements are evaluated on usedFacats and the property is requirementMet is set to false, when a facet has requirments that are not met.

Fixes: #1399