### PR TITLE
[FEATURE] Rootpage without defautllanguage

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -27,10 +27,10 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 use Apache_Solr_Document;
 use Apache_Solr_Response;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\FieldProcessor\Service;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Util;
@@ -554,7 +554,13 @@ class Indexer extends AbstractIndexer
             $siteLanguages[] = $solrConfiguration['language'];
         }
 
-        $translationOverlays = $this->getTranslationOverlaysForPage($pageId, $site->getSysLanguageMode());
+        $defaultLanguageUid = $this->getDefaultLanguageUid($item, $site->getRootPage(), $siteLanguages);
+
+        $translationOverlays = $this->getTranslationOverlaysForPage(
+            $pageId,
+            $site->getSysLanguageMode($defaultLanguageUid)
+        );
+
         foreach ($translationOverlays as $key => $translationOverlay) {
             if (!in_array($translationOverlay['sys_language_uid'],
                 $siteLanguages)
@@ -566,12 +572,38 @@ class Indexer extends AbstractIndexer
         $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId, 0, $item->getMountPointIdentifier());
         $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays);
 
-        $solrConnections[0] = $defaultConnection;
+        if ($defaultLanguageUid == 0) {
+            $solrConnections[0] = $defaultConnection;
+        }
+
         foreach ($translationConnections as $systemLanguageUid => $solrConnection) {
             $solrConnections[$systemLanguageUid] = $solrConnection;
         }
 
         return $solrConnections;
+    }
+
+    /**
+     * @param Item $item An index queue item
+     * @param array $rootPage
+     * @param array $siteLanguages
+     *
+     * @return int
+     * @throws \Apache_Solr_Exception
+     */
+    private function getDefaultLanguageUid(Item $item, array $rootPage, array $siteLanguages)
+    {
+        $defaultLanguageUid = 0;
+        if (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) > 1) {
+            unset($siteLanguages[array_search('0', $siteLanguages)]);
+            $defaultLanguageUid = $siteLanguages[min(array_keys($siteLanguages))];
+        } elseif (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) == 1) {
+            throw new \Apache_Solr_Exception('Root page ' .
+                                             $item->getRootPageUid() .
+                                             ' is set to hide default translation, but no other language is configured!');
+        }
+
+        return $defaultLanguageUid;
     }
 
     /**

--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -314,12 +314,14 @@ class Site
     /**
      * Gets the site's config.sys_language_mode setting
      *
+     * @param int $languageUid
+     *
      * @return string The site's config.sys_language_mode
      */
-    public function getSysLanguageMode()
+    public function getSysLanguageMode($languageUid = 0)
     {
         if (is_null($this->sysLanguageMode)) {
-            Util::initializeTsfe($this->getRootPageId());
+            Util::initializeTsfe($this->getRootPageId(), $languageUid);
             $this->sysLanguageMode = $GLOBALS['TSFE']->sys_language_mode;
         }
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_with_rootPage_set_to_hide_default_language.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_with_rootPage_set_to_hide_default_language.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_registry>
+		<uid>4711</uid>
+		<entry_namespace>tx_solr</entry_namespace>
+		<entry_key>servers</entry_key>
+		<entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_en/";}}</entry_value>
+	</sys_registry>
+
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 1
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    category_stringM = SOLR_RELATION
+                                    category_stringM {
+                                        localField = tags
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<extendToSubpages>1</extendToSubpages>
+		<l18n_cfg>1</l18n_cfg>
+	</pages>
+
+	<pages_language_overlay>
+		<uid>2</uid>
+		<pid>1</pid>
+		<sys_language_uid>1</sys_language_uid>
+		<doktype>1</doktype>
+	</pages_language_overlay>
+
+	<sys_language>
+		<uid>1</uid>
+		<title>English</title>
+	</sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Charset\CharsetConverter;
@@ -343,5 +344,28 @@ class IndexerTest extends IntegrationTest
         }
 
         return $result;
+    }
+
+    /**
+     * @test
+     */
+    public function getSolrConnectionsByItemReturnsNoDefaultConnectionIfRootPageIsHideDefaultLanguage()
+    {
+        $this->importDataSetFromFixture('can_index_with_rootPage_set_to_hide_default_language.xml');
+        $itemMetaData = [
+            'uid' => 1,
+            'root' => 1,
+            'item_type' => 'pages',
+            'item_uid' => 1,
+            'indexing_configuration' => '',
+            'has_indexing_properties' => false
+        ];
+        $item = new Item($itemMetaData);
+
+        $result = $this->callInaccessibleMethod($this->indexer,'getSolrConnectionsByItem', $item);
+
+        $this->assertInstanceOf(SolrService::class, $result[1], "Expect SolrService object in connection array item with key 1.");
+        $this->assertCount(1, $result, "Expect only one SOLR connection.");
+        $this->assertArrayNotHasKey(0, $result, "Expect, that there is no solr connection returned for default language,");
     }
 }


### PR DESCRIPTION
If the root page is set to 'hide default translation of page' this causes a 404 in TypoScriptFrontendController with initializing the TSFE. To avoid this a language uid has to be thrown to the initialize function.