### PR TITLE
[TASK] Migrate SolrConfigurationStatus::getPages to use PagesRepository (#1372)

### DIFF
--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Report;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\SystemDomain\SystemDomainRepository;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
@@ -195,13 +196,9 @@ class SolrConfigurationStatus extends AbstractSolrStatus
      */
     protected function getRootPages()
     {
-        return $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-            'uid, title',
-            'pages',
-            'is_siteroot = 1 AND deleted = 0 AND hidden = 0 AND pid != -1 AND doktype IN(1,4) ',
-            '', '', '',
-            'uid'
-        );
+        $pagesRepository = GeneralUtility::makeInstance(PagesRepository::class);
+
+        return $pagesRepository->findAllRootPages();
     }
 
     /**


### PR DESCRIPTION
Use PagesRepository::findAllRootPages instead of $GLOBALS['TYPO3_DB']

Fixes: #1372 