### PR TITLE
[BUG] Language is lost for link in custom record with sys_language_mode = content_fallback

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.xml
@@ -15,9 +15,10 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-
                 config.sys_language_mode = ignore
                 config.sys_language_uid = 0
+                config.linkVars = L
+
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
@@ -59,24 +60,26 @@
                             foo = 1
                             foo {
                                 table = tx_fakeextension_domain_model_bar
-
                                 fields {
                                     title = title
-                                    category_stringM = SOLR_RELATION
-                                    category_stringM {
-                                        localField = tags
-                                        multiValue = 1
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}&L={field:__solr_index_language}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-
                 [globalVar = GP:L = 1]
                     plugin.tx_solr.solr.path = /solr/core_de/
                     config.sys_language_uid = 1
                 [end]
+
             ]]>
         </config>
         <sorting>100</sorting>
@@ -95,7 +98,7 @@
     <tx_fakeextension_domain_model_bar>
         <uid>88</uid>
         <pid>1</pid>
-        <title>orignal</title>
+        <title>original</title>
     </tx_fakeextension_domain_model_bar>
 
     <tx_fakeextension_domain_model_bar>
@@ -106,21 +109,28 @@
         <l10n_parent>88</l10n_parent>
     </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_related_mm>
-        <uid_local>99</uid_local>
-        <uid_foreign>12</uid_foreign>
-        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
-    </tx_fakeextension_domain_model_related_mm>
-
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>8</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
         <pid>1</pid>
-        <tag>the tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>12</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
         <pid>1</pid>
-        <tag>translated tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.xml
@@ -15,9 +15,10 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-
                 config.sys_language_mode = ignore
                 config.sys_language_uid = 0
+                config.linkVars = L
+
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
@@ -59,24 +60,26 @@
                             foo = 1
                             foo {
                                 table = tx_fakeextension_domain_model_bar
-
                                 fields {
                                     title = title
-                                    category_stringM = SOLR_RELATION
-                                    category_stringM {
-                                        localField = tags
-                                        multiValue = 1
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-
                 [globalVar = GP:L = 1]
                     plugin.tx_solr.solr.path = /solr/core_de/
                     config.sys_language_uid = 1
                 [end]
+
             ]]>
         </config>
         <sorting>100</sorting>
@@ -95,7 +98,7 @@
     <tx_fakeextension_domain_model_bar>
         <uid>88</uid>
         <pid>1</pid>
-        <title>orignal</title>
+        <title>original</title>
     </tx_fakeextension_domain_model_bar>
 
     <tx_fakeextension_domain_model_bar>
@@ -106,21 +109,29 @@
         <l10n_parent>88</l10n_parent>
     </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_related_mm>
-        <uid_local>99</uid_local>
-        <uid_foreign>12</uid_foreign>
-        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
-    </tx_fakeextension_domain_model_related_mm>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>8</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
         <pid>1</pid>
-        <tag>the tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>12</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
         <pid>1</pid>
-        <tag>translated tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.xml
@@ -15,9 +15,11 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-
-                config.sys_language_mode = ignore
+                config.sys_language_overlay = hideNonTranslated
+                config.sys_language_mode = content_fallback; 0
                 config.sys_language_uid = 0
+                config.linkVars = L
+
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
@@ -59,24 +61,26 @@
                             foo = 1
                             foo {
                                 table = tx_fakeextension_domain_model_bar
-
                                 fields {
                                     title = title
-                                    category_stringM = SOLR_RELATION
-                                    category_stringM {
-                                        localField = tags
-                                        multiValue = 1
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-
                 [globalVar = GP:L = 1]
                     plugin.tx_solr.solr.path = /solr/core_de/
                     config.sys_language_uid = 1
                 [end]
+
             ]]>
         </config>
         <sorting>100</sorting>
@@ -91,11 +95,13 @@
         <pid>1</pid>
         <sys_language_uid>1</sys_language_uid>
         <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
     </pages_language_overlay>
     <tx_fakeextension_domain_model_bar>
         <uid>88</uid>
         <pid>1</pid>
-        <title>orignal</title>
+        <title>original</title>
     </tx_fakeextension_domain_model_bar>
 
     <tx_fakeextension_domain_model_bar>
@@ -106,21 +112,29 @@
         <l10n_parent>88</l10n_parent>
     </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_related_mm>
-        <uid_local>99</uid_local>
-        <uid_foreign>12</uid_foreign>
-        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
-    </tx_fakeextension_domain_model_related_mm>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>8</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
         <pid>1</pid>
-        <tag>the tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_mmrelated>
-        <uid>12</uid>
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
         <pid>1</pid>
-        <tag>translated tag</tag>
-    </tx_fakeextension_domain_model_mmrelated>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -101,13 +101,68 @@ class IndexerTest extends IntegrationTest
     }
 
     /**
+     * @return array
+     */
+    public function getTranslatedRecordDataProvider()
+    {
+        return [
+            'with_l_paramater' => ['can_index_custom_translated_record_with_l_param.xml'],
+            'without_l_paramater' => ['can_index_custom_translated_record_without_l_param.xml'],
+            'without_l_paramater_and_content_fallback' => ['can_index_custom_translated_record_without_l_param_and_content_fallback.xml']
+        ];
+    }
+
+    /**
+     * @dataProvider getTranslatedRecordDataProvider
+     * @test
+     */
+    public function testCanIndexTranslatedCustomRecord($fixture)
+    {
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+
+        // create fake extension database table and TCA
+        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+
+        $this->importDataSetFromFixture($fixture);
+
+        $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
+        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+
+        $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 777);
+        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+
+        // do we have the record in the index with the value from the mm relation?
+        $this->waitToBeVisibleInSolr('core_en');
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+        $this->assertContains('"numFound":2', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"title":"original"', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"title":"original2"', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"url":"index.php?id=1&L=0&tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
+        $this->assertContains('"url":"index.php?id=1&L=0&tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
+
+        $this->waitToBeVisibleInSolr('core_de');
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_de/select?q=*:*');
+        $this->assertContains('"numFound":2', $solrContent, 'Could not find translated record in solr document into solr');
+        $this->assertContains('"title":"translation"', $solrContent, 'Could not index  translated document into solr');
+        $this->assertContains('"title":"translation2"', $solrContent, 'Could not index  translated document into solr');
+        $this->assertContains('"url":"index.php?id=1&L=1&tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
+        $this->assertContains('"url":"index.php?id=1&L=1&tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
+
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+    }
+
+    /**
      * This testcase should check if we can queue an custom record with MM relations.
      *
      * @test
      */
     public function canIndexTranslatedItemWithMMRelation()
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
 
         // create fake extension database table and TCA
         $this->importDumpFromFixture('fake_extension2_table.sql');
@@ -119,14 +174,16 @@ class IndexerTest extends IntegrationTest
         $this->assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
-        $this->waitToBeVisibleInSolr();
-        $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+        $this->waitToBeVisibleInSolr('core_de');
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_de/select?q=*:*');
 
         $this->assertContains('"category_stringM":["translated tag"]', $solrContent, 'Did not find MM related tag');
         $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
         $this->assertContains('"title":"translation"', $solrContent, 'Could not index document into solr');
-        $this->cleanUpSolrServerAndAssertEmpty();
-    }
+
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+     }
 
     /**
      * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -63,6 +63,15 @@ abstract class IntegrationTest extends FunctionalTestCase
     ];
 
     /**
+     * @var array
+     */
+    protected $testSolrCores = [
+        'core_en',
+        'core_de',
+        'core_dk'
+    ];
+
+    /**
      * @return void
      */
     public function setUp()
@@ -183,12 +192,15 @@ abstract class IntegrationTest extends FunctionalTestCase
     }
 
     /**
+     * @param string $coreName
      * @return void
      */
-    protected function cleanUpSolrServerAndAssertEmpty()
+    protected function cleanUpSolrServerAndAssertEmpty($coreName = 'core_en')
     {
+        $this->validateTestCoreName($coreName);
+
         // cleanup the solr server
-        $result = file_get_contents('http://localhost:8999/solr/core_en/update?stream.body=<delete><query>*:*</query></delete>&commit=true');
+        $result = file_get_contents('http://localhost:8999/solr/' . $coreName . '/update?stream.body=<delete><query>*:*</query></delete>&commit=true');
 
         if (strpos($result, '<int name="QTime">') == false) {
             $this->fail('Could not empty solr test index');
@@ -201,12 +213,25 @@ abstract class IntegrationTest extends FunctionalTestCase
     }
 
     /**
+     * @param string $coreName
      * @return void
      */
-    protected function waitToBeVisibleInSolr()
+    protected function waitToBeVisibleInSolr($coreName = 'core_en')
     {
-        $url = 'http://localhost:8999/solr/core_en/update?softCommit=true';
+        $this->validateTestCoreName($coreName);
+        $url = 'http://localhost:8999/solr/' . $coreName . '/update?softCommit=true';
         get_headers($url);
+    }
+
+    /**
+     * @param string $coreName
+     * @throws \InvalidArgumentException
+     */
+    protected function validateTestCoreName($coreName)
+    {
+        if(!in_array($coreName, $this->testSolrCores)) {
+            throw new \InvalidArgumentException('No valid testcore passed');
+        }
     }
 
     /**


### PR DESCRIPTION
This PR:

* Removes the cache for $TSFE->sys_language_contentOL and intializes tsfe for every record (Util::initializeTsfe is cached anyways)
* Adds an integration test for the scenario (config.sys_language_mode = content_fallback; 0)

Fixes: #1416