### PR TITLE
[TASK] Check in default template if several partials should be used

### DIFF
--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -54,11 +54,20 @@
 
 	<div id="tx-solr-search-functions">
 		<f:if condition="{hasSearched}">
-			<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
-			<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
+			<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchSorting}">
+				<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
+			</f:if>
+			<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchFaceting}">
+				<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
+			</f:if>
 		</f:if>
-		<f:render partial="Search/LastSearches" section="LastSearches" arguments="{resultSet:resultSet}" />
-		<f:render partial="Search/FrequentlySearched" section="FrequentlySearched" />
+
+		<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchLastSearches}">
+			<f:render partial="Search/LastSearches" section="LastSearches" arguments="{resultSet:resultSet}" />
+		</f:if>
+		<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchFrequentSearches}">
+			<f:render partial="Search/FrequentlySearched" section="FrequentlySearched" />
+		</f:if>
 	</div>
 
 </f:section>


### PR DESCRIPTION
This PR:

* Adds a check to the default template if the frequentSearches, lastSearches, faceting or sorting is active and only render the partial when this is the case.

Note: If you do not use these features, please remove the rendering from your templates.

Fixes: #1423