### PR TITLE
[TASK] Remove usage of GeneralUtility::removeXSS

### DIFF
--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -1105,8 +1105,7 @@ class Query
     public static function cleanKeywords($keywords)
     {
         $keywords = trim($keywords);
-        $keywords = GeneralUtility::removeXSS($keywords);
-        $keywords = htmlentities($keywords, ENT_QUOTES, $GLOBALS['TSFE']->metaCharset);
+        $keywords = htmlspecialchars($keywords);
         return $keywords;
     }
 


### PR DESCRIPTION
The method GeneralUtility::removeXSS has been deprecated in CMS8 ans
has been removed in CMS9. Replace it by calls to htmlspecialchars().

Resolves: #1439