### PR TITLE
[TASK] Make HelpButtonViewHelper compilable

### DIFF
--- a/Classes/ViewHelpers/Backend/Button/HelpButtonViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Button/HelpButtonViewHelper.php
@@ -26,13 +26,17 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Button;
 
 use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrViewHelper;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * View helper to return a help button
  *
  */
-class HelpButtonViewHelper extends AbstractSolrViewHelper
+class HelpButtonViewHelper extends AbstractSolrViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -40,18 +44,26 @@ class HelpButtonViewHelper extends AbstractSolrViewHelper
     protected $escapeOutput = false;
 
     /**
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('title', 'string', 'Title', true);
+        $this->registerArgument('description', 'string', 'Description', true);
+    }
+
+    /**
      * Render a help button wit the given title and content
      *
-     * @param string $title Help title
-     * @return mixed
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
      */
-    public function render($title)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $content = $this->renderChildren();
-
         return BackendUtility::wrapInHelp('', '', '', [
-            'title' => $title,
-            'description' => $content
+            'title' => $arguments['title'],
+            'description' => $arguments['description']
         ]);
     }
 }

--- a/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
@@ -123,10 +123,7 @@
 					<f:format.raw>{indexQueueInitializationSelector}</f:format.raw>
 				</div>
 				<f:form.submit name="initializeIndexQueue" value="Queue Selected Content for Indexing" class="btn btn-sm btn-default"/>
-				<solr:backend.button.HelpButton title="Index Queue Initialization">
-					<f:translate key="solr.backend.index_queue_module.help" />
-				</solr:backend.button.HelpButton>
-
+				<solr:backend.button.helpButton title="Index Queue Initialization" description="{f:translate(key:'solr.backend.index_queue_module.help')}" />
 			</f:form>
 		</div>
 	</div>


### PR DESCRIPTION
As the render method is deprecated and compilable is faster
there is no reason not to change the ViewHelper.

Resolves: #1453