### PR TITLE
[BUGFIX] Fix usage of NullTimeTracker

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -390,7 +390,7 @@ class Util
         $cacheId = $pageId . '|' . $language;
 
         if (!is_object($GLOBALS['TT'])) {
-            $GLOBALS['TT'] = GeneralUtility::makeInstance(TimeTracker::class);
+            $GLOBALS['TT'] = GeneralUtility::makeInstance(TimeTracker::class, false);
         }
 
         if (!isset($tsfeCache[$cacheId]) || !$useCache) {

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -34,7 +34,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
+use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -390,7 +390,7 @@ class Util
         $cacheId = $pageId . '|' . $language;
 
         if (!is_object($GLOBALS['TT'])) {
-            $GLOBALS['TT'] = GeneralUtility::makeInstance(NullTimeTracker::class);
+            $GLOBALS['TT'] = GeneralUtility::makeInstance(TimeTracker::class);
         }
 
         if (!isset($tsfeCache[$cacheId]) || !$useCache) {


### PR DESCRIPTION
The NullTimeTracker has been deprecated with CMS8 and removed with
CMS9. Switch to the regular TimeTracker.

Resolves: #1461