### PR TITLE
[TASK] Use strict string comparion

### DIFF
--- a/Classes/Access/RootlineElement.php
+++ b/Classes/Access/RootlineElement.php
@@ -96,7 +96,7 @@ class RootlineElement
     {
         $elementAccess = explode(self::PAGE_ID_GROUP_DELIMITER, $element);
 
-        if (count($elementAccess) === 1 || $elementAccess[0] == 'c') {
+        if (count($elementAccess) === 1 || $elementAccess[0] === 'c') {
             // the content access groups part of the access rootline
             $this->type = self::ELEMENT_TYPE_CONTENT;
 
@@ -105,7 +105,7 @@ class RootlineElement
             } else {
                 $elementGroups = $elementAccess[1];
             }
-        } elseif ($elementAccess[0] == 'r') {
+        } elseif ($elementAccess[0] === 'r') {
             // record element type
             if (count($elementAccess) !== 2) {
                 throw new RootlineElementFormatException(

--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -163,7 +163,7 @@ class IndexingConfigurationSelectorField
 
         foreach ($tablesToIndex as $configurationName => $tableName) {
             $icon = 'tcarecords-' . $tableName . '-default';
-            if ($tableName == 'pages') {
+            if ($tableName === 'pages') {
                 $icon = 'apps-pagetree-page-default';
             }
 

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -245,7 +245,7 @@ class Relation
      */
     protected function getTranslationOverlay($tableName, $record)
     {
-        if ($tableName == 'pages') {
+        if ($tableName === 'pages') {
             return $GLOBALS['TSFE']->sys_page->getPageOverlay($record, $GLOBALS['TSFE']->sys_language_uid);
         }
 

--- a/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
+++ b/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
@@ -91,7 +91,7 @@ class FrequentSearchesService
         } else {
             $terms = $this->getFrequentSearchTermsFromStatistics($frequentSearchConfiguration);
 
-            if ($frequentSearchConfiguration['sortBy'] == 'hits') {
+            if ($frequentSearchConfiguration['sortBy'] === 'hits') {
                 arsort($terms);
             } else {
                 ksort($terms);

--- a/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
@@ -238,7 +238,7 @@ class Faceting implements ParameterBuilder
         $solrSorting = $this->sorting;
 
         // alpha and lex alias for index
-        if ($this->sorting == 'alpha' || $this->sorting == 'lex') {
+        if ($this->sorting === 'alpha' || $this->sorting === 'lex') {
             $solrSorting = 'index';
         }
 

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -166,7 +166,7 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             }
 
             // the key contains the misspelled word expect the internal key "collation"
-            if ($key == 'collation') {
+            if ($key === 'collation') {
                 continue;
             }
             //create the spellchecking object structure

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -82,10 +82,10 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         DataHandler $tceMain
     ) {
         // workspaces: collect garbage only for LIVE workspace
-        if ($command == 'delete' && $GLOBALS['BE_USER']->workspace == 0) {
+        if ($command === 'delete' && $GLOBALS['BE_USER']->workspace == 0) {
             $this->collectGarbage($table, $uid);
 
-            if ($table == 'pages') {
+            if ($table === 'pages') {
                 $this->getIndexQueue()->deleteItem($table, $uid);
             }
         }
@@ -123,7 +123,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      */
     public function collectGarbage($table, $uid)
     {
-        if ($table == 'tt_content' || $table == 'pages' || $table == 'pages_language_overlay') {
+        if ($table === 'tt_content' || $table === 'pages' || $table === 'pages_language_overlay') {
             $this->collectPageGarbage($table, $uid);
         } else {
             $this->collectRecordGarbage($table, $uid);
@@ -269,7 +269,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         DataHandler $tceMain
     ) {
         // workspaces: collect garbage only for LIVE workspace
-        if ($command == 'move' && $table == 'pages' && $GLOBALS['BE_USER']->workspace == 0) {
+        if ($command === 'move' && $table === 'pages' && $GLOBALS['BE_USER']->workspace == 0) {
             // TODO the below comment is not valid anymore, pid has been removed from doc ID
             // ...still needed?
 
@@ -353,7 +353,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         /** @noinspection PhpUnusedParameterInspection */
         DataHandler $tceMain
     ) {
-        if ($status == 'new') {
+        if ($status === 'new') {
             // a newly created record, skip
             return;
         }
@@ -377,12 +377,12 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
         if ($this->tcaService->isHidden($table, $record)
             || $this->isInvisibleByStartOrEndtime($table, $record)
             || $this->hasFrontendGroupsRemoved($table, $record)
-            || ($table == 'pages' && $this->isPageExcludedFromSearch($record))
-            || ($table == 'pages' && !$this->isIndexablePageType($record))
+            || ($table === 'pages' && $this->isPageExcludedFromSearch($record))
+            || ($table === 'pages' && !$this->isIndexablePageType($record))
         ) {
             $this->collectGarbage($table, $uid);
 
-            if ($table == 'pages') {
+            if ($table === 'pages') {
                 $this->deleteSubpagesWhenExtendToSubpagesIsSet($table, $uid, $fields);
             }
         }
@@ -416,7 +416,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      */
     protected function isRelatedQueueRecordMarkedAsIndexed($table, $record)
     {
-        if ($table == 'tt_content' || $table == 'pages_language_overlay') {
+        if ($table === 'tt_content' || $table === 'pages_language_overlay') {
             $table = 'pages';
             $uid = $record['pid'];
         } else {

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -540,7 +540,7 @@ class Indexer extends AbstractIndexer
         $solrConnections = [];
 
         $pageId = $item->getRootPageUid();
-        if ($item->getType() == 'pages') {
+        if ($item->getType() === 'pages') {
             $pageId = $item->getRecordUid();
         }
 

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -215,7 +215,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
         $pages = $this->getPages();
 
         $pageIdField = 'pid';
-        if ($this->type == 'pages') {
+        if ($this->type === 'pages') {
             $pageIdField = 'uid';
         }
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -329,13 +329,13 @@ class Queue
     private function addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId)
     {
         $additionalRecordFields = '';
-        if ($itemType == 'pages') {
+        if ($itemType === 'pages') {
             $additionalRecordFields = ', doktype, uid';
         }
 
         $record = $this->getRecordCached($itemType, $itemUid, $additionalRecordFields);
 
-        if (empty($record) || ($itemType == 'pages' && !Util::isAllowedPageType($record, $indexingConfiguration))) {
+        if (empty($record) || ($itemType === 'pages' && !Util::isAllowedPageType($record, $indexingConfiguration))) {
             return;
         }
 
@@ -401,7 +401,7 @@ class Queue
             $itemTypeHasStartTimeColumn = true;
             $changedTimeColumns .= ', ' . $GLOBALS['TCA'][$itemType]['ctrl']['enablecolumns']['starttime'];
         }
-        if ($itemType == 'pages') {
+        if ($itemType === 'pages') {
             // does not carry time information directly, but needed to support
             // canonical pages
             $changedTimeColumns .= ', content_from_pid';
@@ -414,7 +414,7 @@ class Queue
             $startTime = $record[$GLOBALS['TCA'][$itemType]['ctrl']['enablecolumns']['starttime']];
         }
 
-        if ($itemType == 'pages') {
+        if ($itemType === 'pages') {
             $record['uid'] = $itemUid;
             // overrule the page's last changed time with the most recent
             //content element change

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -128,7 +128,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         $value,
         DataHandler $tceMain
     ) {
-        if ($command == 'delete' && $table == 'tt_content' && $GLOBALS['BE_USER']->workspace == 0) {
+        if ($command === 'delete' && $table === 'tt_content' && $GLOBALS['BE_USER']->workspace == 0) {
             // skip workspaces: index only LIVE workspace
             $pid = $this->getValidatedPid($tceMain, $table, $uid);
             $this->indexQueue->updateItem('pages', $pid, time());
@@ -159,7 +159,7 @@ class RecordMonitor extends AbstractDataHandlerListener
 
         // track publish / swap events for records (workspace support)
         // command "version"
-        if ($command == 'version' && $value['action'] == 'swap') {
+        if ($command === 'version' && $value['action'] === 'swap') {
             switch ($table) {
                 /** @noinspection PhpMissingBreakStatementInspection */
                 case 'tt_content':
@@ -207,7 +207,7 @@ class RecordMonitor extends AbstractDataHandlerListener
             }
         }
 
-        if ($command == 'move' && $table == 'pages' && $GLOBALS['BE_USER']->workspace == 0) {
+        if ($command === 'move' && $table === 'pages' && $GLOBALS['BE_USER']->workspace == 0) {
             // moving pages in LIVE workspace
             $solrConfiguration = Util::getSolrConfigurationFromPageId($uid);
             $record = $this->configurationAwareRecordService->getRecord('pages', $uid, $solrConfiguration);
@@ -248,7 +248,7 @@ class RecordMonitor extends AbstractDataHandlerListener
             return;
         }
 
-        if ($status == 'new') {
+        if ($status === 'new') {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];
         }
         if (Util::isDraftRecord($table, $recordUid)) {
@@ -259,7 +259,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         $recordPageId = $this->getRecordPageId($status, $recordTable, $recordUid, $uid, $fields, $tceMain);
 
         // when a content element changes we need to updated the page instead
-        if ($recordTable == 'tt_content') {
+        if ($recordTable === 'tt_content') {
             $recordTable = 'pages';
             $recordUid = $recordPageId;
         }
@@ -330,7 +330,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         // Clear existing index queue items to prevent mount point duplicates.
         // This needs to be done before the overlay handling, because handling an overlay record should
         // not trigger a deletion.
-        if ($recordTable == 'pages') {
+        if ($recordTable === 'pages') {
             $this->indexQueue->deleteItem('pages', $recordUid);
         }
 
@@ -339,7 +339,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         if ($isLocalizedRecord) {
             // if it's a localization overlay, update the original record instead
             $recordUid = $record[$GLOBALS['TCA'][$recordTable]['ctrl']['transOrigPointerField']];
-            if ($recordTable == 'pages_language_overlay') {
+            if ($recordTable === 'pages_language_overlay') {
                 $recordTable = 'pages';
             }
         }
@@ -353,7 +353,7 @@ class RecordMonitor extends AbstractDataHandlerListener
             $this->indexQueue->updateItem($recordTable, $recordUid);
         }
 
-        if ($recordTable == 'pages') {
+        if ($recordTable === 'pages') {
             $this->doPagesPostUpdateOperations($fields, $recordUid);
         }
     }
@@ -423,9 +423,9 @@ class RecordMonitor extends AbstractDataHandlerListener
      */
     protected function getRecordPageId($status, $recordTable, $recordUid, $originalUid, array $fields, DataHandler $tceMain)
     {
-        if ($status == 'update' && !isset($fields['pid'])) {
+        if ($status === 'update' && !isset($fields['pid'])) {
             $recordPageId = $this->getValidatedPid($tceMain, $recordTable, $recordUid);
-            if (($recordTable == 'pages') && ($this->rootPageResolver->getIsRootPageId($recordUid))) {
+            if (($recordTable === 'pages') && ($this->rootPageResolver->getIsRootPageId($recordUid))) {
                 $recordPageId = $originalUid;
             }
 

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -1345,7 +1345,7 @@ class Query
     {
         $sortParameter = $sorting;
         list($sortField) = explode(' ', $sorting);
-        if ($sortField == 'relevance') {
+        if ($sortField === 'relevance') {
             $sortParameter = '';
             return $sortParameter;
         }

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -153,7 +153,7 @@ class Faceting implements Modifier, SearchRequestAware
             $facetConfiguration = $allFacets[$facetName . '.'];
             $tag = $this->getFilterTag($facetConfiguration, $keepAllFacetsOnSelection);
             $filterParts = $this->getFilterParts($facetConfiguration, $facetName, $filterValues);
-            $operator = ($facetConfiguration['operator'] == 'OR') ? ' OR ' : ' AND ';
+            $operator = ($facetConfiguration['operator'] === 'OR') ? ' OR ' : ' AND ';
             $facetFilters[] = $tag . '(' . implode($operator, $filterParts) . ')';
         }
 

--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -200,7 +200,7 @@ class Site
         $pageIds = [];
         $maxDepth = intval($maxDepth);
 
-        if ($rootPageId == 'SITE_ROOT') {
+        if ($rootPageId === 'SITE_ROOT') {
             $rootPageId = $this->rootPage['uid'];
             $pageIds[] = (int)$this->rootPage['uid'];
         }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -350,7 +350,7 @@ class TypoScriptConfiguration
     {
         $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.additionalPageIds';
         $result = $this->getValueByPathOrDefaultValue($path, '');
-        if (trim($result) == '') {
+        if (trim($result) === '') {
             return $defaultIfEmpty;
         }
 
@@ -370,7 +370,7 @@ class TypoScriptConfiguration
     {
         $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.allowedPageTypes';
         $result = $this->getValueByPathOrDefaultValue($path, '');
-        if (trim($result) == '') {
+        if (trim($result) === '') {
             return $defaultIfEmpty;
         }
 
@@ -390,7 +390,7 @@ class TypoScriptConfiguration
         $path = 'plugin.tx_solr.index.queue.pages.excludeContentByClass';
         $result = $this->getValueByPathOrDefaultValue($path, '');
 
-        if (trim($result) == '') {
+        if (trim($result) === '') {
             return $defaultIfEmpty;
         }
 
@@ -444,7 +444,7 @@ class TypoScriptConfiguration
         foreach ($indexingConfigurations as $indexingConfigurationName) {
             $monitoredTable = $this->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
             $monitoredTables[] = $monitoredTable;
-            if ($monitoredTable == 'pages') {
+            if ($monitoredTable === 'pages') {
                 // when monitoring pages, also monitor creation of translations
                 $monitoredTables[] = 'pages_language_overlay';
             }
@@ -634,7 +634,7 @@ class TypoScriptConfiguration
         $possibleConfigurations = [];
 
         foreach ($configuration as $configurationName => $indexingEnabled) {
-            $isObject = substr($configurationName, -1) == '.';
+            $isObject = substr($configurationName, -1) === '.';
             if ($isObject || !$indexingEnabled) {
                 continue;
             }

--- a/Classes/System/Logging/DebugWriter.php
+++ b/Classes/System/Logging/DebugWriter.php
@@ -89,7 +89,7 @@ class DebugWriter
     {
         $parameters = ['extKey' => 'solr', 'msg' => $message, 'level' => $level, 'data' => $data];
         $message = isset($parameters['msg']) ? $parameters['msg'] : '';
-        if (TYPO3_MODE == 'BE') {
+        if (TYPO3_MODE === 'BE') {
             DebugUtility::debug($parameters, $parameters['extKey'], 'DevLog ext:solr: ' . $message);
         } else {
             echo $message . ':<br/>';

--- a/Classes/System/TCA/TCAService.php
+++ b/Classes/System/TCA/TCAService.php
@@ -80,7 +80,7 @@ class TCAService
             ||
             (isset($this->tca[$table]['ctrl']['delete']) && !empty($record[$this->tca[$table]['ctrl']['delete']]))
             ||
-            ($table == 'pages' && !empty($record['no_search']))
+            ($table === 'pages' && !empty($record['no_search']))
         ) {
             return false;
         }
@@ -220,7 +220,7 @@ class TCAService
             $fields[] = $this->tca[$table]['ctrl']['delete'];
         }
 
-        if ($table == 'pages') {
+        if ($table === 'pages') {
             $fields[] = 'no_search';
             $fields[] = 'doktype';
         }

--- a/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
@@ -74,13 +74,13 @@ class IndexQueueWorkerTaskAdditionalFieldProvider implements AdditionalFieldProv
             return $additionalFields;
         }
 
-        if ($schedulerModule->CMD == 'add') {
+        if ($schedulerModule->CMD === 'add') {
             $taskInfo['site'] = null;
             $taskInfo['documentsToIndexLimit'] = 50;
             $taskInfo['forcedWebRoot'] = '';
         }
 
-        if ($schedulerModule->CMD == 'edit') {
+        if ($schedulerModule->CMD === 'edit') {
             $taskInfo['site'] = $task->getSite();
             $taskInfo['documentsToIndexLimit'] = $task->getDocumentsToIndexLimit();
             $taskInfo['forcedWebRoot'] = $task->getForcedWebRoot();

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -108,7 +108,7 @@ class ReIndexTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
         $this->task = $task;
         $this->schedulerModule = $schedulerModule;
 
-        if ($schedulerModule->CMD == 'edit') {
+        if ($schedulerModule->CMD === 'edit') {
             $this->site = $task->getSite();
         }
     }


### PR DESCRIPTION
switch from `==` to `===`. Not done currently if compared to empty string or with integers to avoid side effects

Resolves: #1479