### PR TITLE
[!!!][TASK] Make custom templates configureable

### DIFF
--- a/Classes/Controller/Backend/PageModuleSummary.php
+++ b/Classes/Controller/Backend/PageModuleSummary.php
@@ -69,7 +69,7 @@ class PageModuleSummary
         $this->addSettingFromFlexForm('Results per Page', 'search.results.resultsPerPage');
         $this->addSettingFromFlexForm('Boost Function', 'search.query.boostFunction');
         $this->addSettingFromFlexForm('Boost Query', 'search.query.boostQuery');
-        $this->addSettingFromFlexForm('Template', 'templateFiles.results');
+        $this->addSettingFromFlexForm('Template', 'view.templateFiles.results');
         return $this->render();
     }
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -68,7 +68,12 @@ class SearchController extends AbstractBaseController
             if($customTemplate === '') {
                 return;
             }
-            $view->setTemplatePathAndFilename($customTemplate);
+
+            if(strpos($customTemplate, 'EXT:') !== false) {
+                $view->setTemplatePathAndFilename($customTemplate);
+            } else {
+                $view->setTemplate($customTemplate);
+            }
         }
     }
 
@@ -78,7 +83,7 @@ class SearchController extends AbstractBaseController
     protected function getCustomTemplateFromConfiguration()
     {
         $templateKey = str_replace('Action', '', $this->actionMethodName);
-        $customTemplate = $this->typoScriptConfiguration->getTemplateByFileKey($templateKey);
+        $customTemplate = $this->typoScriptConfiguration->getViewTemplateByFileKey($templateKey);
         return $customTemplate;
     }
 

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -2010,16 +2010,30 @@ class TypoScriptConfiguration
     /**
      * Returns the configured template for a specific template fileKey.
      *
-     * plugin.tx_solr.search.templateFiles.<fileKey>
+     * plugin.tx_solr.view.templateFiles.<fileKey>
      *
      * @param string $fileKey
      * @param string $defaultIfEmpty
      * @return string
      */
-    public function getTemplateByFileKey($fileKey, $defaultIfEmpty = '')
+    public function getViewTemplateByFileKey($fileKey, $defaultIfEmpty = '')
     {
-        $templateFileName = $this->getValueByPathOrDefaultValue('plugin.tx_solr.templateFiles.' . $fileKey, $defaultIfEmpty);
+        $templateFileName = $this->getValueByPathOrDefaultValue('plugin.tx_solr.view.templateFiles.' . $fileKey, $defaultIfEmpty);
         return (string)$templateFileName;
+    }
+
+    /**
+     * Returns the configured available template files for the flexform.
+     *
+     * plugin.tx_solr.view.templateFiles.[fileKey].availableTemplates.
+     *
+     * @param string $fileKey
+     * @return array
+     */
+    public function getAvailableTemplatesByFileKey($fileKey)
+    {
+        $path = 'plugin.tx_solr.view.templateFiles.' . $fileKey . '.availableTemplates.';
+        return (array)$this->getObjectByPathOrDefault($path, []);
     }
 
     /**

--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -40,17 +40,16 @@
                 </TCEforms>
                 <type>array</type>
                 <el>
-                    <templateFiles.form>
+                    <view.templateFiles.form>
                         <TCEforms>
-                            <exclude>1</exclude>
-                            <label>Custom Entry Template</label>
+                            <label>Custom Template</label>
                             <config>
-                                <type>input</type>
-                                <eval>trim</eval>
-                                <size>45</size>
+                                <section>1</section>
+                                <type>select</type>
+                                <itemsProcFunc>ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions->getAvailableTemplates</itemsProcFunc>
                             </config>
                         </TCEforms>
-                    </templateFiles.form>
+                    </view.templateFiles.form>
                     <view.pluginNamespace>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Configuration/FlexForms/Results.xml
+++ b/Configuration/FlexForms/Results.xml
@@ -155,17 +155,16 @@
                 </TCEforms>
                 <type>array</type>
                 <el>
-                    <templateFiles.results>
+                    <view.templateFiles.results>
                         <TCEforms>
-                            <exclude>1</exclude>
-                            <label>Custom Entry Template</label>
+                            <label>Custom Template</label>
                             <config>
-                                <type>input</type>
-                                <eval>trim</eval>
-                                <size>45</size>
+                                <section>1</section>
+                                <type>select</type>
+                                <itemsProcFunc>ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions->getAvailableTemplates</itemsProcFunc>
                             </config>
                         </TCEforms>
-                    </templateFiles.results>
+                    </view.templateFiles.results>
                     <view.pluginNamespace>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -17,15 +17,6 @@ plugin.tx_solr {
 		password = {$plugin.tx_solr.solr.password}
 	}
 
-	# By convention the templates get loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html
-	# If you want to define a different entry template, you can do this here to overwrite the convensional default template
-
-	#templateFiles {
-	#	frequentSearched = EXT:solr/Resources/Private/Templates/Search/FrequentlySearched.html
-	#	results = EXT:solr/Resources/Private/Templates/Search/Results.html
-	#	form = EXT:solr/Resources/Private/Templates/Search/Form.html
-	#}
-
 	index {
 		additionalFields {
 
@@ -251,6 +242,28 @@ plugin.tx_solr {
 
 	view {
 		pluginNamespace = tx_solr
+
+        // By convention the templates is loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html
+        // If you want to define a different entry template, you can do this here to overwrite the conventional default template
+        // if you want to use FLUID fallbacks you can just configure the template name, otherwise you could also use a full reference EXT:/.../
+        // The templates that you configure in availableTemplate can be used in the flexform by the editor to select a template for the concrete plugin instance.
+        templateFiles {
+            //	results = Results
+            //	results.availableTemplates {
+            // 		default {
+            // 			label = Default Searchresults Template
+            // 			file = Results
+            // 		}
+            //	}
+            //	form = Form
+            //	form.availableTemplates {
+            //	 	default {
+            //			label = Default Searchform Template
+            //			file = Form
+            // 		}
+            // }
+            //	frequentSearched = FrequentlySearched
+        }
 	}
 
 	logging {

--- a/Documentation/Configuration/Reference/TxSolrView.rst
+++ b/Documentation/Configuration/Reference/TxSolrView.rst
@@ -29,4 +29,96 @@ pluginNamespace
 :Since: 7.0
 :Default: tx_solr
 
-Plugin namespace. Can be used to change the plugin namespace and can be changed by instance in the flexform.
+    Plugin namespace. Can be used to change the plugin namespace and can be changed by instance in the flexform.
+
+
+templateFiles
+-------------
+
+By convention the templates is loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html.
+If you want to define a different entry template, you can do this here to overwrite the conventional default template.
+If you want to use FLUID fallbacks you can just configure the template name, otherwise you could also use a full reference EXT:/.../.
+
+The templates that you configure in availableTemplate can be used in the flexform by the editor to select a template for the concrete plugin instance.
+
+templateFiles.result
+--------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.view.templateFiles.result
+:Since: 7.0 (Replaces previous setting plugin.tx_solr.templateFiles.result)
+:Default: Results
+
+    By convention the "Results" template from you configured FLUID template path will be used As alternative you can configure a different template name here (e.g. MyResults or a full path to an entry template here).
+
+templateFiles.result.availableTemplates
+---------------------------------------
+
+:Type: Array
+:TS Path: plugin.tx_solr.view.templateFiles.result.availableTemplates
+:Since: 7.0
+:Default: none
+
+    Allows to configure templates that are available in the flexform to switch.
+
+    Example:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.view.templateFiles.results.availableTemplates {
+        default {
+            label = Default Searchresults Template
+            file = Results
+        }
+        finder {
+            label = Productfinder Template
+            file = ProductFinder
+        }
+    }
+
+
+templateFiles.form
+------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.view.templateFiles.form
+:Since: 7.0 (Replaces previous setting plugin.tx_solr.templateFiles.form)
+:Default: Form
+
+    By convention the "Form" template from you configured FLUID template path will be used . As alternative you can configure a different template name here (e.g. MyForm or a full path to an entry template here).
+
+templateFiles.form.availableTemplates
+-------------------------------------
+
+:Type: Array
+:TS Path: plugin.tx_solr.view.templateFiles.form.availableTemplates
+:Since: 7.0
+:Default: none
+
+    Allows to configure templates that are available in the flexform to switch.
+
+    Example:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.view.templateFiles.form.availableTemplates {
+        default {
+            label = Default Searchform Template
+            file = Form
+        }
+        specialform {
+            label = Extended Search Form
+            file = BetterForm
+        }
+    }
+
+
+templateFiles.frequentSearched
+------------------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.view.templateFiles.frequentSearched
+:Since: 7.0 (Replaces previous setting plugin.tx_solr.templateFiles.frequentSearched)
+:Default: FrequentlySearched
+
+    By convention the "FrequentlySearched" template from you configured FLUID template path will be used . As alternative you can configure a different template name here (e.g. FrequentlySearched or a full path to an entry template here).

--- a/Tests/Integration/Controller/Backend/Fixtures/fakeFlexform.xml
+++ b/Tests/Integration/Controller/Backend/Fixtures/fakeFlexform.xml
@@ -68,7 +68,7 @@
         </sheet>
         <sheet index="sOptions">
             <language index="lDEF">
-                <field index="templateFiles.results">
+                <field index="view.templateFiles.results">
                     <value index="vDEF">myTemplateFile.html</value>
                 </field>
             </language>

--- a/Tests/Integration/Controller/Fixtures/can_render_search_customTemplateFromTs.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_customTemplateFromTs.xml
@@ -56,10 +56,6 @@
                         path   = /solr/core_en/
                     }
 
-                    templateFiles {
-                    	results = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
-                    }
-
                     index {
                         additionalFields {
 
@@ -351,6 +347,13 @@
                     statistics = 1
                     statistics {
                         anonymizeIP = 0
+                    }
+
+
+                    view {
+                        templateFiles {
+                            results = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
+                        }
                     }
 
                     viewHelpers {

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -113,4 +113,39 @@ class FlexFormUserFunctionsTest extends UnitTest
         $userFunc->getFacetFieldsFromSchema($parentInformation);
         $this->assertCount(0, $parentInformation['items']);
     }
+
+    /**
+     * @test
+     */
+    public function canGetExpectedSelectOptions()
+    {
+        /** @var FlexFormUserFunctions $userFunc */
+        $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
+            ->setMethods([
+                'getAvailableTemplateFromTypoScriptConfiguration',
+                'getConfigurationFromPageId'
+            ])->getMock();
+
+        $userFunc->expects($this->once())->method('getAvailableTemplateFromTypoScriptConfiguration')
+            ->with(4711, 'results')
+            ->will($this->returnValue([
+            'myTemplate.' => [
+                'label' => 'MyCustomTemplate',
+                'file' => 'Results'
+            ]
+        ]));
+
+        $parentInformation = [
+            'flexParentDatabaseRow' => [
+                'pid' => 4711,
+            ],
+            'field' => 'view.templateFiles.results'
+        ];
+
+        $userFunc->getAvailableTemplates($parentInformation);
+
+        // we expect to get to options, the configured option and a default reset option
+        $this->assertCount(2, $parentInformation['items']);
+    }
+
 }


### PR DESCRIPTION
Until version 6.1.x you can define a custom entry template e.g. with

plugin.tx_solr.templateFiles.results = EXT:solr/Resources/Templates/PiResults/results.htm

Due to the move to FLUID this setting was moved to the "view" section.

plugin.tx_solr.view.templateFiles.results = EXT:solr/Resources/Templates/PiResults/results.htm

Beside that it also supports(and this is also recommended) to just use the templateName

plugin.tx_solr.templateFiles.results = MyResults

By using this, you can benefit from the fallback that FLUID provides

To make the life easier for editors, you can also define a set of availableTemplates, that are selectable in the flexform:

Example:

```
    plugin.tx_solr.view.templateFiles.results.availableTemplates {
        default {
            label = Default Searchresults Template
            file = Results
        }
        finder {
            label = Productfinder Template
            file = ProductFinder
        }
    }
```

Migration:

Use ``plugin.tx_solr.view.templateFiles``instead of ``plugin.tx_solr.templateFiles``

Fixes: #1412