### PR TITLE
[TASK] Make sure that UnitTest do not depend on proper logger configuration

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -71,11 +71,13 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
     /**
      * @param SystemLanguageRepository $systemLanguageRepository
      * @param PagesRepositoryAtExtSolr|null $pagesRepositoryAtExtSolr
+     * @param SolrLogManager $solrLogManager
      */
-    public function __construct(SystemLanguageRepository $systemLanguageRepository = null, PagesRepositoryAtExtSolr $pagesRepositoryAtExtSolr = null)
+    public function __construct(SystemLanguageRepository $systemLanguageRepository = null, PagesRepositoryAtExtSolr $pagesRepositoryAtExtSolr = null, SolrLogManager $solrLogManager = null)
     {
         $this->systemLanguageRepository = isset($systemLanguageRepository) ? $systemLanguageRepository : GeneralUtility::makeInstance(SystemLanguageRepository::class);
         $this->pagesRepositoryAtExtSolr = isset($pagesRepositoryAtExtSolr) ? $pagesRepositoryAtExtSolr : GeneralUtility::makeInstance(PagesRepositoryAtExtSolr::class);
+        $this->logger                   = isset($solrLogManager) ? $solrLogManager : GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     /**
@@ -96,7 +98,6 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
     public function getConnection($host = '', $port = 8983, $path = '/solr/', $scheme = 'http', $username = '', $password = '')
     {
         if (empty($host)) {
-            $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
             $this->logger->log(
                 SolrLogManager::WARNING,
                 'ApacheSolrForTypo3\Solr\ConnectionManager::getConnection() called with empty host parameter. Using configuration from TSFE, might be inaccurate. Always provide a host or use the getConnectionBy* methods.'

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -79,13 +79,14 @@ class IndexService
      * @param Site $site
      * @param Queue|null $queue
      * @param Dispatcher|null $dispatcher
+     * @param SolrLogManager|null $solrLogManager
      */
-    public function __construct(Site $site, Queue $queue = null, Dispatcher $dispatcher = null)
+    public function __construct(Site $site, Queue $queue = null, Dispatcher $dispatcher = null, SolrLogManager $solrLogManager = null)
     {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->site = $site;
         $this->indexQueue = is_null($queue) ? GeneralUtility::makeInstance(Queue::class) : $queue;
         $this->signalSlotDispatcher = is_null($dispatcher) ? GeneralUtility::makeInstance(Dispatcher::class) : $dispatcher;
+        $this->logger = is_null($solrLogManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $solrLogManager;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -98,12 +98,13 @@ class SearchResultSetService
     /**
      * @param TypoScriptConfiguration $configuration
      * @param Search $search
+     * @param SolrLogManager $solrLogManager
      */
-    public function __construct(TypoScriptConfiguration $configuration, Search $search)
+    public function __construct(TypoScriptConfiguration $configuration, Search $search, SolrLogManager $solrLogManager = null)
     {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
+        $this->logger = is_null($solrLogManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $solrLogManager;
     }
 
     /**
@@ -161,7 +162,7 @@ class SearchResultSetService
     protected function getPreparedQuery($rawQuery, $resultsPerPage)
     {
         /* @var $query Query */
-        $query = GeneralUtility::makeInstance(Query::class, $rawQuery, $this->typoScriptConfiguration);
+        $query = $this->getQueryInstance($rawQuery);
 
         $this->applyPageSectionsRootLineFilter($query);
 
@@ -753,5 +754,15 @@ class SearchResultSetService
         foreach ($response->response->docs as $searchResult) {
             $resultSet->addSearchResult($searchResult);
         }
+    }
+
+    /**
+     * @param string $rawQuery
+     * @return Query|object
+     */
+    protected function getQueryInstance($rawQuery)
+    {
+        $query = GeneralUtility::makeInstance(Query::class, $rawQuery, $this->typoScriptConfiguration);
+        return $query;
     }
 }

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -106,13 +106,16 @@ class PageIndexerRequest
      * PageIndexerRequest constructor.
      *
      * @param string $jsonEncodedParameters json encoded header
+     * @param SolrLogManager|null $solrLogManager
+     * @param ExtensionConfiguration|null $extensionConfiguration
      */
-    public function __construct($jsonEncodedParameters = null)
+    public function __construct($jsonEncodedParameters = null, SolrLogManager $solrLogManager = null, ExtensionConfiguration $extensionConfiguration = null)
     {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->requestId = uniqid();
         $this->timeout = (float)ini_get('default_socket_timeout');
-        $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+
+        $this->logger = is_null($solrLogManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $solrLogManager;
+        $this->extensionConfiguration = is_null($extensionConfiguration) ? GeneralUtility::makeInstance(ExtensionConfiguration::class) : $extensionConfiguration;
 
         if (is_null($jsonEncodedParameters)) {
             return;

--- a/Classes/Query.php
+++ b/Classes/Query.php
@@ -194,12 +194,13 @@ class Query
      * @param TypoScriptConfiguration $solrConfiguration
      * @param SiteHashService|null $siteHashService
      * @param EscapeService|null $escapeService
+     * @param SolrLogManager|null $solrLogManager
      */
-    public function __construct($keywords, $solrConfiguration = null, SiteHashService $siteHashService = null, EscapeService $escapeService = null)
+    public function __construct($keywords, $solrConfiguration = null, SiteHashService $siteHashService = null, EscapeService $escapeService = null, SolrLogManager $solrLogManager = null)
     {
         $keywords = (string)$keywords;
 
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+        $this->logger = is_null($solrLogManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $solrLogManager;
         $this->solrConfiguration = is_null($solrConfiguration) ? Util::getSolrConfiguration() : $solrConfiguration;
         $this->siteHashService = is_null($siteHashService) ? GeneralUtility::makeInstance(SiteHashService::class) : $siteHashService;
         $this->escapeService = is_null($escapeService) ? GeneralUtility::makeInstance(EscapeService::class) : $escapeService;

--- a/Classes/SolrService.php
+++ b/Classes/SolrService.php
@@ -168,6 +168,7 @@ class SolrService extends \Apache_Solr_Service
      * @param SynonymParser $synonymParser
      * @param StopWordParser $stopWordParser
      * @param SchemaParser $schemaParser
+     * @param SolrLogManager $logManager
      */
     public function __construct(
         $host = '',
@@ -177,11 +178,13 @@ class SolrService extends \Apache_Solr_Service
         TypoScriptConfiguration $typoScriptConfiguration = null,
         SynonymParser $synonymParser = null,
         StopWordParser $stopWordParser = null,
-        SchemaParser $schemaParser = null
+        SchemaParser $schemaParser = null,
+        SolrLogManager $logManager = null
     ) {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 
         $this->setScheme($scheme);
+
+        $this->logger = is_null($logManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $logManager;
         $this->configuration = is_null($typoScriptConfiguration) ? Util::getSolrConfiguration() : $typoScriptConfiguration;
         $this->synonymParser = is_null($synonymParser) ? GeneralUtility::makeInstance(SynonymParser::class) : $synonymParser;
         $this->stopWordParser = is_null($stopWordParser) ? GeneralUtility::makeInstance(StopWordParser::class) : $stopWordParser;

--- a/Classes/SuggestQuery.php
+++ b/Classes/SuggestQuery.php
@@ -23,7 +23,10 @@ namespace ApacheSolrForTypo3\Solr;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 
 /**
  * A query specialized to get search suggestions
@@ -47,15 +50,18 @@ class SuggestQuery extends Query
      *
      * @param string $keywords
      * @param TypoScriptConfiguration $solrConfiguration
+     * @param SiteHashService $siteHashService
+     * @param EscapeService $escapeService
+     * @param SolrLogManager $solrLogManager
      */
-    public function __construct($keywords, $solrConfiguration = null)
+    public function __construct($keywords, $solrConfiguration = null, SiteHashService $siteHashService = null, EscapeService $escapeService = null, SolrLogManager $solrLogManager = null)
     {
         $keywords = (string)$keywords;
         if ($solrConfiguration == null) {
             $solrConfiguration = Util::getSolrConfiguration();
         }
 
-        parent::__construct('', $solrConfiguration);
+        parent::__construct('', $solrConfiguration, $siteHashService, $escapeService, $solrLogManager);
 
         $this->configuration = $solrConfiguration->getObjectByPathOrDefault('plugin.tx_solr.suggest.', []);
 

--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -53,15 +53,32 @@ class SolrLogManager
     protected $debugWriter = null;
 
     /**
+     * @var string
+     */
+    protected $className = '';
+
+    /**
      * SolrLogManager constructor.
      *
-     * @param $className
+     * @param string $className
      * @param DebugWriter $debugWriter
      */
     public function __construct($className, DebugWriter $debugWriter = null)
     {
-        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger($className);
+        $this->className = $className;
         $this->debugWriter = isset($debugWriter) ? $debugWriter : GeneralUtility::makeInstance(DebugWriter::class);
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Log\Logger
+     */
+    protected function getLogger()
+    {
+        if ($this->logger === null) {
+            $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger($this->className);
+        }
+
+        return $this->logger;
     }
 
     /**
@@ -75,7 +92,7 @@ class SolrLogManager
      */
     public function log($level, $message, array $data = [])
     {
-        $this->logger->log($level, $message, $data);
+        $this->getLogger()->log($level, $message, $data);
         $this->debugWriter->write($level, $message, $data);
     }
 }

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -31,6 +31,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Statistics;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use Dkd\DkdReports\Reports\Status;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
@@ -61,12 +62,18 @@ class IndexServiceTest extends UnitTest
     protected $indexService;
 
     /**
+     * @var SolrLogManager
+     */
+    protected $logManagerMock;
+
+    /**
      * @return void
      */
     public function setUp() {
         $this->siteMock = $this->getDumbMock(Site::class);
         $this->queueMock = $this->getDumbMock(Queue::class);
         $this->dispatcherMock = $this->getDumbMock(Dispatcher::class);
+        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
     }
 
     /**
@@ -79,7 +86,7 @@ class IndexServiceTest extends UnitTest
 
         // we create an IndexeService where indexItem is mocked to avoid real indexing in the unit test
         $indexService = $this->getMockBuilder(IndexService::class)
-            ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock])
+            ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock, $this->logManagerMock])
             ->setMethods(['indexItem'])
             ->getMock();
 
@@ -106,7 +113,7 @@ class IndexServiceTest extends UnitTest
         $this->queueMock->expects($this->once())->method('getStatisticsBySite')->will($this->returnValue($statisticMock));
 
         $indexService = $this->getMockBuilder(IndexService::class)
-            ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock])
+            ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock, $this->logManagerMock])
             ->setMethods(['indexItem'])
             ->getMock();
 

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -128,7 +128,8 @@ class RepositoryTest extends UnitTest
         /* @var $apacheSolrDocumentRepository Repository */
         $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage', 'getSearch']);
         $apacheSolrDocumentRepository->expects($this->once())->method('getSearch')->willReturn($search);
-        $apacheSolrDocumentRepository->expects($this->any())->method('getQueryForPage')->willReturn(GeneralUtility::makeInstance(Query::class, ''));
+        $queryMock = $this->getDumbMock(Query::class);
+        $apacheSolrDocumentRepository->expects($this->any())->method('getQueryForPage')->willReturn($queryMock);
         $actualApacheSolrDocumentCollection = $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(777, 0);
 
         $this->assertSame($expectedApacheSolrDocumentCollection, $actualApacheSolrDocumentCollection);

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -26,12 +26,16 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
 use Apache_Solr_Response;
 use Apache_Solr_HttpTransport_Response;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
+use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Search\SpellcheckingComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
 
@@ -64,18 +68,49 @@ class SearchResultSetTest extends UnitTest
     protected $searchResultSetService;
 
     /**
+     * @var SolrLogManager
+     */
+    protected $solrLogManagerMock;
+
+    /**
+     * @var Query
+     */
+    protected $queryMock;
+
+    /**
+     * @var SiteHashService
+     */
+    protected $siteHashServiceMock;
+
+    /**
+     * @var EscapeService
+     */
+    protected $escapeServiceMock;
+
+    /**
      * @return void
      */
     public function setUp()
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->searchMock = $this->getDumbMock(Search::class);
-        $this->pluginMock = $this->getDumbMock(AbstractPlugin::class);
+        $this->solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+
+        $this->siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
+        $this->escapeServiceMock = $this->getDumbMock(EscapeService::class);
+        $this->escapeServiceMock->expects($this->any())->method('escape')->will($this->returnArgument(0));
 
         $this->searchResultSetService = $this->getMockBuilder(SearchResultSetService::class)
-            ->setMethods(['setPerPageInSession', 'getPerPageFromSession', 'getRegisteredSearchComponents'])
-            ->setConstructorArgs([$this->configurationMock, $this->searchMock, $this->pluginMock])
+            ->setMethods(['setPerPageInSession', 'getPerPageFromSession', 'getRegisteredSearchComponents', 'getQueryInstance'])
+            ->setConstructorArgs([$this->configurationMock, $this->searchMock, $this->solrLogManagerMock])
             ->getMock();
+
+        // @todo we should fake the result of getQueryInstance with a mock and move the tests that test Query partly into the QueryTest
+        $this->searchResultSetService->expects($this->any())->method('getQueryInstance')->will(
+            $this->returnCallback(function($queryString){
+                return new Query($queryString, $this->configurationMock, $this->siteHashServiceMock, $this->escapeServiceMock, $this->solrLogManagerMock);
+            })
+        );
     }
 
     /**
@@ -277,8 +312,16 @@ class SearchResultSetTest extends UnitTest
      */
     public function assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse($expextedQueryString, $expectedOffset, \Apache_Solr_Response $fakeResponse)
     {
-        $this->searchMock->expects($this->once())->method('search')->with($expextedQueryString, $expectedOffset, null)->will(
-            $this->returnValue($fakeResponse)
+        $this->searchMock->expects($this->once())->method('search')->will(
+            $this->returnCallback(
+                function(Query $query, $offset) use($expextedQueryString, $expectedOffset, $fakeResponse) {
+
+                    $this->assertSame($expextedQueryString, $query->getKeywords(), "Search was not triggered with an expected queryString");
+                    $this->assertSame($expectedOffset, $offset);
+                    return $fakeResponse;
+                }
+
+            )
         );
     }
 

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -24,16 +24,20 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetQueryBuilderRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetUrlDecoderRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Faceting;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Fluid\Core\Parser\Interceptor\Escape;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Faceting class
@@ -58,8 +62,12 @@ class FacetingTest extends UnitTest
         $facetRegistry = new FacetRegistry();
         $facetRegistry->injectObjectManager($fakeObjectManager);
 
+        $siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
+        $escapeServiceMock = $this->getDumbMock(EscapeService::class);
+        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+
         /** @var $query \ApacheSolrForTypo3\Solr\Query */
-        $query = GeneralUtility::makeInstance(Query::class, 'test', $fakeConfiguration);
+        $query = new Query('test', $fakeConfiguration, $siteHashServiceMock, $escapeServiceMock, $solrLogManagerMock);
         /** @var $facetModifier \ApacheSolrForTypo3\Solr\Query\Modifier\Faceting */
         $facetModifier = GeneralUtility::makeInstance(Faceting::class, $facetRegistry);
         $facetModifier->setSearchRequest($fakeSearchRequest);

--- a/Tests/Unit/QueryTest.php
+++ b/Tests/Unit/QueryTest.php
@@ -24,10 +24,13 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\ReturnFields;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -1432,7 +1435,13 @@ class QueryTest extends UnitTest
      */
     protected function getInitializedTestQuery($queryString = 'test', TypoScriptConfiguration $solrConfiguration = null)
     {
-        $query = GeneralUtility::makeInstance(Query::class, $queryString, $solrConfiguration);
+        $siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
+        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+
+        // since the escape service does not have any dependencies and is just doing some simple escape logic we pass a real instance
+        $escapeService = new EscapeService();
+
+        $query = new Query($queryString, $solrConfiguration, $siteHashServiceMock, $escapeService, $solrLogManagerMock);
         return $query;
     }
 }

--- a/Tests/Unit/SuggestQueryTest.php
+++ b/Tests/Unit/SuggestQueryTest.php
@@ -24,8 +24,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\SuggestQuery;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class
@@ -45,7 +48,11 @@ class SuggestQueryTest extends UnitTest
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $suggestQuery = new SuggestQuery('typ', $fakeConfiguration);
+        $siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
+        $escapeServiceMock = $this->getDumbMock(EscapeService::class);
+        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+
+        $suggestQuery = new SuggestQuery('typ', $fakeConfiguration, $siteHashServiceMock, $escapeServiceMock, $solrLogManagerMock);
 
         $this->assertFalse($suggestQuery->getIsCollapsing(), 'Collapsing should never be active for a suggest query, even when active');
     }


### PR DESCRIPTION
During the investigation for #1469 i recognized that the unit tests depend on a proper logger configuration. This is because the SolrLogManager is instanciated in many places and directly evaluatest the configuration.

To make the unit tests in dependent it should be possible to pass the SolrLogManager from outside and mock it.

Allong with that we should make sure that the logger is only instanciated when really something is logged.

Fixes: #1489