### PR TITLE
[BUGFIX] searchUsingSpellCheckerSuggestion not supported.

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -104,6 +104,21 @@ class SearchResultSet
     protected $sortings = null;
 
     /**
+     * @var bool
+     */
+    protected $isAutoCorrected = false;
+
+    /**
+     * @var string
+     */
+    protected $initialQueryString = '';
+
+    /**
+     * @var string
+     */
+    protected $correctedQueryString = '';
+
+    /**
      * @return \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet
      */
     public function __construct()
@@ -340,5 +355,53 @@ class SearchResultSet
     public function addSearchResult(SearchResult $searchResult)
     {
         $this->searchResults[] = $searchResult;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsAutoCorrected()
+    {
+        return $this->isAutoCorrected;
+    }
+
+    /**
+     * @param boolean $wasAutoCorrected
+     */
+    public function setIsAutoCorrected($wasAutoCorrected)
+    {
+        $this->isAutoCorrected = $wasAutoCorrected;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInitialQueryString()
+    {
+        return $this->initialQueryString;
+    }
+
+    /**
+     * @param string $initialQueryString
+     */
+    public function setInitialQueryString($initialQueryString)
+    {
+        $this->initialQueryString = $initialQueryString;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCorrectedQueryString()
+    {
+        return $this->correctedQueryString;
+    }
+
+    /**
+     * @param string $correctedQueryString
+     */
+    public function setCorrectedQueryString($correctedQueryString)
+    {
+        $this->correctedQueryString = $correctedQueryString;
     }
 }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1704,7 +1704,7 @@ class TypoScriptConfiguration
      * @param int $defaultIfEmpty
      * @return int
      */
-    public function getSearchSpellcheckingNumberOfSuggestionsToTry($defaultIfEmpty = 0)
+    public function getSearchSpellcheckingNumberOfSuggestionsToTry($defaultIfEmpty = 1)
     {
         return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.spellchecking.numberOfSuggestionsToTry', $defaultIfEmpty);
     }

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -128,7 +128,7 @@ plugin.tx_solr {
 		spellchecking {
 			wrap = |<div class="spelling-suggestions">###LLL:didYouMean### |</div>|
 			searchUsingSpellCheckerSuggestion = 0
-			numberOfSuggestionsToTry = 0
+			numberOfSuggestionsToTry = 1
 		}
 
 		lastSearches = 0

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -10,10 +10,21 @@
 
 		<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace, resultSet: resultSet}" />
 
-		<f:if condition="{resultSet.usedQuery.keywordsCleaned}">
-			<span class="searched-for">
-				<s:translate key="results_searched_for" arguments="{0:'\"{resultSet.usedQuery.keywordsCleaned}\"'}">Searched for %s</s:translate>
-			</span>
+		<f:if condition="{resultSet.isAutoCorrected}">
+			<f:then>
+				<span class="searched-for">
+					<s:translate key="no_results_nothing_found" arguments="{0: resultSet.initialQueryString}">Nothing found for "%s".</s:translate>
+					<s:translate key="no_results_search_for_original" arguments="{0: resultSet.correctedQueryString}">Search instead for "%s".</s:translate>
+				</span>
+			</f:then>
+
+			<f:else>
+				<f:if condition="{resultSet.usedQuery.keywordsCleaned}">
+					<span class="searched-for">
+						<s:translate key="results_searched_for" arguments="{0: resultSet.usedQuery.keywordsCleaned}">Searched for "%s"</s:translate>
+					</span>
+				</f:if>
+			</f:else>
 		</f:if>
 
 		<f:if condition="{resultSet.hasSpellCheckingSuggestions}">


### PR DESCRIPTION
This pr:

* Enables the setting searchUsingSpellCheckerSuggestion for the FLUID templating
* Adds a test case
* Set's the default Setting of numberOfSuggestionsToTry to 1 since 0 as default makes no sence

Fixes: #1468