### PR TITLE
[TASK] Test against TYPO3 dev-master with allow_failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,15 @@ env:
   matrix:
     - TYPO3_VERSION="^8.7"
     - TYPO3_VERSION="8.x-dev"
+    - TYPO3_VERSION="9.x-dev"
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: TYPO3_VERSION="9.x-dev"
+      php: 7.0
+    - env: TYPO3_VERSION="9.x-dev"
+      php: 7.1
 
 before_install:
   - composer self-update


### PR DESCRIPTION
This pr:

* Readds TYPO3 dev-master with allow_failure to keep track of problems with the current TYPO3 master

Fixes: #1499