### PR TITLE
[FEATURE] Allow to set the template of s:widget.resultPaginate

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
@@ -31,7 +31,13 @@ class ResultPaginateController extends AbstractWidgetController
     /**
      * @var array
      */
-    protected $configuration = ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'addQueryStringMethod' => ''];
+    protected $configuration = [
+        'insertAbove' => true,
+        'insertBelow' => true,
+        'maximumNumberOfLinks' => 10,
+        'addQueryStringMethod' => '',
+        'templatePath' => ''
+    ];
 
     /**
      * @var \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet
@@ -64,6 +70,11 @@ class ResultPaginateController extends AbstractWidgetController
     protected $numberOfPages = 1;
 
     /**
+     * @var string
+     */
+    protected $templatePath = '';
+
+    /**
      * @return void
      */
     public function initializeAction()
@@ -74,6 +85,9 @@ class ResultPaginateController extends AbstractWidgetController
         $this->configuration['itemsPerPage'] = $this->getItemsPerPage();
         $this->numberOfPages = (int)ceil($this->resultSet->getUsedSearch()->getNumberOfResults() / $this->configuration['itemsPerPage']);
         $this->maximumNumberOfLinks = (int)$this->configuration['maximumNumberOfLinks'];
+        if (!empty($this->configuration['templatePath'])) {
+            $this->templatePath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($this->configuration['templatePath']);
+        }
     }
 
     /**
@@ -109,6 +123,9 @@ class ResultPaginateController extends AbstractWidgetController
         $this->view->assign('contentArguments', [$this->widgetConfiguration['as'] => $this->getDocuments(), 'pagination' => $this->buildPagination()]);
         $this->view->assign('configuration', $this->configuration);
         $this->view->assign('resultSet', $this->resultSet);
+        if (!empty($this->templatePath)) {
+            $this->view->setTemplatePathAndFilename($this->templatePath);
+        }
     }
 
     /**

--- a/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
@@ -47,7 +47,7 @@ class ResultPaginateViewHelper extends AbstractWidgetViewHelper
      * @return \TYPO3\CMS\Extbase\Mvc\ResponseInterface
      * @throws \TYPO3\CMS\Fluid\Core\Widget\Exception\MissingControllerException
      */
-    public function render(SearchResultSet $resultSet, $as = 'documents', array $configuration = ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10])
+    public function render(SearchResultSet $resultSet, $as = 'documents', array $configuration = ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'templatePath' => ''])
     {
         return $this->initiateSubRequest();
     }


### PR DESCRIPTION
By using the following code it is now possible to override the path of the
ResultPaginateViewHelper by defining the path in the configuration attribute:

<s:widget.resultPaginate
	resultSet="{resultSet}"
	configuration="{templatePath:'EXT:theme/Resources/Private/Templates/Solr/Paginate.html'}"
>