### PR TITLE
[TASK] Get rid of dependency to sys_domain record.

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -28,8 +28,13 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Service\SiteService;
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * SiteRepository
@@ -181,11 +186,19 @@ class SiteRepository
      * Creates an instance of the Site object.
      *
      * @param integer $rootPageId
+     * @throws \InvalidArgumentException
      * @return Site
      */
     protected function buildSite($rootPageId)
     {
-        return GeneralUtility::makeInstance(Site::class, $rootPageId);
+        $rootPageRecord = (array)BackendUtility::getRecord('pages', $rootPageId);
+
+        $this->validateRootPageRecord($rootPageId, $rootPageRecord);
+        $solrConfiguration = Util::getSolrConfigurationFromPageId($rootPageId);
+        $domain = $this->getDomainFromConfigurationOrFallbackToDomainRecord($rootPageId);
+        $siteHash = $this->getSiteHashForDomain($domain);
+
+        return GeneralUtility::makeInstance(Site::class, $solrConfiguration, $rootPageRecord, $domain, $siteHash);
     }
 
     /**
@@ -197,5 +210,58 @@ class SiteRepository
     {
         $servers = (array)$this->registry->get('tx_solr', 'servers', []);
         return $servers;
+    }
+
+    /**
+     * @param $rootPageId
+     * @return NULL|string
+     */
+    protected function getDomainFromConfigurationOrFallbackToDomainRecord($rootPageId)
+    {
+            /** @var $siteService SiteService */
+        $siteService = GeneralUtility::makeInstance(SiteService::class);
+        $domain = $siteService->getFirstDomainForRootPage($rootPageId);
+        if ($domain === '') {
+            $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
+            $rootLine = $pageSelect->getRootLine($rootPageId);
+            $domain = BackendUtility::firstDomainRecord($rootLine);
+            return (string)$domain;
+        }
+
+        return $domain;
+    }
+
+    /**
+     * @param string $domain
+     * @return string
+     */
+    protected function getSiteHashForDomain($domain)
+    {
+        /** @var $siteHashService SiteHashService */
+        $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
+        $siteHash = $siteHashService->getSiteHashForDomain($domain);
+        return $siteHash;
+    }
+
+    /**
+     * @param int $rootPageId
+     * @param array $rootPageRecord
+     * @throws \InvalidArgumentException
+     */
+    protected function validateRootPageRecord($rootPageId, $rootPageRecord)
+    {
+        if (empty($rootPageRecord)) {
+            throw new \InvalidArgumentException(
+                'The rootPageRecord for the given rootPageRecord ID \'' . $rootPageId . '\' could not be found in the database and can therefore not be used as site root rootPageRecord.',
+                1487326416
+            );
+        }
+
+        if (!Site::isRootPage($rootPageRecord)) {
+            throw new \InvalidArgumentException(
+                'The rootPageRecord for the given rootPageRecord ID \'' . $rootPageId . '\' is not marked as root rootPageRecord and can therefore not be used as site root rootPageRecord.',
+                1309272922
+            );
+        }
     }
 }

--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Report;
 
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\SystemDomain\SystemDomainRepository;
+use ApacheSolrForTypo3\Solr\System\Service\SiteService;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -150,7 +151,21 @@ class SolrConfigurationStatus extends AbstractSolrStatus
 
         $domainRecords = $this->systemDomainRepository->findDomainRecordsByRootPagesIds($rootPageIds);
         foreach ($rootPageIds as $rootPageId) {
+            $hasDomainRecord = true;
+            $hasDomainInTypoScript = true;
+
             if (!array_key_exists($rootPageId, $domainRecords)) {
+                $hasDomainRecord = false;
+            }
+
+            /** @var $siteService SiteService */
+            $siteService = GeneralUtility::makeInstance(SiteService::class);
+            $domain = $siteService->getFirstDomainForRootPage($rootPageId);
+            if ($domain === '') {
+                $hasDomainInTypoScript = false;
+            }
+
+            if (!$hasDomainRecord && !$hasDomainInTypoScript) {
                 $rootPagesWithoutDomain[$rootPageId] = $rootPages[$rootPageId];
             }
         }

--- a/Classes/System/Service/SiteService.php
+++ b/Classes/System/Service/SiteService.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types = 1);
+
+namespace ApacheSolrForTypo3\Solr\System\Service;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Retrieves site related information.
+ *
+ * @todo When we have something like this available in TYPO39 and drop TYPO8 compatibility we can drop this class.
+ */
+class SiteService implements SingletonInterface
+{
+
+    /** @var array */
+    protected $sites = [];
+
+    /**
+     * Initialize domain configuration
+     * @param array $sites
+     */
+    public function __construct(array $sites = [])
+    {
+        $this->sites = (count($sites) === 0) ? (array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'] : $sites;
+    }
+
+    /**
+     * @param int $rootPageId
+     * @return string
+     */
+    public function getFirstDomainForRootPage(int $rootPageId): string
+    {
+        $siteByPageId = $this->getSiteForRootPageId($rootPageId);
+        return $this->getFirstDomainFromSiteArray($siteByPageId);
+    }
+
+    /**
+     * Returns the configured domain from a site array or an empty string.
+     *
+     * @param array $site
+     * @return string
+     */
+    protected function getFirstDomainFromSiteArray(array $site): string
+    {
+        return (empty($site['domains'][0])) ? '' : $site['domains'][0];
+    }
+
+    /**
+     * Retrieves the configured site for a rootPageId.
+     *
+     * @param int $pageId
+     * @return array
+     */
+    protected function getSiteForRootPageId(int $pageId): array
+    {
+        return is_array($this->sites[$pageId]) ? $this->sites[$pageId] : [];
+    }
+}

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -484,3 +484,48 @@ The following example shows, how you can configure a custom switchable entry tem
            }
        }
    }
+
+
+**I want to use EXT:solr with a deployment and pass connection settings from outside e.g. by the environment, how can i do that?**
+
+When you deploy a system automatically and you use EXT:solr there are some things that might be complicated:
+
+* You want to use a different solr endpoint for each environment
+* EXT:solr depends on an existing domain record
+
+To avoid that, you can set or generate these settings in the TYPO3 AdditionalConfigruation.php file and use them in your system.
+
+To configure a used domain you cat set:
+
+::
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][###rootPageId###]['domains'] = ['mydomain.com'];
+
+You can also define the data for your solr endpoints there and use them in the typoscript:
+
+::
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][###rootPageId###]['solrhost'] = 'solr1.local';
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][###rootPageId###]['solrport'] = 8083;
+
+And use them in your TypoScript configuration:
+
+::
+
+    plugin.tx_solr {
+        solr {
+            host = TEXT
+            host {
+                value = {$plugin.tx_solr.solr.host}
+                override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|sites|###rootPageId###|solrhost
+            }
+            port = TEXT
+            port {
+                value = {$plugin.tx_solr.solr.port}
+                override.data = global:TYPO3_CONF_VARS|EXTCONF|solr|sites|###rootPageId###|solrport
+            }
+        }
+    }
+
+
+

--- a/Documentation/Releases/solr-release-7-0.rst
+++ b/Documentation/Releases/solr-release-7-0.rst
@@ -224,6 +224,22 @@ This setting was not evaluated in EXT:solrfluid before and is now available also
 * https://github.com/TYPO3-Solr/ext-solr/pull/1501
 
 
+Get rid of dependency to sys_domain record
+------------------------------------------
+
+By now EXT:solr had the dependency on an existing domain record. This can be a problem, when you domain is dynamic or
+you need to be able to generate it.
+
+Now you can configure a domain by the rootPageId in the TYPO3_CONF_VARS, the domain record is still used, when nothing is configured here.
+
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][###rootPageId###]['domains'] = ['mydomain.com'];
+
+**Note:**
+
+There might be an approach to support this in TYPO3 Version 9 by the core and we will adopt this then.
+
+* https://github.com/TYPO3-Solr/ext-solr/pull/1512
+
 Preparations for TYPO3 9
 ------------------------
 

--- a/Resources/Private/Partials/Backend/NoSiteAvailable.html
+++ b/Resources/Private/Partials/Backend/NoSiteAvailable.html
@@ -11,7 +11,7 @@
 		<f:be.infobox title="There is no site configured for your solr extension!" state="3">
 			<p>Please check the following:</p>
 			<ul>
-				<li>Your page has a domain record.</li>
+				<li>Your site has a domain configured, please create a domain record on the root page, or configure it in "TYPO3_CONF_VARS|EXTCONF|solr|sites|###rootPageId###|domains"</li>
 				<li>Your site has a page, marked as root page.</li>
 				<li>Your page has included the solr typoscript configuration.</li>
 				<li>You've initialized the solr connections in the backend with the menu item "Initialize solr connections"</li>

--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -83,6 +83,9 @@
     </f:if>
 
     <hr class="double" />
+    Used domain: {site.domain}
+
+    <hr class="double" />
     API key: {apiKey}
 
     <hr class="double" />

--- a/Tests/Integration/Domain/Site/Fixtures/can_get_site_by_page_id.xml
+++ b/Tests/Integration/Domain/Site/Fixtures/can_get_site_by_page_id.xml
@@ -16,5 +16,10 @@
 		<uid>2</uid>
 		<pid>1</pid>
 	</pages>
+	<sys_domain>
+		<uid>1</uid>
+		<pid>1</pid>
+		<domainName>my-database-domain.de</domainName>
+	</sys_domain>
 
 </dataset>

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -75,7 +75,7 @@ class SiteRepositoryTest extends IntegrationTest
      */
     public function canGetSiteByRootPageIdNonExistingRoot()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $this->importDataSetFromFixture('can_get_site_by_root_page_id.xml');
         $siteRepository->getSiteByRootPageId(42);
@@ -97,9 +97,34 @@ class SiteRepositoryTest extends IntegrationTest
      */
     public function canGetSiteByPageIdNonExistingPage()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $this->importDataSetFromFixture('can_get_site_by_page_id.xml');
         $siteRepository->getSiteByPageId(42);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSiteWithDomainFromTYPO3CONFVARS()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][1]['domains'] = ['my-confvars-domain.de'];
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->importDataSetFromFixture('can_get_site_by_page_id.xml');
+        $domain = $siteRepository->getSiteByPageId(1)->getDomain();
+        $this->assertSame('my-confvars-domain.de', $domain, 'Can not configured domain with TYPO3_CONF_VARS');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetSiteWithDomainFromDomainRecord()
+    {
+        /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->importDataSetFromFixture('can_get_site_by_page_id.xml');
+        $site = $siteRepository->getSiteByPageId(1);
+        $domain = $site->getDomain();
+        $this->assertSame('my-database-domain.de', $domain, 'Can not configured domain with sys_domain record');
     }
 }

--- a/Tests/Integration/SiteTest.php
+++ b/Tests/Integration/SiteTest.php
@@ -57,7 +57,10 @@ class SiteTest extends IntegrationTest
      */
     public function canCreateInstanceWithRootSiteUidOK() {
         $this->importDataSetFromFixture('can_create_instance_with_root_site.xml');
-        $this->site = GeneralUtility::makeInstance(Site::class, 1);
+
+            /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->site = $siteRepository->getSiteByRootPageId(1);
         $this->assertEquals(1, $this->site->getRootPageId());
     }
 
@@ -66,8 +69,10 @@ class SiteTest extends IntegrationTest
      */
     public function canCreateInstanceWithRootSiteUidNOK() {
         $this->importDataSetFromFixture('can_create_instance_with_root_site.xml');
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $this->site = GeneralUtility::makeInstance(Site::class, 2);
+        $this->expectException(\InvalidArgumentException::class);
+        /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->site = $siteRepository->getSiteByRootPageId(2);
     }
 
     /**
@@ -75,8 +80,11 @@ class SiteTest extends IntegrationTest
      */
     public function canCreateInstanceWithNonRootSiteUidOK() {
         $this->importDataSetFromFixture('can_create_instance_with_non_root_site.xml');
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $this->site = GeneralUtility::makeInstance(Site::class, 1);
+        $this->expectException(\InvalidArgumentException::class);
+
+        /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->site = $siteRepository->getSiteByRootPageId(1);
     }
 
     /**
@@ -84,7 +92,10 @@ class SiteTest extends IntegrationTest
      */
     public function canCreateInstanceWithNonRootSiteUidNOK() {
         $this->importDataSetFromFixture('can_create_instance_with_non_root_site.xml');
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $this->site = GeneralUtility::makeInstance(Site::class, 2);
+        $this->expectException(\InvalidArgumentException::class);
+
+        /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $this->site = $siteRepository->getSiteByRootPageId(2);
     }
 }

--- a/Tests/Unit/System/Service/SiteServiceTest.php
+++ b/Tests/Unit/System/Service/SiteServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\System\Service;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\System\Service\SiteService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Unit test for the SiteService
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SiteServiceTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetFirstDomainByPage()
+    {
+        $sites = [
+            32 => [
+                'domains' => ['mysite.com']
+            ],
+            78 => [
+                'domains' => ['mymicrosite.com']
+            ]
+        ];
+
+        $siteService = new SiteService($sites);
+        $this->assertSame('mymicrosite.com', $siteService->getFirstDomainForRootPage(78));
+        $this->assertSame('mymicrosite.com', $siteService->getFirstDomainForRootPage(78));
+        $this->assertSame('mysite.com', $siteService->getFirstDomainForRootPage(32));
+    }
+
+    /**
+     * @test
+     */
+    public function canGetEmptyDomainWhenNothingIsConfigured()
+    {
+        $siteService = new SiteService();
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites']);
+        $this->assertSame('', $siteService->getFirstDomainForRootPage(32));
+    }
+}


### PR DESCRIPTION
For some environments (e.g. automated deployment / cloud provides) the domain name can be provided by the environment and using the sys_domain record is complicated since it needs to be created by environment on the instance.

This pr allows:

* To configure the domains in $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][#
##rootPageId###]['domains'] = ['mydomain.com'];
* When nothing is configured there, a fallback to the sys_domain record is used.
* As soon as this is available in the TYPO3 core (maybe v 9.0) we will read the domain configuration from the central configuation.
* The calculation of the siteHash and of the solrConfiguration was moved to the repository to avoid doing this on each call.

Fixes: #1511