### PR TITLE
[TASK] Provide .gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/Build/ export-ignore
+/Tests/ export-ignore
+/.dockerignore export-ignore
+/.gitattributes export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/.styleci.yml export-ignore
+/Dockerfile export-ignore
+/CONTRIBUTING.md export-ignore


### PR DESCRIPTION
By using a .gitattributes file it is possible to reduce
the size of the project when using composer as all
files and directories with 'export-ignore' are not included then