### PR TITLE
[TASK]Backport: Properly escape output of viewhelpers.

### DIFF
--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -62,9 +62,9 @@ class ScoreCalculationService
         foreach ($highScores as $highScore) {
             /** @var $highScore Score */
             $scores[] = '
-				<td>+ ' . $highScore->getScore() . '</td>
-				<td>' . $highScore->getFieldName() . '</td>
-				<td>' . $highScore->getBoost() . '</td>';
+				<td>+ ' . htmlspecialchars($highScore->getScore()) . '</td>
+				<td>' . htmlspecialchars($highScore->getFieldName()) . '</td>
+				<td>' . htmlspecialchars($highScore->getBoost()) . '</td>';
 
             $totalScore += $highScore->getScore();
         }


### PR DESCRIPTION
Related Issue: https://github.com/TYPO3-Solr/ext-solr/issues/1444
Comes from: https://github.com/TYPO3-Solr/ext-solr/pull/1445/files

Fixes: #1444