### PR TITLE
[TASK] Avoid error on update from 6.1.x

### DIFF
--- a/Classes/Backend/SolrModule/AdministrationModuleManager.php
+++ b/Classes/Backend/SolrModule/AdministrationModuleManager.php
@@ -1,0 +1,50 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Backend\SolrModule;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Administration Module Manager
+ *
+ * @deprecated Not supported with fluid templating, will be removed in 8.0
+ * @author Ingo Renner <ingo@typo3.org>
+ */
+class AdministrationModuleManager
+{
+
+    /**
+     * Registers a Solr administration module
+     *
+     * @deprecated Not supported with fluid templating, please register your module as solr submodule, will be removed in 8.0
+     * @param string $extensionIdentifier Identifier for the extension, that is the vendor followed by a dot followed by the extension key
+     * @param string $controllerName Controller name
+     * @param array $controllerActions Array of valid controller actions
+     * @return void
+     */
+    public static function registerModule($extensionIdentifier, $controllerName, array $controllerActions)
+    {
+        GeneralUtility::logDeprecatedFunction();
+    }
+}

--- a/Classes/CommandResolver.php
+++ b/Classes/CommandResolver.php
@@ -1,0 +1,49 @@
+<?php
+namespace ApacheSolrForTypo3\Solr;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2009-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * command resolver
+ *
+ * @deprecated Not supported with fluid templating, will be removed in 8.0
+ * @author Ingo Renner <ingo@typo3.org>
+ */
+class CommandResolver {
+
+    /**
+     * This method is deprecated an only the signature is kept, to avoid error during the update from 6.1.0 to 7.0.0
+     *
+     * @deprecated Not supported with fluid templating, will be removed in 8.0
+     * @param string $plugins comma separated list of plugin names (without pi_ prefix)
+     * @param string $commandName command name
+     * @param string $commandClass name of the class implementing the command
+     * @param int $requirements Bitmask of which requirements need to be met for a command to be executed
+     */
+    public static function registerPluginCommand($plugins, $commandName, $commandClass, $requirements = 2)
+    {
+        GeneralUtility::logDeprecatedFunction();
+    }
+}

--- a/Classes/Facet/FacetRendererFactory.php
+++ b/Classes/Facet/FacetRendererFactory.php
@@ -1,0 +1,51 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Facet;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Facet renderer factory, creates facet renderers depending on the configured
+ * type of a facet.
+ *
+ * @deprecated Not supported with fluid templating, will be removed in 8.0
+ * @author Ingo Renner <ingo@typo3.org>
+ */
+class FacetRendererFactory
+{
+
+    /**
+     * Register a facet type with its helper classes.
+     *
+     * @deprecated Not supported with fluid templating, please use FacetRegistry instead. will be removed in 8.0
+     * @param string $facetType Facet type that can be used in a TypoScript facet configuration
+     * @param string $rendererClassName Class used to render the facet UI
+     * @param string $filterEncoderClassName Class used to translate filter parameter from the URL to Lucene filter syntax
+     * @param string $queryFacetBuilderClassName Class used to build the facet parameters according to the facet's configuration
+     */
+    public static function registerFacetType($facetType, $rendererClassName, $filterEncoderClassName = '', $queryFacetBuilderClassName = '')
+    {
+        GeneralUtility::logDeprecatedFunction();
+    }
+}

--- a/Classes/Plugin/PluginCommand.php
+++ b/Classes/Plugin/PluginCommand.php
@@ -1,0 +1,59 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Plugin;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2009-2015 Ingo Renner <ingo@typo3.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Plugin command interface
+ *
+ * @deprecated Not supported with fluid templating, will be removed in 8.0
+ * @author Ingo Renner <ingo@typo3.org>
+ */
+interface PluginCommand
+{
+    const REQUIREMENTS_NUM_BITS = 4;
+
+    const REQUIREMENT_NONE = 1; // 0001
+    const REQUIREMENT_HAS_SEARCHED = 2; // 0010
+    const REQUIREMENT_NO_RESULTS = 4; // 0100
+    const REQUIREMENT_HAS_RESULTS = 8; // 1000
+
+    /**
+     * Constructor.
+     *
+     * FIXME interface must not define a constructor, change this to a setter
+     *
+     * @param CommandPluginBase $parent Parent plugin object.
+     */
+    public function __construct(CommandPluginBase $parent);
+
+    /**
+     * execute method
+     *
+     */
+    public function execute();
+}


### PR DESCRIPTION
This PR:

During the update from 6.1.x the localconf.php as a cached state that uses removed code. To avoid this we readd only the signature of those methods to avoid an php error.
The following signatures have been readded (and will be removed after the release of EXT:solr 7.0.0):

* AdministrationModuleManager::registerModule
* CommandResolver::registerPluginCommand
* PluginCommand
* FacetRendererFactory::registerFacetType

Allong with that it makes sence to clear the cache in your TYPO3 project after the autoloader dump:

```
"scripts": {
    "post-autoload-dump": [
      "rm -Rf {$web-dir}/typo3temp/Cache/*"
    ]
  },
```

Fixes: #1518