### PR TITLE
[BUGFIX] Backport - Relation handler should handle pages overlays correctly (#1422)

### DIFF
--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -22,8 +22,4 @@
 			<directory suffix=".php">../../Classes/</directory>
 		</whitelist>
 	</filter>
-
-	<logging>
-		<log type="coverage-clover" target="coverage.integration.clover"/>
-	</logging>
 </phpunit>

--- a/Build/Test/UnitTests.xml
+++ b/Build/Test/UnitTests.xml
@@ -22,7 +22,4 @@
 			<directory suffix=".php">../../Classes/</directory>
 		</whitelist>
 	</filter>
-	<logging>
-		<log type="coverage-clover" target="coverage.unit.clover"/>
-	</logging>
 </phpunit>

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -29,7 +29,7 @@ fi
 
 echo "Run unit tests"
 UNIT_BOOTSTRAP=".Build/vendor/nimut/testing-framework/res/Configuration/UnitTestsBootstrap.php"
-.Build/bin/phpunit --colors -c Build/Test/UnitTests.xml --bootstrap=$UNIT_BOOTSTRAP
+.Build/bin/phpunit --colors -c Build/Test/UnitTests.xml --bootstrap=$UNIT_BOOTSTRAP --coverage-clover=coverage.unit.clover
 if [ $? -ne "0" ]; then
     echo "Error during running the unit tests please check and fix them"
     exit 1
@@ -69,4 +69,4 @@ fi
 
 echo "Run integration tests"
 INTEGRATION_BOOTSTRAP=".Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTestsBootstrap.php"
-.Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP
+.Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.clover

--- a/Build/Test/publish_coverage.sh
+++ b/Build/Test/publish_coverage.sh
@@ -7,5 +7,6 @@ export COMPOSER_BIN_DIR="$HOME/.composer/vendor/bin"
 # Add TYPO3_BIN_DIR and COMPOSER_BIN_DIR to $PATH
 export PATH="$TYPO3_BIN_DIR:$COMPOSER_BIN_DIR:$PATH"
 
+ls -la
 ocular code-coverage:upload --format=php-clover coverage.unit.clover
-ocular code-coverage:upload --format=php-clover coverage.functional.clover
+ocular code-coverage:upload --format=php-clover coverage.integration.clover

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -537,6 +537,10 @@ class Queue
     {
         $localizedChangedTime = 0;
 
+        if ($itemType === 'pages') {
+            $itemType = 'pages_language_overlay';
+        }
+
         if (isset($GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'])) {
             // table is localizable
             $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -109,7 +109,7 @@ class IndexServiceTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    relatedPageTitles_stringM = SOLR_RELATION
+                                    relatedPageTitles_stringM {
+                                        localField = page_relations
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages_language_overlay>
+        <uid>2</uid>
+        <pid>1</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages_language_overlay>
+
+    <pages>
+        <uid>10</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Related page</title>
+    </pages>
+
+    <pages_language_overlay>
+        <uid>11</uid>
+        <pid>10</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <title>Translated related page</title>
+    </pages_language_overlay>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>orignal</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_related_pages_mm>
+        <uid_local>99</uid_local>
+        <uid_foreign>10</uid_foreign>
+        <tablenames>pages</tablenames>
+    </tx_fakeextension_domain_model_related_pages_mm>
+
+    <tx_fakeextension_domain_model_related_pages_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>10</uid_foreign>
+        <tablenames>pages</tablenames>
+    </tx_fakeextension_domain_model_related_pages_mm>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+    </sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_bar_tca.php
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_bar_tca.php
@@ -150,6 +150,7 @@ return [
                 'type' => 'check'
             ]
         ],
+        // mm relation
         'tags' => [
             'exclude' => 1,
             'label' => 'Tags:',
@@ -164,8 +165,25 @@ return [
                 'maxitems' => '200',
                 'minitems' => '0',
                 'show_thumbs' => '1'
-              ]
+            ]
         ],
+        // mm relation to a page
+        'page_relations' => [
+            'exclude' => 1,
+            'label' => 'Page relations',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'enableMultiSelectFilterTextfield' => true,
+                'foreign_table' => 'pages',
+                'MM' => 'tx_fakeextension_domain_model_related_pages_mm',
+                'size' => 10,
+                'autoSizeMax' => 30,
+                'maxitems' => 9999,
+                'readOnly' => true,
+            ],
+        ],
+        // direct relation
         'category' => [
             'exclude' => 1,
             'label' => 'Category',
@@ -178,9 +196,9 @@ return [
                     'expandSingle' => 1,
                 ],
             ],
-        ]
-     ],
-     'types' => [
+        ],
+    ],
+    'types' => [
         '0' => [
             'showitem' => 'l10n_parent, l10n_diffsource,title,tags'
         ]

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS tx_fakeextension_domain_model_bar;
-
 CREATE TABLE tx_fakeextension_domain_model_bar (
 	uid int(11) NOT NULL auto_increment,
 	pid int(11) DEFAULT '0' NOT NULL,
@@ -31,8 +29,6 @@ CREATE TABLE tx_fakeextension_domain_model_bar (
 	PRIMARY KEY (uid)
 );
 
-DROP TABLE IF EXISTS tx_fakeextension_domain_model_related_mm;
-
 CREATE TABLE tx_fakeextension_domain_model_related_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
@@ -42,8 +38,15 @@ CREATE TABLE tx_fakeextension_domain_model_related_mm (
    KEY uid_foreign (uid_foreign)
 );
 
-
-DROP TABLE IF EXISTS tx_fakeextension_domain_model_mmrelated;
+CREATE TABLE tx_fakeextension_domain_model_related_pages_mm (
+   uid_local int(11) unsigned DEFAULT '0' NOT NULL,
+   uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+   tablenames varchar(90) DEFAULT '' NOT NULL,
+   fieldname varchar(90) DEFAULT '' NOT NULL,
+   sorting int(11) unsigned DEFAULT '0' NOT NULL,
+   KEY uid_local (uid_local),
+   KEY uid_foreign (uid_foreign)
+);
 
 CREATE TABLE tx_fakeextension_domain_model_mmrelated (
 	uid int(11) NOT NULL auto_increment,
@@ -74,8 +77,6 @@ CREATE TABLE tx_fakeextension_domain_model_mmrelated (
 	PRIMARY KEY (uid)
 );
 
-
-DROP TABLE IF EXISTS tx_fakeextension_domain_model_directrelated;
 
 CREATE TABLE tx_fakeextension_domain_model_directrelated (
 	uid int(11) NOT NULL auto_increment,

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension_table.sql
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension_table.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS tx_fakeextension_domain_model_foo;
-
 CREATE TABLE tx_fakeextension_domain_model_foo (
 	uid int(11) NOT NULL auto_increment,
 	pid int(11) DEFAULT '0' NOT NULL,

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_overlay = 1
+                config.sys_language_mode = content_fallback
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            pages = 1
+                            pages {
+                                table = pages
+                                fields {
+                                    title = title
+                                    relatedPageTitles_stringM = SOLR_RELATION
+                                    relatedPageTitles_stringM {
+                                        localField = page_relations
+                                        enableRecursiveValueResolution = 0
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Page</title>
+    </pages>
+    <pages_language_overlay>
+        <uid>2</uid>
+        <pid>1</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
+        <title>Seite</title>
+        <relations>1</relations>
+    </pages_language_overlay>
+
+    <pages>
+        <uid>10</uid>
+        <pid>0</pid>
+        <doktype>1</doktype>
+        <title>Related page</title>
+    </pages>
+    <pages_language_overlay>
+        <uid>11</uid>
+        <pid>10</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
+        <title>Verwante Seite</title>
+    </pages_language_overlay>
+
+    <tx_fakeextension3_pages_mm>
+        <uid_local>10</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <tablenames>pages_language_overlay</tablenames>
+        <fieldname>page_relations</fieldname>
+        <sorting>0</sorting>
+        <sorting_foreign>0</sorting_foreign>
+    </tx_fakeextension3_pages_mm>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+    </sys_language>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'columns' => [
+        'page_relations' => [
+            'exclude' => 1,
+            'label' => 'Page relations',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'enableMultiSelectFilterTextfield' => true,
+                'foreign_table' => 'pages',
+                'MM' => 'tx_fakeextension3_pages_mm',
+                'MM_opposite_field' => 'relations',
+                'MM_match_fields' => [
+                    'tablenames' => 'pages_language_overlay',
+                    'fieldname' => 'page_relations'
+                ],
+                'size' => 10,
+                'autoSizeMax' => 30,
+                'maxitems' => 9999,
+                'readOnly' => true,
+            ],
+        ],
+        'relations' => [
+            'label' => 'Used as relation to',
+            'config' => [
+                'type' => 'group',
+                'allowed' => '*',
+                'internal_type' => 'db',
+                'MM' => 'tx_fakeextension3_pages_mm',
+                'MM_oppositeUsage' => [
+                    'pages' => [
+                        'page_relations',
+                    ],
+                ],
+                'readOnly' => true
+            ]
+        ]
+    ]
+];

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'columns' => [
+        'page_relations' => [
+            'exclude' => 1,
+            'label' => 'Page relations',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'enableMultiSelectFilterTextfield' => true,
+                'foreign_table' => 'pages',
+                'MM' => 'tx_fakeextension3_pages_mm',
+                'MM_opposite_field' => 'relations',
+                'MM_match_fields' => [
+                    'tablenames' => 'pages',
+                    'fieldname' => 'page_relations'
+                ],
+                'size' => 10,
+                'autoSizeMax' => 30,
+                'maxitems' => 9999,
+                'readOnly' => true,
+            ],
+        ],
+        'relations' => [
+            'label' => 'Used as relation to',
+            'config' => [
+                'type' => 'group',
+                'allowed' => '*',
+                'internal_type' => 'db',
+                'MM' => 'tx_fakeextension3_pages_mm',
+                'MM_oppositeUsage' => [
+                    'pages' => [
+                        'page_relations',
+                    ],
+                ],
+                'readOnly' => true
+            ]
+        ]
+    ]
+];

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE tx_fakeextension3_pages_mm (
+   uid_local int(11) unsigned DEFAULT '0' NOT NULL,
+   uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+   tablenames varchar(90) DEFAULT '' NOT NULL,
+   fieldname varchar(90) DEFAULT '' NOT NULL,
+   sorting int(11) unsigned DEFAULT '0' NOT NULL,
+   sorting_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+   KEY uid_local (uid_local),
+   KEY uid_foreign (uid_foreign)
+);
+
+CREATE TABLE pages (
+   page_relations int(11) unsigned DEFAULT '0' NOT NULL,
+   relations varchar(90) DEFAULT '' NOT NULL
+);
+
+CREATE TABLE pages_language_overlay (
+   page_relations int(11) unsigned DEFAULT '0' NOT NULL,
+   relations varchar(90) DEFAULT '' NOT NULL
+);

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -81,7 +81,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_mm_relation.xml');
@@ -122,7 +122,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
 
         $this->importDataSetFromFixture($fixture);
@@ -165,7 +165,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_translated_record_with_mm_relation.xml');
@@ -195,7 +195,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_mm_relationAndAdditionalWhere.xml');
@@ -214,6 +214,39 @@ class IndexerTest extends IntegrationTest
     }
 
     /**
+     * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.
+     *
+     * @test
+     */
+    public function canIndexItemWithMMRelationToATranslatedPage()
+    {
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+
+
+        // create fake extension database table and TCA
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $this->importDataSetFromFixture('can_index_custom_translated_record_with_mm_relation_to_a_page.xml');
+
+        $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
+        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+
+        // do we have the record in the index with the value from the mm relation?
+        $this->waitToBeVisibleInSolr('core_en');
+        $this->waitToBeVisibleInSolr('core_de');
+
+        $solrContentEn = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+        $solrContentDe = file_get_contents('http://localhost:8999/solr/core_de/select?q=*:*');
+
+        $this->assertContains('"relatedPageTitles_stringM":["Related page"]', $solrContentEn, 'Can not find related page title');
+        $this->assertContains('"relatedPageTitles_stringM":["Translated related page"]', $solrContentDe, 'Can not find translated related page title');
+
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+    }
+
+    /**
      * This testcase is used to check if direct relations can be resolved with the RELATION configuration
      *
      * @test
@@ -223,7 +256,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relation.xml');
@@ -255,7 +288,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relationAndAdditionalWhere.xml');
@@ -281,7 +314,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_directrelated'] = include($this->getFixturePathByName('fake_extension2_directrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_configuration_in_rootline.xml');
@@ -366,7 +399,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_outside_site_root.xml');

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -139,7 +139,7 @@ class RecordMonitorTest extends IntegrationTest
     public function canUseCorrectIndexingConfigurationForANewNonPagesRecord()
     {
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension_table.sql');
+        $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         // create faked tce main call data
@@ -257,7 +257,7 @@ class RecordMonitorTest extends IntegrationTest
         $this->setExpectedException(NoPidException::class);
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension_table.sql');
+        $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         // create faked tce main call data
@@ -732,7 +732,7 @@ class RecordMonitorTest extends IntegrationTest
      */
     public function updateRecordOutsideSiteRoot()
     {
-        $this->importDumpFromFixture('fake_extension_table.sql');
+        $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         $this->importDataSetFromFixture('update_record_outside_siteroot.xml');
@@ -760,7 +760,7 @@ class RecordMonitorTest extends IntegrationTest
      */
     public function updateRecordOutsideSiteRootReferencedInTwoSites()
     {
-        $this->importDumpFromFixture('fake_extension_table.sql');
+        $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         $this->importDataSetFromFixture('update_record_outside_siteroot_from_two_sites.xml');
@@ -788,7 +788,7 @@ class RecordMonitorTest extends IntegrationTest
      */
     public function updateRecordOutsideSiteRootLocatedInOtherSite()
     {
-        $this->importDumpFromFixture('fake_extension_table.sql');
+        $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
 
         $this->importDataSetFromFixture('update_record_outside_siteroot_from_other_siteroot.xml');

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -29,12 +29,15 @@ use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageGenerator;
 use TYPO3\CMS\Frontend\Utility\EidUtility;
+use TYPO3\CMS\Install\Service\SqlExpectedSchemaService;
+use TYPO3\CMS\Install\Service\SqlSchemaMigrationService;
 
 
 /**
@@ -124,19 +127,56 @@ abstract class IntegrationTest extends FunctionalTestCase
 
     /**
      * @param string $fixtureName
+     * @param boolean $debugOutput
      */
-    protected function importDumpFromFixture($fixtureName)
+    protected function importDumpFromFixture($fixtureName, $debugOutput = true)
     {
         /** @var $database  \TYPO3\CMS\Core\Database\DatabaseConnection */
         $database = $GLOBALS['TYPO3_DB'];
-        $database->debugOutput = true;
-
+        $database->debugOutput = $debugOutput;
         $dumpContent = $this->getFixtureContentByName($fixtureName);
         $dumpContent = str_replace(["\r", "\n"], '', $dumpContent);
-
         $queries = GeneralUtility::trimExplode(';', $dumpContent, true);
         foreach ($queries as $query) {
             $database->sql_query($query);
+        }
+    }
+
+    /**
+     * Imports an ext_tables.sql definition as done by the install tool.
+     *
+     * @param string $fixtureName
+     */
+    protected function importExtTablesDefinition($fixtureName)
+    {
+        // create fake extension database table and TCA
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        /** @var $schemaMigrationService SqlSchemaMigrationService */
+        $schemaMigrationService = $objectManager->get(SqlSchemaMigrationService::class);
+        /** @var  $expectedSchemaService SqlExpectedSchemaService */
+        $expectedSchemaService = $objectManager->get(SqlExpectedSchemaService::class);
+
+        $expectedSchemaString = $expectedSchemaService->getTablesDefinitionString(true);
+        $statements = $schemaMigrationService->getStatementArray($expectedSchemaString, true);
+        list($_, $insertCount) = $schemaMigrationService->getCreateTables($statements, true);
+
+        $fieldDefinitionsFile = $schemaMigrationService->getFieldDefinitions_fileContent($this->getFixtureContentByName($fixtureName));
+        $fieldDefinitionsDatabase = $schemaMigrationService->getFieldDefinitions_database();
+        $difference = $schemaMigrationService->getDatabaseExtra($fieldDefinitionsFile, $fieldDefinitionsDatabase);
+        $updateStatements = $schemaMigrationService->getUpdateSuggestions($difference);
+
+        $schemaMigrationService->performUpdateQueries($updateStatements['add'], $updateStatements['add']);
+        $schemaMigrationService->performUpdateQueries($updateStatements['change'], $updateStatements['change']);
+        $schemaMigrationService->performUpdateQueries($updateStatements['create_table'], $updateStatements['create_table']);
+
+        foreach ($insertCount as $table => $count) {
+            $insertStatements = $schemaMigrationService->getTableInsertStatements($statements, $table);
+            foreach ($insertStatements as $insertQuery) {
+                $insertQuery = rtrim($insertQuery, ';');
+                /** @var DatabaseConnection $database */
+                $database = $GLOBALS['TYPO3_DB'];
+                $database->admin_query($insertQuery);
+            }
         }
     }
 
@@ -164,11 +204,13 @@ abstract class IntegrationTest extends FunctionalTestCase
     /**
      * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
      */
-    protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0)
+    protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $config = [])
     {
         /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
         $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
-            $TYPO3_CONF_VARS, $id, $type);
+            $TYPO3_CONF_VARS, $id, $type, $no_cache, $cHash, $_2, $MP, $RDCT);
+
+
         EidUtility::initLanguage();
         $TSFE->initFEuser();
         $TSFE->set_no_cache();
@@ -176,7 +218,12 @@ abstract class IntegrationTest extends FunctionalTestCase
         $TSFE->determineId();
         $TSFE->initTemplate();
         $TSFE->getConfigArray();
+        $TSFE->config = array_merge($TSFE->config, $config);
+
         Bootstrap::getInstance();
+
+        // only needed for FrontendGroupRestriction.php
+        $GLOBALS['TSFE']->gr_list =  $TSFE->gr_list;
         $TSFE->settingLanguage();
         $TSFE->settingLocale();
 


### PR DESCRIPTION
Table pages has diferent handling over overlays. Now the
ContantObject/Relation handles these correctly. Along with that, the functionallity
was added in the tests to import an ext_tables.sql like database definition.

Fixes: #1421