### PR TITLE
[BUGFIX] Add fluid namespace data attribute to html tag

### DIFF
--- a/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/"
+	  data-namespace-typo3-fluid="true">
 <f:if condition="{configuration.insertAbove}">
 	<f:render section="paginator" arguments="{pagination: contentArguments.pagination, configuration:configuration, resultSet:resultSet}" />
 </f:if>


### PR DESCRIPTION
To prevent the HTML tag from rendering in the final output add the fluid namespace data attribute.

Fixes: #1545 