### PR TITLE
[BUGFIX] QueryBuilder does not quote aliases if 'as' is lower cased

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -84,7 +84,7 @@ class StatisticsRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilder();
         $statisticsQueryBuilder = $queryBuilder
-            ->select('keywords', 'num_found as hits')
+            ->select('keywords', 'num_found AS hits')
             ->add('select', $queryBuilder->expr()->count('keywords', 'count'), true)
             ->from($this->table)
             ->andWhere(


### PR DESCRIPTION
TYPO3 CMS QueryBuilder before 8.7.4 does not accept 'as' for select aliases.

Fixes: #1562