### PR TITLE
[TASK] Introduce constant for plugin.tx_solr.enabled

### DIFF
--- a/Configuration/TypoScript/Solr/constants.txt
+++ b/Configuration/TypoScript/Solr/constants.txt
@@ -1,5 +1,6 @@
-
 plugin.tx_solr {
+	# cat=solr: basic/10/enable; type=boolean; label=Enable/disable Solr extension: EXT:solr should only be enabled for relevant sys_languages, to avoid unnecessary connections and overwritten contents.
+	enabled = 1
 
 	solr {
 		scheme = http

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -1,6 +1,6 @@
 plugin.tx_solr {
 
-	enabled = 1
+	enabled = {$plugin.tx_solr.enabled}
 
 	enableDebugMode = 0
 


### PR DESCRIPTION
To allow simple configuration of enabled Solr connections, this commit
introduces a constant for plugin.tx_solr.enabled.

Fixes: #1567