### PR TITLE
[BUGFIX] Backport Fix sorting and counts in statistics module

### DIFF
--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -185,8 +185,8 @@
                                 <td class="nowrap"><strong>{i.cycle}.</strong></td>
                                 <td>{item.keywords}</td>
                                 <td>{item.count}</td>
-                                <td>{item.hits}</td>
-                                <td><f:format.number decimals="1">{item.percent}</f:format.number>%</td>
+                                <td>{item.hits -> f:format.number(decimals: 1)}</td>
+                                <td>{item.percent -> f:format.number(decimals: 1)}%</td>
                             </tr>
                         </f:for>
                         </tbody>

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -43,8 +43,8 @@ class StatisticsRepositoryTest extends IntegrationTest
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getTopKeyWordsWithHits(1, $daysSinceFixture);
         $expectedResult = [
-            ['mergedrows' => 2, 'count' => 2, 'hits' => 5, 'keywords' => 'content'],
-            ['mergedrows' => 1, 'count' => 1, 'hits' => 6, 'keywords' => 'typo3']
+            ['keywords' => 'content', 'count' => '2', 'hits' => '5.0000'],
+            ['keywords' => 'typo3', 'count' => '1', 'hits' => '6.0000' ]
         ];
         $this->assertSame($expectedResult, $topHits);
     }
@@ -63,7 +63,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
 
         $expectedResult = [
-            ['mergedrows' => 1, 'count' => 1, 'hits' => 0, 'keywords' => 'cms'],
+            ['keywords' => 'cms', 'count' => '1', 'hits' => '0.0000']
         ];
 
         $this->assertSame($expectedResult, $topHits);


### PR DESCRIPTION
* fixed "top 5" and "search statistics" queries for correct calculations
* removed PHP calculations where possible and replace it with SQL
* adapted StatisticsRepositoryTest for SQLs results

Fixes: #1584
Backport from #1582
