### PR TITLE
[TASK] Extract queries from Queue to repository

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -1,0 +1,641 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
+use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class QueueItemRepository
+ * Handles all CRUD operations to tx_solr_indexqueue_item table
+ *
+ */
+class QueueItemRepository extends AbstractRepository
+{
+    /**
+     * @var string
+     */
+    protected $table = 'tx_solr_indexqueue_item';
+
+    /**
+     * @var SolrLogManager
+     */
+    protected $logger;
+
+    /**
+     * QueueItemRepository constructor.
+     */
+    public function __construct()
+    {
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+    }
+
+    /**
+     * Fetches the last indexed row
+     *
+     * @param int $rootPageId The root page uid for which to get the last indexed row
+     * @return array
+     */
+    public function findLastIndexedRow(int $rootPageId) : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $row = $queryBuilder
+            ->select('uid', 'indexed')
+            ->from($this->table)
+            ->where($queryBuilder->expr()->eq('root', $rootPageId))
+            // @todo: without following line this query returns some row if nothing is indexed -> clarify if this behaviour is OK or we need following line
+            //->andWhere($queryBuilder->expr()->neq('indexed', 0))
+            ->orderBy('indexed', 'DESC')
+            ->setMaxResults(1)
+            ->execute()->fetchAll();
+
+        return $row;
+    }
+
+    /**
+     * Finds indexing errors for the current site
+     *
+     * @param Site $site
+     * @return array Error items for the current site's Index Queue
+     */
+    public function findErrorsBySite(Site $site) : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $errors = $queryBuilder
+            ->select('uid', 'item_type', 'item_uid', 'errors')
+            ->from($this->table)
+            ->andWhere(
+                $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter('')),
+                $queryBuilder->expr()->eq('root', $site->getRootPageId())
+            )
+            ->execute()->fetchAll();
+
+        return $errors;
+    }
+
+    /**
+     * Resets all the errors for all index queue items.
+     *
+     * @return int affected rows
+     */
+    public function flushAllErrors() : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $affectedRows = $queryBuilder
+            ->update($this->table)
+            ->set('errors', '')
+            ->where(
+                $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter(''))
+            )
+            ->execute();
+        return $affectedRows;
+    }
+
+    /**
+     * Updates an existing queue entry by $itemType $itemUid and $rootPageId.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid, usually an integer uid, could be a
+     *      different value for non-database-record types.
+     * @param string $indexingConfiguration The name of the related indexConfiguration
+     * @param int $rootPageId The uid of the rootPage
+     * @param int $changedTime The forced change time that should be used for updating
+     * @return int affected rows
+     */
+    public function updateExistingItemByItemTypeAndItemUidAndRootPageId(string $itemType, int $itemUid, int $rootPageId, int $changedTime, string $indexingConfiguration = '') : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->update($this->table)
+            ->set('changed', $changedTime)
+            ->andWhere(
+                $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
+                $queryBuilder->expr()->eq('item_uid', $itemUid),
+                $queryBuilder->expr()->eq('root', $rootPageId)
+            );
+
+        if (!empty($indexingConfiguration)) {
+            $queryBuilder->set('indexing_configuration', $indexingConfiguration);
+        }
+
+        return $queryBuilder->execute();
+    }
+
+    /**
+     * Adds an item to the index queue.
+     *
+     * Not meant for public use.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid, usually an integer uid, could be a different value for non-database-record types.
+     * @param int $rootPageId
+     * @param int $changedTime
+     * @param string $indexingConfiguration The item's indexing configuration to use. Optional, overwrites existing / determined configuration.
+     * @return int the number of inserted rows, which is typically 1
+     */
+    public function add(string $itemType, int $itemUid, int $rootPageId, int $changedTime, string $indexingConfiguration) : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        return $queryBuilder
+            ->insert($this->table)
+            ->values([
+                'root' => $rootPageId,
+                'item_type' => $itemType,
+                'item_uid' => $itemUid,
+                'changed' => $changedTime,
+                'errors' => '',
+                'indexing_configuration' => $indexingConfiguration
+            ])
+            ->execute();
+
+    }
+
+    /**
+     * Gets the most recent changed time of a page's content elements
+     *
+     * @param int $pageUid
+     * @return int|null Timestamp of the most recent content element change or null if nothing is found.
+     */
+    public function getPageItemChangedTimeByPageUid(int $pageUid)
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+        $pageContentLastChangedTime = $queryBuilder
+            ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $pageUid)
+            )
+            ->execute()->fetch();
+
+        return $pageContentLastChangedTime['changed_time'];
+    }
+
+    /**
+     * Gets the most recent changed time for an item taking into account
+     * localized records.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid
+     * @return int Timestamp of the most recent content element change
+     */
+    public function getLocalizableItemChangedTime(string $itemType, int $itemUid) : int
+    {
+        $localizedChangedTime = 0;
+
+        if ($itemType === 'pages') {
+            $itemType = 'pages_language_overlay';
+        }
+
+        if (isset($GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'])) {
+            // table is localizable
+            $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];
+
+            $queryBuilder = $this->getQueryBuilder();
+            $queryBuilder->getRestrictions()->removeAll();
+            $localizedChangedTime = $queryBuilder
+                ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
+                ->from($itemType)
+                ->orWhere(
+                    $queryBuilder->expr()->eq('uid', $itemUid),
+                    $queryBuilder->expr()->eq($translationOriginalPointerField, $itemUid)
+                )->execute()->fetchColumn(0);
+        }
+
+        return (int)$localizedChangedTime;
+    }
+
+    /**
+     * Returns prepared QueryBuilder for contains* methods in this repository
+     *
+     * @param string $itemType
+     * @param int $itemUid
+     * @return QueryBuilder
+     */
+    protected function getQueryBuilderForContainsMethods(string $itemType, int $itemUid) : QueryBuilder
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        return $queryBuilder->count('uid')->from($this->table)
+            ->andWhere(
+                $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
+                $queryBuilder->expr()->eq('item_uid', $itemUid)
+            );
+    }
+
+    /**
+     * Checks whether the Index Queue contains a specific item.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid
+     * @return bool TRUE if the item is found in the queue, FALSE otherwise
+     */
+    public function containsItem(string $itemType, int $itemUid) : bool
+    {
+        return (bool)$this->getQueryBuilderForContainsMethods($itemType, $itemUid)->execute()->fetchColumn(0);
+    }
+
+    /**
+     * Checks whether the Index Queue contains a specific item.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid
+     * @param integer $rootPageId
+     * @return bool TRUE if the item is found in the queue, FALSE otherwise
+     */
+    public function containsItemWithRootPageId(string $itemType, int $itemUid, int $rootPageId) : bool
+    {
+        $queryBuilder = $this->getQueryBuilderForContainsMethods($itemType, $itemUid);
+        return (bool)$queryBuilder
+            ->andWhere($queryBuilder->expr()->eq('root', $rootPageId))
+            ->execute()->fetchColumn(0);
+    }
+
+    /**
+     * Checks whether the Index Queue contains a specific item that has been
+     * marked as indexed.
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int $itemUid The item's uid
+     * @return bool TRUE if the item is found in the queue and marked as
+     *      indexed, FALSE otherwise
+     */
+    public function containsIndexedItem(string $itemType, int $itemUid) : bool
+    {
+        $queryBuilder = $this->getQueryBuilderForContainsMethods($itemType, $itemUid);
+        return (bool)$queryBuilder
+            ->andWhere($queryBuilder->expr()->gt('indexed', 0))
+            ->execute()->fetchColumn(0);
+    }
+
+    /**
+     * Returns the list with Uids to delete by given item type and optional item Uid
+     *
+     * @param string $itemType The item's type, usually a table name.
+     * @param int|null $itemUid The item's uid
+     * @return array the list with item Uids to delete
+     */
+    protected function getItemListToDeleteByItemTypeAndOptionalItemUid(string $itemType, int $itemUid = null) : array
+    {
+        $queryBuilderForItemListToDelete = $this->getQueryBuilder();
+        $queryBuilderForItemListToDelete
+            ->select('uid')
+            ->from($this->table)
+            ->andWhere(
+                $queryBuilderForItemListToDelete->expr()->eq('item_type', $queryBuilderForItemListToDelete->createNamedParameter($itemType))
+            );
+
+        if (isset($itemUid)) {
+            $queryBuilderForItemListToDelete->andWhere($queryBuilderForItemListToDelete->expr()->eq('item_uid', $itemUid));
+        }
+
+        return $queryBuilderForItemListToDelete->execute()->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * Removes an item from the Index Queue.
+     *
+     * @todo: use transaction
+     *        use sub-select for tx_solr_indexqueue_indexing_property IN() clause and native WHERE clause for tx_solr_indexqueue_item instead of fetching and concat it with PHP
+     * @param string $itemType The type of the item to remove, usually a table name.
+     * @param int $itemUid The uid of the item to remove
+     */
+    public function deleteItem(string $itemType, int $itemUid = null)
+    {
+        $items = $this->getItemListToDeleteByItemTypeAndOptionalItemUid($itemType, $itemUid);
+        if (empty($items)) {
+            return;
+        }
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->delete($this->table)
+            ->where(
+                $queryBuilder->expr()->in('uid', $items)
+            )
+            ->execute();
+
+        $queryBuilder2 = $this->getQueryBuilder();
+        $queryBuilder2
+            ->delete('tx_solr_indexqueue_indexing_property')
+            ->where(
+                $queryBuilder2->expr()->in('uid', $items)
+            )
+            ->execute();
+    }
+
+    /**
+     * Removes all items of a certain type from the Index Queue.
+     *
+     * @param string $itemType The type of items to remove, usually a table name.
+     */
+    public function deleteItemsByType(string $itemType)
+    {
+        $this->deleteItem($itemType);
+    }
+
+    /**
+     * Removes all items of a certain site from the Index Queue. Accepts an
+     * optional parameter to limit the deleted items by indexing configuration.
+     *
+     * @param Site $site The site to remove items for.
+     * @param string $indexingConfigurationName Name of a specific indexing configuration
+     * @throws \Exception
+     */
+    public function deleteItemsBySite(Site $site, string $indexingConfigurationName = '')
+    {
+        $queryBuilderForDeletingItems = $this->getQueryBuilder();
+        $queryBuilderForDeletingItems
+            ->delete($this->table)
+            ->where($queryBuilderForDeletingItems->expr()->eq('root', $site->getRootPageId()));
+        if (!empty($indexingConfigurationName)) {
+            $queryBuilderForDeletingItems->andWhere($queryBuilderForDeletingItems->expr()->eq('indexing_configuration', $queryBuilderForDeletingItems->createNamedParameter($indexingConfigurationName)));
+        }
+
+        $queryBuilderForDeletingProperties = $queryBuilderForDeletingItems->getConnection()->createQueryBuilder();
+        $queryBuilderForDeletingProperties
+            ->delete('tx_solr_indexqueue_indexing_property')
+            ->innerJoin(
+                'properties',
+                $this->table,
+                'items',
+                (string)$queryBuilderForDeletingProperties->expr()->andX(
+                    $queryBuilderForDeletingProperties->expr()->eq('items.uid', $queryBuilderForDeletingProperties->quoteIdentifier('properties.item_id')),
+                    $queryBuilderForDeletingProperties->expr()->eq('items.root' , $site->getRootPageId()),
+                    empty($indexingConfigurationName) ? '' : $queryBuilderForDeletingProperties->expr()->eq(
+                        'items.indexing_configuration', $queryBuilderForDeletingProperties->createNamedParameter($indexingConfigurationName)
+                    )
+                )
+            );
+
+        $queryBuilderForDeletingItems->getConnection()->beginTransaction();
+        try {
+            $queryBuilderForDeletingItems->execute();
+            $queryBuilderForDeletingProperties->execute();
+
+            $queryBuilderForDeletingItems->getConnection()->commit();
+        } catch (\Exception $e) {
+            $queryBuilderForDeletingItems->getConnection()->rollback();
+            throw $e;
+        }
+    }
+
+    /**
+     * Removes all items from the Index Queue.
+     *
+     * @return int The number of affected rows. For a truncate this is unreliable as theres no meaningful information.
+     */
+    public function deleteAllItems()
+    {
+        return $this->getQueryBuilder()->getConnection()->truncate($this->table);
+    }
+
+    /**
+     * Gets a single Index Queue item by its uid.
+     *
+     * @param int $uid Index Queue item uid
+     * @return Item|null The request Index Queue item or NULL if no item with $itemId was found
+     */
+    public function findItemByUid(int $uid)
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $indexQueueItemRecord = $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->where($queryBuilder->expr()->eq('uid', $uid))
+            ->execute()->fetch();
+
+        if (!isset($indexQueueItemRecord['uid'])) {
+            return null;
+        }
+
+        /** @var Item $item*/
+        $item = GeneralUtility::makeInstance(Item::class, $indexQueueItemRecord);
+        return $item;
+    }
+
+    /**
+     * Gets Index Queue items by type and uid.
+     *
+     * @param string $itemType item type, usually  the table name
+     * @param int $itemUid item uid
+     * @return Item[] An array of items matching $itemType and $itemUid
+     */
+    public function findItemsByItemTypeAndItemUid(string $itemType, int $itemUid) : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $compositeExpression = $queryBuilder->expr()->andX(
+            $queryBuilder->expr()->eq('item_type', $queryBuilder->getConnection()->quote($itemType, \PDO::PARAM_STR)),
+            $queryBuilder->expr()->eq('item_uid', $itemUid)
+        );
+        return $this->getItemsByCompositeExpression($compositeExpression, $queryBuilder);
+    }
+
+    /**
+     * Returns a collection of items by CompositeExpression.
+     * D
+     *
+     * @param CompositeExpression|null $expression Optional expression to filter records.
+     * @param QueryBuilder|null $queryBuilder QueryBuilder to use
+     * @return array
+     */
+    protected function getItemsByCompositeExpression(CompositeExpression $expression = null, QueryBuilder $queryBuilder = null) : array
+    {
+        if (! $queryBuilder instanceof QueryBuilder) {
+            $queryBuilder = $this->getQueryBuilder();
+        }
+
+        $queryBuilder->select('*')->from($this->table);
+        if (isset($expression)) {
+            $queryBuilder->where($expression);
+        }
+
+        $indexQueueItemRecords = $queryBuilder->execute()->fetchAll();
+        return $this->getIndexQueueItemObjectsFromRecords($indexQueueItemRecords);
+    }
+
+    /**
+     * Returns all items in the queue.
+     *
+     * @return Item[] all Items from Queue without restrictions
+     */
+    public function findAll() : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $allRecords = $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->execute()->fetchAll();
+        return $this->getIndexQueueItemObjectsFromRecords($allRecords);
+    }
+
+    /**
+     * Gets $limit number of items to index for a particular $site.
+     *
+     * @param Site $site TYPO3 site
+     * @param int $limit Number of items to get from the queue
+     * @return Item[] Items to index to the given solr server
+     */
+    public function findItemsToIndex(Site $site, int $limit = 50) : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        // determine which items to index with this run
+        $indexQueueItemRecords = $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->andWhere(
+                $queryBuilder->expr()->eq('root', $site->getRootPageId()),
+                $queryBuilder->expr()->gt('changed', 'indexed'),
+                $queryBuilder->expr()->lte('changed', time()),
+                $queryBuilder->expr()->eq('errors', $queryBuilder->createNamedParameter(''))
+            )
+            ->orderBy('indexing_priority', 'DESC')
+            ->addOrderBy('changed', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->setMaxResults($limit)
+            ->execute()->fetchAll();
+
+        return $this->getIndexQueueItemObjectsFromRecords($indexQueueItemRecords);
+    }
+
+    /**
+     * Creates an array of ApacheSolrForTypo3\Solr\IndexQueue\Item objects from an array of
+     * index queue records.
+     *
+     * @param array $indexQueueItemRecords Array of plain index queue records
+     * @return array Array of ApacheSolrForTypo3\Solr\IndexQueue\Item objects
+     */
+    protected function getIndexQueueItemObjectsFromRecords(array $indexQueueItemRecords) : array
+    {
+        $indexQueueItems = [];
+        $tableUids = [];
+        $tableRecords = [];
+
+        // grouping records by table
+        foreach ($indexQueueItemRecords as $indexQueueItemRecord) {
+            $tableUids[$indexQueueItemRecord['item_type']][] = $indexQueueItemRecord['item_uid'];
+        }
+
+        // fetching records by table, saves us a lot of single queries
+        foreach ($tableUids as $table => $uids) {
+            $uidList = implode(',', $uids);
+
+            $queryBuilderForRecordTable = $this->getQueryBuilder();
+            $queryBuilderForRecordTable->getRestrictions()->removeAll();
+            $resultsFromRecordTable = $queryBuilderForRecordTable
+                ->select('*')
+                ->from($table)
+                ->where($queryBuilderForRecordTable->expr()->in('uid', $uidList))
+                ->execute();
+            $records = [];
+            while ($record = $resultsFromRecordTable->fetch()) {
+                $records[$record['uid']] = $record;
+            }
+
+            $tableRecords[$table] = $records;
+
+            if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'])) {
+                $params = ['table' => $table, 'uids' => $uids, 'tableRecords' => &$tableRecords];
+                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'] as $reference) {
+                    GeneralUtility::callUserFunction($reference, $params, $this);
+                }
+                unset($params);
+            }
+        }
+
+        // creating index queue item objects and assigning / mapping
+        // records to index queue items
+        foreach ($indexQueueItemRecords as $indexQueueItemRecord) {
+            if (isset($tableRecords[$indexQueueItemRecord['item_type']][$indexQueueItemRecord['item_uid']])) {
+                $indexQueueItems[] = GeneralUtility::makeInstance(
+                    Item::class,
+                    $indexQueueItemRecord,
+                    $tableRecords[$indexQueueItemRecord['item_type']][$indexQueueItemRecord['item_uid']]
+                );
+            } else {
+                $this->logger->log(
+                    SolrLogManager::ERROR,
+                    'Record missing for Index Queue item. Item removed.',
+                    [
+                        $indexQueueItemRecord
+                    ]
+                );
+                $this->deleteItem($indexQueueItemRecord['item_type'],
+                    $indexQueueItemRecord['item_uid']);
+            }
+        }
+
+        return $indexQueueItems;
+    }
+
+    /**
+     * Marks an item as failed and causes the indexer to skip the item in the
+     * next run.
+     *
+     * @param int|Item $item Either the item's Index Queue uid or the complete item
+     * @param string $errorMessage Error message
+     * @return int affected rows
+     */
+    public function markItemAsFailed($item, string $errorMessage = ''): int
+    {
+        if ($item instanceof Item) {
+            $itemUid = $item->getIndexQueueUid();
+        } else {
+            $itemUid = (int)$item;
+        }
+
+        if (empty($errorMessage)) {
+            // simply set to "TRUE"
+            $errorMessage = '1';
+        }
+
+        $queryBuilder = $this->getQueryBuilder();
+        return (int)$queryBuilder
+            ->update($this->table)
+            ->set('errors', $errorMessage)
+            ->where($queryBuilder->expr()->eq('uid', $itemUid))
+            ->execute();
+    }
+
+    /**
+     * Sets the timestamp of when an item last has been indexed.
+     *
+     * @param Item $item
+     * @return int affected rows
+     */
+    public function updateIndexTimeByItem(Item $item) : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        return (int)$queryBuilder
+            ->update($this->table)
+            ->set('indexed', time())
+            ->where($queryBuilder->expr()->eq('uid', $item->getIndexQueueUid()))
+            ->execute();
+    }
+}


### PR DESCRIPTION
Following functions extracted from Queue to QueueItemRepository

| Queue old | QueueItemRepository new | comment |
|-----------|:-----------------------|:-----------------------:|
| getLastIndexedRow() | findLastIndexedRow() | removed |
| getErrorsBySite() | findErrorsBySite() | delegation |
| resetAllErrors() | flushAllErrors() | delegation |
| updateExistingItem() | updateExistingItemByItemTypeAndItemUidAndRootPageId() | removed |
| addNewItem() | add() | delegation |
| getPageItemChangedTime() | getPageItemChangedTimeByPageUid() | delegation |
| getLocalizableItemChangedTime() | getLocalizableItemChangedTime() | removed |
| containsItem() | containsItem() | delegation |
| containsItemWithRootPageId() | containsItemWithRootPageId() | delegation |
| containsIndexedItem() | containsIndexedItem() | delegation |
| deleteItem() | deleteItem() | delegation |
| deleteItemsByType() | deleteItemsByType() | delegation |
| deleteItemsBySite() | deleteItemsBySite() | delegation |
| deleteAllItems() | deleteAllItems() | delegation |
| getItem() | findItemByUid() | delegation |
| getItems() | findItemsByItemTypeAndItemUid() | delegation |
| getAllItems() | findAll() | delegation |
| getItemsByWhereClause() | getItemsByCompositeExpression() | removed |
| getIndexQueueItemObjectsFromRecords() | getIndexQueueItemObjectsFromRecords() | removed |
| getItemsToIndex() | findItemsToIndex() | delegation |
| markItemAsFailed() | markItemAsFailed() | delegation |
| updateIndexTimeByItem() | updateIndexTimeByItem() | delegation |

Fixes: #1180