### PR TITLE
[BUGFIX] MySQL Query for search buckets is faulty

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -201,8 +201,7 @@ class StatisticsRepository extends AbstractRepository
         $result = $queryBuilder
             ->addSelectLiteral(
                 'FLOOR(`tstamp`/' . $bucketSeconds . ') AS `bucket`',
-                // @todo: Works only with MySQL. Add own column with Date type to prevent converting DateTime to Date
-                'unix_timestamp(from_unixtime(`tstamp`, "%y-%m-%d")) AS `timestamp`',
+                '(`tstamp` - (`tstamp` % 86400)) AS `timestamp`',
                 $queryBuilder->expr()->count('*', 'numQueries')
             )
             ->from($this->table)


### PR DESCRIPTION
* replace excl. MySQL functions with pure math in getQueriesOverTime()
* fixes faulty calculation, because bucket and calculated timestamp was calculated for wrong day
* closes #1556, because using new date column requires database migrations

Fixes: #1575