### PR TITLE
 [BUGFIX] Backport: MySQL Query for search buckets is faulty

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -147,9 +147,11 @@ class StatisticsRepository
         $timeStart = $now - 86400 * intval($days); // 86400 seconds/day
 
         $queries = $this->getDatabase()->exec_SELECTgetRows(
-            'FLOOR(tstamp/' . $bucketSeconds . ') AS bucket, unix_timestamp(from_unixtime(tstamp, "%y-%m-%d")) as timestamp, COUNT(*) AS numQueries',
+            'FLOOR(tstamp/' . intval($bucketSeconds) . ') AS bucket, ' .
+            '(`tstamp` - (`tstamp` % 86400)) AS `timestamp`, ' .
+            'COUNT(*) AS numQueries',
             'tx_solr_statistics',
-            'tstamp > ' . $timeStart . ' AND root_pid = ' . $rootPageId,
+            'tstamp > ' . intval($timeStart) . ' AND root_pid = ' . intval($rootPageId),
             'bucket, timestamp',
             'bucket ASC'
         );


### PR DESCRIPTION
* replace excl. MySQL functions with pure math in getQueriesOverTime()
* fixes faulty calculation, because bucket and calculated timestamp was calculated for wrong day
* Backport comes from #1591

Fixes: #1602, related #1575