### PR TITLE
[TASK] Check why custom template is not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ matrix:
       php: 7.0
     - env: TYPO3_VERSION="9.x-dev"
       php: 7.1
-    - env: TYPO3_VERSION="8.x-dev"
-      php: 7.0
-    - env: TYPO3_VERSION="8.x-dev"
-      php: 7.1
 
 before_install:
   - composer self-update

--- a/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
@@ -16,7 +16,9 @@
         <config>
             <![CDATA[
                 config.disableAllHeaderCode = 1
-                config.tx_extbase {
+
+                //todo: using modules.tx_solr is required since this runs in BE context. We should find a solution to test it in a real frontend context
+                module.tx_solr {
                 	view {
                         templateRootPaths.10 = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/
                         widget.ApacheSolrForTypo3\Solr\ViewHelpers\Widget\ResultPaginateViewHelper.templateRootPath = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/


### PR DESCRIPTION
This pr:

* Sets the path to "module.tx_solr" because the test is running in the backend context
* We need to find a solution to run it in a real frontend context