### PR TITLE
[TASK] rewrite/extract queries from Initializer\Page

### DIFF
--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -243,4 +243,25 @@ class PagesRepository extends AbstractRepository
                 . BackendUtility::deleteClause('pages')
             )->execute()->fetchAll();
     }
+
+    /**
+     * Finds all pages by given where clause
+     *
+     * @param string $whereClause
+     * @return array
+     */
+    public function findAllMountPagesByWhereClause(string $whereClause) : array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+        return $queryBuilder
+            ->select(
+                'uid',
+                'mount_pid AS mountPageSource',
+                'uid AS mountPageDestination',
+                'mount_pid_ol AS mountPageOverlayed')
+            ->from($this->table)
+            ->add('where', $whereClause)
+            ->execute()->fetchAll();
+    }
 }


### PR DESCRIPTION
Following Methods were changed:

| Initializer\Page old | QueueItemRepository new | comment for old method|
|-----------|:-----------------------|:-----------------------:|
| getPageIdsOfExistingMountPages() | findPageIdsOfExistingMountPagesByMountIdentifier() | removed |
| addMountedPagesToIndexQueue() | - | uses QueueItemRepository::initializeByNativeSQLStatement() instead of executing directly |
| addIndexQueueItemIndexingProperties() | findAllIndexQueueItemsByRootPidAndMountIdentifierAndMountedPids() | using in step |
| findMountPages() | PagesRepository::findAllMountPagesByWhereClause() | removed |

Fixes: #1599