### PR TITLE
[BUGFIX] doctrines query builder doesn't add 'where' append

### DIFF
--- a/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
@@ -56,7 +56,7 @@ class QueueStatisticsRepository extends AbstractRepository
                 $queryBuilder->quoteIdentifier('changed'),
                 $queryBuilder->quoteIdentifier('pending')
             ]), true)
-            ->add('select', vsprintf('%s AS %s', [
+            ->add('select', vsprintf('(%s) AS %s', [
                 $queryBuilder->expr()->notLike('errors', '""'),
                 $queryBuilder->quoteIdentifier('failed')
             ]), true)
@@ -66,8 +66,7 @@ class QueueStatisticsRepository extends AbstractRepository
             ->groupBy('pending', 'failed');
 
         if (!empty($indexingConfigurationName)) {
-            $queryBuilder->add('where',
-                $queryBuilder->expr()->eq('indexing_configuration', $queryBuilder->createNamedParameter($indexingConfigurationName)), true);
+            $queryBuilder->andWhere($queryBuilder->expr()->eq('indexing_configuration', $queryBuilder->createNamedParameter($indexingConfigurationName)));
         }
 
         return $this->buildQueueStatisticFromResultSet($queryBuilder->execute()->fetchAll());

--- a/Tests/Integration/IndexQueue/Fixtures/can_get_statistics_by_site_and_custom_indexing_configuration.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_get_statistics_by_site_and_custom_indexing_configuration.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>2</pid>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>3</pid>
+        <doktype>1</doktype>
+    </pages>
+
+    <!-- scheduled site 1 -->
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>customIndexingConfigurationName</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <!-- scheduled site 2 -->
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>customIndexingConfigurationName</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+
+    <!-- failed -->
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>3</item_uid>
+        <indexing_configuration>customIndexingConfigurationName</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors>can not open page</errors>
+    </tx_solr_indexqueue_item>
+
+    <!-- processed -->
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>4</item_uid>
+        <indexing_configuration>customIndexingConfigurationName</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>1449151778</indexed>
+        <errors></errors>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -279,6 +279,27 @@ class QueueTest extends IntegrationTest
     /**
      * @test
      */
+    public function canGetStatisticsByCustomIndexingConfigurationName()
+    {
+        $this->importDataSetFromFixture('can_get_statistics_by_site_and_custom_indexing_configuration.xml');
+        $this->assertItemsInQueue(4);
+
+        $site = $this->siteRepository->getSiteByPageId(2);
+        $statistics = $this->indexQueue->getStatisticsBySite($site, 'customIndexingConfigurationName');
+
+        $this->assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed custom items from queue');
+        $this->assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed custom items from queue');
+        $this->assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed custom items from queue');
+
+        $notExistingIndexingConfStatistic = $this->indexQueue->getStatisticsBySite($site, 'notExistingIndexingConfigurationName');
+        $this->assertSame(0, $notExistingIndexingConfStatistic->getSuccessCount(), 'Can not get successful processed items from queue for not existing indexing configuration');
+        $this->assertSame(0, $notExistingIndexingConfStatistic->getFailedCount(), 'Can not get failed processed items from queue for not existing indexing configuration');
+        $this->assertSame(0, $notExistingIndexingConfStatistic->getPendingCount(), 'Can not get pending processed items from queue for not existing indexing configuration');
+    }
+
+    /**
+     * @test
+     */
     public function canGetLastIndexNonExistingRoot()
     {
         $this->importDataSetFromFixture('can_get_last_index_time.xml');


### PR DESCRIPTION
added test case for fetching statistics by custom indexingConfigurationName

Fixes: #1630