### PR TITLE
[TASK] Use doctrine in ApacheSolrForTypo3\Solr\ContentObject\Relation

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_multiple_mm_relations.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_multiple_mm_relations.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    category_stringM = SOLR_RELATION
+                                    category_stringM {
+                                        localField = tags
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>testnews</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>8</uid_foreign>
+        <sorting>2</sorting>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <sorting>4</sorting>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>8</uid>
+        <pid>1</pid>
+        <tag>the tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>2</uid>
+        <pid>1</pid>
+        <tag>another tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_bar;
+
 CREATE TABLE tx_fakeextension_domain_model_bar (
 	uid int(11) NOT NULL auto_increment,
 	pid int(11) DEFAULT '0' NOT NULL,
@@ -30,6 +32,8 @@ CREATE TABLE tx_fakeextension_domain_model_bar (
 	PRIMARY KEY (uid)
 );
 
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_related_mm;
+
 CREATE TABLE tx_fakeextension_domain_model_related_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
@@ -38,6 +42,8 @@ CREATE TABLE tx_fakeextension_domain_model_related_mm (
    KEY uid_local (uid_local),
    KEY uid_foreign (uid_foreign)
 );
+
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_related_pages_mm;
 
 CREATE TABLE tx_fakeextension_domain_model_related_pages_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
@@ -48,6 +54,8 @@ CREATE TABLE tx_fakeextension_domain_model_related_pages_mm (
    KEY uid_local (uid_local),
    KEY uid_foreign (uid_foreign)
 );
+
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_mmrelated;
 
 CREATE TABLE tx_fakeextension_domain_model_mmrelated (
 	uid int(11) NOT NULL auto_increment,
@@ -78,6 +86,7 @@ CREATE TABLE tx_fakeextension_domain_model_mmrelated (
 	PRIMARY KEY (uid)
 );
 
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_directrelated;
 
 CREATE TABLE tx_fakeextension_domain_model_directrelated (
 	uid int(11) NOT NULL auto_increment,


### PR DESCRIPTION
The old MySQL-Only native function "FIELD(uid..." is not supported by other platforms,
therefore we need to order it in PHP

Fixes: #1370