### PR TITLE
[BUGFIX] Backport: Add default typoscript view configuration

### DIFF
--- a/Configuration/TypoScript/Solr/constants.txt
+++ b/Configuration/TypoScript/Solr/constants.txt
@@ -1,6 +1,12 @@
 
 plugin.tx_solr {
 
+	view {
+		templateRootPath = EXT:solr/Resources/Private/Templates/
+		partialRootPath = EXT:solr/Resources/Private/Partials/
+		layoutRootPath = EXT:solr/Resources/Private/Layouts/
+	}
+
 	solr {
 		scheme = http
 		host = localhost

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -243,6 +243,16 @@ plugin.tx_solr {
 	view {
 		pluginNamespace = tx_solr
 
+		templateRootPaths {
+			0 = {$plugin.tx_solr.templateRootPath}
+		}
+		partialRootPaths {
+			0 = {$plugin.tx_solr.partialRootPath}
+		}
+		layoutRootPaths {
+			0 = {$plugin.tx_solr.layoutRootPath}
+		}
+
         // By convention the templates is loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html
         // If you want to define a different entry template, you can do this here to overwrite the conventional default template
         // if you want to use FLUID fallbacks you can just configure the template name, otherwise you could also use a full reference EXT:/.../


### PR DESCRIPTION
since CMS 8.7.5 templates -, partials - and layout paths must be set

comes from: #1625

Fixes: #1633