### PR TITLE
[TASK] Backport: Check why build fails

### DIFF
--- a/Configuration/TypoScript/Solr/constants.txt
+++ b/Configuration/TypoScript/Solr/constants.txt
@@ -1,6 +1,12 @@
 
 plugin.tx_solr {
 
+	view {
+		templateRootPath = EXT:solr/Resources/Private/Templates/
+		partialRootPath = EXT:solr/Resources/Private/Partials/
+		layoutRootPath = EXT:solr/Resources/Private/Layouts/
+	}
+
 	solr {
 		scheme = http
 		host = localhost

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -243,6 +243,16 @@ plugin.tx_solr {
 	view {
 		pluginNamespace = tx_solr
 
+		templateRootPaths {
+			0 = {$plugin.tx_solr.templateRootPath}
+		}
+		partialRootPaths {
+			0 = {$plugin.tx_solr.partialRootPath}
+		}
+		layoutRootPaths {
+			0 = {$plugin.tx_solr.layoutRootPath}
+		}
+
         // By convention the templates is loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html
         // If you want to define a different entry template, you can do this here to overwrite the conventional default template
         // if you want to use FLUID fallbacks you can just configure the template name, otherwise you could also use a full reference EXT:/.../

--- a/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
@@ -16,7 +16,9 @@
         <config>
             <![CDATA[
                 config.disableAllHeaderCode = 1
-                config.tx_extbase {
+
+                //todo: using modules.tx_solr is required since this runs in BE context. We should find a solution to test it in a real frontend context
+                module.tx_solr {
                 	view {
                         templateRootPaths.10 = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/
                         widget.ApacheSolrForTypo3\Solr\ViewHelpers\Widget\ResultPaginateViewHelper.templateRootPath = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -799,7 +799,7 @@ class SearchControllerTest extends IntegrationTest
     public function canRenderDetailAction()
     {
         $request = $this->getPreparedRequest('detail');
-        $request->setArgument('documentId', 'b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/1/0/0/0');
+        $request->setArgument('documentId', '23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/1/0/0/0');
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -55,7 +55,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
-        $this->assertContains('b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/1/0/0/0', $solrContent);
+        $this->assertContains('23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/1/0/0/0', $solrContent);
 
         $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1, 0, 0);
 
@@ -64,7 +64,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
         /** @var $searchResultsSetService SearchResultSetService */
         $searchResultsSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
-        $document = $searchResultsSetService->getDocumentById('b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/1/0/0/0');
+        $document = $searchResultsSetService->getDocumentById('23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/1/0/0/0');
 
         $this->assertSame($document->getTitle(), 'Products', 'Could not get document from solr by id');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fakeResponse.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fakeResponse.json
@@ -29,7 +29,7 @@
             "facet.field": ["type",
                 "{!ex=subTitle}subTitle",
                 "rootline"],
-            "fq": ["siteHash:\"b8c8d04e66c58f01283ef81a4ded197f26ab402a\"",
+            "fq": ["siteHash:\"23c51a0d5cf548afecc043a7068902e8f82a22a0\"",
                 "{!typo3access}-1,0"],
             "hl.requireFieldMatch": "true",
             "mm": "2<-35%",
@@ -56,9 +56,9 @@
         "maxScore": 1.0,
         "docs": [
             {
-                "id": "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/6/0/0/0",
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0",
                 "site": "",
-                "siteHash": "b8c8d04e66c58f01283ef81a4ded197f26ab402a",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
                 "type": "pages",
                 "uid": 6,
                 "pid": 1,
@@ -83,9 +83,9 @@
                 "isElevated": false
             },
             {
-                "id": "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/7/0/0/0",
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0",
                 "site": "",
-                "siteHash": "b8c8d04e66c58f01283ef81a4ded197f26ab402a",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
                 "type": "pages",
                 "uid": 7,
                 "pid": 1,
@@ -110,9 +110,9 @@
                 "isElevated": false
             },
             {
-                "id": "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/8/0/0/0",
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0",
                 "site": "",
-                "siteHash": "b8c8d04e66c58f01283ef81a4ded197f26ab402a",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
                 "type": "pages",
                 "uid": 8,
                 "pid": 1,
@@ -164,13 +164,13 @@
         "facet_intervals": {}
     },
     "highlighting": {
-        "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/6/0/0/0": {
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0": {
             "content": [""]
         },
-        "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/7/0/0/0": {
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0": {
             "content": [""]
         },
-        "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/8/0/0/0": {
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0": {
             "content": [""]
         }
     },
@@ -184,18 +184,18 @@
         "parsedquery": "(+MatchAllDocsQuery(*:*) ())/no_coord",
         "parsedquery_toString": "+*:* ()",
         "explain": {
-            "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/6/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
-            "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/7/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
-            "b8c8d04e66c58f01283ef81a4ded197f26ab402a/pages/8/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n"
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n"
         },
         "QParser": "ExtendedDismaxQParser",
         "altquerystring": null,
         "boost_queries": null,
         "parsed_boost_queries": [],
         "boostfuncs": null,
-        "filter_queries": ["siteHash:\"b8c8d04e66c58f01283ef81a4ded197f26ab402a\"",
+        "filter_queries": ["siteHash:\"23c51a0d5cf548afecc043a7068902e8f82a22a0\"",
             "{!typo3access}-1,0"],
-        "parsed_filter_queries": ["siteHash:b8c8d04e66c58f01283ef81a4ded197f26ab402a",
+        "parsed_filter_queries": ["siteHash:23c51a0d5cf548afecc043a7068902e8f82a22a0",
             "ConstantScore(org.typo3.solr.search.AccessFilter@7b7c4a74)"],
         "timing": {
             "time": 9.0,


### PR DESCRIPTION
This pr:

* Changes the expected id since the encryption key of the testing framework was changed.
* since CMS 8.7.5 templates -, partials - and layout paths must be set
* Sets the path to "module.tx_solr" because the test is running in the backend context
  * We need to find a solution to run it in a real frontend context

Comes From: #1611, #1616, #1625, 

Fixes: #1644, fixes: #1633