### PR TITLE
IndexMaintenance documentation: fix params in create core call

### DIFF
--- a/Documentation/Solr/IndexMaintenance.rst
+++ b/Documentation/Solr/IndexMaintenance.rst
@@ -69,6 +69,6 @@ Since we support configSets a core could be generated with the following http ca
 
 .. code-block:: bash
 
-    curl 'http://host:port/path-to-solr/admin/cores?action=CREATE&name=core_de&configSet=ext_solr_8_0_0&schema=german/schema.xml&dataDir=dataDir=../../data/german'
+    curl 'http://host:port/path-to-solr/admin/cores?action=CREATE&name=core_de&configSet=ext_solr_8_0_0&schema=german/schema.xml&dataDir=../../data/german'
 
 


### PR DESCRIPTION
With the current command, i'll end up with a datadir of `/<installation-path>/server/solr/core_de/dataDir=../../data/german/`