### PR TITLE
[TASK] Enable escaping in TranslateViewHelper and AbstractWidgetViewHelper

### DIFF
--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -32,11 +32,6 @@ class TranslateViewHelper extends CoreTranslateViewHelper
     protected $escapeChildren = true;
 
     /**
-     * @var bool
-     */
-    protected $escapeOutput = false;
-
-    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/Widget/AbstractWidgetViewHelper.php
+++ b/Classes/Widget/AbstractWidgetViewHelper.php
@@ -80,16 +80,6 @@ abstract class AbstractWidgetViewHelper extends AbstractCoreWidgetViewHelper imp
     private $widgetContext;
 
     /**
-     * @var bool
-     */
-    protected $escapeChildren = false;
-
-    /**
-     * @var bool
-     */
-    protected $escapeOutput = false;
-
-    /**
      * @param AjaxWidgetContextHolder $ajaxWidgetContextHolder
      * @return void
      */

--- a/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
@@ -20,10 +20,20 @@
 					<li class="previous">
 						<f:if condition="{pagination.previousPage} > 1">
 							<f:then>
-								<a href="{s:uri.paginate.resultPage(page: pagination.previousPage)}" class="solr-ajaxified"><s:translate key="paginate_previous">&laquo;</s:translate></a>
+								<a href="{s:uri.paginate.resultPage(page: pagination.previousPage)}" class="solr-ajaxified">
+									<f:if condition="{s:translate(key: 'paginate_previous')}">
+										<f:then><s:translate key="paginate_previous" /></f:then>
+										<f:else>&laquo;</f:else>
+									</f:if>
+								</a>
 							</f:then>
 							<f:else>
-								<a href="{s:uri.paginate.resultPage()}" class="solr-ajaxified"><s:translate key="paginate_previous">&laquo;</s:translate></a>
+								<a href="{s:uri.paginate.resultPage()}" class="solr-ajaxified">
+									<f:if condition="{s:translate(key: 'paginate_previous')}">
+										<f:then><s:translate key="paginate_previous" /></f:then>
+										<f:else>&laquo;</f:else>
+									</f:if>
+								</a>
 							</f:else>
 						</f:if>
 					</li>
@@ -57,7 +67,12 @@
 				</f:if>
 				<f:if condition="{pagination.nextPage}">
 					<li class="last next">
-						<a href="{s:uri.paginate.resultPage(page: pagination.nextPage)}" class="solr-ajaxified"><s:translate key="paginate_next">&raquo;</s:translate></a>
+						<a href="{s:uri.paginate.resultPage(page: pagination.nextPage)}" class="solr-ajaxified">
+							<f:if condition="{s:translate(key: 'paginate_next')}">
+								<f:then><s:translate key="paginate_next" /></f:then>
+								<f:else>&raquo;</f:else>
+							</f:if>
+						</a>
 					</li>
 				</f:if>
 			</ul>


### PR DESCRIPTION
This pr:

* Enabled the escaping for the Translate and AbstractWidgetViewHelper to avoid the output of unwanted content.