### PR TITLE
[TASK] Do not ping solr server before search

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestBuilder;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Mvc\Controller\SolrControllerContext;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Service\ConfigurationService;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager as SolrConfigurationManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -230,5 +231,19 @@ abstract class AbstractBaseController extends ActionController
         }
 
         return $this->searchRequestBuilder;
+    }
+
+    /**
+     * Called when the solr server is unavailable.
+     *
+     * @return void
+     */
+    protected function handleSolrUnavailable()
+    {
+        if ($this->typoScriptConfiguration->getLoggingExceptions()) {
+            /** @var SolrLogManager $logger */
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+            $logger->log(SolrLogManager::ERROR, 'Solr server is not available');
+        }
     }
 }

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -26,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Controller;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -68,20 +67,6 @@ class SuggestController extends AbstractBaseController
         }
 
         return htmlspecialchars($jsonPCallback) . '(' . json_encode($result) . ')';
-    }
-
-    /**
-     * Called when the solr server is unavailable.
-     *
-     * @return void
-     */
-    protected function handleSolrUnavailable()
-    {
-        if ($this->typoScriptConfiguration->getLoggingExceptions()) {
-                /** @var SolrLogManager $logger */
-            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
-            $logger->log(SolrLogManager::ERROR, 'Solr server is not available');
-        }
     }
 
 }

--- a/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
@@ -67,7 +67,7 @@
                         scheme = http
                         host   = localhost
                         port   = 8999
-                        path   = /solr/core_en/
+                        path   = /solr/core_fail/
                     }
 
                     index {


### PR DESCRIPTION
Currently the solr server is pinged before every request. In the most cases the solr server is available and the unavailablility is an exception. Therefore we do not ping the solr server and catch a missing connection in the catch block. By using this approach we need to do only one request to the solr server in the most cases instead of two before. This finally improves the speed of the search.

Fixes: #1404