### PR TITLE
[BUGFIX] Can not overwrite facet sortBy to count

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\SortingExpression;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -235,18 +236,12 @@ class Faceting implements ParameterBuilder
      */
     protected function applySorting(array $facetParameters)
     {
-        if (!GeneralUtility::inList('count,index,alpha,lex,1,0,true,false', $this->sorting)) {
-            // when the sorting is not in the list of valid values we do not apply it.
-            return $facetParameters;
-        }
-        $solrSorting = $this->sorting;
-
-        // alpha and lex alias for index
-        if ($this->sorting === 'alpha' || $this->sorting === 'lex') {
-            $solrSorting = 'index';
+        $sortingExpression = new SortingExpression();
+        $globalSortingExpression = $sortingExpression->getForFacet($this->sorting);
+        if (!empty($globalSortingExpression)) {
+            $facetParameters['facet.sort'] = $globalSortingExpression;
         }
 
-        $facetParameters['facet.sort'] = $solrSorting;
 
         return $facetParameters;
     }

--- a/Classes/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilder.php
@@ -31,8 +31,10 @@ class DefaultFacetQueryBuilder implements FacetQueryBuilderInterface {
         $tags = $this->buildExcludeTags($facetConfiguration, $configuration);
         $facetParameters['facet.field'][] = $tags . $facetConfiguration['field'];
 
-        if (in_array($facetConfiguration['sortBy'], ['alpha', 'index', 'lex'])) {
-            $facetParameters['f.' . $facetConfiguration['field'] . '.facet.sort'] = 'lex';
+        $sortingExpression = new SortingExpression();
+        $facetSortExpression = $sortingExpression->getForFacet($facetConfiguration['sortBy']);
+        if (!empty($facetSortExpression)) {
+            $facetParameters['f.' . $facetConfiguration['field'] . '.facet.sort'] = $facetSortExpression;
         }
 
         return $facetParameters;

--- a/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
+++ b/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
@@ -1,0 +1,71 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017- Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Expression for facet sorting
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @author Jens Jacobsen <jens.jacobsen@ueberbit.de>
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets
+ */
+class SortingExpression
+{
+    /**
+     * Return expression for facet sorting
+     *
+     * @param string $sorting
+     * @return string
+     */
+    public function getForFacet($sorting)
+    {
+        $noSortingSet = $sorting !== 0 && $sorting !== FALSE && empty($sorting);
+        $sortingIsCount = $sorting === 'count' || $sorting === 1 || $sorting === '1' || $sorting === TRUE;
+        if ($noSortingSet) {
+            return '';
+        } elseif ($sortingIsCount) {
+            return 'count';
+        } else {
+            return 'index';
+        }
+    }
+
+    /**
+     * Return expression for facet sorting combined with direction
+     *
+     * @param string $sorting
+     * @param string $direction
+     * @return string
+     */
+    public function getForJsonFacet($sorting, $direction)
+    {
+        $expression = $this->getForFacet($sorting);
+        $direction = strtolower($direction);
+        if (!empty($direction) && in_array($direction, ['asc', 'desc'])) {
+            $expression .= ' ' . $direction;
+        }
+        return $expression;
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\SortingExpression;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Unit test for the SortingExpression
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @author Jens Jacobsen <jens.jacobsen@ueberbit.de>
+ */
+class SortingExpressionTest extends UnitTest
+{
+    public function canBuildSortExpressionDataProvider()
+    {
+        return [
+            'byAlpha' => ['sorting' => 'alpha', 'direction' => '', 'isJson' => false, 'expectedResult' => 'index'],
+            'byLex' => ['sorting' => 'lex', 'direction' => '', 'isJson' => false, 'expectedResult' => 'index'],
+            'byOne' => ['sorting' => 1, 'direction' => '', 'isJson' => false, 'expectedResult' => 'count'],
+            'byZero' => ['sorting' => 0, 'direction' => '', 'isJson' => false, 'expectedResult' => 'index'],
+            'byTrue' => ['sorting' => true, 'direction' => '', 'isJson' => false, 'expectedResult' => 'count'],
+            'byFalse' => ['sorting' => false, 'direction' => '', 'isJson' => false, 'expectedResult' => 'index'],
+
+            'byIndex' => ['sorting' => 'index', 'direction' => '', 'isJson' => false, 'expectedResult' => 'index'],
+            'byCount' => ['sorting' => 'count', 'direction' => '', 'isJson' => false, 'expectedResult' => 'count'],
+
+            'byAlphaJson' => ['sorting' => 'alpha', 'direction' => '', 'isJson' => true, 'expectedResult' => 'index'],
+            'byAlphaJsonSortAsc' => ['sorting' => 'alpha', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'index asc'],
+            'byAlphaJsonSortDesc' => ['sorting' => 'alpha', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'index desc'],
+            'byLexJson' => ['sorting' => 'lex', 'direction' => '', 'isJson' => true, 'expectedResult' => 'index'],
+            'byLexJsonSortAsc' => ['sorting' => 'lex', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'index asc'],
+            'byLexJsonSortDesc' => ['sorting' => 'lex', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'index desc'],
+
+            'byOneJson' => ['sorting' => 1, 'direction' => '', 'isJson' => true, 'expectedResult' => 'count'],
+            'byOneJsonSortAsc' => ['sorting' => 1, 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'count asc'],
+            'byOneJsonSortDesc' => ['sorting' => 1, 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'count desc'],
+            'byZeroJson' => ['sorting' => 0, 'direction' => '', 'isJson' => true, 'expectedResult' => 'index'],
+            'byZeroJsonSortAsc' => ['sorting' => 0, 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'index asc'],
+            'byZeroJsonSortDesc' => ['sorting' => 0, 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'index desc'],
+
+            'byTrueJson' => ['sorting' => true, 'direction' => '', 'isJson' => true, 'expectedResult' => 'count'],
+            'byTrueJsonSortAsc' => ['sorting' => true, 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'count asc'],
+            'byTrueJsonSortDesc' => ['sorting' => true, 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'count desc'],
+            'byFalseJson' => ['sorting' => false, 'direction' => '', 'isJson' => true, 'expectedResult' => 'index'],
+            'byFalseJsonSortAsc' => ['sorting' => false, 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'index asc'],
+            'byFalseJsonSortDesc' => ['sorting' => false, 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'index desc'],
+
+            'byIndexJson' => ['sorting' => 'index', 'direction' => '', 'isJson' => true, 'expectedResult' => 'index'],
+            'byIndexJsonSortAsc' => ['sorting' => 'index', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'index asc'],
+            'byIndexJsonSortDesc' => ['sorting' => 'index', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'index desc'],
+
+            'byCountJson' => ['sorting' => 'count', 'direction' => '', 'isJson' => true, 'expectedResult' => 'count'],
+            'byCountJsonSortAsc' => ['sorting' => 'count', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'count asc'],
+            'byCountJsonSortDesc' => ['sorting' => 'count', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'count desc'],
+        ];
+    }
+
+    /**
+     * @param string $sorting
+     * @param string $direction
+     * @param boolean $isJson
+     * @param string $expectedResult
+     * @dataProvider canBuildSortExpressionDataProvider
+     * @test
+     */
+    public function canBuildSortExpression($sorting, $direction, $isJson, $expectedResult)
+    {
+        $expression = new SortingExpression();
+        if ($isJson) {
+            $result = $expression->getForJsonFacet($sorting, $direction);
+        } else {
+            $result = $expression->getForFacet($sorting);
+        }
+        $this->assertSame($expectedResult, $result, 'Unexpected expression for solr server');
+    }
+}

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -120,7 +120,7 @@ class FacetingTest extends UnitTest
      *
      * @test
      */
-    public function testCanAddSortByQueryArgument()
+    public function testCanAddSortByIndexArgument()
     {
         $fakeConfigurationArray = [];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
@@ -131,16 +131,42 @@ class FacetingTest extends UnitTest
             ]
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
-
-
         $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
-
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertContains('lex',  $queryParameter['f.type.facet.sort'], 'Query string did not contain expected snipped');
+        $this->assertContains('index',  $queryParameter['f.type.facet.sort'], 'Query string did not contain expected snipped');
+    }
+    /**
+     * Checks if the faceting modifier can add a simple facet with a sortBy property with the value count.
+     *
+     *  facets {
+     *     type {
+     *        field = type
+     *        sortBy = count
+     *     }
+     *  }
+     *
+     * @test
+     */
+    public function testCanAddSortByCountArgument()
+    {
+        $fakeConfigurationArray = [];
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
+            'type.' => [
+                'field' => 'type',
+                'sortBy' => 'count'
+            ]
+        ];
+        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
+        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+        $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        $this->assertContains('count',  $queryParameter['f.type.facet.sort'], 'Query string did not contain expected snipped');
     }
 
     /**


### PR DESCRIPTION
This pr:

* Allows to overwrite the sorting on facet base back to count
* Extracts the logic to generate the sorting into an own class
* Uses this class in the DefaultFacetQueryBuilder and Faceting parameter builder

Fixes: #1666