### PR TITLE
[!!!][WIP][TASK] Prepare api for grouping

### DIFF
--- a/Classes/Domain/Search/ResultSet/Grouping/Group.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/Group.php
@@ -1,0 +1,141 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
+
+/**
+ * Class Group
+ *
+ * @author Frans Saris <frans@beech.it>
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping
+ */
+class Group
+{
+    /**
+     * @var string
+     */
+    protected $groupValue = '';
+
+    /**
+     * @var int
+     */
+    protected $numFound = 0;
+
+    /**
+     * @var int
+     */
+    protected $start = 0;
+
+    /**
+     * @var float
+     */
+    protected $maxScore = 0;
+
+    /**
+     * @var SearchResultCollection
+     */
+    protected $searchResults;
+
+    /**
+     * @param string $groupValue
+     * @param int $numFound
+     * @param int $start
+     * @param float $maxScore
+     */
+    public function __construct($groupValue, $numFound, $start, $maxScore)
+    {
+        $this->groupValue = $groupValue;
+        $this->numFound = $numFound;
+        $this->start = $start;
+        $this->maxScore = $maxScore;
+    }
+
+    /**
+     * Get groupValue
+     *
+     * @return string
+     */
+    public function getGroupValue()
+    {
+        return $this->groupValue;
+    }
+
+    /**
+     * Get numFound
+     *
+     * @return int
+     */
+    public function getNumFound()
+    {
+        return $this->numFound;
+    }
+
+    /**
+     * Get start
+     *
+     * @return int
+     */
+    public function getStart()
+    {
+        return $this->start;
+    }
+
+    /**
+     * Get maxScore
+     *
+     * @return float
+     */
+    public function getMaxScore()
+    {
+        return $this->maxScore;
+    }
+
+    /**
+     * @return SearchResultCollection
+     */
+    public function getSearchResults(): SearchResultCollection
+    {
+        return $this->searchResults;
+    }
+
+    /**
+     * @param SearchResultCollection $searchResults
+     */
+    public function setSearchResults(SearchResultCollection $searchResults)
+    {
+        $this->searchResults = $searchResults;
+    }
+
+    /**
+     * @param SearchResult $searchResult
+     */
+    public function addSearchResult(SearchResult $searchResult)
+    {
+        $this->searchResults[] = $searchResult;
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Grouping/GroupCollection.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping;
 
 /***************************************************************
  *  Copyright notice
@@ -24,23 +24,12 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 
 /**
- * The SearchResultBuilder is responsible to build a SearchResult object from an Apache_Solr_Document
- * and should use a different class as SearchResult if configured.
+ * The Group contains the Group objects.
  *
- * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
- * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping
  */
-class SearchResultBuilder extends \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder {
-
-
-    /**
-     * @deprecated Since 8.0.0 will be removed in 9.0.0 This class was moved to the \Domain\Search\ResultSet\Result package, please use this one
-     */
-    public function __contruct()
-    {
-        GeneralUtility::logDeprecatedFunction();
-    }
-}
+class GroupCollection extends AbstractCollection {}

--- a/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * A ResultParser is responsible to create the result object structure from the \Apache_Solr_Response
+ * and assign it to the SearchResultSet.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser
+ */
+abstract class AbstractResultParser {
+
+    /**
+     * @var SearchResultBuilder
+     */
+    protected $searchResultBuilder;
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $typoScriptConfiguration;
+
+    /**
+     * @var DocumentEscapeService
+     */
+    protected $documentEscapeService;
+
+    /**
+     * AbstractResultParser constructor.
+     * @param TypoScriptConfiguration|null $typoScriptConfiguration
+     * @param SearchResultBuilder|null $resultBuilder
+     * @param DocumentEscapeService|null $documentEscapeService
+     */
+    public function __construct(TypoScriptConfiguration $typoScriptConfiguration = null,
+                                SearchResultBuilder $resultBuilder = null,
+                                DocumentEscapeService $documentEscapeService = null) {
+        $this->typoScriptConfiguration = $typoScriptConfiguration;
+        $this->searchResultBuilder = is_null($resultBuilder) ? GeneralUtility::makeInstance(SearchResultBuilder::class) : $resultBuilder;
+        $this->documentEscapeService = is_null($documentEscapeService) ? GeneralUtility::makeInstance(DocumentEscapeService::class, $typoScriptConfiguration) : $documentEscapeService;
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @param bool $useRawDocuments
+     * @return SearchResultCollection
+     */
+    abstract public function parse(SearchResultSet $resultSet, bool $useRawDocuments = true);
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return mixed
+     */
+    abstract public function canParse(SearchResultSet $resultSet);
+}

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The DefaultResultParser is able to parse normal(ungroupd results)
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser
+ */
+class DefaultResultParser extends AbstractResultParser {
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @param bool $useRawDocuments
+     * @return SearchResultCollection|array|object
+     */
+    public function parse(SearchResultSet $resultSet, bool $useRawDocuments = true)
+    {
+        $searchResults = GeneralUtility::makeInstance(SearchResultCollection::class);
+        $parsedData = $resultSet->getResponse()->getParsedData();
+        if (!is_array($parsedData->response->docs)) {
+            return $searchResults;
+        }
+
+        $documents = $parsedData->response->docs;
+        if (!$useRawDocuments) {
+            $documents = $this->documentEscapeService->applyHtmlSpecialCharsOnAllFields($documents);
+        }
+
+        foreach ($documents as $searchResult) {
+            $searchResultObject = $this->searchResultBuilder->fromApacheSolrDocument($searchResult);
+            $searchResults[] = $searchResultObject;
+        }
+
+        return $searchResults;
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return bool
+     */
+    public function canParse(SearchResultSet $resultSet)
+    {
+        // This parsers should not be used when grouping is enabled
+        if ($this->typoScriptConfiguration->getSearchGrouping())
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Util;
+
+/**
+ * Applies htmlspecialschars on documents of a solr response.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser
+ */
+class DocumentEscapeService {
+
+    /**
+     * @var TypoScriptConfiguration|null
+     */
+    protected $typoScriptConfiguration = null;
+
+    /**
+     * DocumentEscapeService constructor.
+     * @param TypoScriptConfiguration|null $typoScriptConfiguration
+     */
+    public function __construct(TypoScriptConfiguration $typoScriptConfiguration = null) {
+        $this->typoScriptConfiguration = is_null($typoScriptConfiguration) ? Util::getSolrConfiguration() : $typoScriptConfiguration;
+    }
+
+    /**
+     * This method is used to apply htmlspecialchars on all document fields that
+     * are not configured to be secure. Secure mean that we know where the content is coming from.
+     *
+     * @param array $documents
+     * @return \Apache_Solr_Document[]
+     */
+    public function applyHtmlSpecialCharsOnAllFields(array $documents)
+    {
+        $trustedSolrFields = $this->typoScriptConfiguration->getSearchTrustedFieldsArray();
+
+        foreach ($documents as $key => $document) {
+            $fieldNames = $document->getFieldNames();
+
+            foreach ($fieldNames as $fieldName) {
+                if (is_array($trustedSolrFields) && in_array($fieldName, $trustedSolrFields)) {
+                    // we skip this field, since it was marked as secure
+                    continue;
+                }
+
+                $document->{$fieldName} = $this->applyHtmlSpecialCharsOnSingleFieldValue($document->{$fieldName});
+            }
+
+            $documents[$key] = $document;
+        }
+
+        return $documents;
+    }
+
+    /**
+     * Applies htmlspecialchars on all items of an array of a single value.
+     *
+     * @param $fieldValue
+     * @return array|string
+     */
+    protected function applyHtmlSpecialCharsOnSingleFieldValue($fieldValue)
+    {
+        if (is_array($fieldValue)) {
+            foreach ($fieldValue as $key => $fieldValueItem) {
+                $fieldValue[$key] = htmlspecialchars($fieldValueItem, null, null, false);
+            }
+        } else {
+            $fieldValue = htmlspecialchars($fieldValue, null, null, false);
+        }
+
+        return $fieldValue;
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class ResultParserRegistry
+ *
+ * @author Frans Saris <frans@beech.it>
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ResultParserRegistry implements SingletonInterface
+{
+    /**
+     * Array of available parser classNames
+     *
+     * @var array
+     */
+    protected $parsers = [
+        100 => DefaultResultParser::class,
+    ];
+
+    /**
+     * @var AbstractResultParser[]
+     */
+    protected $parserInstances;
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $typoScriptConfiguration;
+
+    /**
+     * ResultParserRegistry constructor.
+     * @param TypoScriptConfiguration $configuration
+     */
+    public function __construct(TypoScriptConfiguration $configuration)
+    {
+        $this->typoScriptConfiguration = $configuration;
+    }
+
+    /**
+     * Get registered parser classNames
+     *
+     * @return array
+     */
+    public function getParsers()
+    {
+        return $this->parsers;
+    }
+
+    /**
+     * Can be used to register a custom parser.
+     *
+     * @param string $className classname of the parser that should be used
+     * @param int $priority higher priority means more important
+     * @throws \InvalidArgumentException
+     */
+    public function registerParser($className, $priority)
+    {
+        // check if the class is available for TYPO3 before registering the driver
+        if (!class_exists($className)) {
+            throw new \InvalidArgumentException('Class ' . $className . ' does not exist.', 1468863997);
+        }
+
+        if (!is_subclass_of($className, AbstractResultParser::class)) {
+            throw new \InvalidArgumentException('Parser ' . $className . ' needs to implement the AbstractResultParser.', 1468863998);
+        }
+
+        if (array_key_exists((int)$priority, $this->parsers)) {
+            throw new \InvalidArgumentException('There is already a parser registerd with priority ' . (int)$priority . '.', 1468863999);
+        }
+
+        $this->parsers[(int)$priority] = $className;
+    }
+
+    /**
+     * @return AbstractResultParser[]
+     */
+    public function getParserInstances()
+    {
+        if ($this->parserInstances === null) {
+            ksort($this->parsers);
+            $orderedParsers = array_reverse($this->parsers);
+            foreach ($orderedParsers as $className) {
+                $this->parserInstances[] = $this->createParserInstance($className);
+            }
+        }
+        return $this->parserInstances;
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return AbstractResultParser|null
+     */
+    public function getParser(SearchResultSet $resultSet)
+    {
+        /** @var AbstractResultParser $parser */
+        foreach ($this->getParserInstances() as $parser) {
+            if ($parser->canParse($resultSet)) {
+                return $parser;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create an instance of a certain parser class
+     *
+     * @return AbstractResultParser
+     */
+    protected function createParserInstance($className)
+    {
+        return GeneralUtility::makeInstance($className, $this->typoScriptConfiguration);
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\Group;
+
+/**
+ * Proxy class for \Apache_Solr_Document to customize \Apache_Solr_Document without
+ * changing the library code.
+ *
+ * Implements
+ *
+ * @author Timo Schmidt <timo.schmidt@dkd.de>
+ */
+class SearchResult extends \Apache_Solr_Document
+{
+
+    /**
+     * @var bool
+     */
+    protected $throwExceptions = false;
+
+    /**
+     * @var SearchResult[]
+     */
+    protected $variants = [];
+
+    /**
+     * Indicates if an instance of this document is a variant (a sub document of another).
+     *
+     * @var bool
+     */
+    protected $isVariant = false;
+
+    /**
+     * References the parent document of the document is a variant.
+     *
+     * @var null
+     */
+    protected $variantParent = null;
+
+    /**
+     * @var Group
+     */
+    protected $group = null;
+
+    /**
+     * @param \Apache_Solr_Document $document
+     * @param bool $throwExceptions
+     */
+    public function __construct(\Apache_Solr_Document $document, $throwExceptions = false)
+    {
+        $this->throwExceptions = false;
+        $this->_documentBoost = $document->_documentBoost;
+        $this->_fields = $document->_fields;
+        $this->_fieldBoosts = $document->_fieldBoosts;
+    }
+
+    /**
+     * @param string $name
+     * @param array $arguments
+     * @throws \Exception
+     * @throws \RuntimeException
+     * @return string
+     */
+    public function __call($name, $arguments)
+    {
+        try {
+            return parent::__call($name, $arguments);
+        } catch (\RuntimeException $e) {
+            if ($this->throwExceptions) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * @return Group
+     */
+    public function getGroup(): Group
+    {
+        return $this->group;
+    }
+
+    /**
+     * @param Group $group
+     */
+    public function setGroup(Group $group)
+    {
+        $this->group = $group;
+    }
+
+    /**
+     * @return SearchResult[]
+     */
+    public function getVariants()
+    {
+        return $this->variants;
+    }
+
+    /**
+     * @param SearchResult $expandedResult
+     */
+    public function addVariant(SearchResult $expandedResult)
+    {
+        $this->variants[] = $expandedResult;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsVariant()
+    {
+        return $this->isVariant;
+    }
+
+    /**
+     * @param bool $isVariant
+     */
+    public function setIsVariant($isVariant)
+    {
+        $this->isVariant = $isVariant;
+    }
+
+    /**
+     * @return null
+     */
+    public function getVariantParent()
+    {
+        return $this->variantParent;
+    }
+
+    /**
+     * @param null $variantParent
+     */
+    public function setVariantParent($variantParent)
+    {
+        $this->variantParent = $variantParent;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->_fields['content'];
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsElevated()
+    {
+        return $this->_fields['isElevated'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->_fields['type'];
+    }
+
+    /**
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->_fields['id'];
+    }
+
+    /**
+     * @return float
+     */
+    public function getScore()
+    {
+        return $this->_fields['score'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->_fields['url'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->_fields['title'];
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result;
 
 /***************************************************************
  *  Copyright notice
@@ -24,23 +24,42 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * The SearchResultBuilder is responsible to build a SearchResult object from an Apache_Solr_Document
  * and should use a different class as SearchResult if configured.
  *
- * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
  * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet
  */
-class SearchResultBuilder extends \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder {
-
+class SearchResultBuilder {
 
     /**
-     * @deprecated Since 8.0.0 will be removed in 9.0.0 This class was moved to the \Domain\Search\ResultSet\Result package, please use this one
+     * This method is used to wrap the \Apache_Solr_Document instance in an instance of the configured SearchResult
+     * class.
+     *
+     * @param \Apache_Solr_Document $originalDocument
+     * @throws \InvalidArgumentException
+     * @return SearchResult
      */
-    public function __contruct()
+    public function fromApacheSolrDocument(\Apache_Solr_Document $originalDocument)
     {
-        GeneralUtility::logDeprecatedFunction();
+        $searchResultClassName = $this->getResultClassName();
+        $result = GeneralUtility::makeInstance($searchResultClassName, $originalDocument);
+        if (!$result instanceof SearchResult) {
+            throw new \InvalidArgumentException('Could not create result object with class: ' . (string)$searchResultClassName, 1470037679);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getResultClassName()
+    {
+        return isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName ']) ?
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '] : SearchResult::class;
     }
 }

--- a/Classes/Domain/Search/ResultSet/Result/SearchResultCollection.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResultCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result;
 
 /***************************************************************
  *  Copyright notice
@@ -24,23 +24,45 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupCollection;
+use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 
 /**
- * The SearchResultBuilder is responsible to build a SearchResult object from an Apache_Solr_Document
- * and should use a different class as SearchResult if configured.
+ * The SearchResultCollection contains the SearchResult object and related objects. e.g groups.
  *
- * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
- * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result
  */
-class SearchResultBuilder extends \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder {
-
+class SearchResultCollection extends AbstractCollection {
 
     /**
-     * @deprecated Since 8.0.0 will be removed in 9.0.0 This class was moved to the \Domain\Search\ResultSet\Result package, please use this one
+     * @var GroupCollection
      */
-    public function __contruct()
+    protected $groups = null;
+
+    /**
+     * SearchResultCollection constructor.
+     * @param array $data
+     */
+    public function __construct(array $data = [])
     {
-        GeneralUtility::logDeprecatedFunction();
+        parent::__construct($data);
+        $this->groups = new GroupCollection();
+    }
+
+    /**
+     * @return GroupCollection
+     */
+    public function getGroups(): GroupCollection
+    {
+        return $this->groups;
+    }
+
+    /**
+     * @param GroupCollection $groups
+     */
+    public function setGroups(GroupCollection $groups)
+    {
+        $this->groups = $groups;
     }
 }

--- a/Classes/Domain/Search/ResultSet/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/SearchResult.php
@@ -24,173 +24,27 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Proxy class for \Apache_Solr_Document to customize \Apache_Solr_Document without
  * changing the library code.
  *
  * Implements
- *
+ * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
  * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
-class SearchResult extends \Apache_Solr_Document
+class SearchResult extends \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult
 {
-
     /**
-     * @var bool
-     */
-    protected $throwExceptions = false;
-
-    /**
-     * @var SearchResult[]
-     */
-    protected $variants = [];
-
-    /**
-     * Indicates if an instance of this document is a variant (a sub document of another).
+     * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
      *
-     * @var bool
-     */
-    protected $isVariant = false;
-
-    /**
-     * References the parent document of the document is a variant.
-     *
-     * @var null
-     */
-    protected $variantParent = null;
-
-    /**
      * @param \Apache_Solr_Document $document
      * @param bool $throwExceptions
      */
     public function __construct(\Apache_Solr_Document $document, $throwExceptions = false)
     {
-        $this->throwExceptions = false;
-        $this->_documentBoost = $document->_documentBoost;
-        $this->_fields = $document->_fields;
-        $this->_fieldBoosts = $document->_fieldBoosts;
-    }
-
-    /**
-     * @param string $name
-     * @param array $arguments
-     * @throws \Exception
-     * @throws \RuntimeException
-     * @return string
-     */
-    public function __call($name, $arguments)
-    {
-        try {
-            return parent::__call($name, $arguments);
-        } catch (\RuntimeException $e) {
-            if ($this->throwExceptions) {
-                throw $e;
-            }
-        }
-    }
-
-    /**
-     * @return SearchResult[]
-     */
-    public function getVariants()
-    {
-        return $this->variants;
-    }
-
-    /**
-     * @param SearchResult $expandedResult
-     */
-    public function addVariant(SearchResult $expandedResult)
-    {
-        $this->variants[] = $expandedResult;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getIsVariant()
-    {
-        return $this->isVariant;
-    }
-
-    /**
-     * @param bool $isVariant
-     */
-    public function setIsVariant($isVariant)
-    {
-        $this->isVariant = $isVariant;
-    }
-
-    /**
-     * @return null
-     */
-    public function getVariantParent()
-    {
-        return $this->variantParent;
-    }
-
-    /**
-     * @param null $variantParent
-     */
-    public function setVariantParent($variantParent)
-    {
-        $this->variantParent = $variantParent;
-    }
-
-    /**
-     * @return string
-     */
-    public function getContent()
-    {
-        return $this->_fields['content'];
-    }
-
-    /**
-     * @return boolean
-     */
-    public function getIsElevated()
-    {
-        return $this->_fields['isElevated'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->_fields['type'];
-    }
-
-    /**
-     * @return integer
-     */
-    public function getId()
-    {
-        return $this->_fields['id'];
-    }
-
-    /**
-     * @return float
-     */
-    public function getScore()
-    {
-        return $this->_fields['score'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl()
-    {
-        return $this->_fields['url'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getTitle()
-    {
-        return $this->_fields['title'];
+        GeneralUtility::logDeprecatedFunction();
+        parent::__construct($document, $throwExceptions);
     }
 }

--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -27,12 +27,18 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\Sorting;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\SortingCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking\Suggestion;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Query;
 use ApacheSolrForTypo3\Solr\Search;
+
+//@deprecated
+//@todo this alias can be removed when the old class was dropped
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult as NewSearchResult;
+
 
 /**
  * The SearchResultSet is used to provided access to the \Apache_Solr_Response and
@@ -79,9 +85,9 @@ class SearchResultSet
     protected $usedAdditionalFilters = [];
 
     /**
-     * @var array
+     * @var SearchResultCollection
      */
-    protected $searchResults = [];
+    protected $searchResults = null;
 
     /**
      * @var int
@@ -125,6 +131,7 @@ class SearchResultSet
     {
         $this->facets = new FacetCollection();
         $this->sortings = new SortingCollection();
+        $this->searchResults = new SearchResultCollection();
     }
 
     /**
@@ -334,7 +341,7 @@ class SearchResultSet
     }
 
     /**
-     * @return array
+     * @return SearchResultCollection
      */
     public function getSearchResults()
     {
@@ -342,7 +349,7 @@ class SearchResultSet
     }
 
     /**
-     * @param array $searchResults
+     * @param SearchResultCollection $searchResults
      */
     public function setSearchResults($searchResults)
     {
@@ -352,7 +359,7 @@ class SearchResultSet
     /**
      * @param SearchResult $searchResult
      */
-    public function addSearchResult(SearchResult $searchResult)
+    public function addSearchResult(NewSearchResult $searchResult)
     {
         $this->searchResults[] = $searchResult;
     }
@@ -404,4 +411,6 @@ class SearchResultSet
     {
         $this->correctedQueryString = $correctedQueryString;
     }
+
+
 }

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -26,7 +26,8 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Suggest;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
@@ -190,11 +191,11 @@ class SuggestService {
      * Adds documents from a collection to the result collection as soon as the limit is not reached.
      *
      * @param array $documents
-     * @param \Apache_Solr_Document[] $documentsToAdd
+     * @param SearchResultCollection $documentsToAdd
      * @param integer $maxDocuments
      * @return array
      */
-    protected function addDocumentsWhenLimitNotReached(array $documents, array $documentsToAdd, int $maxDocuments)  : array
+    protected function addDocumentsWhenLimitNotReached(array $documents, SearchResultCollection $documentsToAdd, int $maxDocuments)  : array
     {
         /** @var SearchResult $document */
         foreach ($documentsToAdd as $document) {

--- a/Classes/Domain/Variants/VariantsProcessor.php
+++ b/Classes/Domain/Variants/VariantsProcessor.php
@@ -25,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Domain\Variants;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -80,7 +80,7 @@ class VariantsProcessor implements SearchResultSetProcessor {
         }
 
         $variantsField = $this->typoScriptConfiguration->getSearchVariantsField();
-        foreach ($response->response->docs as $key => $resultDocument) {
+        foreach ($resultSet->getSearchResults() as $key => $resultDocument) {
             /** @var $resultDocument SearchResult */
             $variantField = $resultDocument->getField($variantsField);
             $variantId = isset($variantField['value']) ? $variantField['value'] : null;

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DocumentEscapeService;
 use ApacheSolrForTypo3\Solr\Search\FacetsModifier;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
@@ -266,10 +267,12 @@ class Search
     /**
      * Returns all results documents raw. Use with caution!
      *
+     * @deprecated Since 8.0.0 will be removed in 9.0.0. Use $resultSet->getSearchResults() this will be initialized by the parser depending on the settings
      * @return \Apache_Solr_Document[]
      */
     public function getResultDocumentsRaw()
     {
+        GeneralUtility::logDeprecatedFunction();
         return $this->getResponseBody()->docs;
     }
 
@@ -277,59 +280,16 @@ class Search
      * Returns all result documents but applies htmlspecialchars() on all fields retrieved
      * from solr except the configured fields in plugin.tx_solr.search.trustedFields
      *
+     * @deprecated Since 8.0.0 will be removed in 9.0.0. Use DocumentEscapeService or
+     * $resultSet->getSearchResults() this will be initialized by the parser depending on the settings.
      * @return \Apache_Solr_Document[]
      */
     public function getResultDocumentsEscaped()
     {
-        return $this->applyHtmlSpecialCharsOnAllFields($this->getResponseBody()->docs);
-    }
-
-    /**
-     * This method is used to apply htmlspecialchars on all document fields that
-     * are not configured to be secure. Secure mean that we know where the content is coming from.
-     *
-     * @param array $documents
-     * @return \Apache_Solr_Document[]
-     */
-    protected function applyHtmlSpecialCharsOnAllFields(array $documents)
-    {
-        $trustedSolrFields = $this->configuration->getSearchTrustedFieldsArray();
-
-        foreach ($documents as $key => $document) {
-            $fieldNames = $document->getFieldNames();
-
-            foreach ($fieldNames as $fieldName) {
-                if (in_array($fieldName, $trustedSolrFields)) {
-                    // we skip this field, since it was marked as secure
-                    continue;
-                }
-
-                $document->{$fieldName} = $this->applyHtmlSpecialCharsOnSingleFieldValue($document->{$fieldName});
-            }
-
-            $documents[$key] = $document;
-        }
-
-        return $documents;
-    }
-
-    /**
-     * Applies htmlspecialchars on all items of an array of a single value.
-     *
-     * @param $fieldValue
-     * @return array|string
-     */
-    protected function applyHtmlSpecialCharsOnSingleFieldValue($fieldValue)
-    {
-        if (is_array($fieldValue)) {
-            foreach ($fieldValue as $key => $fieldValueItem) {
-                $fieldValue[$key] = htmlspecialchars($fieldValueItem, null, null, false);
-            }
-        } else {
-            $fieldValue = htmlspecialchars($fieldValue, null, null, false);
-        }
-
-        return $fieldValue;
+        GeneralUtility::logDeprecatedFunction();
+        /** @var $escapeService DocumentEscapeService */
+        $escapeService = GeneralUtility::makeInstance(DocumentEscapeService::class, $this->configuration);
+        return $escapeService->applyHtmlSpecialCharsOnAllFields($this->getResponseBody()->docs);
     }
 
     /**

--- a/Classes/System/Data/AbstractCollection.php
+++ b/Classes/System/Data/AbstractCollection.php
@@ -147,6 +147,10 @@ abstract class AbstractCollection implements \IteratorAggregate, \Countable, \Ar
      */
     public function offsetSet($offset, $value)
     {
+        if ($offset === null) {
+            $this->data[] = $value;
+            return;
+        }
         $this->data[$offset] = $value;
     }
 

--- a/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
+++ b/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
@@ -52,14 +52,18 @@ class PageBrowserRangeViewHelper extends AbstractSolrFrontendViewHelper
         $to = $arguments['to'];
         $total = $arguments['total'];
 
-        $search = self::getUsedSearchResultSetFromRenderingContext($renderingContext)->getUsedSearch();
+        $resultSet = self::getUsedSearchResultSetFromRenderingContext($renderingContext);
+        $search = $resultSet->getUsedSearch();
         $variableProvider = $renderingContext->getVariableProvider();
 
+        $numberOfResultsOnPage = $resultSet->getSearchResults()->getCount();
+        $numberOfAllResults = $resultSet->getAllResultCount();
+
         $resultsFrom = $search->getResponseBody()->start + 1;
-        $resultsTo = $resultsFrom + count($search->getResultDocumentsRaw()) - 1;
+        $resultsTo = $resultsFrom + $numberOfResultsOnPage - 1;
         $variableProvider->add($from, $resultsFrom);
         $variableProvider->add($to, $resultsTo);
-        $variableProvider->add($total, $search->getNumberOfResults());
+        $variableProvider->add($total, $numberOfAllResults);
 
         $content = $renderChildrenClosure();
 

--- a/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
@@ -16,7 +16,6 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller;
 
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetController;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 /**
  * Class ResultPaginateController
@@ -120,7 +119,7 @@ class ResultPaginateController extends AbstractWidgetController
         if ($this->currentPage < 1) {
             $this->currentPage = 1;
         }
-        $this->view->assign('contentArguments', [$this->widgetConfiguration['as'] => $this->getDocuments(), 'pagination' => $this->buildPagination()]);
+        $this->view->assign('contentArguments', [$this->widgetConfiguration['as'] => $this->resultSet->getSearchResults(), 'pagination' => $this->buildPagination()]);
         $this->view->assign('configuration', $this->configuration);
         $this->view->assign('resultSet', $this->resultSet);
         if (!empty($this->templatePath)) {
@@ -173,18 +172,5 @@ class ResultPaginateController extends AbstractWidgetController
             $pagination['previousPage'] = $this->currentPage - 1;
         }
         return $pagination;
-    }
-
-    /**
-     * @return \Apache_Solr_Document[]
-     */
-    protected function getDocuments()
-    {
-        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
-        if (!empty($extbaseFrameworkConfiguration['features']['useRawDocuments'])) {
-            return $this->resultSet->getUsedSearch()->getResultDocumentsRaw();
-        } else {
-            return $this->resultSet->getUsedSearch()->getResultDocumentsEscaped();
-        }
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -24,7 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\OptionBase
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -14,7 +14,7 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\OptionBase
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DefaultResultParser;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Unit test case for the SearchResult.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class DefaultParserTest extends UnitTest
+{
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $configurationMock;
+
+    /**
+     * @var DefaultResultParser
+     */
+    protected $parser;
+
+    public function setUp()
+    {
+        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->parser = new DefaultResultParser($this->configurationMock);
+    }
+
+    /**
+     * @test
+     */
+    public function parseWillCreateResultCollectionFromSolrResponse()
+    {
+        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+
+        $fakedSolrResponse = $this->getFixtureContentByName('fakeResponse.json');
+        $fakeHttpResponse = $this->getDumbMock(\Apache_Solr_HttpTransport_Response::class);
+        $fakeHttpResponse->expects($this->once())->method('getBody')->will($this->returnValue($fakedSolrResponse));
+        $fakeResponse = new \Apache_Solr_Response($fakeHttpResponse);
+
+        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $collection = $this->parser->parse($fakeResultSet, true);
+        $this->assertCount(3, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function canParseReturnsFalseWhenGroupingIsEnabled()
+    {
+        $resultMock = $this->getDumbMock(SearchResultSet::class);
+        $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(true));
+        $this->assertFalse($this->parser->canParse($resultMock));
+    }
+
+    /**
+     * @test
+     */
+    public function canParseReturnsTrueWhenGroupingIsDisabled()
+    {
+        $resultMock = $this->getDumbMock(SearchResultSet::class);
+        $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(false));
+        $this->assertTrue($this->parser->canParse($resultMock));
+    }
+
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fakeResponse.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fakeResponse.json
@@ -1,0 +1,264 @@
+{
+    "responseHeader": {
+        "status": 0,
+        "QTime": 9,
+        "params": {
+            "hl.fragsize": "20",
+            "spellcheck": "true",
+            "enableElevation": "true",
+            "facet": "true",
+            "facet.mincount": "1",
+            "spellcheck.maxCollationTries": "0",
+            "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline",
+            "hl.simple.pre": "<span class=\"results-highlight\">",
+            "q.alt": "*:*",
+            "json.nl": "map",
+            "hl.fl": "content",
+            "wt": "json",
+            "spellcheck.collate": "true",
+            "hl": "true",
+            "rows": "5",
+            "echoParams": "all",
+            "debugQuery": "true",
+            "fl": "*,score,isElevated:[elevated]",
+            "start": "5",
+            "facet.sort": "count",
+            "q": "*",
+            "forceElevation": "true",
+            "hl.simple.post": "</span>",
+            "facet.field": ["type",
+                "{!ex=subTitle}subTitle",
+                "rootline"],
+            "fq": ["siteHash:\"23c51a0d5cf548afecc043a7068902e8f82a22a0\"",
+                "{!typo3access}-1,0"],
+            "hl.requireFieldMatch": "true",
+            "mm": "2<-35%",
+            "indent": "true",
+            "spellcheck.extendedResults": "false",
+            "hl.mergeContiguous": "true",
+            "f.content.hl.maxAlternateFieldLength": "200",
+            "spellcheck.onlyMorePopular": "false",
+            "defType": "edismax",
+            "pf": "content^2.0",
+            "df": "content",
+            "hl.snippets": "3",
+            "f.content.hl.alternateField": "content",
+            "spellcheck.dictionary": ["default",
+                "wordbreak"],
+            "q.op": "OR",
+            "spellcheck.count": "1",
+            "ps": "15"
+        }
+    },
+    "response": {
+        "numFound": 8,
+        "start": 5,
+        "maxScore": 1.0,
+        "docs": [
+            {
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0",
+                "site": "",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
+                "type": "pages",
+                "uid": 6,
+                "pid": 1,
+                "typeNum": 0,
+                "created": "1970-01-01T01:00:00Z",
+                "changed": "1970-01-01T01:00:00Z",
+                "rootline": ["0-1",
+                    "1-1/6"],
+                "access": "c:0",
+                "title": "T-Shirts",
+                "subTitle": "Men",
+                "navTitle": "",
+                "author": "",
+                "description": "",
+                "abstract": "",
+                "content": "",
+                "teaser": "",
+                "url": "http:///.Build/bin/phpunit",
+                "_version_": 1527228677005246464,
+                "indexed": "2016-02-26T09:26:04Z",
+                "score": 1.0,
+                "isElevated": false
+            },
+            {
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0",
+                "site": "",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
+                "type": "pages",
+                "uid": 7,
+                "pid": 1,
+                "typeNum": 0,
+                "created": "1970-01-01T01:00:00Z",
+                "changed": "1970-01-01T01:00:00Z",
+                "rootline": ["0-1",
+                    "1-1/7"],
+                "access": "c:0",
+                "title": "Sweatshirts",
+                "subTitle": "Men",
+                "navTitle": "",
+                "author": "",
+                "description": "",
+                "abstract": "",
+                "content": "",
+                "teaser": "",
+                "url": "http:///.Build/bin/phpunit",
+                "_version_": 1527228677102764032,
+                "indexed": "2016-02-26T09:26:04Z",
+                "score": 1.0,
+                "isElevated": false
+            },
+            {
+                "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0",
+                "site": "",
+                "siteHash": "23c51a0d5cf548afecc043a7068902e8f82a22a0",
+                "type": "pages",
+                "uid": 8,
+                "pid": 1,
+                "typeNum": 0,
+                "created": "1970-01-01T01:00:00Z",
+                "changed": "1970-01-01T01:00:00Z",
+                "rootline": ["0-1",
+                    "1-1/8"],
+                "access": "c:0",
+                "title": "Sweatshirts",
+                "subTitle": "Woman",
+                "navTitle": "",
+                "author": "",
+                "description": "",
+                "abstract": "",
+                "content": "",
+                "teaser": "",
+                "url": "http:///.Build/bin/phpunit",
+                "_version_": 1527228677204475904,
+                "indexed": "2016-02-26T09:26:04Z",
+                "score": 1.0,
+                "isElevated": false
+            }
+        ]
+    },
+    "facet_counts": {
+        "facet_queries": {},
+        "facet_fields": {
+            "type": {
+                "pages": 8
+            },
+            "subTitle": {
+                "men": 4,
+                "woman": 3
+            },
+            "rootline": {
+                "0-1": 8,
+                "1-1/2": 1,
+                "1-1/3": 1,
+                "1-1/4": 1,
+                "1-1/5": 1,
+                "1-1/6": 1,
+                "1-1/7": 1,
+                "1-1/8": 1
+            }
+        },
+        "facet_dates": {},
+        "facet_ranges": {},
+        "facet_intervals": {}
+    },
+    "highlighting": {
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0": {
+            "content": [""]
+        },
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0": {
+            "content": [""]
+        },
+        "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0": {
+            "content": [""]
+        }
+    },
+    "debug": {
+        "queryBoosting": {
+            "q": "*",
+            "match": null
+        },
+        "rawquerystring": "*",
+        "querystring": "*",
+        "parsedquery": "(+MatchAllDocsQuery(*:*) ())/no_coord",
+        "parsedquery_toString": "+*:* ()",
+        "explain": {
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/7/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n",
+            "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/8/0/0/0": "\n1.0 = (MATCH) sum of:\n  1.0 = (MATCH) MatchAllDocsQuery, product of:\n    1.0 = queryNorm\n"
+        },
+        "QParser": "ExtendedDismaxQParser",
+        "altquerystring": null,
+        "boost_queries": null,
+        "parsed_boost_queries": [],
+        "boostfuncs": null,
+        "filter_queries": ["siteHash:\"23c51a0d5cf548afecc043a7068902e8f82a22a0\"",
+            "{!typo3access}-1,0"],
+        "parsed_filter_queries": ["siteHash:23c51a0d5cf548afecc043a7068902e8f82a22a0",
+            "ConstantScore(org.typo3.solr.search.AccessFilter@7b7c4a74)"],
+        "timing": {
+            "time": 9.0,
+            "prepare": {
+                "time": 1.0,
+                "query": {
+                    "time": 1.0
+                },
+                "facet": {
+                    "time": 0.0
+                },
+                "mlt": {
+                    "time": 0.0
+                },
+                "highlight": {
+                    "time": 0.0
+                },
+                "stats": {
+                    "time": 0.0
+                },
+                "expand": {
+                    "time": 0.0
+                },
+                "spellcheck": {
+                    "time": 0.0
+                },
+                "elevator": {
+                    "time": 0.0
+                },
+                "debug": {
+                    "time": 0.0
+                }
+            },
+            "process": {
+                "time": 8.0,
+                "query": {
+                    "time": 2.0
+                },
+                "facet": {
+                    "time": 3.0
+                },
+                "mlt": {
+                    "time": 0.0
+                },
+                "highlight": {
+                    "time": 3.0
+                },
+                "stats": {
+                    "time": 0.0
+                },
+                "expand": {
+                    "time": 0.0
+                },
+                "spellcheck": {
+                    "time": 0.0
+                },
+                "elevator": {
+                    "time": 0.0
+                },
+                "debug": {
+                    "time": 0.0
+                }
+            }
+        }
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Result\Parser;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\ResultParserRegistry;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser\TestResultParser;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Unit test case for the ResultParserRegistryTest.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ResultParserRegistryTest extends UnitTest
+{
+
+    /**
+     * @var ResultParserRegistry
+     */
+    protected $registry;
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $configurationMock;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->registry = new ResultParserRegistry($this->configurationMock);
+    }
+
+    /**
+     * @test
+     */
+    public function canRegisterAndRetrieveParserWithAHigherPriority()
+    {
+        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $this->registry->registerParser(TestResultParser::class, 200);
+        $retrievedParser = $this->registry->getParser($fakeResultSet);
+        $this->assertInstanceOf(TestResultParser::class, $retrievedParser, 'Did not retrieve register custom parser with higher priority');
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
@@ -1,6 +1,5 @@
 <?php
-
-namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser;
 
 /***************************************************************
  *  Copyright notice
@@ -24,23 +23,36 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\AbstractResultParser;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DefaultResultParser;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
- * The SearchResultBuilder is responsible to build a SearchResult object from an Apache_Solr_Document
- * and should use a different class as SearchResult if configured.
+ * Fake test parser
  *
- * @deprecated This class was moved to the \Domain\Search\ResultSet\Result package, please use this one. Will be removed in 9.0
- * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet
+ * @author Timo Hund <timo.hund@dkd.de>
  */
-class SearchResultBuilder extends \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder {
-
+class TestResultParser extends AbstractResultParser
+{
 
     /**
-     * @deprecated Since 8.0.0 will be removed in 9.0.0 This class was moved to the \Domain\Search\ResultSet\Result package, please use this one
+     * @param SearchResultSet $resultSet
+     * @param bool $useRawDocuments
+     * @return SearchResultCollection
      */
-    public function __contruct()
+    public function parse(SearchResultSet $resultSet, bool $useRawDocuments = true)
     {
-        GeneralUtility::logDeprecatedFunction();
+        // TODO: Implement parse() method.
+    }
+
+    /**
+     * @param SearchResultSet $resultSet
+     * @return mixed
+     */
+    public function canParse(SearchResultSet $resultSet)
+    {
+        return true;
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Result;
 
 /***************************************************************
  *  Copyright notice
@@ -25,7 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 
 /**
  * Unit test case for the SearchResult.

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -27,7 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 use Apache_Solr_Response;
 use Apache_Solr_HttpTransport_Response;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
@@ -212,12 +212,11 @@ class SearchResultSetTest extends UnitTest
 
         $resultSet  = $this->searchResultSetService->search($fakeRequest);
 
-        $response   = $resultSet->getResponse();
-        $documents  = $response->response->docs;
+        $documents  = $resultSet->getSearchResults();
 
         $this->assertSame(3, count($documents), 'Did not get 3 documents from fake response');
         $firstResult = $documents[0];
-        $this->assertSame('PAGES', $firstResult->type, 'Could not get modified type from result');
+        $this->assertSame('PAGES', $firstResult->getType(), 'Could not get modified type from result');
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch'] = $processSearchResponseBackup;
     }
@@ -273,10 +272,10 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest->setResultsPerPage(10);
 
         $resultSet = $this->searchResultSetService->search($fakeRequest);
-        $this->assertSame(1, count($resultSet->getResponse()->response->docs), 'Unexpected amount of document');
+        $this->assertSame(1, count($resultSet->getSearchResults()), 'Unexpected amount of document');
 
             /** @var  $fistResult SearchResult */
-        $fistResult = $resultSet->getResponse()->response->docs[0];
+        $fistResult = $resultSet->getSearchResults()[0];
         $this->assertSame(5, count($fistResult->getVariants()), 'Unexpected amount of expanded result');
     }
 

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -25,7 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
@@ -139,10 +140,12 @@ class SuggestServiceTest extends UnitTest
         ]));
 
         $fakeTopResults = $this->getDumbMock(SearchResultSet::class);
-        $fakeResultDocuments = [
-            $this->getFakedSearchResult('http://www.typo3-solr.com/a','pages','hello solr','my suggestions'),
-            $this->getFakedSearchResult('http://www.typo3-solr.com/b','news','what new in solr','new autosuggest'),
-        ];
+        $fakeResultDocuments = new SearchResultCollection(
+            [
+                $this->getFakedSearchResult('http://www.typo3-solr.com/a','pages','hello solr','my suggestions'),
+                $this->getFakedSearchResult('http://www.typo3-solr.com/b','news','what new in solr','new autosuggest'),
+            ]
+        );
 
         $fakeTopResults->expects($this->once())->method('getSearchResults')->will($this->returnValue($fakeResultDocuments));
         $this->searchResultSetServiceMock->expects($this->once())->method('search')->will($this->returnValue($fakeTopResults));

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -28,7 +28,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\HighlightResultViewHelper;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -26,7 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Test\ViewHelpers\Document;
 
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\RelevanceViewHelper;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -171,7 +171,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '])) {
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '] = \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResult::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '] = \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult::class;
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultSetClassName '])) {


### PR DESCRIPTION
This pr:

* Extracts the document parsing into a parser class (to make it replaceable e.g. for grouping)
* Removes the wraping of $response->response->docs, not $resultSet->getSearchResults needs to be used to retrieve the results (is the case be default).

Related: #1136