### PR TITLE
[TASK] Remove constructor dependency to TypoScriptConfiguration from ResultParser

### DIFF
--- a/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
@@ -45,27 +45,19 @@ abstract class AbstractResultParser {
     protected $searchResultBuilder;
 
     /**
-     * @var TypoScriptConfiguration
-     */
-    protected $typoScriptConfiguration;
-
-    /**
      * @var DocumentEscapeService
      */
     protected $documentEscapeService;
 
     /**
      * AbstractResultParser constructor.
-     * @param TypoScriptConfiguration|null $typoScriptConfiguration
      * @param SearchResultBuilder|null $resultBuilder
      * @param DocumentEscapeService|null $documentEscapeService
      */
-    public function __construct(TypoScriptConfiguration $typoScriptConfiguration = null,
-                                SearchResultBuilder $resultBuilder = null,
+    public function __construct(SearchResultBuilder $resultBuilder = null,
                                 DocumentEscapeService $documentEscapeService = null) {
-        $this->typoScriptConfiguration = $typoScriptConfiguration;
         $this->searchResultBuilder = is_null($resultBuilder) ? GeneralUtility::makeInstance(SearchResultBuilder::class) : $resultBuilder;
-        $this->documentEscapeService = is_null($documentEscapeService) ? GeneralUtility::makeInstance(DocumentEscapeService::class, $typoScriptConfiguration) : $documentEscapeService;
+        $this->documentEscapeService = is_null($documentEscapeService) ? GeneralUtility::makeInstance(DocumentEscapeService::class) : $documentEscapeService;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -69,7 +70,8 @@ class DefaultResultParser extends AbstractResultParser {
     public function canParse(SearchResultSet $resultSet)
     {
         // This parsers should not be used when grouping is enabled
-        if ($this->typoScriptConfiguration->getSearchGrouping())
+        $configuration = $resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration();
+        if ($configuration instanceof TypoScriptConfiguration && $configuration->getSearchGrouping())
         {
             return false;
         }

--- a/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
@@ -53,20 +53,6 @@ class ResultParserRegistry implements SingletonInterface
     protected $parserInstances;
 
     /**
-     * @var TypoScriptConfiguration
-     */
-    protected $typoScriptConfiguration;
-
-    /**
-     * ResultParserRegistry constructor.
-     * @param TypoScriptConfiguration $configuration
-     */
-    public function __construct(TypoScriptConfiguration $configuration)
-    {
-        $this->typoScriptConfiguration = $configuration;
-    }
-
-    /**
      * Get registered parser classNames
      *
      * @return array
@@ -138,6 +124,6 @@ class ResultParserRegistry implements SingletonInterface
      */
     protected function createParserInstance($className)
     {
-        return GeneralUtility::makeInstance($className, $this->typoScriptConfiguration);
+        return GeneralUtility::makeInstance($className);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Result\Parser;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DefaultResultParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
@@ -49,7 +50,7 @@ class DefaultParserTest extends UnitTest
     public function setUp()
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->parser = new DefaultResultParser($this->configurationMock);
+        $this->parser = new DefaultResultParser();
     }
 
     /**
@@ -74,9 +75,13 @@ class DefaultParserTest extends UnitTest
      */
     public function canParseReturnsFalseWhenGroupingIsEnabled()
     {
-        $resultMock = $this->getDumbMock(SearchResultSet::class);
+        $requestMock = $this->getDumbMock(SearchRequest::class);
+        $requestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($this->configurationMock));
+        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue($requestMock));
+
         $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(true));
-        $this->assertFalse($this->parser->canParse($resultMock));
+        $this->assertFalse($this->parser->canParse($fakeResultSet));
     }
 
     /**
@@ -84,9 +89,13 @@ class DefaultParserTest extends UnitTest
      */
     public function canParseReturnsTrueWhenGroupingIsDisabled()
     {
-        $resultMock = $this->getDumbMock(SearchResultSet::class);
+        $requestMock = $this->getDumbMock(SearchRequest::class);
+        $requestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($this->configurationMock));
+        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue($requestMock));
+
         $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(false));
-        $this->assertTrue($this->parser->canParse($resultMock));
+        $this->assertTrue($this->parser->canParse($fakeResultSet));
     }
 
 }


### PR DESCRIPTION
To allow a simple registration, there should not be a constructor dependency to TypoScriptConfiguration for the result parsers.