### PR TITLE
[BUGFIX] broken count in pagination #1681

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
@@ -172,6 +172,8 @@ class ResultPaginateController extends AbstractWidgetController
         if ($this->currentPage > 1) {
             $pagination['previousPage'] = $this->currentPage - 1;
         }
+        // calculate starting count for <ol> (items per page multiplied by (number of pages -1) and adding +1)
+        $pagination['resultCountStart'] = (($this->getItemsPerPage() * ($this->currentPage-1))+1);
         return $pagination;
     }
 

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -53,7 +53,7 @@
 				<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 			</f:if>
 			<s:widget.resultPaginate resultSet="{resultSet}">
-				<ol start="{pagination.displayRangeStart}" class="results-list">
+				<ol start="{pagination.resultCountStart}" class="results-list">
 					<f:for each="{documents}" as="document">
 						<f:render partial="Result/Document" section="Document" arguments="{resultSet:resultSet, document:document}" />
 					</f:for>


### PR DESCRIPTION
fix start attribute for <ol> tag by calculating and adding a proper count into the pagination data.

Resolves: #1681 
