### PR TITLE
[BUGFIX] Convert function argument to int to match signature

### DIFF
--- a/Classes/ContextMenu/ItemProviders/InitializeConnectionProvider.php
+++ b/Classes/ContextMenu/ItemProviders/InitializeConnectionProvider.php
@@ -75,7 +75,7 @@ class InitializeConnectionProvider extends AbstractProvider
 
         /** @var $rootPageResolver RootPageResolver */
         $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
-        return $rootPageResolver->getIsRootPageId($this->identifier);
+        return $rootPageResolver->getIsRootPageId((int)$this->identifier);
     }
 
     /**


### PR DESCRIPTION
The identifier field of AbstractProvider is defined as being of type string.
The RootPageResolver expects an int as argument for the call to getIsRootPageId(). This mismatch
causes a check for pageId 0 to fail