### PR TITLE
[TASK] "Show more" and "Show less" javascript is missing

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -44,6 +44,9 @@
     'Search - (Example) Suggest/autocomplete with jquery');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/Facets/Options/',
+    'Search - (Example) Options facet on author field');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Facets/OptionsToggle/',
     'Search - (Example) Options with on/off toggle');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',

--- a/Configuration/TypoScript/Examples/Facets/Options/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/Options/setup.txt
@@ -1,9 +1,8 @@
 plugin.tx_solr.search.faceting = 1
 plugin.tx_solr.search.faceting.facets {
-    typeToggle {
-        label = Type Toggle
-        field = type
-        partialName = OptionsToggle
+    author {
+        label = Author
+        field = author
     }
 }
 

--- a/Resources/Public/JavaScript/facet_options_controller.js
+++ b/Resources/Public/JavaScript/facet_options_controller.js
@@ -1,0 +1,31 @@
+/**
+ * The Controller. Controller responds to user actions and
+ * invokes changes on the model.
+ */
+function OptionFacetController() {
+    var _this = this;
+
+    this.init = function () {
+        jQuery('.tx-solr-facet-hidden').hide();
+        jQuery('a.tx-solr-facet-show-all').click(function() {
+            if (jQuery(this).parent().siblings('.tx-solr-facet-hidden:visible').length == 0) {
+                jQuery(this).parent().siblings('.tx-solr-facet-hidden').show();
+                jQuery(this).text(jQuery(this).data('label-less'));
+            } else {
+                jQuery(this).parent().siblings('.tx-solr-facet-hidden').hide();
+                jQuery(this).text(jQuery(this).data('label-more'));
+            }
+
+            return false;
+        });
+    };
+}
+
+jQuery(document).ready(function () {
+    var optionsController = new OptionFacetController();
+    optionsController.init();
+
+    jQuery("body").on("tx_solr_updated", function() {
+        optionsController.init();
+    });
+});


### PR DESCRIPTION
The javascript to toggle the visibility of facet options was missing.
This pr, adds the facet_options_controller.js that add's the toggeling again.

Beside that an example typoscript file for the options facet was added, that
includes this javascript file in TYPO3.

Fixes: #1713