### PR TITLE
[TASK] Allow to group facet options by prefix

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
@@ -15,6 +15,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased;
  */
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 
 /**
  * Collection for facet options.
@@ -25,4 +26,51 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
  */
 class OptionCollection extends AbstractFacetItemCollection
 {
+
+    /**
+     * Returns an array of prefixes from the option labels.
+     *
+     * Red, Blue, Green => r, g, b
+     *
+     * Can be used in combination with getByPrefix() to group facet options by prefix (e.g. alphabetical).
+     *
+     * @param int $length
+     * @return array
+     */
+    public function getLowercaseLabelPrefixes($length = 1)
+    {
+        $prefixes = $this->getLabelPrefixes($length);
+        return array_map('strtolower', $prefixes);
+    }
+
+    /**
+     * @param string $filteredPrefix
+     * @return AbstractFacetItemCollection
+     */
+    public function getByLowercaseLabelPrefix($filteredPrefix)
+    {
+        return $this->getFilteredCopy(function(Option $option) use ($filteredPrefix)
+        {
+            $filteredPrefixLength = strlen($filteredPrefix);
+            $currentPrefix = substr(strtolower($option->getLabel()),0, $filteredPrefixLength);
+
+            return $currentPrefix === $filteredPrefix;
+        });
+    }
+
+    /**
+     * @param int $length
+     * @return array
+     */
+    protected function getLabelPrefixes($length = 1) : array
+    {
+        $prefixes = [];
+        foreach ($this->data as $option) {
+            /** @var $option Option */
+            $prefix = substr($option->getLabel(), 0, $length);
+            $prefixes[$prefix] = $prefix;
+        }
+
+        return array_values($prefixes);
+    }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
@@ -13,6 +13,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Opt
  *
  * The TYPO3 project - inspiring people to share!
 */
+
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractOptionFacetItem;
 
 /**

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
@@ -1,0 +1,77 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Class LabelFilterViewHelper
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options
+ */
+class LabelFilterViewHelper extends AbstractSolrFrontendViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('options', OptionCollection::class, 'The facets that should be filtered', true);
+        $this->registerArgument('prefix', 'string', 'The prefix where options should be filtered on', true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        /** @var  $options OptionCollection */
+        $options = $arguments['options'];
+        $requiredPrefix = strtolower($arguments['prefix']);
+        $filtered = $options->getByLowercaseLabelPrefix($requiredPrefix);
+
+        $templateVariableProvider = $renderingContext->getVariableProvider();
+        $templateVariableProvider->add('filteredOptions', $filtered);
+        $content = $renderChildrenClosure();
+        $templateVariableProvider->remove('filteredOptions');
+
+        return $content;
+    }
+}

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
@@ -1,0 +1,103 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
+use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Class LabelPrefixesViewHelper
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ * @package ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options
+ */
+class LabelPrefixesViewHelper extends AbstractSolrFrontendViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('options', OptionCollection::class, 'The options where prefixed should be available', true);
+        $this->registerArgument('length', 'int', 'The length of the prefixed that should be retrieved', false, 1);
+        $this->registerArgument('sortBy', 'string', 'The sorting mode (count,alpha)', false, 'count');
+
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        /** @var  $options OptionCollection */
+        $options = $arguments['options'];
+        $length = isset($arguments['length']) ? $arguments['length'] : 1;
+        $sortBy = isset($arguments['sortBy']) ? $arguments['sortBy'] : 'count';
+        $prefixes = $options->getLowercaseLabelPrefixes($length);
+
+        $prefixes = static::applySortBy($prefixes, $sortBy);
+
+        $templateVariableProvider = $renderingContext->getVariableProvider();
+        $templateVariableProvider->add('prefixes', $prefixes);
+        $content = $renderChildrenClosure();
+        $templateVariableProvider->remove('prefixes');
+
+        return $content;
+    }
+
+    /**
+     * Applies the configured sortBy.
+     *
+     * @param array $prefixes
+     * @param string $sortBy
+     * @return array
+     */
+    protected static function applySortBy(array $prefixes, $sortBy): array
+    {
+        if($sortBy === 'count' || $sortBy === '')
+        {
+            return $prefixes;
+        }
+
+        if($sortBy === 'alpha')
+        {
+            sort($prefixes);
+            return $prefixes;
+        }
+    }
+}

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -50,6 +50,9 @@
     'Configuration/TypoScript/Examples/Facets/OptionsToggle/',
     'Search - (Example) Options with on/off toggle');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/',
+    'Search - (Example) Options grouped by prefix');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Facets/QueryGroup/',
     'Search - (Example) QueryGroup facet on the created field');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',

--- a/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.txt
@@ -1,0 +1,13 @@
+plugin.tx_solr.search.faceting = 1
+plugin.tx_solr.search.faceting.facets {
+    author {
+        label = Author
+        field = author
+        partialName = OptionsPrefixGrouped
+    }
+}
+
+page.includeJSFooterlibs {
+    solr-jquery = EXT:solr/Resources/Public/JavaScript/JQuery/jquery.min.js
+    solr-options = EXT:solr/Resources/Public/JavaScript/facet_options_controller.js
+}

--- a/Documentation/Development/ViewHelpers.rst
+++ b/Documentation/Development/ViewHelpers.rst
@@ -10,43 +10,48 @@ With the current release we ship the following concrete ViewHelpers:
 
 |
 
-+---------------------------------+----------------------------------------------------------------+
-| **Path**                        | **Description**                                                |
-+---------------------------------+----------------------------------------------------------------+
-| s:debug.documentScoreAnalyzer   | Used to render the score analysis.                             |
-+---------------------------------+----------------------------------------------------------------+
-| s:debug.query                   | Shows the solr query debug information.                        |
-+---------------------------------+----------------------------------------------------------------+
-| s:document.highlightResult      | Performs the highlighting on a document.                       |
-+---------------------------------+----------------------------------------------------------------+
-| s:document.relevance            | Shows the relevance information for a document.                |
-+---------------------------------+----------------------------------------------------------------+
-| s:facet.area.group              | Filters the facets in the rendering scope to one group.        |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.facet.addFacetItem        | Add's a facet item to the current url.                         |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.facet.removeAllFacets     | Removes all facet items from the current url.                  |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.facet.removeFacet         | Removes all options from one facet.                            |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.facet.removeFacetItem     | Removes a single facet item from the url.                      |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.facet.setFacetItem        | Sets one single item for a facet (and removes other setted)    |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.paginate.resultPage       | Creates a link to a result page of the current search.         |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.search.currentSearch      | Creates a link to the current search (with facets, sorting...) |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.search.startNewSearch     | Creates a link for a new search by a term.                     |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.sorting.removeSorting     | Creates a link to the current search and removes the sorting.  |
-+---------------------------------+----------------------------------------------------------------+
-| s:uri.sorting.setSorting        | Creates a link to the current search and sets a new sorting.   |
-+---------------------------------+----------------------------------------------------------------+
-| s:pageBrowserRange              | Provides the range data for the pagination.                    |
-+---------------------------------+----------------------------------------------------------------+
-| s:searchForm                    | Renders the searchForm.                                        |
-+---------------------------------+----------------------------------------------------------------+
-| s:translate                     | Custom translate ViewHelper (uses translations from ext:solr)  |
-+---------------------------------+----------------------------------------------------------------+
++------------------------------------------------+----------------------------------------------------------------+
+| **Path**                                       | **Description**                                                |
++------------------------------------------------+----------------------------------------------------------------+
+| s:debug.documentScoreAnalyzer                  | Used to render the score analysis.                             |
++------------------------------------------------+----------------------------------------------------------------+
+| s:debug.query                                  | Shows the solr query debug information.                        |
++------------------------------------------------+----------------------------------------------------------------+
+| s:document.highlightResult                     | Performs the highlighting on a document.                       |
++------------------------------------------------+----------------------------------------------------------------+
+| s:document.relevance                           | Shows the relevance information for a document.                |
++------------------------------------------------+----------------------------------------------------------------+
+| s:facet.area.group                             | Filters the facets in the rendering scope to one group.        |
++------------------------------------------------+----------------------------------------------------------------+
+| s:facet.options.group.prefix.labelPrefixes     | Provides an array of available label prefixes that can be used |
+|                                                | to filter with s:facet.options.group.prefix.labelFilter.       |
++------------------------------------------------+----------------------------------------------------------------+
+| s:facet.options.group.prefix.labelFilter       | Filters the options of a facet by a given prefix.              |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.facet.addFacetItem                       | Add's a facet item to the current url.                         |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.facet.removeAllFacets                    | Removes all facet items from the current url.                  |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.facet.removeFacet                        | Removes all options from one facet.                            |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.facet.removeFacetItem                    | Removes a single facet item from the url.                      |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.facet.setFacetItem                       | Sets one single item for a facet (and removes other setted)    |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.paginate.resultPage                      | Creates a link to a result page of the current search.         |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.search.currentSearch                     | Creates a link to the current search (with facets, sorting...) |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.search.startNewSearch                    | Creates a link for a new search by a term.                     |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.sorting.removeSorting                    | Creates a link to the current search and removes the sorting.  |
++------------------------------------------------+----------------------------------------------------------------+
+| s:uri.sorting.setSorting                       | Creates a link to the current search and sets a new sorting.   |
++------------------------------------------------+----------------------------------------------------------------+
+| s:pageBrowserRange                             | Provides the range data for the pagination.                    |
++------------------------------------------------+----------------------------------------------------------------+
+| s:searchForm                                   | Renders the searchForm.                                        |
++------------------------------------------------+----------------------------------------------------------------+
+| s:translate                                    | Custom translate ViewHelper (uses translations from ext:solr)  |
++------------------------------------------------+----------------------------------------------------------------+
 

--- a/Documentation/Frontend/Facets.rst
+++ b/Documentation/Frontend/Facets.rst
@@ -69,6 +69,31 @@ indexed into solr. Shown in the frontend it will look like this:
 | Domain Classes  | Domain\\Search\\ResultSet\\Facets\\OptionBased\\Options\\* |
 +-----------------+---------------+--------------------------------------------+
 
+**Grouping by option prefix**:
+
+When you have an option facet with very much options you might want to group the options by an prefix of an option. This can be used e.g. to group the options alphabetically.
+
+The following example shows how options can be grouped by prefix (from EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.txt):
+
+.. code-block:: xml
+
+    <s:facet.options.group.prefix.labelPrefixes options="{facet.options}" length="1" sortBy="alpha">
+        <f:for each="{prefixes}" as="prefix">
+            <li>
+                {prefix}
+                <ul>
+                    <s:facet.options.group.prefix.labelFilter options="{facet.options}" prefix="{prefix}">
+                        <f:for each="{filteredOptions}" as="option">
+                            <li class="facet-option" data-facet-item-value="{option.value}">
+                                + <a class="facet solr-ajaxified" href="{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}">{option.label}</a>
+                                <span class="facet-result-count">({option.documentCount})</span>
+                            </li>
+                        </f:for>
+                    </s:facet.options.group.prefix.labelFilter>
+                </ul>
+            </li>
+        </f:for>
+    </s:facet.options.group.prefix.labelPrefixes>
 
 Query Group
 -----------
@@ -318,8 +343,8 @@ This template is used to render only the area for a few facets. The following pa
 
 Looking at the code above we see to important details that are important for solr.
 
-Facet Grouping
---------------
+Facet Grouping (Areas)
+----------------------
 
 The first important part if the **facet.area.group** ViewHelper. By default all facets in the group **main** will be rendered.
 This value is the default value.
@@ -364,3 +389,4 @@ If you need another rendering for one facet you can overwrite the used partial w
 
 Combining all of these concepts together with the flexibility of fluid you are able to render facets in a very
 flexible way.
+

--- a/Resources/Private/Partials/Facets/OptionsPrefixGrouped.html
+++ b/Resources/Private/Partials/Facets/OptionsPrefixGrouped.html
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+      xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+      xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
+<h5 class="facet-label">{facet.label}</h5>
+<ul class="facet-option-list facet-type-options fluidfacet" data-facet-name="{facet.name}" data-facet-label="{facet.label}">
+    <s:facet.options.group.prefix.labelPrefixes options="{facet.options}" length="1" sortBy="alpha">
+        <f:for each="{prefixes}" as="prefix">
+            <li>
+                {prefix}
+                <ul>
+                    <s:facet.options.group.prefix.labelFilter options="{facet.options}" prefix="{prefix}">
+                        <f:for each="{filteredOptions}" as="option">
+                            <li class="facet-option" data-facet-item-value="{option.value}">
+                                + <a class="facet solr-ajaxified" href="{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}">{option.label}</a><span class="facet-result-count">({option.documentCount})</span>
+                            </li>
+                        </f:for>
+                    </s:facet.options.group.prefix.labelFilter>
+                </ul>
+            </li>
+        </f:for>
+    </s:facet.options.group.prefix.labelPrefixes>
+</ul>
+
+</html>

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -59,4 +59,55 @@ class OptionCollectionTest extends UnitTest
         $this->assertSame($blue, $sortedOptions->getByPosition(1), 'First sorted item was not blue');
         $this->assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
     }
+
+    /**
+     * @test
+     */
+    public function canGetLabelPrefixes()
+    {
+        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
+
+        $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
+        $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);
+        $yellow = new Option($facet, 'Lemon Yellow', 'lemon_yellow', 3);
+        $red = new Option($facet, 'Rubin Red', 'rubin_red', 9);
+        $royalGreen = new Option($facet, 'Royal Green', 'royal_green', 14);
+
+        $facet->addOption($red);
+        $facet->addOption($blue);
+        $facet->addOption($yellow);
+        $facet->addOption($roseRed);
+        $facet->addOption($royalGreen);
+
+        $labelPrefixes = $facet->getOptions()->getLowercaseLabelPrefixes(1);
+        $this->assertSame(['r','p','l'], $labelPrefixes, 'Can not get expected label prefixes');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetByLowercaseLabelPrefix()
+    {
+        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
+
+        $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
+        $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);
+        $yellow = new Option($facet, 'Lemon Yellow', 'lemon_yellow', 3);
+        $red = new Option($facet, 'Rubin Red', 'rubin_red', 9);
+        $royalGreen = new Option($facet, 'Royal Green', 'royal_green', 14);
+
+        $facet->addOption($red);
+        $facet->addOption($blue);
+        $facet->addOption($yellow);
+        $facet->addOption($roseRed);
+        $facet->addOption($royalGreen);
+
+        $optionsStartingWithL = $facet->getOptions()->getByLowercaseLabelPrefix('l');
+        $this->assertCount(1, $optionsStartingWithL, 'Unexpected amount of options starting with l');
+
+        $optionsStartingWithR = $facet->getOptions()->getByLowercaseLabelPrefix('r');
+        $this->assertCount(3, $optionsStartingWithR, 'Unexpected amount of options starting with r');
+    }
 }

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\ViewHelpers\Facet\Options\Group\Prefix;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelFilterViewHelper;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class LabelFilterViewHelperTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canMakeOnlyExpectedFacetsAvailableInStaticContext()
+    {
+        $facet = $this->getDumbMock(OptionsFacet::class);
+
+        $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
+        $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);
+        $yellow = new Option($facet, 'Lemon Yellow', 'lemon_yellow', 3);
+        $red = new Option($facet, 'Rubin Red', 'rubin_red', 9);
+        $royalGreen = new Option($facet, 'Royal Green', 'royal_green', 14);
+
+        $optionCollection = new OptionCollection();
+        $optionCollection->add($roseRed);
+        $optionCollection->add($blue);
+        $optionCollection->add($yellow);
+        $optionCollection->add($red);
+        $optionCollection->add($royalGreen);
+
+        $variableContainer = $this->getMockBuilder(TemplateVariableContainer::class)->setMethods(['remove'])->getMock();
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+
+        $testArguments['options'] = $optionCollection;
+        $testArguments['prefix'] = 'p';
+
+        LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
+        $this->assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
+
+        /** @var  $optionCollection OptionCollection */
+        $optionCollection = $variableContainer->get('filteredOptions');
+        $this->assertSame(1, $optionCollection->getCount());
+        $this->assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
+    }
+}

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\ViewHelpers\Facet\Options\Group\Prefix;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelPrefixesViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class LabelPrefixesViewHelperTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canGetPrefixesSortedByOrderInCollection()
+    {
+        $optionCollection = $this->getTestFacetOptionCollection();
+
+        $variableContainer = $this->getMockBuilder(TemplateVariableContainer::class)->setMethods(['remove'])->getMock();
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+
+        $testArguments['options'] = $optionCollection;
+        $testArguments['length'] = 1;
+        LabelPrefixesViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
+        $this->assertTrue($variableContainer->exists('prefixes'), 'Expected that prefixes has been set');
+        $prefixes = $variableContainer->get('prefixes');
+        $this->assertSame(['r','p','l'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetPrefixesSortedAlphabeticalByLabel()
+    {
+        $optionCollection = $this->getTestFacetOptionCollection();
+
+        $variableContainer = $this->getMockBuilder(TemplateVariableContainer::class)->setMethods(['remove'])->getMock();
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+
+        $testArguments['options'] = $optionCollection;
+        $testArguments['length'] = 1;
+        $testArguments['sortBy'] = 'alpha';
+        LabelPrefixesViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
+        $prefixes = $variableContainer->get('prefixes');
+        $this->assertSame(['l','p','r'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
+    }
+
+    /**
+     * @return OptionCollection
+     */
+    protected function getTestFacetOptionCollection(): OptionCollection
+    {
+        $facet = $this->getDumbMock(OptionsFacet::class);
+
+        $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
+        $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);
+        $yellow = new Option($facet, 'Lemon Yellow', 'lemon_yellow', 3);
+        $red = new Option($facet, 'Rubin Red', 'rubin_red', 2);
+        $royalGreen = new Option($facet, 'Royal Green', 'royal_green', 1);
+
+        $optionCollection = new OptionCollection();
+        $optionCollection->add($roseRed);
+        $optionCollection->add($blue);
+        $optionCollection->add($yellow);
+        $optionCollection->add($red);
+        $optionCollection->add($royalGreen);
+        return $optionCollection;
+    }
+}


### PR DESCRIPTION
This pr:

* Adds the possibility to group facet options by a prefix
* This can be used, e.g. to group the facet options alphabetically by the first letter
* Adds an example configuration "Search - (Example) Options grouped by prefix" that uses the logic to group the author options by starting letter

Fixes: #1715