### PR TITLE
[TASK] Add SOLR_CLASSIFICATION content object

### DIFF
--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -1,0 +1,114 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\ContentObject;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Classification\Classification as ClassificationItem;
+use ApacheSolrForTypo3\Solr\Domain\Index\Classification\ClassificationService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * A content object (cObj) to classify content based on a configuration.
+ *
+ * Example usage:
+ *
+ * keywords = SOLR_CLASSIFICATION # supports stdWrap
+ * keywords {
+ *   field = __solr_page_content # a comma separated field. instead of field you can also use "value"
+ *   classes {
+ *     1 {
+ *        patterns = smartphone, mobile, mobilephone # list of patterns that need to match to assign that class
+ *        class = mobilephone # class that should be assigned when a pattern matches
+ *     }
+ *   }
+ * }
+ */
+class Classification
+{
+    const CONTENT_OBJECT_NAME = 'SOLR_CLASSIFICATION';
+
+    /**
+     * Executes the SOLR_CLASSIFICATION content object.
+     *
+     * Returns mapped classes when the field matches on of the configured patterns ...
+     *
+     * @param string $name content object name 'SOLR_CONTENT'
+     * @param array $configuration for the content object
+     * @param string $TyposcriptKey not used
+     * @param \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObject parent cObj
+     * @return string serialized array representation of the given list
+     */
+    public function cObjGetSingleExt(
+        /** @noinspection PhpUnusedParameterInspection */ $name,
+        array $configuration,
+        /** @noinspection PhpUnusedParameterInspection */ $TyposcriptKey,
+        $contentObject
+    ) {
+
+        if (!is_array($configuration['classes.'])) {
+            throw new \InvalidArgumentException('No class configuration configured for SOLR_CLASSIFICATION object. Given configuration: ' . serialize($configuration));
+        }
+
+        $configuredMappedClasses = $configuration['classes.'];
+        unset($configuration['classes.']);
+
+        $data = '';
+        if (isset($configuration['value'])) {
+            $data = $configuration['value'];
+            unset($configuration['value']);
+        }
+
+        if (!empty($configuration)) {
+            $data = $contentObject->stdWrap($data, $configuration);
+        }
+        $classifications = $this->buildClassificationsFromConfiguration($configuredMappedClasses);
+        /** @var $classificationService ClassificationService */
+        $classificationService = GeneralUtility::makeInstance(ClassificationService::class);
+        $classes = serialize($classificationService->getMatchingClassNames((string)$data, $classifications));
+
+        return $classes;
+    }
+
+    /**
+     * Builds an array of Classification objects from the passed classification configuration.
+     *
+     * @param array $configuredMappedClasses
+     * @return ClassificationItem[]
+     */
+    protected function buildClassificationsFromConfiguration($configuredMappedClasses) : array
+    {
+        $classifications = [];
+        foreach ($configuredMappedClasses as $class) {
+            if (empty($class['patterns']) || empty($class['class'])) {
+                throw new \InvalidArgumentException('A class configuration in SOLR_CLASSIFCATION needs to have a pattern and a class configured. Given configuration: ' . serialize($class));
+            }
+
+            $patterns = GeneralUtility::trimExplode(',', $class['patterns']);
+            $className = $class['class'];
+            $classifications[] = GeneralUtility::makeInstance(ClassificationItem::class, $patterns, $className);
+        }
+
+        return $classifications;
+    }
+}

--- a/Classes/Domain/Index/Classification/Classification.php
+++ b/Classes/Domain/Index/Classification/Classification.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+/**
+ * Class Classification
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\Classification
+ */
+class Classification {
+
+    /**
+     * Array of regular expressions
+     *
+     * @var array
+     */
+    protected $matchPatterns = [];
+
+    /**
+     * @var string
+     */
+    protected $mappedClass = '';
+
+    /**
+     * Classification constructor.
+     */
+    public function __construct(array $matchPatterns = [], string $mappedClass = '')
+    {
+        $this->matchPatterns = $matchPatterns;
+        $this->mappedClass = $mappedClass;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMatchPatterns(): array
+    {
+        return $this->matchPatterns;
+    }
+
+    /**
+     * @param array $matchPatterns
+     */
+    public function setMatchPatterns(array $matchPatterns)
+    {
+        $this->matchPatterns = $matchPatterns;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMappedClass(): string
+    {
+        return $this->mappedClass;
+    }
+
+    /**
+     * @param string $mappedClass
+     */
+    public function setMappedClass(string $mappedClass)
+    {
+        $this->mappedClass = $mappedClass;
+    }
+}

--- a/Classes/Domain/Index/Classification/ClassificationService.php
+++ b/Classes/Domain/Index/Classification/ClassificationService.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Class ClassificationService
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\Classification
+ */
+class ClassificationService {
+
+    /**
+     * @param string $stringToMatch
+     * @param Classification[] $classifications
+     * @return array
+     */
+    public function getMatchingClassNames(string $stringToMatch, $classifications) : array
+    {
+        $matchingClassification = [];
+        foreach ($classifications as $classification) {
+            /** @var $classification Classification */
+            foreach ($classification->getMatchPatterns() as $matchPattern)
+            {
+                if (preg_match_all('~' . $matchPattern . '~ims', $stringToMatch) > 0) {
+                    $matchingClassification[] = $classification->getMappedClass();
+                    // if we found one match, we do not need to check the other patterns
+                    break;
+                }
+            }
+        }
+
+        return $matchingClassification;
+    }
+}

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -384,10 +384,9 @@ class PageIndexer extends Indexer
         }
 
         if (!$indexActionResult['pageIndexed']) {
-            throw new \RuntimeException(
-                'Failed indexing page Index Queue item ' . $item->getIndexQueueUid(),
-                1331837081
-            );
+            $message = 'Failed indexing page Index Queue item: ' . $item->getIndexQueueUid() . ' url: ' . $indexRequestUrl;
+
+            throw new \RuntimeException($message, 1331837081);
         }
 
         return $response;

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -658,6 +658,58 @@ Example:
         additionalWhereClause = pid=2
     }
 
+SOLR_CLASSIFICATION
+~~~~~~~~~~~~~~~~~~~
+
+:Since: 8.0
+
+Allows to classify documents based on a configured pattern
+
+Example:
+
+.. code-block:: typoscript
+
+    topic_stringM = SOLR_CLASSIFICATION
+    topic_stringM {
+        field = __solr_page_content
+        classes {
+            programming {
+                patterns = php, java, javascript, go
+                class = programming
+            }
+            cms {
+                patterns = TYPO3, joomla
+                class = cms
+            }
+            database {
+                patterns = mysql, MariaDB, postgreSQL
+                class = database
+            }
+        }
+    }
+
+
+**field**
+
+:Type: String
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].fields.[fieldName].field
+:Since: 8.0
+
+Name of the database field, that should be used to as content to classify. The special field __solr_page_content can
+be used during page indexing to classify the content of the page.
+
+**classes**
+
+:Type: Array
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].fields.[fieldName].field
+:Since: 8.0
+
+Array of classification configurations. Each configuration needs to have the property "patterns", that is a list of patters that need to match and "class", that is the mapped class that will be indexed then.
+
+**Note**:
+
+The output field needs to be a multivalue field since an indexed item can have multiple classes.
+
 enableCommits
 -------------
 

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -24,17 +24,17 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
+use ApacheSolrForTypo3\Solr\ContentObject\Classification;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
- * Tests for the SOLR_MULTIVALUE cObj.
+ * Tests for the SOLR_CLASSIFICATION cObj.
  *
- * @author Ingo Renner <ingo@typo3.org>
+ * @author Timo Hund <timo.hund@dkd.de>
  */
-class MultivalueTest extends UnitTest
+class ClassificationTest extends UnitTest
 {
     /**
      * @var ContentObjectRenderer
@@ -44,53 +44,37 @@ class MultivalueTest extends UnitTest
     /**
      * @test
      */
-    public function convertsCommaSeparatedListFromRecordToSerializedArrayOfTrimmedValues()
+    public function canClassifyContent()
     {
         $GLOBALS['TSFE']->cObjectDepthCounter = 2;
+        $content = 'i like TYPO3 more then joomla';
+        $this->contentObject->start(['content' => $content]);
 
-        $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
-
-        $this->contentObject->start(['list' => $list]);
-
-        $actual = $this->contentObject->cObjGetSingle(
-            Multivalue::CONTENT_OBJECT_NAME,
-            [
-                'field' => 'list',
-                'separator' => ','
+        $configuration = [
+            'field' => 'content',
+            'classes.' => [
+                [
+                    'patterns' => 'TYPO3, joomla, core media',
+                    'class' => 'cms'
+                ],
+                [
+                    'patterns' => 'php, java, go, groovy',
+                    'class' => 'programming_language'
+                ]
             ]
-        );
+        ];
 
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * @test
-     */
-    public function convertsCommaSeparatedListFromValueToSerializedArrayOfTrimmedValues()
-    {
-        $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
-
-        $this->contentObject->start([]);
-
-        $actual = $this->contentObject->cObjGetSingle(
-            Multivalue::CONTENT_OBJECT_NAME,
-            [
-                'value' => $list,
-                'separator' => ','
-            ]
-        );
-
+        $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
+        $expected = serialize(['cms']);
         $this->assertEquals($expected, $actual);
     }
 
     protected function setUp()
     {
         // fake a registered hook
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][Multivalue::CONTENT_OBJECT_NAME] = [
-            Multivalue::CONTENT_OBJECT_NAME,
-            Multivalue::class
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][Classification::CONTENT_OBJECT_NAME] = [
+            Classification::CONTENT_OBJECT_NAME,
+            Classification::class
         ];
 
         $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Classification;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Classification\Classification;
+use ApacheSolrForTypo3\Solr\Domain\Index\Classification\ClassificationService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class ClassificationServiceTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetMatchingClassifications() {
+
+        $matchPatterns = ['smartphones', 'handy', 'smartphone', 'mobile', 'mobilephone'];
+        $mappedClass = 'mobilephone';
+        $mobilePhoneClassification = new Classification($matchPatterns, $mappedClass);
+
+        $matchPatterns = ['clock', 'watch', 'watches'];
+        $mappedClass = 'watch';
+        $watchClassification = new Classification($matchPatterns, $mappedClass);
+
+        $service = new ClassificationService();
+        $matches = $service->getMatchingClassNames('I have a smartphone in my hand.', [$mobilePhoneClassification, $watchClassification]);
+        $this->assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
+
+        $matches = $service->getMatchingClassNames('I have a smartphone in my hand and a watch on my arm.', [$mobilePhoneClassification, $watchClassification]);
+        $this->assertSame(['mobilephone', 'watch'], $matches, 'Unexpected matched classification');
+
+        $matches = $service->getMatchingClassNames('I have nothing on my arm and in my hand.', [$mobilePhoneClassification, $watchClassification]);
+        $this->assertSame([], $matches, 'Unexpected matched classification');
+
+        $matches = $service->getMatchingClassNames('I like my SMARTPHONE.', [$mobilePhoneClassification, $watchClassification]);
+        $this->assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
+
+    }
+}

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class AbstractIndexerTest extends UnitTest
+{
+
+    public function setUp()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'] = [];
+    }
+
+    /**
+     * @test
+     */
+    public function isSerializedValueCanHandleCustomContentElements()
+    {
+        $indexingConfiguration = [
+            'topic_stringM' => 'SOLR_CLASSIFICATION',
+            'categories_stringM' => 'SOLR_RELATION',
+            'categories_stringM.' => [
+                'multiValue' => true
+            ],
+            'csv_stringM' => 'SOLR_MULTIVALUE',
+            'category_stringM' => 'SOLR_RELATION'
+        ];
+
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Response of SOLR_CLASSIFICATION is expected to be serialized');
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
+
+
+        $this->assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM', 'Non configured fields should allways be unserialized'));
+        $this->assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM', 'Non configured fields should allways be unserialized'));
+    }
+
+    /**
+     * @test
+     */
+    public function isSerializedValueCanHandleCustomInvalidSerializedValueDetector()
+    {
+        // register invalid detector
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][] = InvalidSerializedValueDetector::class;
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageRegExp('/.*InvalidSerializedValueDetector must implement interface.*/');
+
+        $indexingConfiguration = [
+            'topic_stringM' => 'SOLR_CLASSIFICATION'
+        ];
+
+        // when an invalid detector is registered we expect that an exception is thrown
+        AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM');
+    }
+
+    /**
+     * @test
+     */
+    public function isSerializedValueCanHandleCustomValidSerializedValueDetector()
+    {
+        // register invalid detector
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][] = ValidSerializedValueDetector::class;
+
+        $indexingConfiguration = [
+            'topic_stringM' => 'SOLR_CLASSIFICATION',
+            'categories_stringM' => 'SOLR_RELATION',
+            'categories_stringM.' => [
+                'multiValue' => true
+            ],
+            'csv_stringM' => 'SOLR_MULTIVALUE',
+            'category_stringM' => 'SOLR_RELATION'
+        ];
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Every value should be treated as serialized by custom detector');
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Every value should be treated as serialized by custom detector');
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Every value should be treated as serialized by custom detector');
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM', 'Every value should be treated as serialized by custom detector'));
+        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM', 'Every value should be treated as serialized by custom detector'));
+    }
+}

--- a/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
@@ -1,0 +1,27 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class InvalidSerializedValueDetector {}

--- a/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
@@ -1,0 +1,43 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+use ApacheSolrForTypo3\Solr\IndexQueue\SerializedValueDetector;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class ValidSerializedValueDetector implements SerializedValueDetector {
+
+    /**
+     * Uses a field's configuration to detect whether its value returned by a
+     * content object is expected to be serialized and thus needs to be
+     * unserialized.
+     *
+     * @param array $indexingConfiguration Current item's indexing configuration
+     * @param string $solrFieldName Current field being indexed
+     * @return bool TRUE if the value is expected to be serialized, FALSE otherwise
+     */
+    public function isSerializedValue(array $indexingConfiguration, $solrFieldName)
+    {
+        return true;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -139,6 +139,12 @@ $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClas
     \ApacheSolrForTypo3\Solr\ContentObject\Relation::class
 ];
 
+$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME] = [
+    ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME,
+    \ApacheSolrForTypo3\Solr\ContentObject\Classification::class
+];
+
+
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 // Register cache for frequent searches


### PR DESCRIPTION
This pr:

* Adds the SOLR_CLASSIFICATION cObject that can be used to classify documents based on configured patterns.

Example:

 ```
plugin.tx_solr.index.queue.pages.fields.topic_stringM = SOLR_CLASSIFICATION
plugin.tx_solr.index.queue.pages.fields.topic_stringM {
   field = __solr_page_content
   classes {
      programming {
         patterns = php, java, javascript, go
         class = programming
      }
      cms {
         patterns = TYPO3, joomla
         class = cms
      }
      database {
         patterns = mysql, MariaDB, postgreSQL
         class = database
      }
   }
}
```

Fixes: #1722 