### PR TITLE
[BUGFIX] Use view constants correctly in setup configuration

### DIFF
--- a/Configuration/TypoScript/Solr/constants.txt
+++ b/Configuration/TypoScript/Solr/constants.txt
@@ -3,9 +3,9 @@ plugin.tx_solr {
 	enabled = 1
 
 	view {
-		templateRootPath = EXT:solr/Resources/Private/Templates/
-		partialRootPath = EXT:solr/Resources/Private/Partials/
-		layoutRootPath = EXT:solr/Resources/Private/Layouts/
+		templateRootPath =
+		partialRootPath =
+		layoutRootPath =
 	}
 
 	solr {

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -101,7 +101,7 @@ plugin.tx_solr {
 			boostQuery =
 
 			// see http://lucene.apache.org/solr/guide/7_0/the-dismax-query-parser.html#the-tie-tie-breaker-parameter
-			tieParameter = 
+			tieParameter =
 
 			filter {
 
@@ -249,13 +249,16 @@ plugin.tx_solr {
 		pluginNamespace = tx_solr
 
 		templateRootPaths {
-			0 = {$plugin.tx_solr.templateRootPath}
+			0 = EXT:solr/Resources/Private/Templates/
+			10 = {$plugin.tx_solr.view.templateRootPath}
 		}
 		partialRootPaths {
-			0 = {$plugin.tx_solr.partialRootPath}
+			0 = EXT:solr/Resources/Private/Partials/
+			10 = {$plugin.tx_solr.view.partialRootPath}
 		}
 		layoutRootPaths {
-			0 = {$plugin.tx_solr.layoutRootPath}
+			0 = EXT:solr/Resources/Private/Layouts/
+			10 = {$plugin.tx_solr.view.layoutRootPath}
 		}
 
         // By convention the templates is loaded from EXT:solr/Resources/Private/Templates/Frontend/Search/(ActionName).html


### PR DESCRIPTION
Furthermore use the constants as primary location and define extension
templates as default fallback. This allows to define own paths with
the need to copy all templates / partials / layouts to that new location.

Fixes: ##1727