### PR TITLE
[BUGFIX] Scheduler unuseable with invalid site

### DIFF
--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Task;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
@@ -74,9 +75,15 @@ abstract class AbstractSolrTask extends AbstractTask {
         if (!is_null($this->site)) {
             return $this->site;
         }
+
+        try {
             /** @var $siteRepository SiteRepository */
-        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        $this->site = $siteRepository->getSiteByRootPageId($this->rootPageId);
+            $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+            $this->site = $siteRepository->getSiteByRootPageId($this->rootPageId);
+        } catch (\InvalidArgumentException $e) {
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+            $logger->log(SolrLogManager::ERROR, 'Scheduler task tried to get invalid site');
+        }
 
         return $this->site;
     }

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -134,12 +134,12 @@ class ReIndexTask extends AbstractSolrTask
      */
     public function getAdditionalInformation()
     {
-        $information = '';
-
-        if ($this->getSite()) {
-            $information = 'Site: ' . $this->getSite()->getLabel();
+        $site = $this->getSite();
+        if (is_null($site)) {
+            return 'Invalid site configuration for scheduler please re-create the task!';
         }
 
+        $information = 'Site: ' . $this->getSite()->getLabel();
         if (!empty($this->indexingConfigurationsToReIndex)) {
             $information .= ', Indexing Configurations: ' . implode(', ',
                     $this->indexingConfigurationsToReIndex);

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -4,7 +4,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2015-2016 Timo Schmidt <timo.schmidt@dkd.de>
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
  *  All rights reserved
  *
  *  This script is part of the TYPO3 project. The TYPO3 project is
@@ -24,47 +24,24 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
+use ApacheSolrForTypo3\Solr\Task\ReIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
- * Testcase for IndexQueueWorkerTask
+ * Testcase for ReIndexTask
  *
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class IndexQueueWorkerTaskTest extends UnitTest
+class ReIndexTaskTest extends UnitTest
 {
-
-    /**
-     * @test
-     */
-    public function canGetWebRoot()
-    {
-        /** @var $indexQueuerWorker IndexQueueWorkerTask */
-        $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['execute'])
-            ->getMock();
-
-            // by default the webroot should be PATH_site
-        $this->assertSame(PATH_site, $indexQueuerWorker->getWebRoot(), 'Not using PATH_site as webroot');
-
-            // can we overwrite it?
-        $indexQueuerWorker->setForcedWebRoot('/var/www/foobar.de/subdir');
-        $this->assertSame('/var/www/foobar.de/subdir', $indexQueuerWorker->getWebRoot(), 'Can not force a webroot');
-
-            // can we use a marker?
-        $indexQueuerWorker->setForcedWebRoot('###PATH_site###../test/');
-        $this->assertSame(PATH_site . '../test/', $indexQueuerWorker->getWebRoot(), 'Could not use a marker in forced webroot');
-    }
 
     /**
      * @test
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-            /** @var $indexQueuerWorker IndexQueueWorkerTask */
-        $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
+            /** @var $indexQueuerWorker ReIndexTask */
+        $indexQueuerWorker = $this->getMockBuilder(ReIndexTask::class)
             ->disableOriginalConstructor()
             ->setMethods(['getSite'])
             ->getMock();


### PR DESCRIPTION
When a task for an invalid site is configured the scheduler shows an exception message.

This pr:

* Catches and logs the exception
* Shows and error message in the desription that the scheduler task should be recreated

Fixes: #1669