### PR TITLE
[TASK] Remove singleOptionMode from documentation

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -53,6 +53,9 @@
     'Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/',
     'Search - (Example) Options grouped by prefix');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/Facets/OptionsSinglemode/',
+    'Search - (Example) Options with singlemode (only one option at a time)');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Facets/QueryGroup/',
     'Search - (Example) QueryGroup facet on the created field');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',

--- a/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.txt
@@ -1,0 +1,14 @@
+plugin.tx_solr.search.faceting = 1
+plugin.tx_solr.search.faceting.facets {
+    typeToggle {
+        label = Type Singlemode
+        field = type
+        partialName = OptionsSinglemode
+        keepAllOptionsOnSelection = 1
+    }
+}
+
+page.includeJSFooterlibs {
+    solr-jquery = EXT:solr/Resources/Public/JavaScript/JQuery/jquery.min.js
+    solr-options = EXT:solr/Resources/Public/JavaScript/facet_options_controller.js
+}

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -860,19 +860,6 @@ Normally, when clicking any option link of a facet this would result in only tha
 
 This is useful if you want to allow the user to select more than one option from a single facet.
 
-faceting.facets.[facetName].singleOptionMode
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Type: Boolean
-:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].singleOptionMode
-:Since: 1.3, 2.0
-:Default: 0
-:Options: 0, 1
-
-When enabled together with keepAllOptionsOnSelection a user can select one option of the facet only at a time. Selecting a different option than the currently selected option results in the new option to replace the old one. The behavior thus is similar to a select box or a set of radio buttons.
-
-This option can not be used together with selectingSelectedFacetOptionRemovesFilter as it overrides its behavior.
-
 faceting.facets.[facetName].operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -528,4 +528,10 @@ And use them in your TypoScript configuration:
     }
 
 
+**I want to use faceting.facets.[facetName].singleOptionMode why was it removed?**
 
+This setting belongs to the rendering and not to the facet itself. You can implement the same behaviour just with the given ViewHelpers.
+
+The behaviour is the same, when you just call the ViewHelper s:uri.facet.setFacetItem instead of s:uri.facet.addFacetItem, which semantically just overwrites the current value.
+
+We've added an example partial "OptionsSinglemode" that shows this behaviour. The example TypoScript template "Search - (Example) Options with singlemode (only one option at a time)" shows how to use this partial in combination with the setting "keepAllOptionsOnSelection".


### PR DESCRIPTION
This pr:

* Add's an example typoscript configuration how to configure the singleOptionMode with fluid templating
* Removes the setting from the documentation
* Add's an faq entry how to implement this behaviour with fluid

Fixes: #1589