### PR TITLE
[TASK] Add filtered options partial

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -58,6 +58,9 @@
     'Configuration/TypoScript/Examples/Facets/OptionsSinglemode/',
     'Search - (Example) Options with singlemode (only one option at a time)');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
+    'Configuration/TypoScript/Examples/Facets/OptionsFiltered/',
+    'Search - (Example) Options filterable by option value');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Facets/QueryGroup/',
     'Search - (Example) QueryGroup facet on the created field');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',

--- a/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.txt
@@ -1,0 +1,13 @@
+plugin.tx_solr.search.faceting = 1
+plugin.tx_solr.search.faceting.facets {
+    typeFiltered {
+        label = Type Filtered
+        field = type
+        partialName = OptionsFiltered
+    }
+}
+
+page.includeJSFooterlibs {
+    solr-jquery = EXT:solr/Resources/Public/JavaScript/JQuery/jquery.min.js
+    solr-options = EXT:solr/Resources/Public/JavaScript/facet_options_controller.js
+}

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -111,6 +111,10 @@
 				<source>Remove all filters</source>
 				<target>Alle Filter entfernen</target>
 			</trans-unit>
+			<trans-unit id="faceting_filter" xml:space="preserve" approved="yes">
+		 	  	<source>Filter</source>
+				<target>Filtern</target>
+			</trans-unit>
 			<trans-unit id="results_range" xml:space="preserve" approved="yes">
 				<source>Displaying results @resultsFrom to @resultsTo of @resultsTotal.</source>
 				<target>Zeige Ergebnisse @resultsFrom bis @resultsTo von @resultsTotal.</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -158,6 +158,9 @@
 			<trans-unit id="faceting_removeAllFilters" xml:space="preserve">
 				<source>Remove all filters</source>
 			</trans-unit>
+			<trans-unit id="faceting_filter" xml:space="preserve">
+				<source>Filter</source>
+			</trans-unit>
 			<trans-unit id="results_range" xml:space="preserve">
 				<source>Displaying results @resultsFrom to @resultsTo of @resultsTotal.</source>
 			</trans-unit>

--- a/Resources/Private/Partials/Facets/OptionsFiltered.html
+++ b/Resources/Private/Partials/Facets/OptionsFiltered.html
@@ -1,0 +1,40 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+      xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+      xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
+
+    <div class="panel">
+        <div class="panel-heading">
+            <h3 class="facet-label panel-title">
+                <span class="glyphicon glyphicon-filter"></span>
+                <a data-toggle="collapse" data-parent="#facet-accordion{facet.name}" href="#facet{facet.name}">{facet.label}</a>
+            </h3>
+        </div>
+
+        <div class="panel-collapse collapse" id="facet{facet.name}">
+            <div class="form-group">
+                <input id="facetfilter{facet.name}" class="form-control facet-filter-box" type="search" placeholder="{s:translate(key: 'faceting_filter', default: 'Filter')}..." />
+            </div>
+
+            <div class="facet-option-list facet-type-options fluidfacet list-group" data-facet-name="{facet.name}" data-facet-label="{facet.label}" id="facet-data{facet.name}">
+                <f:for each="{facet.options}" as="option" iteration="iteration">
+                    <div class="list-group-item facet-filter-item facet-option{f:if(condition:'{iteration.index} > 9', then:' tx-solr-facet-hidden')}" data-facet-item-value="{option.value}">
+                        <a class="facet solr-ajaxified" href="{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}">{option.label}</a> <span class="facet-result-count badge">{option.documentCount}</span>
+                    </div>
+                </f:for>
+                <f:if condition="{facet.options -> f:count()} > 10">
+                    <div class="list-group-item">
+                        <a href="#" class="tx-solr-facet-show-all" data-label-more="{s:translate(key:'faceting_showMore', extensionName:'solr')}" data-label-less="{s:translate(key:'faceting_showFewer', extensionName:'solr')}">
+                            <s:translate key="faceting_showMore" extensionName="solr">Show more</s:translate>
+                        </a>
+                    </div>
+                </f:if>
+            </div>
+        </div>
+
+
+    </div>
+
+</html>

--- a/Resources/Public/JavaScript/facet_options_controller.js
+++ b/Resources/Public/JavaScript/facet_options_controller.js
@@ -6,6 +6,12 @@ function OptionFacetController() {
     var _this = this;
 
     this.init = function () {
+        _this.initToggle();
+        _this.initFilter();
+    };
+
+    this.initToggle = function () {
+
         jQuery('.tx-solr-facet-hidden').hide();
         jQuery('a.tx-solr-facet-show-all').click(function() {
             if (jQuery(this).parent().siblings('.tx-solr-facet-hidden:visible').length == 0) {
@@ -18,7 +24,24 @@ function OptionFacetController() {
 
             return false;
         });
-    };
+    }
+
+    this.initFilter = function () {
+        filterableFacets = jQuery(".facet-filter-box").closest('.facet');
+        filterableFacets.each(
+            function () {
+                var searchBox = jQuery(this).find('.facet-filter-box');
+                var searchItems = jQuery(this).find('.facet-filter-item');
+                searchBox.on("keyup", function() {
+                    var value = searchBox.val().toLowerCase();
+                    searchItems.each(function() {
+                        var filteredItem = jQuery(this);
+                        filteredItem.toggle(filteredItem.text().toLowerCase().indexOf(value) > -1)
+                    });
+                });
+            }
+        );
+    }
 }
 
 jQuery(document).ready(function () {


### PR DESCRIPTION
When you have an options facet with a lot of items you might want to allow the user to filter those options with a seperat filter field.

This pr:
* Add's an options partial "OptionsFiltered" that renders a search box above the facet that allows to filter the options

Fixes: #1436