### PR TITLE
[BUGFIX] Add quotes for filters from flexform

### DIFF
--- a/Classes/System/Service/ConfigurationService.php
+++ b/Classes/System/Service/ConfigurationService.php
@@ -129,7 +129,12 @@ class ConfigurationService
 
         foreach ($filters as $filter) {
             $filter = $filter['field'];
-            $filterConfiguration[] = $filter['field'] . ':' . $filter['value'];
+
+            $fieldName = $filter['field'];
+            $fieldValue = $filter['value'];
+            $quotedFieldValue = '"' . str_replace('"', '\"', $fieldValue) . '"';
+
+            $filterConfiguration[] =  $fieldName . ':' . $quotedFieldValue;
         }
         return $filterConfiguration;
     }

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -282,6 +282,14 @@ Example:
         badKeywords.data = GP:q
     }
 
+Note: When you want to filter for something with whitespaces you might need to quote the filter term.
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.filter {
+        johnsDoesPages = author:"John Doe"
+    }
+
 
 query.filter.__pageSections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -36,17 +36,30 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
  */
 class ConfigurationServiceTest extends UnitTest
 {
+
     /**
+     * @return array
+     */
+    public function overrideFilterDataProvider()
+    {
+        return [
+            'simpleInteger' => ['id', 4711, 'id:"4711"'],
+            'escapedString' => ['id', 'foo"bar', 'id:"foo\"bar"']
+        ];
+    }
+
+    /**
+     * @dataProvider overrideFilterDataProvider
      * @test
      */
-    public function canOverrideConfigurationWithFlexFormSettings()
+    public function canOverrideConfigurationWithFlexFormSettings($filterField, $filterValue, $expectedFilterString)
     {
         $fakeFlexFormArrayData = [
             'search' =>
                 [
                     'query' => [
                         'filter' => [
-                            ['field' => ['field' => 'id', 'value' => 4711]]
+                            ['field' => ['field' => $filterField, 'value' => $filterValue]]
                         ]
                     ]
                 ]
@@ -65,6 +78,6 @@ class ConfigurationServiceTest extends UnitTest
         $configurationService->overrideConfigurationWithFlexFormSettings('foobar', $typoScriptConfiguration);
 
             // the filter should be overwritten by the flexform
-        $this->assertEquals(['id:4711'], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
+        $this->assertEquals([$expectedFilterString], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
     }
 }


### PR DESCRIPTION
This pr:

* Adds quotes to filters defined in the flexform to allow filters with whitespaces

Fixes: #1742