### PR TITLE
[BUGFIX] Always return value as expected

### DIFF
--- a/Resources/Private/Php/SolrPhpClient/Apache/Solr/Response.php
+++ b/Resources/Private/Php/SolrPhpClient/Apache/Solr/Response.php
@@ -199,13 +199,6 @@ class Apache_Solr_Response
                 }
 
                 foreach ($originalDocument as $key => $value) {
-                    //If a result is an array with only a single
-                    //value then its nice to be able to access
-                    //it as if it were always a single value
-                    if ($this->_collapseSingleValueArrays && is_array($value) && count($value) <= 1) {
-                        $value = array_shift($value);
-                    }
-
                     $document->$key = $value;
                 }
 


### PR DESCRIPTION
If a field is an array, an array should be returned within Solr
document. This is necessary for e.g. be able to iterate over a property
in a Fluid file. If returning either an array or a string, an exception
in Fluid is thrown because it expects an array.

Resolves: #1689