### PR TITLE
[TASK] Remove deprecated "show_thumbs" and "wizards" from Forms action flexform

### DIFF
--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -18,15 +18,6 @@
                                 <type>group</type>
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
-                                <show_thumbs>1</show_thumbs>
-                                <wizards>
-                                    <suggest>
-                                        <type>suggest</type>
-                                        <default>
-                                            <searchWholePhrase>1</searchWholePhrase>
-                                        </default>
-                                    </suggest>
-                                </wizards>
                             </config>
                         </TCEforms>
                     </search.targetPage>


### PR DESCRIPTION
This pr:

* Removes the deprecated options "show_thumbs" and "wizards" from the flexform

See also:

https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/8.6/Deprecation-79440-TcaChanges.html

Fixes: #1750