### PR TITLE
[TASK] Support json faceting for options facet

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Faceting.php
@@ -26,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\SortingExpression;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * The Faceting ParameterProvider is responsible to build the solr query parameters
@@ -232,16 +231,17 @@ class Faceting implements ParameterBuilder
     /**
      * Reads the facet sorting configuration and applies it to the queryParameters.
      *
+     * @param array $facetParameters
      * @return array
      */
     protected function applySorting(array $facetParameters)
     {
         $sortingExpression = new SortingExpression();
         $globalSortingExpression = $sortingExpression->getForFacet($this->sorting);
+
         if (!empty($globalSortingExpression)) {
             $facetParameters['facet.sort'] = $globalSortingExpression;
         }
-
 
         return $facetParameters;
     }

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
@@ -40,6 +40,11 @@ abstract class AbstractFacetItem
     protected $selected = false;
 
     /**
+     * @var array
+     */
+    protected $metrics = [];
+
+    /**
      * @var AbstractFacet
      */
     protected $facet;
@@ -49,13 +54,15 @@ abstract class AbstractFacetItem
      * @param string $label
      * @param int $documentCount
      * @param bool $selected
+     * @param array $metrics
      */
-    public function __construct(AbstractFacet $facet, $label = '', $documentCount = 0, $selected = false)
+    public function __construct(AbstractFacet $facet, $label = '', $documentCount = 0, $selected = false, $metrics = [])
     {
         $this->facet = $facet;
         $this->label = $label;
         $this->documentCount = $documentCount;
         $this->selected = $selected;
+        $this->metrics = $metrics;
     }
 
     /**
@@ -88,6 +95,14 @@ abstract class AbstractFacetItem
     public function getSelected()
     {
         return $this->selected;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMetrics()
+    {
+        return $this->metrics;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionFacetItem.php
@@ -36,11 +36,12 @@ class AbstractOptionFacetItem extends AbstractFacetItem
      * @param string $value
      * @param int $documentCount
      * @param bool $selected
+     * @param array $metrics
      */
-    public function __construct(AbstractFacet $facet, $label = '', $value = '', $documentCount = 0, $selected = false)
+    public function __construct(AbstractFacet $facet, $label = '', $value = '', $documentCount = 0, $selected = false, $metrics = [])
     {
         $this->value = $value;
-        parent::__construct($facet, $label, $documentCount, $selected);
+        parent::__construct($facet, $label, $documentCount, $selected, $metrics);
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
@@ -31,9 +31,10 @@ class Option extends AbstractOptionFacetItem
      * @param string $value
      * @param int $documentCount
      * @param bool $selected
+     * @param array $metrics
      */
-    public function __construct(OptionsFacet $facet, $label = '', $value = '', $documentCount = 0, $selected = false)
+    public function __construct(OptionsFacet $facet, $label = '', $value = '', $documentCount = 0, $selected = false, $metrics = [])
     {
-        parent::__construct($facet, $label, $value, $documentCount, $selected);
+        parent::__construct($facet, $label, $value, $documentCount, $selected, $metrics);
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -33,9 +33,9 @@ class OptionsFacetParser extends AbstractFacetParser
         $response = $resultSet->getResponse();
         $fieldName = $facetConfiguration['field'];
         $label = $this->getPlainLabelOrApplyCObject($facetConfiguration);
-        $optionsFromSolrResponse = isset($response->facet_counts->facet_fields->{$fieldName}) ? get_object_vars($response->facet_counts->facet_fields->{$fieldName}) : [];
+        $optionsFromSolrResponse = $this->getOptionsFromSolrResponse($facetName, $response);
+        $metricsFromSolrResponse = $this->getMetricsFromSolrResponse($facetName, $response);
         $optionsFromRequest = $this->getActiveFacetValuesFromRequest($resultSet, $facetName);
-
         $hasOptionsInResponse = !empty($optionsFromSolrResponse);
         $hasSelectedOptionsInRequest = count($optionsFromRequest) > 0;
         $hasNoOptionsToShow = !$hasOptionsInResponse && !$hasSelectedOptionsInRequest;
@@ -67,7 +67,7 @@ class OptionsFacetParser extends AbstractFacetParser
 
             $isOptionsActive = in_array($optionsValue, $optionsFromRequest);
             $label = $this->getLabelFromRenderingInstructions($optionsValue, $count, $facetName, $facetConfiguration);
-            $facet->addOption(new Option($facet, $label, $optionsValue, $count, $isOptionsActive));
+            $facet->addOption(new Option($facet, $label, $optionsValue, $count, $isOptionsActive, $metricsFromSolrResponse[$optionsValue]));
         }
 
         // after all options have been created we apply a manualSortOrder if configured
@@ -77,5 +77,52 @@ class OptionsFacetParser extends AbstractFacetParser
         $this->applyReverseOrder($facet, $facetConfiguration);
 
         return $facet;
+    }
+
+    /**
+     * @param string $facetName
+     * @param \Apache_Solr_Response $response
+     * @return array
+     */
+    protected function getOptionsFromSolrResponse($facetName, \Apache_Solr_Response $response)
+    {
+        $optionsFromSolrResponse = [];
+        if (!isset($response->facets->{$facetName})) {
+            return $optionsFromSolrResponse;
+        }
+
+        foreach ($response->facets->{$facetName}->buckets as $bucket) {
+            $optionValue = $bucket->val;
+            $optionCount = $bucket->count;
+            $optionsFromSolrResponse[$optionValue] = $optionCount;
+        }
+
+        return $optionsFromSolrResponse;
+    }
+
+    /**
+     * @param string $facetName
+     * @param \Apache_Solr_Response $response
+     * @return array
+     */
+    protected function getMetricsFromSolrResponse($facetName, \Apache_Solr_Response $response)
+    {
+        $metricsFromSolrResponse = [];
+
+        if (!isset($response->facets->{$facetName}->buckets)) {
+            return [];
+        }
+
+        foreach ($response->facets->{$facetName}->buckets as $bucket) {
+            $bucketVariables = get_object_vars($bucket);
+            foreach ($bucketVariables as $key => $value) {
+                if (strpos($key, 'metrics_') === 0) {
+                    $metricsKey = str_replace('metrics_', '', $key);
+                    $metricsFromSolrResponse[$bucket->val][$metricsKey] = $value;
+                }
+            }
+        }
+
+        return $metricsFromSolrResponse;
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -1,0 +1,140 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+*/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\DefaultFacetQueryBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetQueryBuilderInterface;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\SortingExpression;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+
+/**
+ * Class OptionsFacetQueryBuilder
+ *
+ * The Options facet query builder builds the facets as json structure
+ *
+ * @Todo: When we use json faceting for other facets some logic of this class can be moved to the base class.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options
+ */
+class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements FacetQueryBuilderInterface {
+
+    /**
+     * @param string $facetName
+     * @param TypoScriptConfiguration $configuration
+     * @return array
+     */
+    public function build($facetName, TypoScriptConfiguration $configuration)
+    {
+        $facetParameters = [];
+        $facetConfiguration = $configuration->getSearchFacetingFacetByName($facetName);
+
+        $jsonFacetOptions = [
+            'type' => 'terms',
+            'field' => $facetConfiguration['field'],
+        ];
+
+        $jsonFacetOptions['limit'] = $this->buildLimitForJson($facetConfiguration, $configuration);
+        $jsonFacetOptions['mincount'] = $this->buildMincountForJson($facetConfiguration, $configuration);
+
+        $sorting = $this->buildSortingForJson($facetConfiguration);
+        if (!empty($sorting)) {
+            $jsonFacetOptions['sort'] = $sorting;
+        }
+
+        if (is_array($facetConfiguration['metrics.'])) {
+            foreach ($facetConfiguration['metrics.'] as $key => $value) {
+                $jsonFacetOptions['facet']['metrics_' . $key] = $value;
+            }
+        }
+
+        $excludeTags = $this->buildExcludeTagsForJson($facetConfiguration, $configuration);
+        if (!empty($excludeTags)) {
+            $jsonFacetOptions['domain']['excludeTags'] = $excludeTags;
+        }
+
+        $facetParameters['json.facet'][$facetName] = $jsonFacetOptions;
+
+        return $facetParameters;
+    }
+
+    /**
+     * @param array $facetConfiguration
+     * @param TypoScriptConfiguration $configuration
+     * @return string
+     */
+    protected function buildExcludeTagsForJson(array $facetConfiguration, TypoScriptConfiguration $configuration)
+    {
+        $isKeepAllOptionsActiveForSingleFacet = $facetConfiguration['keepAllOptionsOnSelection'] == 1;
+        $isKeepAllOptionsActiveGlobalsAndCountsEnabled = $configuration->getSearchFacetingKeepAllFacetsOnSelection()
+            && $configuration->getSearchFacetingCountAllFacetsForSelection();
+
+        if ($isKeepAllOptionsActiveForSingleFacet || $isKeepAllOptionsActiveGlobalsAndCountsEnabled) {
+            return $facetConfiguration['field'];
+        } else {
+            // keepAllOptionsOnSelection globally active
+            $facets = [];
+            foreach ($configuration->getSearchFacetingFacets() as $facet) {
+                $facets[] = $facet['field'];
+            }
+            return implode(',', $facets);
+        }
+    }
+
+    /**
+     * @param array $facetConfiguration
+     * @param TypoScriptConfiguration $configuration
+     * @return int
+     */
+    protected function buildLimitForJson(array $facetConfiguration, TypoScriptConfiguration $configuration)
+    {
+        if (isset($facetConfiguration['facetLimit'])) {
+            return (int)$facetConfiguration['facetLimit'];
+        } elseif ($configuration->getSearchFacetingFacetLimit() > 0) {
+            return $configuration->getSearchFacetingFacetLimit();
+        } else {
+            return -1;
+        }
+    }
+
+    /**
+     * @param array $facetConfiguration
+     * @param TypoScriptConfiguration $configuration
+     * @return int
+     */
+    protected function buildMincountForJson(array $facetConfiguration, TypoScriptConfiguration $configuration)
+    {
+        if (isset($facetConfiguration['minimumCount'])) {
+            return (int)$facetConfiguration['minimumCount'];
+        } elseif ($configuration->getSearchFacetingMinimumCount() > 0) {
+            return $configuration->getSearchFacetingMinimumCount();
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * @param array $facetConfiguration
+     * @return string
+     */
+    protected function buildSortingForJson(array $facetConfiguration) {
+        if (isset($facetConfiguration['sortBy'])) {
+            $sortingExpression = new SortingExpression();
+            $sorting = $facetConfiguration['sortBy'];
+            $direction = $facetConfiguration['sortDirection'];
+            return $sortingExpression->getForJsonFacet($sorting, $direction);
+        }
+        return '';
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsPackage.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsPackage.php
@@ -28,4 +28,11 @@ class OptionsPackage extends AbstractFacetPackage {
     public function getParserClassName() {
         return (string)OptionsFacetParser::class;
     }
+
+    /**
+     * @return string
+     */
+    public function getQueryBuilderClassName() {
+        return (string)OptionsFacetQueryBuilder::class;
+    }
 }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1911,6 +1911,21 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns if the facet count should be calculated based on the facet selection when
+     * plugin.tx_solr.search.faceting.keepAllFacetsOnSelection has been enabled
+     *
+     * plugin.tx_solr.search.faceting.countAllFacetsForSelection
+     *
+     * @param bool $defaultIfEmpty
+     * @return bool
+     */
+    public function getSearchFacetingCountAllFacetsForSelection($defaultIfEmpty = false)
+    {
+        $countAllFacetsForSelection = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.faceting.countAllFacetsForSelection', $defaultIfEmpty);
+        return $this->getBool($countAllFacetsForSelection);
+    }
+
+    /**
      * Returns the configured faceting configuration.
      *
      * plugin.tx_solr.search.faceting.facets

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -710,7 +710,7 @@ faceting.facetLimit
 :Since: 6.0
 :Default: 100
 
-    Number of options of a facet returned from solr.
+Number of options of a facet returned from solr.
 
 
 faceting.singleFacetMode
@@ -843,6 +843,49 @@ Defines a comma separated list of options that are excluded (The value needs to 
 
 Important: This setting only makes sence for option based facets (option, query, hierarchy)
 
+
+faceting.facets.[facetName].facetLimit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Integer
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].facetLimit
+:Since: 8.0
+:Default: -1
+
+Hard limit of options returned by solr.
+
+**Note**: This is only available for options facets.
+
+faceting.facets.[facetName].metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Array
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].metrics
+:Since: 8.0
+:Default: empty
+
+Metrics can be use to collect and enhance facet options with statistical data of the facetted documents. They can
+be used to render useful information in the context of an facet option.
+
+Example:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.faceting.facets {
+      category {
+        field = field
+        label = Category
+        metrics {
+            downloads = sum(downloads_intS)
+        }
+      }
+    }
+
+
+The example above will make the metric "downloads" available for all category options. In this case it will be the sum of all downloads
+of this category item. In the frontend you can render this metric with "<facetoptions.>.metrics.downloads" and use it for example to show it instead of the normal option count.
+
+
 faceting.facets.[facetName].partialName
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -891,6 +934,8 @@ faceting.facets.[facetName].sortBy
 Sets how a single facet's options are sorted, by default they are sorted by number of results, highest on top.
 Facet options can also be sorted alphabetically by setting the option to alpha.
 
+Note: Since 8.0 sortBy for option facets can also be a function applied on the faceted documents (e.g. avg(price_floatS)).
+
 faceting.facets.[facetName].manualSortOrder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -925,6 +970,21 @@ Using `faceting.facets.[facetName].manualSortOrder = Travel, Health` will result
     + Economy (185)
     + Culture (179)
     + Automobile (99)
+
+faceting.facets.[facetName].minimumCount
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Integer
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].minumumCount
+:Since: 8.0
+:Default: 1
+
+Set's the minimumCount for a single facet. This can be usefull e.g. to set the minimumCount of a single facet to 0,
+to have the options available even when there is result available.
+
+**Note**: This setting is only available for facets that are using the json faceting API of solr. By now this
+is only available for the options facets.
+
 
 faceting.facets.[facetName].reverseOrder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -792,6 +792,35 @@ class SearchControllerTest extends IntegrationTest
     /**
      * @test
      */
+    public function canRenderASecondFacetOnTheTypeField()
+    {
+        $this->importDataSetFromFixture('can_render_search_controller.xml');
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+
+        $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $overwriteConfiguration = [];
+        $overwriteConfiguration['search.']['faceting.']['facets.']['myType.'] = [
+            'label' => 'My Type',
+            'field' => 'type',
+        ];
+
+        /** @var $configurationManager ConfigurationManager */
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+        $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
+        $this->searchController->setResetConfigurationBeforeInitialize(false);
+
+        //not in the content but we expect to get shoes suggested
+        $_GET['q'] = '*';
+        $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
+        $this->assertContains('id="facetmyType"', $this->searchResponse->getContent());
+        $this->assertContains('id="facettype"', $this->searchResponse->getContent());
+
+    }
+
+    /**
+     * @test
+     */
     public function formActionIsRenderingTheForm()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
@@ -1,76 +1,92 @@
 {
   "responseHeader": {
     "status": 0,
-    "QTime": 11,
+    "QTime": 13,
     "params": {
-      "spellcheck": "true",
-      "facet": "true",
-      "enableElevation": "false",
-      "hl.tag.post": "</em>",
-      "spellcheck.maxCollationTries": "5",
-      "q.alt": "*:*",
-      "hl": "true",
-      "echoParams": "all",
-      "debugQuery": "true",
-      "fl": "*,score",
-      "bf": "recip(ms(NOW,filter_dateS),3.16e-11,1,1)^20.0",
-      "facet.field": [
-        "type_stringS",
-        "category_stringM"
-      ],
-      "fq": [
-        "siteHash:\"73f9dbeae83ff400a97eedfb88e33a5a9d9f58fe\"",
-        "{!typo3access}-2,0,1"
-      ],
-      "hl.fragsize": "100",
-      "facet.mincount": "1",
-      "qf": "content^10.0 title^12.0 category_textM^2.0",
-      "hl.tag.pre": "<em class=\"match\">",
-      "hl.fl": "content",
-      "json.nl": "map",
-      "spellcheck.collate": "true",
-      "wt": "json",
-      "rows": "10",
-      "hl.useFastVectorHighlighter": "true",
-      "start": "0",
-      "facet.sort": "count",
-      "q": "",
-      "hl.requireFieldMatch": "true",
-      "mm": "2<-35%",
-      "indent": "true",
-      "spellcheck.extendedResults": "false",
-      "hl.mergeContiguous": "true",
-      "f.content.hl.maxAlternateFieldLength": "200",
-      "spellcheck.onlyMorePopular": "false",
-      "defType": "edismax",
-      "pf": "content^2.0",
       "df": "content",
-      "hl.snippets": "3",
-      "f.content.hl.alternateField": "content",
+      "ps": "15",
       "spellcheck.dictionary": [
         "default",
         "wordbreak"
       ],
+      "hl": "true",
+      "echoParams": "all",
+      "indent": "true",
+      "fl": "*,score",
+      "hl.requireFieldMatch": "true",
+      "hl.fragsize": "200",
+      "fq": [
+        "{!collapse field=variantId}",
+        "siteHash:\"31c20e448477ffc7544f4d1d0b17ea48c06a3a48\"",
+        "{!typo3access}-1,0"
+      ],
+      "spellcheck.maxCollationTries": "1",
+      "hl.simple.pre": "<span class=\"results-highlight\">",
+      "hl.useFastVectorHighlighter": "true",
+      "defType": "edismax",
+      "hl.mergeContiguous": "true",
+      "expand.rows": "10",
+      "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline description^4.0 abstract subtitle navtitle author",
+      "hl.fl": "content",
+      "wt": "json",
+      "f.content.hl.alternateField": "content",
+      "hl.tag.pre": "<span class=\"results-highlight\">",
+      "mm": "2<-35%",
+      "json.nl": "map",
+      "start": "0",
+      "hl.tag.post": "</span>",
+      "rows": "0",
+      "f.content.hl.maxAlternateFieldLength": "200",
+      "spellcheck.extendedResults": "false",
+      "hl.snippets": "3",
+      "facet.limit": "100",
+      "json.facet": "{\"type\":{\"type\":\"terms\",\"field\":\"type_stringS\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type_stringS,category_stringM\"}},\"category_stringM\":{\"type\":\"terms\",\"field\":\"category_stringM\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type_stringS,category_stringM\"}}}",
+      "q": "*",
+      "expand": "true",
+      "enableElevation": "false",
+      "hl.simple.post": "</span>",
+      "spellcheck": "true",
+      "pf": "content^2.0",
+      "spellcheck.onlyMorePopular": "false",
+      "facet.mincount": "1",
       "spellcheck.count": "1",
-      "ps": "15"
+      "facet": "true",
+      "debugQuery": "false",
+      "facet.sort": "count",
+      "spellcheck.collate": "true"
     }
   },
   "response": {
-    "numFound": 10,
+    "numFound": 14,
     "start": 0,
-    "maxScore": 1.0868415
+    "maxScore": 1.0,
+    "docs": []
   },
   "facet_counts": {
     "facet_queries": {},
-    "facet_fields": {
-      "type_stringS": {
-        "page": 9,
-        "event": 1
-      },
-      "category_stringM": {}
-    },
-    "facet_dates": {},
+    "facet_fields": {},
     "facet_ranges": {},
-    "facet_intervals": {}
-  }
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  },
+  "facets": {
+    "count": 10,
+    "type": {
+      "buckets": [
+        {
+          "val": "page",
+          "count": 9
+        },
+        {
+          "val": "event",
+          "count": 1
+        }
+      ]
+    },
+    "category_stringM": {
+      "buckets": []
+    }
+  },
+  "highlighting": {},
+  "expanded": {}
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -1,0 +1,270 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2011 Markus Goldbach <markus.goldbach@dkd.de>
+ *  (c) 2012-2015 Ingo Renner <ingo@typo3.org>
+ *  (c) 2016 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacetQueryBuilder;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase for the dateRange queryBuilder
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class OptionsFacetQueryBuilderTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canBuildSortParameter()
+    {
+        /**
+         * sortBy = index
+         * sortDirection = desc
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category',
+            'sortBy' => 'index',
+            'sortDirection' => 'desc',
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => -1,
+                    'mincount' => 1,
+                    'sort' => 'index desc',
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+
+
+    /**
+     * @test
+     */
+    public function canBuildLimitParameter()
+    {
+        /**
+         * limit 20
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category',
+            'facetLimit' => 20,
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => 20,
+                    'mincount' => 1,
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+
+    /**
+     * @test
+     */
+    public function canBuildLimitParameterFromGlobalSetting()
+    {
+        /**
+         * limit
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category'
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->will(
+            $this->returnValue(15)
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => 15,
+                    'mincount' => 1,
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+
+    /**
+     * @test
+     */
+    public function canBuildMincountParameter()
+    {
+        /**
+         * mincount = 2
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category',
+            'minimumCount' => 2,
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => -1,
+                    'mincount' => 2,
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+
+    /**
+     * @test
+     */
+    public function canBuildMincountParameterFromGlobalSetting()
+    {
+        /**
+         * mincount = 2
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category'
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->will(
+            $this->returnValue(5)
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => -1,
+                    'mincount' => 5,
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+
+    /**
+     * @test
+     */
+    public function canBuildMetricsParameter()
+    {
+        /**
+         * metrics {
+         *    downloads = sum(downloads_intS)
+         * }
+         */
+        $fakeFacetConfiguration = [
+            'field' => 'category',
+            'metrics.' => [
+                'downloads' => 'sum(downloads_intS)',
+            ],
+        ];
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
+            $this->returnValue($fakeFacetConfiguration)
+        );
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
+            $this->returnValue([])
+        );
+
+        $builder = new OptionsFacetQueryBuilder();
+        $facetParameters = $builder->build('category', $configurationMock);
+        $expectedFacetParameters = [
+            'json.facet' => [
+                'category' => [
+                    'type' => 'terms',
+                    'field' => 'category',
+                    'limit' => -1,
+                    'mincount' => 1,
+                    'facet' => [
+                        'metrics_downloads' => 'sum(downloads_intS)',
+                    ],
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_jsonfacets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_jsonfacets.json
@@ -1,0 +1,27 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 2,
+    "params": {
+      "q": "*:*",
+      "json.facet": "{\n   type:{\n     type : terms,\n     field : type,\n     mincount : 2\n   }\n }\n",
+      "rows": "0"
+    }
+  },
+  "response": {
+    "numFound": 19,
+    "start": 0,
+    "docs": []
+  },
+  "facets": {
+    "count": 19,
+    "type": {
+      "buckets": [
+        {
+          "val": "tx_myext_domain_model_mytype",
+          "count": 19
+        }
+      ]
+    }
+  }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
@@ -1,76 +1,92 @@
 {
   "responseHeader": {
     "status": 0,
-    "QTime": 11,
+    "QTime": 13,
     "params": {
-      "spellcheck": "true",
-      "facet": "true",
-      "enableElevation": "false",
-      "hl.tag.post": "</em>",
-      "spellcheck.maxCollationTries": "5",
-      "q.alt": "*:*",
-      "hl": "true",
-      "echoParams": "all",
-      "debugQuery": "true",
-      "fl": "*,score",
-      "bf": "recip(ms(NOW,filter_dateS),3.16e-11,1,1)^20.0",
-      "facet.field": [
-        "type_stringS",
-        "category_stringM"
-      ],
-      "fq": [
-        "siteHash:\"73f9dbeae83ff400a97eedfb88e33a5a9d9f58fe\"",
-        "{!typo3access}-2,0,1"
-      ],
-      "hl.fragsize": "100",
-      "facet.mincount": "1",
-      "qf": "content^10.0 title^12.0 category_textM^2.0",
-      "hl.tag.pre": "<em class=\"match\">",
-      "hl.fl": "content",
-      "json.nl": "map",
-      "spellcheck.collate": "true",
-      "wt": "json",
-      "rows": "10",
-      "hl.useFastVectorHighlighter": "true",
-      "start": "0",
-      "facet.sort": "count",
-      "q": "",
-      "hl.requireFieldMatch": "true",
-      "mm": "2<-35%",
-      "indent": "true",
-      "spellcheck.extendedResults": "false",
-      "hl.mergeContiguous": "true",
-      "f.content.hl.maxAlternateFieldLength": "200",
-      "spellcheck.onlyMorePopular": "false",
-      "defType": "edismax",
-      "pf": "content^2.0",
       "df": "content",
-      "hl.snippets": "3",
-      "f.content.hl.alternateField": "content",
+      "ps": "15",
       "spellcheck.dictionary": [
         "default",
         "wordbreak"
       ],
+      "hl": "true",
+      "echoParams": "all",
+      "indent": "true",
+      "fl": "*,score",
+      "hl.requireFieldMatch": "true",
+      "hl.fragsize": "200",
+      "fq": [
+        "{!collapse field=variantId}",
+        "siteHash:\"31c20e448477ffc7544f4d1d0b17ea48c06a3a48\"",
+        "{!typo3access}-1,0"
+      ],
+      "spellcheck.maxCollationTries": "1",
+      "hl.simple.pre": "<span class=\"results-highlight\">",
+      "hl.useFastVectorHighlighter": "true",
+      "defType": "edismax",
+      "hl.mergeContiguous": "true",
+      "expand.rows": "10",
+      "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline description^4.0 abstract subtitle navtitle author",
+      "hl.fl": "content",
+      "wt": "json",
+      "f.content.hl.alternateField": "content",
+      "hl.tag.pre": "<span class=\"results-highlight\">",
+      "mm": "2<-35%",
+      "json.nl": "map",
+      "start": "0",
+      "hl.tag.post": "</span>",
+      "rows": "0",
+      "f.content.hl.maxAlternateFieldLength": "200",
+      "spellcheck.extendedResults": "false",
+      "hl.snippets": "3",
+      "facet.limit": "100",
+      "json.facet": "{\"type\":{\"type\":\"terms\",\"field\":\"type_stringS\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type_stringS,category_stringM\"}},\"category_stringM\":{\"type\":\"terms\",\"field\":\"category_stringM\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type_stringS,category_stringM\"}}}",
+      "q": "*",
+      "expand": "true",
+      "enableElevation": "false",
+      "hl.simple.post": "</span>",
+      "spellcheck": "true",
+      "pf": "content^2.0",
+      "spellcheck.onlyMorePopular": "false",
+      "facet.mincount": "1",
       "spellcheck.count": "1",
-      "ps": "15"
+      "facet": "true",
+      "debugQuery": "false",
+      "facet.sort": "count",
+      "spellcheck.collate": "true"
     }
   },
   "response": {
-    "numFound": 10,
+    "numFound": 14,
     "start": 0,
-    "maxScore": 1.0868415
+    "maxScore": 1.0,
+    "docs": []
   },
   "facet_counts": {
     "facet_queries": {},
-    "facet_fields": {
-      "type_stringS": {
-        "page": 9,
-        "event": 1
-      },
-      "category_stringM": {}
-    },
-    "facet_dates": {},
+    "facet_fields": {},
     "facet_ranges": {},
-    "facet_intervals": {}
-  }
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  },
+  "facets": {
+    "count": 10,
+    "type": {
+      "buckets": [
+        {
+          "val": "page",
+          "count": 9
+        },
+        {
+          "val": "event",
+          "count": 1
+        }
+      ]
+    },
+    "category_stringM": {
+      "buckets": []
+    }
+  },
+  "highlighting": {},
+  "expanded": {}
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_two_used_facets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_two_used_facets.json
@@ -1,73 +1,98 @@
 {
-    "responseHeader": {
-        "status": 0,
-        "QTime": 4,
-        "params": {
-            "hl.fragsize": "200",
-            "spellcheck": "true",
-            "enableElevation": "false",
-            "facet": "true",
-            "hl.tag.post": "</span>",
-            "facet.mincount": "1",
-            "spellcheck.maxCollationTries": "0",
-            "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline",
-            "hl.tag.pre": "<span class=\"results-highlight\">",
-            "json.nl": "map",
-            "hl.fl": "content",
-            "wt": "json",
-            "spellcheck.collate": "true",
-            "hl": "true",
-            "rows": "10",
-            "f.title.facet.sort": "lex",
-            "fl": "id,title,siteHash,score",
-            "debugQuery": "true",
-            "echoParams": "all",
-            "hl.useFastVectorHighlighter": "true",
-            "start": "0",
-            "facet.sort": "count",
-            "q": "kasper",
-            "facet.field": ["type",
-                "title"],
-            "fq": ["siteHash:\"c56040516adcfdb545d2120d595a56930f6ddaa3\"",
-                "{!typo3access}-1,0",
-                "(title:\"jpeg\" AND title:\"kasper\\\"s\")"],
-            "hl.requireFieldMatch": "true",
-            "mm": "2<-35%",
-            "indent": "true",
-            "spellcheck.extendedResults": "false",
-            "hl.mergeContiguous": "true",
-            "f.content.hl.maxAlternateFieldLength": "200",
-            "spellcheck.onlyMorePopular": "false",
-            "defType": "edismax",
-            "pf": "content^2.0",
-            "df": "content",
-            "hl.snippets": "3",
-            "f.content.hl.alternateField": "content",
-            "spellcheck.dictionary": ["default",
-                "wordbreak"],
-            "q.op": "OR",
-            "spellcheck.count": "1",
-            "ps": "15"
-        }
-    },
-    "response": {
-        "numFound": 1,
-        "start": 0,
-        "maxScore": 0.8142768
-    },
-    "facet_counts": {
-        "facet_queries": {},
-        "facet_fields": {
-            "type": {
-                "tx_solr_file": 1
-            },
-            "title": {
-                "jpeg": 1,
-                "kasper\"s": 1
-            }
-        },
-        "facet_dates": {},
-        "facet_ranges": {},
-        "facet_intervals": {}
+  "responseHeader": {
+    "status": 0,
+    "QTime": 5,
+    "params": {
+      "df": "content",
+      "ps": "15",
+      "spellcheck.dictionary": [
+        "default",
+        "wordbreak"
+      ],
+      "hl": "true",
+      "echoParams": "all",
+      "indent": "true",
+      "fl": "*,score",
+      "hl.requireFieldMatch": "true",
+      "hl.fragsize": "200",
+      "fq": [
+        "{!collapse field=variantId}",
+        "siteHash:\"31c20e448477ffc7544f4d1d0b17ea48c06a3a48\"",
+        "{!typo3access}-1,0",
+        "(title:\"jpeg\" AND title:\"kasper\\\"s\")"
+      ],
+      "spellcheck.maxCollationTries": "1",
+      "hl.simple.pre": "<span class=\"results-highlight\">",
+      "hl.useFastVectorHighlighter": "true",
+      "defType": "edismax",
+      "hl.mergeContiguous": "true",
+      "expand.rows": "10",
+      "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline description^4.0 abstract subtitle navtitle author",
+      "hl.fl": "content",
+      "wt": "json",
+      "f.content.hl.alternateField": "content",
+      "hl.tag.pre": "<span class=\"results-highlight\">",
+      "mm": "2<-35%",
+      "json.nl": "map",
+      "start": "0",
+      "hl.tag.post": "</span>",
+      "rows": "0",
+      "f.content.hl.maxAlternateFieldLength": "200",
+      "spellcheck.extendedResults": "false",
+      "hl.snippets": "3",
+      "facet.limit": "100",
+      "json.facet": "{\"type\":{\"type\":\"terms\",\"field\":\"type\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type,title\"}},\"mytitle\":{\"type\":\"terms\",\"field\":\"title\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type,title\"}}}",
+      "q": "*",
+      "expand": "true",
+      "enableElevation": "false",
+      "hl.simple.post": "</span>",
+      "spellcheck": "true",
+      "pf": "content^2.0",
+      "spellcheck.onlyMorePopular": "false",
+      "facet.mincount": "1",
+      "spellcheck.count": "1",
+      "facet": "true",
+      "debugQuery": "false",
+      "facet.sort": "count",
+      "spellcheck.collate": "true"
     }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "maxScore": 1.0,
+    "docs": []
+  },
+  "facet_counts": {
+    "facet_queries": {},
+    "facet_fields": {},
+    "facet_ranges": {},
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  },
+  "facets": {
+    "count": 1,
+    "type": {
+      "buckets": [
+        {
+          "val": "pages",
+          "count": 1
+        }
+      ]
+    },
+    "mytitle": {
+      "buckets": [
+        {
+          "val": "jpeg",
+          "count": 1
+        },
+        {
+          "val": "kasper\"s",
+          "count": 1
+        }
+      ]
+    }
+  },
+  "highlighting": {},
+  "expanded": {}
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_used_facet.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_used_facet.json
@@ -1,67 +1,89 @@
 {
-    "responseHeader": {
-        "status": 0,
-        "QTime": 2,
-        "params": {
-            "hl.fragsize": "200",
-            "spellcheck": "true",
-            "enableElevation": "false",
-            "facet": "true",
-            "hl.tag.post": "</span>",
-            "facet.mincount": "1",
-            "spellcheck.maxCollationTries": "0",
-            "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline",
-            "hl.tag.pre": "<span class=\"results-highlight\">",
-            "json.nl": "map",
-            "hl.fl": "content",
-            "wt": "json",
-            "spellcheck.collate": "true",
-            "hl": "true",
-            "rows": "10",
-            "fl": "id,title,siteHash,score",
-            "debugQuery": "true",
-            "echoParams": "all",
-            "hl.useFastVectorHighlighter": "true",
-            "start": "0",
-            "facet.sort": "count",
-            "q": "kasper",
-            "facet.field": "type",
-            "fq": ["siteHash:\"c56040516adcfdb545d2120d595a56930f6ddaa3\"",
-                "{!typo3access}-1,0",
-                "(type:\"pages\")"],
-            "hl.requireFieldMatch": "true",
-            "mm": "2<-35%",
-            "indent": "true",
-            "spellcheck.extendedResults": "false",
-            "hl.mergeContiguous": "true",
-            "f.content.hl.maxAlternateFieldLength": "200",
-            "spellcheck.onlyMorePopular": "false",
-            "defType": "edismax",
-            "pf": "content^2.0",
-            "df": "content",
-            "hl.snippets": "3",
-            "f.content.hl.alternateField": "content",
-            "spellcheck.dictionary": ["default",
-                "wordbreak"],
-            "q.op": "OR",
-            "spellcheck.count": "1",
-            "ps": "15"
-        }
-    },
-    "response": {
-        "numFound": 0,
-        "start": 0,
-        "maxScore": 0.46310526
-    },
-    "facet_counts": {
-        "facet_queries": {},
-        "facet_fields": {
-            "type": {
-                "pages": 5
-            }
-        },
-        "facet_dates": {},
-        "facet_ranges": {},
-        "facet_intervals": {}
+  "responseHeader": {
+    "status": 0,
+    "QTime": 10,
+    "params": {
+      "df": "content",
+      "ps": "15",
+      "spellcheck.dictionary": [
+        "default",
+        "wordbreak"
+      ],
+      "hl": "true",
+      "echoParams": "all",
+      "indent": "true",
+      "fl": "*,score",
+      "hl.requireFieldMatch": "true",
+      "hl.fragsize": "200",
+      "fq": [
+        "{!collapse field=variantId}",
+        "siteHash:\"31c20e448477ffc7544f4d1d0b17ea48c06a3a48\"",
+        "{!typo3access}-1,0",
+        "(type_stringS:\"page\")"
+      ],
+      "spellcheck.maxCollationTries": "1",
+      "hl.simple.pre": "<span class=\"results-highlight\">",
+      "hl.useFastVectorHighlighter": "true",
+      "defType": "edismax",
+      "hl.mergeContiguous": "true",
+      "expand.rows": "10",
+      "qf": "content^40.0 title^5.0 keywords^2.0 tagsH1^5.0 tagsH2H3^3.0 tagsH4H5H6^2.0 tagsInline description^4.0 abstract subtitle navtitle author",
+      "hl.fl": "content",
+      "wt": "json",
+      "f.content.hl.alternateField": "content",
+      "hl.tag.pre": "<span class=\"results-highlight\">",
+      "mm": "2<-35%",
+      "json.nl": "map",
+      "start": "0",
+      "hl.tag.post": "</span>",
+      "rows": "0",
+      "f.content.hl.maxAlternateFieldLength": "200",
+      "spellcheck.extendedResults": "false",
+      "hl.snippets": "3",
+      "facet.limit": "100",
+      "json.facet": "{\"type\":{\"type\":\"terms\",\"field\":\"type\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type,category_stringM\"}},\"category_stringM\":{\"type\":\"terms\",\"field\":\"category_stringM\",\"limit\":100,\"mincount\":1,\"domain\":{\"excludeTags\":\"type,category_stringM\"}}}",
+      "q": "*",
+      "expand": "true",
+      "enableElevation": "false",
+      "hl.simple.post": "</span>",
+      "spellcheck": "true",
+      "pf": "content^2.0",
+      "spellcheck.onlyMorePopular": "false",
+      "facet.mincount": "1",
+      "spellcheck.count": "1",
+      "facet": "true",
+      "debugQuery": "false",
+      "facet.sort": "count",
+      "spellcheck.collate": "true"
     }
+  },
+  "response": {
+    "numFound": 42,
+    "start": 0,
+    "maxScore": 1.0,
+    "docs": []
+  },
+  "facet_counts": {
+    "facet_queries": {},
+    "facet_fields": {},
+    "facet_ranges": {},
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  },
+  "facets": {
+    "count": 5,
+    "type": {
+      "buckets": [
+        {
+          "val": "pages",
+          "count": 5
+        }
+      ]
+    },
+    "category_stringM": {
+      "buckets": []
+    }
+  },
+  "highlighting": {},
+  "expanded": {}
 }

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -115,6 +115,41 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $this->assertCount(1, $searchResultSet->getFacets());
     }
 
+
+    /**
+     * @test
+     */
+    public function canReconstituteJsonFacetModelFromResponse()
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_jsonfacets.json');
+
+        // before the reconstitution of the domain object from the response we expect that no facets
+        // are present
+        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+
+        $facetConfiguration = [
+            'showEmptyFacets' => 1,
+            'facets.' => [
+                'type.' => [
+                    'label' => 'My Type',
+                    'field' => 'type'
+                ]
+            ]
+        ];
+
+        $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
+        $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
+        $processor->process($searchResultSet);
+
+        // after the reconstitution they should be 1 facet present
+        $this->assertCount(1, $searchResultSet->getFacets());
+
+        /** @var $optionFacet OptionsFacet */
+        $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
+        $this->assertSame('tx_myext_domain_model_mytype', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Custom type facet not found');
+        $this->assertSame(19, $optionFacet->getOptions()->getByPosition(0)->getDocumentCount(), 'Custom type facet count not correct');
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -105,7 +105,9 @@ class FacetingTest extends UnitTest
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertContains('type',  $queryParameter['facet.field'][0], 'Query string did not contain expected snipped');
+
+        $expectedJsonFacet = '{"type":{"type":"terms","field":"type","limit":100,"mincount":1,"domain":{"excludeTags":"type"}}}';
+        $this->assertSame($expectedJsonFacet,  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
     /**
@@ -135,9 +137,11 @@ class FacetingTest extends UnitTest
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
         $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertContains('index',  $queryParameter['f.type.facet.sort'], 'Query string did not contain expected snipped');
+        $this->assertContains('"sort":"index"',  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
+
     /**
      * Checks if the faceting modifier can add a simple facet with a sortBy property with the value count.
      *
@@ -164,9 +168,11 @@ class FacetingTest extends UnitTest
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
         $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertContains('count',  $queryParameter['f.type.facet.sort'], 'Query string did not contain expected snipped');
+
+        $this->assertContains('"sort":"count"',  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
     /**
@@ -207,10 +213,11 @@ class FacetingTest extends UnitTest
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertEquals('{!ex=type,color}type',  $queryParameter['facet.field'][0], 'Query string did not contain expected snipped');
-        $this->assertEquals('{!ex=type,color}color',  $queryParameter['facet.field'][1], 'Query string did not contain expected snipped');
+
+        $jsonData = \json_decode($queryParameter['json.facet']);
+        $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
     }
 
     /**
@@ -251,9 +258,10 @@ class FacetingTest extends UnitTest
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+        $jsonData = \json_decode($queryParameter['json.facet']);
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertEquals('{!ex=type}type',  $queryParameter['facet.field'][0], 'Query string did not contain expected snipped');
-        $this->assertEquals('color',  $queryParameter['facet.field'][1], 'Query string did not contain expected snipped');
+        $this->assertEquals('type',  $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('color',  $jsonData->color->field, 'Query string did not contain expected snipped');
     }
 
     /**


### PR DESCRIPTION
Since Apache Solr 5.x there is a new json faceting api available that enhances the possibility of facetting with solr.

This pr:

* Migrates the options facets to use the new json faceting api
* Allows to use the configuration minimumCount, sortBy and facetingLimit on a facet base
* Adds a new feature called "metrics" that allow to collect statistical data of facetted items

Thanks to Jens Jacobsen who worked on that at the codesprint 2017 and ueberbit that sponsored his working time for that.

Fixes: #1137