### PR TITLE
[BUGFIX] Allow < as character in the content

### DIFF
--- a/Classes/HtmlContentExtractor.php
+++ b/Classes/HtmlContentExtractor.php
@@ -146,23 +146,35 @@ class HtmlContentExtractor
     public static function cleanContent($content)
     {
         $content = self::stripControlCharacters($content);
-
         // remove Javascript
-        $content = preg_replace('@<script[^>]*>.*?<\/script>@msi', '',
-            $content);
+        $content = preg_replace('@<script[^>]*>.*?<\/script>@msi', '', $content);
 
         // remove internal CSS styles
         $content = preg_replace('@<style[^>]*>.*?<\/style>@msi', '', $content);
 
         // prevents concatenated words when stripping tags afterwards
         $content = str_replace(['<', '>'], [' <', '> '], $content);
-        $content = strip_tags($content);
-        $content = str_replace(["\t", "\n", "\r", '&nbsp;'], ' ',
-            $content);
+        $content = static::stripTags($content);
+
+        $content = str_replace(["\t", "\n", "\r", '&nbsp;'], ' ', $content);
         $content = self::stripUnicodeRanges($content);
         $content = trim($content);
 
         return $content;
+    }
+
+    /**
+     * Strips html tags, but keeps single < and > characters.
+     *
+     * @param string $content
+     * @return mixed
+     */
+    protected static function stripTags($content)
+    {
+        $content = preg_replace('@<([^>]+(<|\z))@msi', '##lt##$1', $content);
+        $content = strip_tags($content);
+        // unescape < that are not used to open a tag
+        return str_replace('##lt##', '<', $content);
     }
 
     /**

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -135,8 +135,10 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
         // clean content
         $content = self::cleanContent($content);
         $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
-        $content = strip_tags($content); // after entity decoding we might have tags again
+        $content = static::stripTags($content); // after entity decoding we might have tags again
+
         $content = trim($content);
+        $content = preg_replace('!\s+!', ' ', $content); // reduce multiple spaces to one space
 
         return $content;
     }


### PR DESCRIPTION
This pr:

* Escapes < when it is not used in the context of a tag to allow to index it as character of the content
* Add's several unit tests for the Typo3PageContentExtractor

Fixes: #1541