### PR TITLE
[TASK] Add compatibility for current TYPO3 9 master state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ env:
   matrix:
     - TYPO3_VERSION="^8.7"
     - TYPO3_VERSION="8.x-dev"
-    - TYPO3_VERSION="9.x-dev"
+    - TYPO3_VERSION="9.x-dev as 8.7.99"
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: TYPO3_VERSION="9.x-dev"
+    - env: TYPO3_VERSION="9.x-dev as 8.7.99"
       php: 7.0
-    - env: TYPO3_VERSION="9.x-dev"
+    - env: TYPO3_VERSION="9.x-dev as 8.7.99"
       php: 7.1
 
 before_install:

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\ContentObject;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Driver\Statement;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -127,8 +128,10 @@ class Relation
             $parentContentObject->currentRecord);
 
         $localTableNameOrg = $localTableName;
+
         // pages has a special overlay table constriction
-        if ($GLOBALS['TSFE']->sys_language_uid > 0 && $localTableName === 'pages') {
+        // @todo this check can be removed when TYPO3 8 support is dropped since pages translations are in pages then as well
+        if ($GLOBALS['TSFE']->sys_language_uid > 0 && $localTableName === 'pages' && Util::getIsTYPO3VersionBelow9()) {
             $localTableName = 'pages_language_overlay';
         }
 

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -344,7 +344,7 @@ class SearchResultSetService
         // hook to modify the search query
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifySearchQuery'] as $classReference) {
-                $queryModifier = GeneralUtility::getUserObj($classReference);
+                $queryModifier = GeneralUtility::makeInstance($classReference);
 
                 if ($queryModifier instanceof Modifier) {
                     if ($queryModifier instanceof SearchAware) {
@@ -400,7 +400,7 @@ class SearchResultSetService
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr'][$eventName] as $classReference) {
-            $afterSearchProcessor = GeneralUtility::getUserObj($classReference);
+            $afterSearchProcessor = GeneralUtility::makeInstance($classReference);
             if ($afterSearchProcessor instanceof SearchResultSetProcessor) {
                 $afterSearchProcessor->process($resultSet);
             }

--- a/Classes/Domain/Variants/IdBuilder.php
+++ b/Classes/Domain/Variants/IdBuilder.php
@@ -72,7 +72,7 @@ class IdBuilder
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId'] as $classReference) {
-            $variantIdModifier = GeneralUtility::getUserObj($classReference);
+            $variantIdModifier = GeneralUtility::makeInstance($classReference);
             if ($variantIdModifier instanceof IdModifier) {
                 $variantId = $variantIdModifier->modifyVariantId($variantId, $systemHash, $type, $uid);
             }

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -279,7 +279,7 @@ abstract class AbstractIndexer
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'] as $classReference) {
-            $serializedValueDetector = GeneralUtility::getUserObj($classReference);
+            $serializedValueDetector = GeneralUtility::makeInstance($classReference);
             if (!$serializedValueDetector instanceof SerializedValueDetector) {
                 $message = get_class($serializedValueDetector) . ' must implement interface ' . SerializedValueDetector::class;
                 throw new \UnexpectedValueException($message, 1404471741);

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -81,8 +81,8 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
     {
         $pageIndexingHookRegistration = PageIndexer::class;
 
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][__CLASS__] = '&' . $pageIndexingHookRegistration . '->authorizeFrontendUser';
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = '&' . $pageIndexingHookRegistration . '->disableCaching';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][__CLASS__] = $pageIndexingHookRegistration . '->authorizeFrontendUser';
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = $pageIndexingHookRegistration . '->disableCaching';
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['pageIndexing'][__CLASS__] = $pageIndexingHookRegistration;
 
         // indexes fields defined in plugin.tx_solr.index.queue.pages.fields

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -123,7 +123,6 @@ class Indexer extends AbstractIndexer
         $this->setLogging($item);
 
         $solrConnections = $this->getSolrConnectionsByItem($item);
-
         foreach ($solrConnections as $systemLanguageUid => $solrConnection) {
             $this->solr = $solrConnection;
 
@@ -461,7 +460,7 @@ class Indexer extends AbstractIndexer
     {
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'] as $classReference) {
-                $documentsModifier = GeneralUtility::getUserObj($classReference);
+                $documentsModifier = GeneralUtility::makeInstance($classReference);
 
                 if ($documentsModifier instanceof PageIndexerDocumentsModifier) {
                     $documents = $documentsModifier->modifyDocuments($item, $language, $documents);
@@ -522,7 +521,6 @@ class Indexer extends AbstractIndexer
         foreach ($translationConnections as $systemLanguageUid => $solrConnection) {
             $solrConnections[$systemLanguageUid] = $solrConnection;
         }
-
         return $solrConnections;
     }
 
@@ -605,6 +603,7 @@ class Indexer extends AbstractIndexer
                 }
                 $translationOverlays[] = [
                     'pid' => $pageId,
+                    'l10n_parent' => $pageId,
                     'sys_language_uid' => $language['uid'],
                 ];
             }
@@ -635,7 +634,8 @@ class Indexer extends AbstractIndexer
         $connections = [];
 
         foreach ($translationOverlays as $translationOverlay) {
-            $pageId = $translationOverlay['pid'];
+            // @todo usage of pid can be removed when TYPO3 8 compatibility is dropped
+            $pageId = (Util::getIsTYPO3VersionBelow9()) ? $translationOverlay['pid'] : $translationOverlay['l10n_parent'];
             $languageId = $translationOverlay['sys_language_uid'];
 
             try {

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -288,7 +288,7 @@ class PageIndexer extends Indexer
         }
 
         if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier']) {
-            $dataUrlModifier = GeneralUtility::getUserObj($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier']);
+            $dataUrlModifier = GeneralUtility::makeInstance($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier']);
 
             if ($dataUrlModifier instanceof PageIndexerDataUrlModifier) {
                 $dataUrl = $dataUrlModifier->modifyDataUrl($dataUrl, [

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -159,7 +159,7 @@ class Queue
 
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueInitialization'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueInitialization'] as $classReference) {
-                $indexQueueInitializationPostProcessor = GeneralUtility::getUserObj($classReference);
+                $indexQueueInitializationPostProcessor = GeneralUtility::makeInstance($classReference);
 
                 if ($indexQueueInitializationPostProcessor instanceof InitializationPostProcessor) {
                     $indexQueueInitializationPostProcessor->postProcessIndexQueueInitialization(
@@ -296,7 +296,7 @@ class Queue
      */
     protected function getHookImplementation($classReference)
     {
-        return GeneralUtility::getUserObj($classReference);
+        return GeneralUtility::makeInstance($classReference);
     }
 
     /**

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -336,7 +336,7 @@ class Search
                 $facetCounts = $unmodifiedFacetCounts;
 
                 foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyFacets'] as $classReference) {
-                    $facetsModifier = GeneralUtility::getUserObj($classReference);
+                    $facetsModifier = GeneralUtility::makeInstance($classReference);
 
                     if ($facetsModifier instanceof FacetsModifier) {
                         $facetCounts = $facetsModifier->modifyFacets($facetCounts);

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\System\Records\Pages;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
@@ -215,14 +216,27 @@ class PagesRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilder();
         $queryBuilder->getRestrictions()->removeAll();
-        return $queryBuilder
-            ->select('pid', 'sys_language_uid')
-            ->from('pages_language_overlay')
-            ->add('where',
-                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT))
-                . BackendUtility::deleteClause('pages_language_overlay')
-                . BackendUtility::BEenableFields('pages_language_overlay')
-            )->execute()->fetchAll();
+
+        //@todo this is only needed for TYPO3 8 backwards compatibility and can be dropped when TYPO3 8 is not supported anymore
+        if (Util::getIsTYPO3VersionBelow9()) {
+            return $queryBuilder
+                ->select('pid', 'sys_language_uid')
+                ->from('pages_language_overlay')
+                ->add('where',
+                    $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT))
+                    . BackendUtility::deleteClause('pages_language_overlay')
+                    . BackendUtility::BEenableFields('pages_language_overlay')
+                )->execute()->fetchAll();
+        } else {
+            return $queryBuilder
+                ->select('pid', 'l10n_parent', 'sys_language_uid')
+                ->from('pages')
+                ->add('where',
+                    $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT))
+                    . BackendUtility::deleteClause('pages')
+                    . BackendUtility::BEenableFields('pages')
+                )->execute()->fetchAll();
+        }
     }
 
     /**

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -267,7 +267,7 @@ class Typo3PageIndexer
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument'] as $classReference) {
-            $postProcessor = GeneralUtility::getUserObj($classReference);
+            $postProcessor = GeneralUtility::makeInstance($classReference);
             if (!$postProcessor instanceof PageDocumentPostProcessor) {
                 throw new \UnexpectedValueException(get_class($pageDocument) . ' must implement interface ' . PageDocumentPostProcessor::class, 1397739154);
             }
@@ -333,7 +333,7 @@ class Typo3PageIndexer
 
         $indexConfigurationName = $this->getIndexConfigurationNameForCurrentPage();
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'] as $classReference) {
-            $substituteIndexer = GeneralUtility::getUserObj($classReference);
+            $substituteIndexer = GeneralUtility::makeInstance($classReference);
 
             if (!$substituteIndexer instanceof SubstitutePageIndexer) {
                 $message = get_class($substituteIndexer) . ' must implement interface ' . SubstitutePageIndexer::class;
@@ -382,7 +382,7 @@ class Typo3PageIndexer
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageAddDocuments'] as $classReference) {
-            $additionalIndexer = GeneralUtility::getUserObj($classReference);
+            $additionalIndexer = GeneralUtility::makeInstance($classReference);
 
             if (!$additionalIndexer instanceof AdditionalPageIndexer) {
                 $message = get_class($additionalIndexer) . ' must implement interface ' . AdditionalPageIndexer::class;

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -469,6 +469,24 @@ class Util
     }
 
     /**
+     * @todo This method is just added for pages_language_overlay compatibility checks and will be removed when TYPO8 support is dropped
+     * @return boolean
+     */
+    public static function getIsTYPO3VersionBelow9()
+    {
+        return (bool)version_compare(TYPO3_branch, '9.0', '<');
+    }
+
+    /**
+     * @todo This method is just added for pages_language_overlay compatibility checks and will be removed when TYPO8 support is dropped
+     * @return string
+     */
+    public static function getPageOverlayTableName()
+    {
+        return self::getIsTYPO3VersionBelow9() ? 'pages_language_overlay' : 'pages';
+    }
+
+    /**
      * This function can be used to check if one of the strings in needles is
      * contained in the haystack.
      *

--- a/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
@@ -38,7 +38,7 @@ abstract class AbstractSolrFrontendTagBasedViewHelper extends AbstractSolrTagBas
      */
     protected function getTypoScriptConfiguration()
     {
-        return $this->controllerContext->getTypoScriptConfiguration();
+        return $this->getControllerContext()->getTypoScriptConfiguration();
     }
 
     /**
@@ -46,6 +46,27 @@ abstract class AbstractSolrFrontendTagBasedViewHelper extends AbstractSolrTagBas
      */
     protected function getSearchResultSet()
     {
-        return $this->controllerContext->getSearchResultSet();
+        return $this->getControllerContext()->getSearchResultSet();
+    }
+
+    /**
+     * @todo The fallback on $this->controllerContext is only needed for TYPO3 8 backwards compatibility and can be dropped when TYPO3 8 is not supported anymore
+     * @return SolrControllerContext
+     * @throws \InvalidArgumentException
+     */
+    protected function getControllerContext()
+    {
+        $controllerContext = null;
+        if (!is_null($this->controllerContext)) {
+            $controllerContext = $this->controllerContext;
+        } elseif (method_exists($this->renderingContext, 'getControllerContext')) {
+            $controllerContext = $this->renderingContext->getControllerContext();
+        }
+
+        if (!$controllerContext instanceof SolrControllerContext) {
+            throw new \InvalidArgumentException('No valid SolrControllerContext found', 1512998673);
+        }
+
+        return $controllerContext;
     }
 }

--- a/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
@@ -40,7 +40,7 @@ abstract class AbstractSolrFrontendViewHelper extends AbstractSolrViewHelper
      */
     protected function getTypoScriptConfiguration()
     {
-        return $this->controllerContext->getTypoScriptConfiguration();
+        return $this->getControllerContext()->getTypoScriptConfiguration();
     }
 
     /**
@@ -48,7 +48,28 @@ abstract class AbstractSolrFrontendViewHelper extends AbstractSolrViewHelper
      */
     protected function getSearchResultSet()
     {
-        return $this->controllerContext->getSearchResultSet();
+        return $this->getControllerContext()->getSearchResultSet();
+    }
+
+    /**
+     * @todo The fallback on $this->controllerContext is only needed for TYPO3 8 backwards compatibility and can be dropped when TYPO3 8 is not supported anymore
+     * @return SolrControllerContext
+     * @throws \InvalidArgumentException
+     */
+    protected function getControllerContext()
+    {
+        $controllerContext = null;
+        if (!is_null($this->controllerContext)) {
+            $controllerContext = $this->controllerContext;
+        } elseif (method_exists($this->renderingContext, 'getControllerContext')) {
+            $controllerContext = $this->renderingContext->getControllerContext();
+        }
+
+        if (!$controllerContext instanceof SolrControllerContext) {
+            throw new \InvalidArgumentException('No valid SolrControllerContext found', 1512998673);
+        }
+
+        return $controllerContext;
     }
 
     /**

--- a/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
@@ -26,7 +26,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Security;
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
  * This view helper implements an ifHasAccessToModule/else condition for BE users/groups.

--- a/Classes/ViewHelpers/Widget/Controller/AbstractPaginateWidgetController.php
+++ b/Classes/ViewHelpers/Widget/Controller/AbstractPaginateWidgetController.php
@@ -72,7 +72,8 @@ abstract class AbstractPaginateWidgetController extends AbstractWidgetController
      * @return void
      */
     public function initializeAction() {
-        ArrayUtility::mergeRecursiveWithOverrule($this->configuration, $this->widgetConfiguration['configuration'], false);
+        $configuration = is_array($this->widgetConfiguration['configuration']) ? $this->widgetConfiguration['configuration'] : [];
+        ArrayUtility::mergeRecursiveWithOverrule($this->configuration, $configuration, false);
         $this->maximumNumberOfLinks = (int)$this->configuration['maximumNumberOfLinks'];
         if (!empty($this->configuration['templatePath'])) {
             $this->templatePath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($this->configuration['templatePath']);
@@ -125,7 +126,7 @@ abstract class AbstractPaginateWidgetController extends AbstractWidgetController
         }
 
         // calculate starting count for <ol> (items per page multiplied by (number of pages -1) and adding +1)
-        $pagination['resultCountStart'] = (($this->getItemsPerPage() * ($this->currentPage-1))+1);
+        $pagination['resultCountStart'] = (($this->getItemsPerPage() * ($this->currentPage - 1)) + 1);
         return $pagination;
     }
 

--- a/Classes/ViewHelpers/Widget/GroupItemPaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/GroupItemPaginateViewHelper.php
@@ -40,15 +40,24 @@ class GroupItemPaginateViewHelper extends AbstractWidgetViewHelper
      */
     protected $controller;
 
+
     /**
-     * @param SearchResultSet $resultSet
-     * @param GroupItem $groupItem The groupItem that should be paginated
-     * @param string $as
-     * @param array $configuration
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('resultSet', SearchResultSet::class, 'resultSet', true);
+        $this->registerArgument('groupItem', GroupItem::class, 'groupItem', true);
+        $this->registerArgument('as', 'string', 'as', false, 'documents');
+        $this->registerArgument('configuration', 'array', 'configuration', false, ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'templatePath' => '']);
+    }
+
+    /**
      * @return \TYPO3\CMS\Extbase\Mvc\ResponseInterface
      * @throws \TYPO3\CMS\Fluid\Core\Widget\Exception\MissingControllerException
      */
-    public function render(SearchResultSet $resultSet, GroupItem $groupItem, $as = 'documents', array $configuration = ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'templatePath' => ''])
+    public function render()
     {
         return $this->initiateSubRequest();
     }

--- a/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
@@ -41,13 +41,21 @@ class ResultPaginateViewHelper extends AbstractWidgetViewHelper
     protected $controller;
 
     /**
-     * @param SearchResultSet $resultSet
-     * @param string $as
-     * @param array $configuration
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('resultSet', SearchResultSet::class, 'resultSet', true);
+        $this->registerArgument('as', 'string', 'as', false, 'documents');
+        $this->registerArgument('configuration', 'array', 'configuration', false, ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'templatePath' => '']);
+    }
+
+    /**
      * @return \TYPO3\CMS\Extbase\Mvc\ResponseInterface
      * @throws \TYPO3\CMS\Fluid\Core\Widget\Exception\MissingControllerException
      */
-    public function render(SearchResultSet $resultSet, $as = 'documents', array $configuration = ['insertAbove' => true, 'insertBelow' => true, 'maximumNumberOfLinks' => 10, 'templatePath' => ''])
+    public function render()
     {
         return $this->initiateSubRequest();
     }

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -980,7 +980,7 @@ class SearchControllerTest extends IntegrationTest
             $fakeTSFE = $this->getConfiguredTSFE([], $importPageId);
             $GLOBALS['TSFE'] = $fakeTSFE;
             $fakeTSFE->newCObj();
-            PageGenerator::pagegenInit();
+            $fakeTSFE->preparePageContentGeneration();
             PageGenerator::renderContent();
             /** @var $pageIndexer \ApacheSolrForTypo3\Solr\Typo3PageIndexer */
             $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);

--- a/Tests/Integration/Fixtures/can_find_connection_for_mouted_page.xml
+++ b/Tests/Integration/Fixtures/can_find_connection_for_mouted_page.xml
@@ -157,7 +157,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point 1</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>
@@ -179,7 +178,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point 2</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -135,8 +135,8 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueryContainsItemAmount(3);
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET hidden=1 WHERE uid=1');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 1], ['hidden' => 1]);
 
         $changeSet = ['hidden' => 1];
 
@@ -167,8 +167,8 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueryContainsItemAmount(4);
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET hidden=1 WHERE uid=1');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 1], ['hidden' => 1]);
         $changeSet = ['hidden' => 1];
 
         $dataHandler = $this->dataHandler;

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.v9.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                fields {
+                                    title = title
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}&L={field:__solr_index_language}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>original</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
+        <pid>1</pid>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
+        <pid>1</pid>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation.v9.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    category_stringM = SOLR_RELATION
+                                    category_stringM {
+                                        localField = tags
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>orignal</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>99</uid_local>
+        <uid_foreign>12</uid_foreign>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>8</uid>
+        <pid>1</pid>
+        <tag>the tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>12</uid>
+        <pid>1</pid>
+        <tag>translated tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.v9.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    relatedPageTitles_stringM = SOLR_RELATION
+                                    relatedPageTitles_stringM {
+                                        localField = page_relations
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages>
+
+    <pages>
+        <uid>10</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Related page</title>
+    </pages>
+
+    <pages>
+        <uid>11</uid>
+        <l10n_parent>10</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <title>Translated related page</title>
+    </pages>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>orignal</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_related_pages_mm>
+        <uid_local>99</uid_local>
+        <uid_foreign>10</uid_foreign>
+        <tablenames>pages</tablenames>
+    </tx_fakeextension_domain_model_related_pages_mm>
+
+    <tx_fakeextension_domain_model_related_pages_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>10</uid_foreign>
+        <tablenames>pages</tablenames>
+    </tx_fakeextension_domain_model_related_pages_mm>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.v9.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                fields {
+                                    title = title
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>original</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
+        <pid>1</pid>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
+        <pid>1</pid>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.v9.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_overlay = hideNonTranslated
+                config.sys_language_mode = content_fallback; 0
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                fields {
+                                    title = title
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.additionalParams = &tx_foo[uid]={field:uid}
+                                        typolink.additionalParams.insertData = 1
+                                        typolink.returnLast = url
+                                        typolink.useCacheHash = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>original</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>99</uid>
+        <pid>1</pid>
+        <title>translation</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>88</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>777</uid>
+        <pid>1</pid>
+        <title>original2</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>9999</uid>
+        <pid>1</pid>
+        <title>translation2</title>
+        <sys_language_uid>1</sys_language_uid>
+        <l10n_parent>777</l10n_parent>
+    </tx_fakeextension_domain_model_bar>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+        <sorting>128</sorting>
+    </sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_with_rootPage_set_to_hide_default_language.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_with_rootPage_set_to_hide_default_language.v9.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_registry>
+		<uid>4711</uid>
+		<entry_namespace>tx_solr</entry_namespace>
+		<entry_key>servers</entry_key>
+		<entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_en/";}}</entry_value>
+	</sys_registry>
+
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 1
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    category_stringM = SOLR_RELATION
+                                    category_stringM {
+                                        localField = tags
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<extendToSubpages>1</extendToSubpages>
+		<l18n_cfg>1</l18n_cfg>
+	</pages>
+
+	<pages>
+		<uid>2</uid>
+		<l10n_parent>1</l10n_parent>
+		<sys_language_uid>1</sys_language_uid>
+		<doktype>1</doktype>
+	</pages>
+
+	<sys_language>
+		<uid>1</uid>
+		<title>English</title>
+	</sys_language>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/localized_page_is_added_to_the_queue.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/localized_page_is_added_to_the_queue.v9.xml
@@ -1,25 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <dataset>
-<!--
-There is following scenario:
-
-  [0]
-   |
-   ——[20] Shared-Pages (Not root)
-   |   |
-   |   ——[24] FirstShared (Not root)
-   |
-   ——[ 1] Page (Root)
-       |
-       ——[14] Mount Point (to [24] to show contents from)
--->
-
 
     <sys_registry>
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"2";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -85,49 +71,21 @@ There is following scenario:
         </config>
         <sorting>100</sorting>
     </sys_template>
-
-    <!-- Shared Pages tree -->
-    <pages>
-        <uid>20</uid>
-        <pid>0</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>254</doktype>
-        <mount_pid>0</mount_pid>
-        <mount_pid_ol>0</mount_pid_ol>
-        <title>Shared-Pages</title>
-        <TSconfig/>
-        <tsconfig_includes/>
-    </pages>
-    <pages>
-        <uid>24</uid>
-        <pid>20</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>1</doktype>
-        <mount_pid>0</mount_pid>
-        <mount_pid_ol>0</mount_pid_ol>
-        <title>FirstShared (Not root)</title>
-        <TSconfig></TSconfig>
-        <tsconfig_includes/>
-    </pages>
-
-    <!-- Site tree -->
     <pages>
         <uid>1</uid>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
+        <hidden>0</hidden>
         <pid>0</pid>
-        <title>Page (Root)</title>
+        <title>Rootpage</title>
     </pages>
     <pages>
-        <uid>14</uid>
-        <pid>1</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>7</doktype>
-        <mount_pid>24</mount_pid>
-        <mount_pid_ol>1</mount_pid_ol>
-        <title>Mount Point</title>
-        <TSconfig/>
-        <content_from_pid>0</content_from_pid>
-        <tsconfig_includes/>
+        <uid>2</uid>
+        <pid>0</pid>
+        <l10n_parent>1</l10n_parent>
+        <doktype>1</doktype>
+        <sys_language_uid>1</sys_language_uid>
+        <title>Translated Rootpage</title>
     </pages>
+
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/localized_page_is_not_added_to_the_queue_when_parent_hidden.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/localized_page_is_not_added_to_the_queue_when_parent_hidden.v9.xml
@@ -1,25 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <dataset>
-<!--
-There is following scenario:
-
-  [0]
-   |
-   ——[20] Shared-Pages (Not root)
-   |   |
-   |   ——[24] FirstShared (Not root)
-   |
-   ——[ 1] Page (Root)
-       |
-       ——[14] Mount Point (to [24] to show contents from)
--->
-
 
     <sys_registry>
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"2";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -85,49 +71,21 @@ There is following scenario:
         </config>
         <sorting>100</sorting>
     </sys_template>
-
-    <!-- Shared Pages tree -->
-    <pages>
-        <uid>20</uid>
-        <pid>0</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>254</doktype>
-        <mount_pid>0</mount_pid>
-        <mount_pid_ol>0</mount_pid_ol>
-        <title>Shared-Pages</title>
-        <TSconfig/>
-        <tsconfig_includes/>
-    </pages>
-    <pages>
-        <uid>24</uid>
-        <pid>20</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>1</doktype>
-        <mount_pid>0</mount_pid>
-        <mount_pid_ol>0</mount_pid_ol>
-        <title>FirstShared (Not root)</title>
-        <TSconfig></TSconfig>
-        <tsconfig_includes/>
-    </pages>
-
-    <!-- Site tree -->
     <pages>
         <uid>1</uid>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
+        <hidden>1</hidden>
         <pid>0</pid>
-        <title>Page (Root)</title>
+        <title>Rootpage</title>
     </pages>
     <pages>
-        <uid>14</uid>
-        <pid>1</pid>
-        <is_siteroot>0</is_siteroot>
-        <doktype>7</doktype>
-        <mount_pid>24</mount_pid>
-        <mount_pid_ol>1</mount_pid_ol>
-        <title>Mount Point</title>
-        <TSconfig/>
-        <content_from_pid>0</content_from_pid>
-        <tsconfig_includes/>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <pid>0</pid>
+        <doktype>1</doktype>
+        <sys_language_uid>1</sys_language_uid>
+        <title>Translated Rootpage</title>
     </pages>
+
 </dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
@@ -139,7 +139,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
@@ -211,7 +211,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>
@@ -232,7 +231,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.v9.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.v9.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_overlay = 1
+                config.sys_language_mode = content_fallback
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            pages = 1
+                            pages {
+                                table = pages
+                                fields {
+                                    title = title
+                                    relatedPageTitles_stringM = SOLR_RELATION
+                                    relatedPageTitles_stringM {
+                                        localField = page_relations
+                                        enableRecursiveValueResolution = 0
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                [globalVar = GP:L = 1]
+                    plugin.tx_solr.solr.path = /solr/core_de/
+                    config.sys_language_uid = 1
+                [end]
+
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Page</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
+        <title>Seite</title>
+        <relations>1</relations>
+    </pages>
+
+    <pages>
+        <uid>10</uid>
+        <pid>0</pid>
+        <doktype>1</doktype>
+        <title>Related page</title>
+    </pages>
+    <pages>
+        <uid>11</uid>
+        <pid>0</pid>
+        <l10n_parent>10</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <deleted>0</deleted>
+        <title>Verwante Seite</title>
+    </pages>
+
+    <tx_fakeextension3_pages_mm>
+        <uid_local>10</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <tablenames>pages</tablenames>
+        <fieldname>page_relations</fieldname>
+        <sorting>0</sorting>
+        <sorting_foreign>0</sorting_foreign>
+    </tx_fakeextension3_pages_mm>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+    </sys_language>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -106,9 +107,12 @@ class PageIndexerTest extends IntegrationTest
         $GLOBALS['TCA']['pages']['columns']['page_relations'] = $additionalPageTca['columns']['page_relations'];
         $GLOBALS['TCA']['pages']['columns']['relations'] = $additionalPageTca['columns']['relations'];
 
-        $additionalPageLanguageOverlayTca = include($this->getFixturePathByName('fake_extension3_pages_language_overlay_tca.php'));
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['page_relations'] = $additionalPageLanguageOverlayTca['columns']['page_relations'];
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['relations'] = $additionalPageLanguageOverlayTca['columns']['relations'];
+        //@todo when TYPO3 8 support is dropped, pages and the translation overlay can use the same tca configuration
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $additionalPageLanguageOverlayTca = include($this->getFixturePathByName('fake_extension3_pages_language_overlay_tca.php'));
+            $GLOBALS['TCA']['pages_language_overlay']['columns']['page_relations'] = $additionalPageLanguageOverlayTca['columns']['page_relations'];
+            $GLOBALS['TCA']['pages_language_overlay']['columns']['relations'] = $additionalPageLanguageOverlayTca['columns']['relations'];
+        }
 
         $this->importDataSetFromFixture('can_index_page_with_relation_to_page.xml');
 

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -165,7 +165,7 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA
-        $this->importDumpFromFixture('fake_extension2_table.sql');
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_record_with_multiple_mm_relations.xml');

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
@@ -130,7 +130,6 @@ There is following scenario:
         <mount_pid_ol>1</mount_pid_ol>
         <title>Mount Point 1</title>
         <TSconfig/>
-        <urltype>1</urltype>
         <content_from_pid>0</content_from_pid>
         <tsconfig_includes/>
     </pages>
@@ -152,7 +151,6 @@ There is following scenario:
         <mount_pid_ol>1</mount_pid_ol>
         <title>Mount Point 2</title>
         <TSconfig/>
-        <urltype>1</urltype>
         <content_from_pid>0</content_from_pid>
         <tsconfig_includes/>
     </pages>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_root_page_from_different_tree_can_be_indexed.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_root_page_from_different_tree_can_be_indexed.xml
@@ -127,7 +127,6 @@
         <mount_pid_ol>1</mount_pid_ol>
         <title>Mount Point</title>
         <TSconfig/>
-        <urltype>1</urltype>
         <content_from_pid>0</content_from_pid>
         <tsconfig_includes/>
     </pages>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\NoPidException;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -180,8 +181,8 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET hidden=0 WHERE uid=1');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 1], ['hidden' => 0]);
         $changeSet = ['hidden' => 0];
 
         $dataHandler = $this->dataHandler;
@@ -203,8 +204,8 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET extendToSubpages=0 WHERE uid=1');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 1], ['extendToSubpages' => 0]);
         $changeSet = ['extendToSubpages' => 0];
 
         $dataHandler = $this->dataHandler;
@@ -226,8 +227,9 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET hidden=1 WHERE uid=1');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 1], ['hidden' => 1]);
+
         $changeSet = ['hidden' => 1];
 
         $dataHandler = $this->dataHandler;
@@ -358,8 +360,8 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnectionBC();
-        $connection->exec('UPDATE pages SET hidden=0 WHERE uid=8');
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 8], ['hidden' => 0]);
 
         $changeSet = ['hidden' => 0];
 
@@ -421,18 +423,29 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         $status = 'update';
-        $table = 'pages_language_overlay';
         $uid = 2;
-        $fields = [
-            'title' => 'New Translated Rootpage',
-            'pid' => 1
-        ];
 
+        // @todo the handling for pages_language_overlay can be removed when the TYPO3 8 support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $table = 'pages_language_overlay';
+            $fields = [
+                'title' => 'New Translated Rootpage',
+                'pid' => 1
+            ];
+        } else {
+            $table = 'pages';
+            $fields = [
+                'title' => 'New Translated Rootpage',
+                'l10n_parent' => 1,
+                'pid' => 0
+            ];
+        }
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-        $this->assertIndexQueueContainsItemAmount(1);
 
+        $this->assertIndexQueueContainsItemAmount(1);
         $firstQueueItem = $this->indexQueue->getItem(1);
+
         $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
         $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
             'First queue item has unexpected indexingConfigurationName');
@@ -448,13 +461,15 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
 
         $status = 'update';
-        $table = 'pages_language_overlay';
         $uid = 2;
-        $fields = [
-            'title' => 'New Translated Rootpage',
-            'pid' => 1,
-            'hidden' => 1
-        ];
+        $fields = ['title' => 'New Translated Rootpage', 'pid' => 1, 'hidden' => 1];
+
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $table = 'pages_language_overlay';
+        } else {
+            $table = 'pages';
+        }
+
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
@@ -476,12 +491,15 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertEmptyIndexQueue();
 
         $status = 'update';
-        $table = 'pages_language_overlay';
         $uid = 2;
-        $fields = [
-            'title' => 'New Translated Rootpage',
-            'pid' => 1
-        ];
+        $fields = ['title' => 'New Translated Rootpage', 'pid' => 1];
+
+        // @todo the handling for pages_language_overlay can be removed when the TYPO3 8 support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $table = 'pages_language_overlay';
+        } else {
+            $table = 'pages';
+        }
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);

--- a/Tests/Integration/System/Records/Pages/Fixtures/can_find_mout_pages_in_rootline.xml
+++ b/Tests/Integration/System/Records/Pages/Fixtures/can_find_mout_pages_in_rootline.xml
@@ -157,7 +157,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point 1</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>
@@ -179,7 +178,6 @@ There is following scenario:
             <mount_pid_ol>1</mount_pid_ol>
             <title>Mount Point 2</title>
             <TSconfig/>
-            <urltype>1</urltype>
             <content_from_pid>0</content_from_pid>
             <tsconfig_includes/>
         </pages>

--- a/Tests/Unit/ViewHelpers/Backend/Document/IsBoostedFieldViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/Document/IsBoostedFieldViewHelperTest.php
@@ -26,7 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Backend\Document;
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\Document\IsBoostedFieldViewHelper;
-
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Testcase for the IsBoostedFieldViewHelper
@@ -62,15 +62,16 @@ class IsBoostedFieldViewHelperTest extends UnitTest
      */
     public function viewHelperRendersThenChildIfGivenFieldIsBoosted()
     {
-        $this->viewHelper->setArguments([
+        $arguments = [
             'document' => $this->apacheSolrDocument,
-            'fieldName' => 'boostedField'
-        ]);
-        $this->viewHelper->initializeArguments();
+            'fieldName' => 'boostedField',
+            '__thenClosure' => function() { return 'thenResult'; },
+            '__elseClosures' => [function() { return 'elseResult'; }]
+        ];
 
-        $this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('then'));
-        $actualResult = $this->viewHelper->render();
-        $this->assertEquals('then', $actualResult);
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $result = IsBoostedFieldViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
+        $this->assertSame('thenResult', $result, 'thenClosure was not rendered');
     }
 
     /**
@@ -78,15 +79,16 @@ class IsBoostedFieldViewHelperTest extends UnitTest
      */
     public function viewHelperRendersElseChildIfNonStringTypeIsGiven()
     {
-        $this->viewHelper->setArguments([
+        $arguments = [
             'document' => $this->apacheSolrDocument,
-            'fieldName' => 'unboostedField'
-        ]);
-        $this->viewHelper->initializeArguments();
+            'fieldName' => 'unboostedField',
+            '__thenClosure' => function() { return 'thenResult'; },
+            '__elseClosures' => [function() { return 'elseResult'; }]
+        ];
 
-        $this->viewHelper->expects($this->at(0))->method('renderElseChild')->will($this->returnValue('else'));
-        $actualResult = $this->viewHelper->render();
-        $this->assertEquals('else', $actualResult);
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $result = IsBoostedFieldViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
+        $this->assertSame('elseResult', $result, 'elseResult was not rendered');
     }
 
 }

--- a/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -26,37 +26,28 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Backend;
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\IsStringViewHelper;
-
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Testcase for the IsStringViewHelper
  */
 class IsStringViewHelperTest extends UnitTest
 {
-    /**
-     * @var IsStringViewHelper
-     */
-    protected $viewHelper;
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->viewHelper = $this->getAccessibleMock(IsStringViewHelper::class, ['renderThenChild', 'renderElseChild']);
-    }
 
     /**
      * @test
      */
     public function viewHelperRendersThenChildIfStringIsGiven()
     {
-        $this->viewHelper->setArguments([
-            'value' => 'givenString'
-        ]);
-        $this->viewHelper->initializeArguments();
+        $arguments = [
+            'value' => 'givenString',
+            '__thenClosure' => function() { return 'thenResult'; },
+            '__elseClosures' => [function() { return 'elseResult'; }]
+        ];
 
-        $this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('then'));
-        $actualResult = $this->viewHelper->render();
-        $this->assertEquals('then', $actualResult);
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $result = IsStringViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
+        $this->assertSame('thenResult', $result, 'thenClosure was not rendered');
     }
 
     /**
@@ -64,13 +55,14 @@ class IsStringViewHelperTest extends UnitTest
      */
     public function viewHelperRendersElseChildIfNotStringTypeIsGiven()
     {
-        $this->viewHelper->setArguments([
-            'value' => ['givenStringInArray']
-        ]);
-        $this->viewHelper->initializeArguments();
+        $arguments = [
+            'value' => ['givenStringInArray'],
+            '__thenClosure' => function() { return 'thenResult'; },
+            '__elseClosures' => [function() { return 'elseResult'; }]
+        ];
 
-        $this->viewHelper->expects($this->at(0))->method('renderElseChild')->will($this->returnValue('else'));
-        $actualResult = $this->viewHelper->render();
-        $this->assertEquals('else', $actualResult);
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $result = IsStringViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
+        $this->assertSame('elseResult', $result, 'elseResult was not rendered');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",
-    "nimut/testing-framework": "^1.1"
+    "nimut/testing-framework": "^2.0"
   },
   "replace": {
     "solr": "self.version",

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -42,6 +42,9 @@ if (TYPO3_MODE == 'BE') {
         ]
     );
 
+    //@todo can be changed to a simple assignment when TYPO3 8 compatibility is dropped
+    $treeComponentId =  ApacheSolrForTypo3\Solr\Util::getIsTYPO3VersionBelow9() ? 'typo3-pagetree' : 'TYPO3/CMS/Backend/PageTree/PageTreeElement';
+
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
         'ApacheSolrForTypo3.' . $_EXTKEY,
         'searchbackend',
@@ -54,7 +57,7 @@ if (TYPO3_MODE == 'BE') {
             'access' => 'user,group',
             'icon' => 'EXT:solr/Resources/Public/Images/Icons/ModuleInfo.svg',
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_mod_info.xlf',
-            'navigationComponentId' => 'typo3-pagetree'
+            'navigationComponentId' => $treeComponentId
         ]
     );
 
@@ -70,7 +73,7 @@ if (TYPO3_MODE == 'BE') {
             'access' => 'user,group',
             'icon' => 'EXT:solr/Resources/Public/Images/Icons/ModuleCoreOptimization.svg',
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_mod_coreoptimize.xlf',
-            'navigationComponentId' => 'typo3-pagetree'
+            'navigationComponentId' => $treeComponentId
         ]
     );
 
@@ -86,7 +89,7 @@ if (TYPO3_MODE == 'BE') {
             'access' => 'user,group',
             'icon' => 'EXT:solr/Resources/Public/Images/Icons/ModuleIndexQueue.svg',
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_mod_indexqueue.xlf',
-            'navigationComponentId' => 'typo3-pagetree'
+            'navigationComponentId' => $treeComponentId
         ]
     );
 
@@ -102,7 +105,7 @@ if (TYPO3_MODE == 'BE') {
             'access' => 'user,group',
             'icon' => 'EXT:solr/Resources/Public/Images/Icons/ModuleIndexAdministration.svg',
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_mod_indexadmin.xlf',
-            'navigationComponentId' => 'typo3-pagetree'
+            'navigationComponentId' => $treeComponentId
         ]
     );
 


### PR DESCRIPTION
TYPO3 9 will be released soon, since we officially support TYPO3 8 LTS we should continue to support TYPO3 8 but allready make required changes for 9

This pr:

* Applies required changes for pages_language_overlays removal: https://review.typo3.org/51272
* Applies required changes for changes in FLUID: https://review.typo3.org/54068
* Replaces the usage of GeneralUtility::getUserObj with GeneralUtility::makeInstance for all hooks since every registered hook should allready be a full qualified classname.
* Replaces calls to PageGenerator::pagegenInit with $TSFE->preparePageContentGeneration()
* Raises nimut/testing-framework dependency to ^2.0

Fixes: #1772