### PR TITLE
[BUGFIX] FacetGroupByPrefix should handle multibyte characters correctly

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
@@ -40,7 +40,7 @@ class OptionCollection extends AbstractFacetItemCollection
     public function getLowercaseLabelPrefixes($length = 1)
     {
         $prefixes = $this->getLabelPrefixes($length);
-        return array_map('strtolower', $prefixes);
+        return array_map('mb_strtolower', $prefixes);
     }
 
     /**
@@ -51,8 +51,8 @@ class OptionCollection extends AbstractFacetItemCollection
     {
         return $this->getFilteredCopy(function(Option $option) use ($filteredPrefix)
         {
-            $filteredPrefixLength = strlen($filteredPrefix);
-            $currentPrefix = substr(strtolower($option->getLabel()),0, $filteredPrefixLength);
+            $filteredPrefixLength = mb_strlen($filteredPrefix);
+            $currentPrefix = mb_substr(mb_strtolower($option->getLabel()), 0, $filteredPrefixLength);
 
             return $currentPrefix === $filteredPrefix;
         });
@@ -67,7 +67,7 @@ class OptionCollection extends AbstractFacetItemCollection
         $prefixes = [];
         foreach ($this->data as $option) {
             /** @var $option Option */
-            $prefix = substr($option->getLabel(), 0, $length);
+            $prefix = mb_substr($option->getLabel(), 0, $length);
             $prefixes[$prefix] = $prefix;
         }
 

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
@@ -64,7 +64,7 @@ class LabelFilterViewHelper extends AbstractSolrFrontendViewHelper
     {
         /** @var  $options OptionCollection */
         $options = $arguments['options'];
-        $requiredPrefix = strtolower($arguments['prefix']);
+        $requiredPrefix = mb_strtolower($arguments['prefix']);
         $filtered = $options->getByLowercaseLabelPrefix($requiredPrefix);
 
         $templateVariableProvider = $renderingContext->getVariableProvider();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -110,4 +110,23 @@ class OptionCollectionTest extends UnitTest
         $optionsStartingWithR = $facet->getOptions()->getByLowercaseLabelPrefix('r');
         $this->assertCount(3, $optionsStartingWithR, 'Unexpected amount of options starting with r');
     }
+
+    /**
+     * @test
+     */
+    public function canGetByLowercaseLabelPrefixWithMultiByteCharacter()
+    {
+        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $facet = new OptionsFacet($searchResultSetMock, 'authors', 'authors_s');
+
+        $ben = new Option($facet, 'Ben', 'ben', 14);
+        $ole = new Option($facet, 'Øle', 'ole', 12);
+
+        $facet->addOption($ben);
+        $facet->addOption($ole);
+
+        $optionsStartingWithO = $facet->getOptions()->getByLowercaseLabelPrefix('ø');
+        $this->assertCount(1, $optionsStartingWithO, 'Unexpected amount of options starting with ø');
+    }
 }
+

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -72,4 +72,34 @@ class LabelFilterViewHelperTest extends UnitTest
         $this->assertSame(1, $optionCollection->getCount());
         $this->assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
     }
+
+    /**
+     * @test
+     */
+    public function canMakeOnlyExpectedFacetsAvailableInStaticContextWithMultiByteCharacters()
+    {
+        $facet = $this->getDumbMock(OptionsFacet::class);
+
+        $ben = new Option($facet, 'Ben', 'ben', 14);
+        $ole = new Option($facet, 'Øle', 'ole', 12);
+
+        $optionCollection = new OptionCollection();
+        $optionCollection->add($ben);
+        $optionCollection->add($ole);
+
+        $variableContainer = $this->getMockBuilder(TemplateVariableContainer::class)->setMethods(['remove'])->getMock();
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+
+        $testArguments['options'] = $optionCollection;
+        $testArguments['prefix'] = 'ø';
+
+        LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
+        $this->assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
+
+        /** @var  $optionCollection OptionCollection */
+        $optionCollection = $variableContainer->get('filteredOptions');
+        $this->assertSame(1, $optionCollection->getCount());
+        $this->assertSame('Øle', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
+    }
 }


### PR DESCRIPTION
This pr:

* Replaces the usage of the substr and strlen methods for the facet grouping by prefix to allow multibyte characeters
* Add's unit tests for this

Fixes: #1780