### PR TITLE
[TASK] Pin testing framework to 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",
-    "nimut/testing-framework": "^2.0"
+    "nimut/testing-framework": "2.0.1"
   },
   "replace": {
     "solr": "self.version",


### PR DESCRIPTION
Pin's the testing framework to 2.0.1. Afterwards we should fix the sql strict issues and
update to 2.0.2 of the testing framework again.

Fixes: #1786