### PR TITLE
[TASK] Allow to install with TYPO3 9 CMS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "typo3/cms": ">=8.7.0"
+    "typo3/cms-core": "^8.7.0 || ^9.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '8.7.0-8.99.99'
+            'typo3' => '8.7.0-9.0.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
This pr:

* Makes the version constraint in composer.json more precise
* Allows to install in 9.0 by ext_emconf.php constraint
* Changes the depedency to the TYPO3 core by using typo3/cms-core instead of typo3/cms

Fixes: #1782