### PR TITLE
[TASK] Allow to run with strict SQL mode

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -754,10 +754,11 @@ class QueueItemRepository extends AbstractRepository
     public function updateHasIndexingPropertiesFlagByItemUid(int $itemUid, bool $hasIndexingPropertiesFlag): int
     {
         $queryBuilder = $this->getQueryBuilder();
+
         return $queryBuilder
             ->update($this->table)
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($itemUid, \PDO::PARAM_INT)))
-            ->set('has_indexing_properties', $queryBuilder->createNamedParameter($hasIndexingPropertiesFlag, \PDO::PARAM_BOOL))
+            ->set('has_indexing_properties', $queryBuilder->createNamedParameter($hasIndexingPropertiesFlag, \PDO::PARAM_INT), false)
             ->execute();
     }
 }

--- a/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
@@ -65,10 +65,13 @@ class LastSearchesRepository extends AbstractRepository
         $queryBuilder = $this->getQueryBuilder();
         return $queryBuilder
             ->select('keywords')
+            ->addSelectLiteral(
+                $queryBuilder->expr()->max('tstamp','maxtstamp')
+            )
             ->from($this->table)
             // There is no support for DISTINCT, a ->groupBy() has to be used instead.
             ->groupBy('keywords')
-            ->orderBy('tstamp', 'DESC')
+            ->orderBy('maxtstamp', 'DESC')
             ->setMaxResults($limit)->execute()->fetchAll();
     }
 

--- a/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
@@ -5,7 +5,7 @@
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8085";s:8:"solrPath";s:16:"/solr/core_fail/";s:8:"language";i:0;s:5:"label";s:76:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_fail/";}}</entry_value>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8889";s:8:"solrPath";s:16:"/solr/core_fail/";s:8:"language";i:0;s:5:"label";s:76:"Congratulations (pid: 1, language: default) - localhost:8889/solr/core_fail/";}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -66,7 +66,7 @@
                     solr {
                         scheme = http
                         host   = localhost
-                        port   = 8999
+                        port   = 8889
                         path   = /solr/core_fail/
                     }
 

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/update_has_indexing_properties_flag.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/update_has_indexing_properties_flag.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello solr</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Index;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Testcase for the QueueItemRepository
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class QueueItemRepositoryTest extends IntegrationTest
+{
+
+    /**
+     * @test
+     */
+    public function canUpdateHasIndexingPropertiesFlagByItemUid()
+    {
+        $this->importDataSetFromFixture('update_has_indexing_properties_flag.xml');
+
+        $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
+
+        $queueItem = $queueItemRepository->findItemByUid(4711);
+        $this->assertFalse($queueItem->hasIndexingProperties());
+
+        $queueItemRepository->updateHasIndexingPropertiesFlagByItemUid(4711, true);
+
+        $queueItem = $queueItemRepository->findItemByUid(4711);
+        $this->assertTrue($queueItem->hasIndexingProperties());
+
+        $queueItemRepository->updateHasIndexingPropertiesFlagByItemUid(4711, false);
+
+        $queueItem = $queueItemRepository->findItemByUid(4711);
+        $this->assertFalse($queueItem->hasIndexingProperties());
+    }
+
+}

--- a/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -77,4 +77,17 @@ class LastSearchesRepositoryTest extends IntegrationTest
         $actual = $this->lastSearchesRepository->findAllKeywords();
         $this->assertSame(['5', '4', '3', '2', '1'], $actual);
     }
+
+    /**
+     * @test
+     */
+    public function lastUpdatedRowIsOnFirstPosition()
+    {
+        $this->importDataSetFromFixture('can_find_and_add_last_searches.xml');
+
+        $this->lastSearchesRepository->add('1', 5);
+
+        $actual = $this->lastSearchesRepository->findAllKeywords();
+        $this->assertSame(['1', '4', '3', '2'], $actual);
+    }
 }

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -128,7 +128,7 @@ class StatisticsRepositoryTest extends IntegrationTest
             'time_preparation' => 2,
             'time_processing' => 27,
             'feuser_id' => 0,
-            'cookie' => '0ad2582d058e2843c9bc3b2273309248s',
+            'cookie' => '0ad2582d058e2843c9bc3b2273309248',
             'ip' => '192.168.144.1',
             'page' => 0,
             'keywords' => 'inserted record',

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_table.sql
@@ -37,7 +37,7 @@ DROP TABLE IF EXISTS tx_fakeextension_domain_model_related_mm;
 CREATE TABLE tx_fakeextension_domain_model_related_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-   tablenames varchar(90) NOT NULL,
+   tablenames varchar(90) DEFAULT '' NOT NULL,
    sorting int(11) unsigned DEFAULT '0' NOT NULL,
    KEY uid_local (uid_local),
    KEY uid_foreign (uid_foreign)
@@ -48,8 +48,8 @@ DROP TABLE IF EXISTS tx_fakeextension_domain_model_related_pages_mm;
 CREATE TABLE tx_fakeextension_domain_model_related_pages_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-   tablenames varchar(90) NOT NULL,
-   fieldname varchar(90) NOT NULL,
+   tablenames varchar(90) DEFAULT '' NOT NULL,
+   fieldname varchar(90) DEFAULT '' NOT NULL,
    sorting int(11) unsigned DEFAULT '0' NOT NULL,
    KEY uid_local (uid_local),
    KEY uid_foreign (uid_foreign)

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
@@ -26,6 +26,7 @@ return [
             'label' => 'Used as relation to',
             'config' => [
                 'type' => 'group',
+                'default' => '',
                 'allowed' => '*',
                 'internal_type' => 'db',
                 'MM' => 'tx_fakeextension3_pages_mm',

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
@@ -26,6 +26,7 @@ return [
             'label' => 'Used as relation to',
             'config' => [
                 'type' => 'group',
+                'default' => '',
                 'allowed' => '*',
                 'internal_type' => 'db',
                 'MM' => 'tx_fakeextension3_pages_mm',

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
@@ -1,8 +1,8 @@
 CREATE TABLE tx_fakeextension3_pages_mm (
    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-   tablenames varchar(90) NOT NULL,
-   fieldname varchar(90) NOT NULL,
+   tablenames varchar(90) DEFAULT '' NOT NULL,
+   fieldname varchar(90) DEFAULT '' NOT NULL,
    sorting int(11) unsigned DEFAULT '0' NOT NULL,
    sorting_foreign int(11) unsigned DEFAULT '0' NOT NULL,
    KEY uid_local (uid_local),
@@ -11,10 +11,10 @@ CREATE TABLE tx_fakeextension3_pages_mm (
 
 CREATE TABLE pages (
    page_relations int(11) unsigned DEFAULT '0' NOT NULL,
-   relations varchar(90) NOT NULL
+   relations varchar(90) DEFAULT '' NOT NULL
 );
 
 CREATE TABLE pages_language_overlay (
    page_relations int(11) unsigned DEFAULT '0' NOT NULL,
-   relations varchar(90) NOT NULL
+   relations varchar(90) DEFAULT '' NOT NULL
 );

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",
-    "nimut/testing-framework": "2.0.1"
+    "nimut/testing-framework": "^2.0"
   },
   "replace": {
     "solr": "self.version",


### PR DESCRIPTION
This pr:

* Uses the latest version of the testing framwork again (with strict sql mode)
* Add's missing default values for custom sql fixtures
* Fixes a bug in the QueueItemRepository::updateHasIndexingPropertiesFlagByItemUid
* Changes the port in can_render_error_message_when_solr_unavailable.xml to avoid port collisions

Fixes: #1785