### PR TITLE
[TASK] Add example to add searchbox on every page

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -35,9 +35,7 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/FilterPages/',
     'Search - (Example) Filter to only show page results');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
-    'Configuration/TypoScript/Examples/IntroPackageSearchBox/',
-    'Search - (Example) Replace Introduction Package search box');
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/ConnectionFromConfVars/',
     'Search - (Example) Use connection settings from TYPO3_CONF_VARS');

--- a/Configuration/TypoScript/Examples/IntroPackageSearchBox/setup.txt
+++ b/Configuration/TypoScript/Examples/IntroPackageSearchBox/setup.txt
@@ -1,5 +1,0 @@
-# replaces the Introduction Package Indexed Search search box
-# with the Solr search box
-
-lib.searchbox >
-lib.searchbox < plugin.tx_solr_PiSearch_Search

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -556,3 +556,21 @@ This can be done with the combination of several settings:
 
 The example above changes the minimumCount to 0, the default value i 1. Setting it to zero allows to have options without any results.
 The setting "keepAllFacetsOnSelection" let all facets remain and with keepAllOptionsOnSelection the options in the type facet remain.
+
+**How can i add a searchbox on every page?**
+
+In most projects you want to add a searchbox on every content page. To support this, the default EXT:solr typoscript template provides the typoscript template path "plugin.tx_solr_PiSearch_Search" that contains a configured typoscript code to render the searchbox. When you want to add that to your project in the most cases you would need to refer to a search result page.
+The following example shows how you can build a typoscript lib object that configures the target page for this plugin instance:
+
+::
+
+    lib.searchbox < plugin.tx_solr_PiSearch_Search
+    lib.searchbox.search.targetPage = 4711
+
+Afterwards you could render the typoscript path "lib.searchbox" with several ways in TYPO3, e.g. with a FLUID ViewHelper:
+
+::
+
+    <f:cObject typoscriptObjectPath="lib.searchbox" />
+
+By adding the snippet to a generic tempate you could render the searchbox on every page.


### PR DESCRIPTION
This pr:

* Add's an FAQ entry, how the searchbox can be added on every page
* Removes the Introduction example to add the searchbox, since there is no searchbox in the introduction package anymore

Fixes: #869