### PR TITLE
[TASK] Group pagination should be resetted when facet is changed

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -428,6 +428,19 @@ class SearchRequest
     }
 
     /**
+     * Can be used to reset all groupPages.
+     *
+     * @return SearchRequest
+     */
+    public function removeAllGroupItemPages(): SearchRequest
+    {
+        $path = $this->prefixWithNamespace('groupPage');
+        $this->argumentsAccessor->reset($path);
+
+        return $this;
+    }
+
+    /**
      * Can be used to paginate within a groupItem.
      *
      * @param string $groupName e.g. type

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -78,10 +78,12 @@ class SearchUriBuilder
     public function getAddFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
     {
         $persistentAndFacetArguments = $previousSearchRequest
-            ->getCopyForSubRequest()->addFacetValue($facetName, $facetValue)
+            ->getCopyForSubRequest()->removeAllGroupItemPages()->addFacetValue($facetName, $facetValue)
             ->getAsArray();
 
         $additionalArguments = $this->getAdditionalArgumentsFromRequestConfiguration($previousSearchRequest);
+        $additionalArguments = is_array($additionalArguments) ? $additionalArguments : [];
+
         $arguments = $persistentAndFacetArguments + $additionalArguments;
 
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
@@ -99,7 +101,7 @@ class SearchUriBuilder
     public function getSetFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
     {
         $previousSearchRequest = $previousSearchRequest
-            ->getCopyForSubRequest()->removeAllFacetValuesByName($facetName);
+            ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacetValuesByName($facetName);
 
         return $this->getAddFacetValueUri($previousSearchRequest, $facetName, $facetValue);
     }
@@ -113,14 +115,13 @@ class SearchUriBuilder
     public function getRemoveFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
     {
         $persistentAndFacetArguments = $previousSearchRequest
-            ->getCopyForSubRequest()->removeFacetValue($facetName, $facetValue)
+            ->getCopyForSubRequest()->removeAllGroupItemPages()->removeFacetValue($facetName, $facetValue)
             ->getAsArray();
 
         $additionalArguments = [];
         if ($previousSearchRequest->getContextTypoScriptConfiguration()->getSearchFacetingFacetLinkUrlParametersUseForFacetResetLinkUrl()) {
             $additionalArguments = $this->getAdditionalArgumentsFromRequestConfiguration($previousSearchRequest);
         }
-
         $arguments = $persistentAndFacetArguments + $additionalArguments;
 
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
@@ -135,7 +136,7 @@ class SearchUriBuilder
     public function getRemoveFacetUri(SearchRequest $previousSearchRequest, $facetName)
     {
         $persistentAndFacetArguments = $previousSearchRequest
-            ->getCopyForSubRequest()->removeAllFacetValuesByName($facetName)
+            ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacetValuesByName($facetName)
             ->getAsArray();
 
         $additionalArguments = [];
@@ -156,7 +157,7 @@ class SearchUriBuilder
     public function getRemoveAllFacetsUri(SearchRequest $previousSearchRequest)
     {
         $persistentAndFacetArguments = $previousSearchRequest
-            ->getCopyForSubRequest()->removeAllFacets()
+            ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacets()
             ->getAsArray();
 
         $additionalArguments = [];

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -313,6 +313,24 @@ class SearchRequestTest extends UnitTest
     /**
      * @test
      */
+    public function canResetAllGroupItemPages()
+    {
+        $query = 'tx_solr%5Bq%5D=typo3';
+        $request = $this->getSearchRequestFromQueryString($query);
+        $request->setGroupItemPage('typeGroup', 'pages', 2);
+        $request->setGroupItemPage('colorGroup', 'colors', 4);
+
+        $requestArguments = $request->getAsArray();
+        $this->assertCount(2, $requestArguments['tx_solr']['groupPage'], 'Expected to have two group pages registered');
+
+        $request->removeAllGroupItemPages();
+        $requestArguments = $request->getAsArray();
+        $this->assertNull($requestArguments['tx_solr']['groupPage'], 'Expected to have two group pages registered');
+    }
+
+    /**
+     * @test
+     */
     public function twoDifferentRequestsHaveADifferentId()
     {
         $newSearchRequest = new SearchRequest();

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -198,4 +198,28 @@ class SearchUriBuilderTest extends UnitTest
         $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->searchUrlBuilder->getRemoveFacetUri($previousRequest, 'type');
     }
+
+    /**
+     * When a page for a group was set, this should be resetted when a facet is selected.
+     *
+     * @test
+     */
+    public function addFacetUriRemovesPreviousGroupPage()
+    {
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+
+        $previousRequest =  new SearchRequest([
+                'tx_solr' => [
+                    'groupPage' => [
+                        'typeGroup' => [
+                            'pages' => 4
+                        ]
+                    ]
+                ]
+            ],
+            0, 0, $configurationMock);
+        $uri = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'type', 'pages');
+        $this->assertSame('tx_solr[filter][0]=type:pages', urldecode($uri), 'Unexpected uri generated');
+    }
 }


### PR DESCRIPTION
When a facet is changed, the paginations of the groups should be resetted since the number
of results might change and the page is not valid anymore.

Fixes: #1808