### PR TITLE
[BUGFIX] fallback to pages on SOLR_RELATION on missing TCA for pages_language_overlay

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -119,33 +119,56 @@ class Relation
     protected function getRelatedItems(
         ContentObjectRenderer $parentContentObject
     ) {
-        $relatedItems = [];
-
-        list($localTableName, $localRecordUid) = explode(':',
-            $parentContentObject->currentRecord);
-
-        $localTableNameOrg = $localTableName;
-        // pages has a special overlay table constriction
-        if ($GLOBALS['TSFE']->sys_language_uid > 0 && $localTableName === 'pages') {
-            $localTableName = 'pages_language_overlay';
-        }
-
-        $localTableTca = $GLOBALS['TCA'][$localTableName];
+        list($localTableNameOrg, $localRecordUid) = explode(':', $parentContentObject->currentRecord);
         $localFieldName = $this->configuration['localField'];
 
-        if (isset($localTableTca['columns'][$localFieldName])) {
-            $localFieldTca = $localTableTca['columns'][$localFieldName];
-            $localRecordUid = $this->getUidOfRecordOverlay($localTableNameOrg, $localRecordUid);
-            if (isset($localFieldTca['config']['MM']) && trim($localFieldTca['config']['MM']) !== '') {
-                $relatedItems = $this->getRelatedItemsFromMMTable($localTableName,
-                    $localRecordUid, $localFieldTca);
-            } else {
-                $relatedItems = $this->getRelatedItemsFromForeignTable($localTableName,
-                    $localRecordUid, $localFieldTca, $parentContentObject);
-            }
+        if (!$this->isTcaConfiguredForTablesField($localTableNameOrg, $localFieldName)) {
+            return [];
+        }
+
+        $localTableName = $this->usePagesLanguageOverlayInsteadOfPagesIfPossible($localTableNameOrg, $localFieldName);
+        $localRecordUid = $this->getUidOfRecordOverlay($localTableNameOrg, $localFieldName, $localRecordUid);
+
+        $localFieldTca = $GLOBALS['TCA'][$localTableName]['columns'][$localFieldName];
+        if (isset($localFieldTca['config']['MM']) && trim($localFieldTca['config']['MM']) !== '') {
+            $relatedItems = $this->getRelatedItemsFromMMTable($localTableName,
+                $localRecordUid, $localFieldTca);
+        } else {
+            $relatedItems = $this->getRelatedItemsFromForeignTable($localTableName,
+                $localRecordUid, $localFieldTca, $parentContentObject);
         }
 
         return $relatedItems;
+    }
+
+    /**
+     * @param string $localTableName
+     * @param string $localFieldName
+     * @return string
+     * @todo this can be removed when TYPO3 8 support is dropped since pages translations are in pages then as well
+     */
+    protected function usePagesLanguageOverlayInsteadOfPagesIfPossible(string $localTableName, string $localFieldName) : string
+    {
+        // pages has a special overlay table constriction
+        if ($GLOBALS['TSFE']->sys_language_uid > 0
+            && $localTableName === 'pages'
+            && $this->isTcaConfiguredForTablesField('pages_language_overlay', $localFieldName)) {
+            return 'pages_language_overlay';
+        }
+
+        return $localTableName;
+    }
+
+    /**
+     * Checks if TCA is available for column by table
+     *
+     * @param string $tableName
+     * @param string $fieldName
+     * @return bool
+     */
+    protected function isTcaConfiguredForTablesField(string $tableName, string $fieldName) : bool
+    {
+        return isset($GLOBALS['TCA'][$tableName]['columns'][$fieldName]);
     }
 
     /**
@@ -156,11 +179,8 @@ class Relation
      * @param array $localFieldTca The local table's TCA
      * @return array Array of related items, values already resolved from related records
      */
-    protected function getRelatedItemsFromMMTable(
-        $localTableName,
-        $localRecordUid,
-        array $localFieldTca
-    ) {
+    protected function getRelatedItemsFromMMTable($localTableName, $localRecordUid, array $localFieldTca)
+    {
         $relatedItems = [];
         $foreignTableName = $localFieldTca['config']['foreign_table'];
         $foreignTableTca = $GLOBALS['TCA'][$foreignTableName];
@@ -374,7 +394,7 @@ class Relation
      * @param int $localRecordUid
      * @return int
      */
-    protected function getUidOfRecordOverlay($localTableName, $localRecordUid)
+    protected function getUidOfRecordOverlay($localTableName, $localFieldName, $localRecordUid)
     {
         // when no language is set at all we do not need to overlay
         if (!isset($GLOBALS['TSFE']->sys_language_uid)) {
@@ -384,6 +404,11 @@ class Relation
         if (!$GLOBALS['TSFE']->sys_language_uid > 0) {
             return $localRecordUid;
         }
+        // when no TCA configured for pages_language_overlay's field, then use original record Uid
+        if ($localTableName === 'pages' && !$this->isTcaConfiguredForTablesField('pages_language_overlay', $localFieldName)) {
+            return $localRecordUid;
+        }
+
         /** @var  $db  \TYPO3\CMS\Core\Database\DatabaseConnection */
         $db = $GLOBALS['TYPO3_DB'];
         $record = $db->exec_SELECTgetSingleRow('*', $localTableName, 'uid = ' . $localRecordUid);

--- a/Tests/Integration/ContentObject/Fixtures/solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml
+++ b/Tests/Integration/ContentObject/Fixtures/solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Page</title>
+    </pages>
+
+    <pages>
+        <uid>7</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>Sub page with assigned category</title>
+    </pages>
+
+    <sys_category_record_mm>
+        <!-- the category id -->
+        <uid_local>123</uid_local>
+        <!-- the page id -->
+        <uid_foreign>7</uid_foreign>
+        <tablenames>pages</tablenames>
+        <fieldname>categories</fieldname>
+        <sorting>1</sorting>
+        <sorting_foreign>1</sorting_foreign>
+    </sys_category_record_mm>
+
+    <sys_category>
+        <uid>123</uid>
+        <pid>0</pid>
+        <title>Some Category</title>
+        <sys_language_uid>0</sys_language_uid>
+    </sys_category>
+</dataset>

--- a/Tests/Integration/ContentObject/Fixtures/solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml
+++ b/Tests/Integration/ContentObject/Fixtures/solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Page</title>
+    </pages>
+
+    <pages>
+        <uid>7</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>Sub page with assigned category</title>
+    </pages>
+
+    <pages_language_overlay>
+        <uid>2</uid>
+        <pid>7</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+        <title>Translated Sub page with assigned category</title>
+    </pages_language_overlay>
+
+    <sys_category_record_mm>
+        <!-- the category id -->
+        <uid_local>123</uid_local>
+        <!-- the page id -->
+        <uid_foreign>7</uid_foreign>
+        <tablenames>pages</tablenames>
+        <fieldname>categories</fieldname>
+        <sorting>1</sorting>
+        <sorting_foreign>1</sorting_foreign>
+    </sys_category_record_mm>
+
+    <sys_category>
+        <uid>123</uid>
+        <pid>0</pid>
+        <title>Some Category</title>
+        <sys_language_uid>0</sys_language_uid>
+    </sys_category>
+</dataset>

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2018 dkd Internet Service GmbH <solr-eb-support@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+use ApacheSolrForTypo3\Solr\ContentObject\Relation;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
+/**
+ * Class RelationTest
+ */
+class RelationTest extends IntegrationTest
+{
+
+    /**
+     * @test
+     * @todo this check can be removed when TYPO3 8 support is dropped since pages translations are in pages then as well
+     *
+     * @dataProvider fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn
+     */
+    public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn($fixtureName)
+    {
+        $this->importDataSetFromFixture($fixtureName);
+        $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
+        /* @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRendererMock = $this->getMockBuilder(ContentObjectRenderer::class)->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
+        $contentObjectRendererMock->currentRecord = 'pages:7';
+        $GLOBALS['TSFE']->sys_language_uid = 1;
+
+        /* @var Relation $solrRelation */
+        $solrRelation = GeneralUtility::makeInstance(Relation::class);
+        $actual = $solrRelation->cObjGetSingleExt(Relation::CONTENT_OBJECT_NAME, ['localField' => 'categories'], null, $contentObjectRendererMock);
+
+        $this->assertSame('Some Category', $actual, 'Can not fallback to table "pages" on non existent column configuration in TCA for table "pages_language_overlay".');
+    }
+
+    /**
+     * canGetRelatedItemsUsingOriginalUidFromPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn
+     *
+     * @return array
+     */
+    public function fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn()
+    {
+        return [
+            ['solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml'],
+            ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml']
+        ];
+    }
+}

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -300,7 +300,7 @@ class PageIndexerTest extends IntegrationTest
      */
     protected function executePageIndexer($typo3ConfVars = [], $pageId = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $languageId = 0)
     {
-        GeneralUtility::_GETset('L', $languageId);
+        GeneralUtility::_GETset($languageId, 'L');
         $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
 
         $config = [


### PR DESCRIPTION

missing column settings in TCA for pages_language_overlay must be fetched from pages TCA
Backported from: #1816

Fixes: #1812