### PR TITLE
[TASK] Allow using complex filter values introduced by round brackets

### DIFF
--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -206,7 +206,16 @@ class Faceting implements Modifier
                             $filterOptions);
                         $filterParts[] = $facetConfiguration['field'] . ':' . $filterValue;
                     } else {
-                        $filterParts[] = $facetConfiguration['field'] . ':"' . addslashes($filterValue) . '"';
+                        $firstChar = substr($filterValue, 0, 1);
+                        // Avoid escaping with double quotes when using a sub-expression with round brackets to be
+                        // able to construct complex filter queries using request parameters.
+                        // EXAMPLE: "tx_solr[filter][]=myfield_intS:(1+2)" can be used to only show documents where
+                        //          "myfield_intS" equals to 1 OR 2.
+                        if ($firstChar === '(') {
+                            $filterParts[] = $facetConfiguration['field'] . ':' . addslashes($filterValue);
+                        } else {
+                            $filterParts[] = $facetConfiguration['field'] . ':"' . addslashes($filterValue) . '"';
+                        }
                     }
                 }
 


### PR DESCRIPTION
By not escaping filter values starting with double quotes you can
define complex filter conditions also in request parameters.

I needed this function for a project and thought it could be useful for anybody else.

This is a very naive approach and I don't know if the filter values have to be checked or escaped again.