### PR TITLE
[TASK] Update nimut/testing-framework to 3.x and allow to install with TYPO3 9.1

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -38,6 +38,12 @@ tools:
     runs: 2
     timeout: 2400
 
+checks:
+    php:
+        excluded_dependencies:
+            - typo3/cms-install
+        avoid_superglobals: false
+
 build_failure_conditions:
   - 'patches.label("Doc Comments").count > 10'
   - 'patches.label("Spacing").count > 15'
@@ -45,3 +51,11 @@ build_failure_conditions:
   - 'issues.severity(>= MAJOR).count > 30'
   - 'project.metric("scrutinizer.quality", < 8)'
   - 'project.metric_change("scrutinizer.test_coverage", < -0.10)'
+
+
+build:
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 jdk:
   - oraclejdk8
@@ -26,15 +27,15 @@ env:
   matrix:
     - TYPO3_VERSION="^8.7"
     - TYPO3_VERSION="8.x-dev"
-    - TYPO3_VERSION="9.x-dev as 8.7.99"
+    - TYPO3_VERSION="^9.1"
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: TYPO3_VERSION="9.x-dev as 8.7.99"
-      php: 7.0
-    - env: TYPO3_VERSION="9.x-dev as 8.7.99"
-      php: 7.1
+  exclude:
+    - php: 7.0
+      env: TYPO3_VERSION="^9.1"
+    - php: 7.1
+      env: TYPO3_VERSION="^9.1"
 
 before_install:
   - composer self-update

--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -54,7 +54,20 @@ echo "Using package path $TYPO3_PATH_PACKAGES"
 echo "Using web path $TYPO3_PATH_WEB"
 
 # Install TYPO3 sources
-composer require --dev typo3/cms="$TYPO3_VERSION"
+if [[ $TYPO3_VERSION = *"9."* ]]; then
+    composer require --dev typo3/cms-backend="$TYPO3_VERSION"
+    composer require --dev typo3/cms-core="$TYPO3_VERSION"
+    composer require --dev typo3/cms-fluid="$TYPO3_VERSION"
+    composer require --dev typo3/cms-frontend="$TYPO3_VERSION"
+    composer require --dev typo3/cms-lang="$TYPO3_VERSION"
+    composer require --dev typo3/cms-extbase="$TYPO3_VERSION"
+    composer require --dev typo3/cms-extbase="$TYPO3_VERSION"
+    composer require --dev typo3/cms-reports="$TYPO3_VERSION"
+    composer require --dev typo3/cms-scheduler="$TYPO3_VERSION"
+    composer require --dev typo3/cms-tstemplate="$TYPO3_VERSION"
+else
+    composer require --dev typo3/cms="$TYPO3_VERSION"
+fi
 
 # Restore composer.json
 git checkout composer.json

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -406,7 +406,9 @@ class Relation
             return $localRecordUid;
         }
         // when no TCA configured for pages_language_overlay's field, then use original record Uid
-        if ($localTableName === 'pages' && !$this->isTcaConfiguredForTablesField('pages_language_overlay', $localFieldName)) {
+        // @todo this can be dropped when TYPO3 8 compatibility is dropped
+        $translatedInPagesLanguageOverlayAndNoTCAPresent = Util::getIsTYPO3VersionBelow9() && !$this->isTcaConfiguredForTablesField('pages_language_overlay', $localFieldName);
+        if ($localTableName === 'pages' && $translatedInPagesLanguageOverlayAndNoTCAPresent) {
             return $localRecordUid;
         }
 

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -688,7 +688,7 @@ class QueryBuilder {
 
         $searchQueryFilters = $this->typoScriptConfiguration->getSearchQueryFilterConfiguration();
 
-        if (count($searchQueryFilters) <= 0) {
+        if (!is_array($searchQueryFilters) || count($searchQueryFilters) <= 0) {
             return $this;
         }
 
@@ -844,7 +844,7 @@ class QueryBuilder {
         }
 
         $searchQueryFilters = $this->typoScriptConfiguration->getSearchQueryFilterConfiguration();
-        if (count($searchQueryFilters) <= 0) {
+        if (!is_array($searchQueryFilters) || count($searchQueryFilters) <= 0) {
             return [];
         }
 

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -228,12 +228,13 @@ class PagesRepository extends AbstractRepository
                     . BackendUtility::BEenableFields('pages_language_overlay')
                 )->execute()->fetchAll();
         } else {
+            $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
             return $queryBuilder
                 ->select('pid', 'l10n_parent', 'sys_language_uid')
                 ->from('pages')
                 ->add('where',
                     $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT))
-                    . BackendUtility::deleteClause('pages')
                     . BackendUtility::BEenableFields('pages')
                 )->execute()->fetchAll();
         }
@@ -249,12 +250,13 @@ class PagesRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilder();
         $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
         return $queryBuilder
             ->select('uid')
             ->from($this->table)
             ->add('where',
                 $queryBuilder->expr()->eq('content_from_pid', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT))
-                . BackendUtility::deleteClause('pages')
             )->execute()->fetchAll();
     }
 

--- a/Classes/ViewHelpers/Widget/FrequentlySearchedViewHelper.php
+++ b/Classes/ViewHelpers/Widget/FrequentlySearchedViewHelper.php
@@ -14,6 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\FrequentlySearchedController;
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetViewHelper;
 
 /**
@@ -27,10 +28,17 @@ class FrequentlySearchedViewHelper extends AbstractWidgetViewHelper
 {
 
     /**
-     * @var \ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\FrequentlySearchedController
-     * @inject
+     * @var FrequentlySearchedController
      */
     protected $controller;
+
+    /**
+     * @param FrequentlySearchedController $controller
+     */
+    public function injectFrequentlySearchedController(FrequentlySearchedController $controller)
+    {
+        $this->controller = $controller;
+    }
 
     /**
      * @return \TYPO3\CMS\Extbase\Mvc\ResponseInterface

--- a/Classes/ViewHelpers/Widget/GroupItemPaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/GroupItemPaginateViewHelper.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\GroupItemPaginateController;
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetViewHelper;
 
 /**
@@ -35,11 +36,17 @@ class GroupItemPaginateViewHelper extends AbstractWidgetViewHelper
 {
 
     /**
-     * @var \ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\GroupItemPaginateController
-     * @inject
+     * @var GroupItemPaginateController
      */
     protected $controller;
 
+    /**
+     * @param GroupItemPaginateController $groupItemPaginateController
+     */
+    public function injectGroupItemPaginateController(GroupItemPaginateController $groupItemPaginateController)
+    {
+        $this->controller = $groupItemPaginateController;
+    }
 
     /**
      * Initializes the arguments

--- a/Classes/ViewHelpers/Widget/LastSearchesViewHelper.php
+++ b/Classes/ViewHelpers/Widget/LastSearchesViewHelper.php
@@ -14,6 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\LastSearchesController;
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetViewHelper;
 
 /**
@@ -27,10 +28,17 @@ class LastSearchesViewHelper extends AbstractWidgetViewHelper
 {
 
     /**
-     * @var \ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\LastSearchesController
-     * @inject
+     * @var LastSearchesController
      */
     protected $controller;
+
+    /**
+     * @param LastSearchesController $lastSearchesController
+     */
+    public function injectLastSearchesController(LastSearchesController $lastSearchesController)
+    {
+        $this->controller = $lastSearchesController;
+    }
 
     /**
      * @return \TYPO3\CMS\Extbase\Mvc\ResponseInterface

--- a/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/ResultPaginateViewHelper.php
@@ -24,8 +24,8 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\ResultPaginateController;
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetViewHelper;
 
 /**
@@ -35,10 +35,17 @@ class ResultPaginateViewHelper extends AbstractWidgetViewHelper
 {
 
     /**
-     * @var \ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller\ResultPaginateController
-     * @inject
+     * @var ResultPaginateController
      */
     protected $controller;
+
+    /**
+     * @param ResultPaginateController $resultPaginateController
+     */
+    public function injectResultPaginateController(ResultPaginateController $resultPaginateController)
+    {
+        $this->controller = $resultPaginateController;
+    }
 
     /**
      * Initializes the arguments

--- a/Classes/Widget/AbstractWidgetViewHelper.php
+++ b/Classes/Widget/AbstractWidgetViewHelper.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Fluid\Core\Widget\AjaxWidgetContextHolder;
 use TYPO3\CMS\Fluid\Core\Widget\Exception\MissingControllerException;
 use TYPO3\CMS\Fluid\Core\Widget\WidgetRequest as CoreWidgetRequest;
 use TYPO3\CMS\Fluid\Core\Widget\WidgetContext;
+use TYPO3\CMS\Extbase\Service\ExtensionService;
 
 
 /**
@@ -70,8 +71,7 @@ abstract class AbstractWidgetViewHelper extends AbstractCoreWidgetViewHelper imp
     protected $objectManager;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Service\ExtensionService
-     * @inject
+     * @var ExtensionService
      */
     protected $extensionService;
 
@@ -79,6 +79,14 @@ abstract class AbstractWidgetViewHelper extends AbstractCoreWidgetViewHelper imp
      * @var \TYPO3\CMS\Fluid\Core\Widget\WidgetContext
      */
     private $widgetContext;
+
+    /**
+     * @param ExtensionService $extensionService
+     */
+    public function injectExtensionService(ExtensionService $extensionService)
+    {
+        $this->extensionService = $extensionService;
+    }
 
     /**
      * @param AjaxWidgetContextHolder $ajaxWidgetContextHolder

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -71,6 +71,7 @@ abstract class IntegrationTest extends FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
+        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
         //this is needed by the TYPO3 core.
         chdir(PATH_site);
@@ -250,6 +251,7 @@ abstract class IntegrationTest extends FunctionalTestCase
         /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
         $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
             $TYPO3_CONF_VARS, $id, $type, $no_cache, $cHash, $_2, $MP, $RDCT);
+        $GLOBALS['TSFE'] = $TSFE;
 
 
         EidUtility::initLanguage();

--- a/Tests/Integration/Report/Fixtures/can_detect_indexing_disabled.v9.xml
+++ b/Tests/Integration/Report/Fixtures/can_detect_indexing_disabled.v9.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                config.index_enable = 0
+
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Search Test</title>
+    </pages>
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>localhost</domainName>
+        <hidden>0</hidden>
+        <sorting>100</sorting>
+    </sys_domain>
+</dataset>

--- a/Tests/Integration/Report/Fixtures/can_detect_missing_rootpage.v9.xml
+++ b/Tests/Integration/Report/Fixtures/can_detect_missing_rootpage.v9.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                config.index_enable = 1
+
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>localhost</domainName>
+        <hidden>0</hidden>
+        <sorting>100</sorting>
+    </sys_domain>
+</dataset>

--- a/Tests/Integration/Report/Fixtures/can_get_green_solr_configuration_status_report.v9.xml
+++ b/Tests/Integration/Report/Fixtures/can_get_green_solr_configuration_status_report.v9.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                config.index_enable = 1
+
+                plugin.tx_solr {
+                    enabled = 1
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Search Test</title>
+    </pages>
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>localhost</domainName>
+        <hidden>0</hidden>
+        <sorting>100</sorting>
+    </sys_domain>
+</dataset>

--- a/Tests/Integration/System/Records/SystemDomain/Fixtures/sys_domain.v9.xml
+++ b/Tests/Integration/System/Records/SystemDomain/Fixtures/sys_domain.v9.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_domain>
+        <uid>17</uid>
+        <pid>24</pid>
+        <domainName>localhost</domainName>
+        <hidden>0</hidden>
+        <sorting>100</sorting>
+    </sys_domain>
+</dataset>

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -70,17 +70,17 @@ class SolrAdminServiceTest extends IntegrationTest
      */
     public function canAddSynonym($baseWord, $synonyms = [])
     {
-        // make sure old synonyms have been deleted
-        $this->solrAdminService->deleteSynonym($baseWord);
-
         $synonymsBeforeAdd = $this->solrAdminService->getSynonyms($baseWord);
         $this->assertEquals([], $synonymsBeforeAdd, 'Synonyms was not empty');
 
         $this->solrAdminService->addSynonym($baseWord, $synonyms);
+        $this->solrAdminService->reloadCore();
+
         $synonymsAfterAdd = $this->solrAdminService->getSynonyms($baseWord);
         $this->assertEquals($synonyms, $synonymsAfterAdd, 'Could not retrieve synonym after adding');
 
         $this->solrAdminService->deleteSynonym($baseWord);
+        $this->solrAdminService->reloadCore();
 
         $synonymsAfterRemove = $this->solrAdminService->getSynonyms($baseWord);
         $this->assertEquals([], $synonymsAfterRemove, 'Synonym was not removed');
@@ -103,16 +103,20 @@ class SolrAdminServiceTest extends IntegrationTest
      */
     public function canAddStopWord($stopWord)
     {
-        // make sure old stopwords are deleted
-        $this->solrAdminService->deleteStopWord($stopWord);
         $stopWords = $this->solrAdminService->getStopWords();
+
         $this->assertNotContains($stopWord, $stopWords, 'Stopwords are not empty after initializing');
 
         $this->solrAdminService->addStopWords($stopWord);
+        $this->solrAdminService->reloadCore();
+
         $stopWordsAfterAdd = $this->solrAdminService->getStopWords();
+
         $this->assertContains($stopWord, $stopWordsAfterAdd, 'Stopword was not added');
 
         $this->solrAdminService->deleteStopWord($stopWord);
+        $this->solrAdminService->reloadCore();
+
         $stopWordsAfterDelete = $this->solrAdminService->getStopWords();
         $this->assertNotContains($stopWord, $stopWordsAfterDelete, 'Stopwords are not empty after removing');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -14,10 +14,10 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsPackage;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage\TestPackage;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
@@ -27,7 +27,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class FacetRegistryTest extends UnitTestCase
+class FacetRegistryTest extends UnitTest
 {
     /**
      * @var ObjectManagerInterface

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -244,7 +244,8 @@ class SearchResultSetTest extends UnitTest
         $resultSet = $this->searchResultSetService->search($fakeRequest);
 
         $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
-        $this->assertSame(count($resultSet->getUsedQuery()->getFilters()), 1, 'There should be one registered filter in the query');
+
+        $this->assertSame(count($resultSet->getUsedQuery()->getFilters()->getValues()), 1, 'There should be one registered filter in the query');
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -46,7 +46,7 @@ class SortingTest extends UnitTest
     protected $resultSetMock;
 
     /**
-     * @test
+     * @return void
      */
     public function setUp()
     {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "typo3/cms-core": "^8.7.0 || ^9.0"
+    "typo3/cms-core": "^8.7.0 || ^9.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.6",
-    "nimut/testing-framework": "^2.0"
+    "phpunit/phpunit": "^6.0",
+    "nimut/testing-framework": "^3.0"
   },
   "replace": {
     "solr": "self.version",


### PR DESCRIPTION
This pr:

* Updates the testing framework to 3.x
* Fixes issues in the tests that are related to the update
* Use inject* Methods inject of injection Annotations since this is a compatible way for TYPO3 8 and 9
* Updates scrutinizer configuration to allow to exclude the typo3/cms-install package

Fixes: #1823