### PR TITLE
[TASK] do not die on indexing process

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Mvc\Controller\SolrControllerContext;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\System\Service\ConfigurationService;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager as SolrConfigurationManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,7 +29,6 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Service\TypoScriptService;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class AbstractBaseController
@@ -45,7 +45,7 @@ abstract class AbstractBaseController extends ActionController
     private $contentObjectRenderer;
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $typoScriptFrontendController;
 

--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -262,6 +262,8 @@ class IndexQueueModuleController extends AbstractModuleController
     /**
      * Indexes a few documents with the index service.
      * @return void
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\StopActionException
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\UnsupportedRequestTypeException
      */
     public function doIndexingRunAction()
     {

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -87,6 +87,7 @@ class IndexService
         $this->indexQueue = is_null($queue) ? GeneralUtility::makeInstance(Queue::class) : $queue;
         $this->signalSlotDispatcher = is_null($dispatcher) ? GeneralUtility::makeInstance(Dispatcher::class) : $dispatcher;
         $this->logger = is_null($solrLogManager) ? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__) : $solrLogManager;
+        define('EXT_SOLR_INDEXING_CONTEXT', true);
     }
 
     /**

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -29,10 +29,10 @@ use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Builder class to build an ApacheSolrDocument
@@ -60,13 +60,13 @@ class Builder
     /**
      * This method can be used to build an Apache_Solr_Document from a TYPO3 page.
      *
-     * @param TypoScriptFrontendController $page
+     * @param OverriddenTypoScriptFrontendController $page
      * @param string $url
      * @param Rootline $pageAccessRootline
      * @param string $mountPointParameter
      * @return Apache_Solr_Document|object
      */
-    public function fromPage(TypoScriptFrontendController $page, $url, Rootline $pageAccessRootline, $mountPointParameter): \Apache_Solr_Document
+    public function fromPage(OverriddenTypoScriptFrontendController $page, $url, Rootline $pageAccessRootline, $mountPointParameter): \Apache_Solr_Document
     {
         /* @var $document \Apache_Solr_Document */
         $document = GeneralUtility::makeInstance(Apache_Solr_Document::class);
@@ -174,12 +174,12 @@ class Builder
     }
 
     /**
-     * @param TypoScriptFrontendController  $page
+     * @param OverriddenTypoScriptFrontendController  $page
      * @param string $accessGroups
      * @param string $mountPointParameter
      * @return string
      */
-    protected function getPageDocumentId(TypoScriptFrontendController $page, string $accessGroups, string $mountPointParameter): string
+    protected function getPageDocumentId(OverriddenTypoScriptFrontendController $page, string $accessGroups, string $mountPointParameter): string
     {
         return Util::getPageDocumentId($page->id, $page->type, $page->sys_language_uid, $accessGroups, $mountPointParameter);
     }

--- a/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
+++ b/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
@@ -26,9 +26,9 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\FrequentSearches;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Core\Cache\Frontend\AbstractFrontend;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * The FrequentSearchesService is used to retrieve the frequent searches from the database or cache.
@@ -47,7 +47,7 @@ class FrequentSearchesService
     protected $cache;
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $tsfe;
 
@@ -64,10 +64,10 @@ class FrequentSearchesService
     /**
      * @param TypoScriptConfiguration $typoscriptConfiguration
      * @param AbstractFrontend $cache
-     * @param TypoScriptFrontendController $tsfe
+     * @param OverriddenTypoScriptFrontendController $tsfe
      * @param StatisticsRepository $statisticsRepository
      */
-    public function __construct(TypoScriptConfiguration $typoscriptConfiguration, AbstractFrontend $cache, TypoScriptFrontendController $tsfe, StatisticsRepository $statisticsRepository = null)
+    public function __construct(TypoScriptConfiguration $typoscriptConfiguration, AbstractFrontend $cache, OverriddenTypoScriptFrontendController $tsfe, StatisticsRepository $statisticsRepository = null)
     {
         $this->configuration = $typoscriptConfiguration;
         $this->cache = $cache;

--- a/Classes/Domain/Search/LastSearches/LastSearchesService.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesService.php
@@ -28,8 +28,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\LastSearches;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Generic\Session;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * The LastSearchesService is responsible to return the LastSearches from the session or database,

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -28,8 +28,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Writes statistics after searches have been conducted.
@@ -165,7 +165,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
     }
 
     /**
-     * @return TypoScriptFrontendController
+     * @return OverriddenTypoScriptFrontendController
      */
     protected function getTSFE()
     {

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -35,8 +35,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class SuggestService
@@ -48,7 +48,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 class SuggestService {
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $tsfe;
 
@@ -69,11 +69,11 @@ class SuggestService {
 
     /**
      * SuggestService constructor.
-     * @param TypoScriptFrontendController $tsfe
+     * @param OverriddenTypoScriptFrontendController $tsfe
      * @param SearchResultSetService $searchResultSetService
      * @param QueryBuilder|null $queryBuilder
      */
-    public function __construct(TypoScriptFrontendController $tsfe, SearchResultSetService $searchResultSetService, TypoScriptConfiguration $typoScriptConfiguration, QueryBuilder $queryBuilder = null)
+    public function __construct(OverriddenTypoScriptFrontendController $tsfe, SearchResultSetService $searchResultSetService, TypoScriptConfiguration $typoScriptConfiguration, QueryBuilder $queryBuilder = null)
     {
         $this->tsfe = $tsfe;
         $this->searchService = $searchResultSetService;

--- a/Classes/IndexQueue/Exception/DocumentPreparationException.php
+++ b/Classes/IndexQueue/Exception/DocumentPreparationException.php
@@ -1,0 +1,33 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\IndexQueue\Exception;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-eb-support@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Exception that is thrown on TYPO3 side in indexing process.
+ */
+class DocumentPreparationException extends IndexingException
+{
+}

--- a/Classes/IndexQueue/Exception/IndexingException.php
+++ b/Classes/IndexQueue/Exception/IndexingException.php
@@ -1,0 +1,34 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\IndexQueue\Exception;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-eb-support@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Exception that is thrown on indexing process. Does not matter on which side, TYPO3 or Apache.
+ * This exception should be used for any errors on indexing process.
+ */
+class IndexingException extends \Exception
+{
+}

--- a/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
@@ -27,8 +27,8 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Index Queue page indexer frontend helper base class implementing common
@@ -77,7 +77,7 @@ abstract class AbstractFrontendHelper implements FrontendHelper
      * Disables caching for page generation to get reliable results.
      *
      * @param array $parameters Parameters from frontend
-     * @param TypoScriptFrontendController $parentObject TSFE object
+     * @param OverriddenTypoScriptFrontendController $parentObject TSFE object
      */
     public function disableCaching(
         /** @noinspection PhpUnusedParameterInspection */

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 use ApacheSolrForTypo3\Solr\Util;
@@ -36,7 +37,6 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Index Queue Page Indexer frontend helper to ask the frontend page indexer to
@@ -57,7 +57,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
     /**
      * the page currently being indexed.
      *
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $page;
 
@@ -259,9 +259,9 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
      * Handles the indexing of the page content during post processing of a
      * generated page.
      *
-     * @param TypoScriptFrontendController $page TypoScript frontend
+     * @param OverriddenTypoScriptFrontendController $page TypoScript frontend
      */
-    public function hook_indexContent(TypoScriptFrontendController $page)
+    public function hook_indexContent(OverriddenTypoScriptFrontendController $page)
     {
         $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -25,11 +25,11 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectPostInitHookInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 use TYPO3\CMS\Frontend\Page\PageRepositoryGetPageHookInterface;
 use TYPO3\CMS\Frontend\Page\PageRepositoryGetPageOverlayHookInterface;
@@ -96,7 +96,7 @@ class UserGroupDetector extends AbstractFrontendHelper implements
      * Will be called by the hook in the TypoScriptFrontendController in the checkEnableFields() method.
      *
      * @param array $parameters
-     * @param TypoScriptFrontendController $tsfe
+     * @param OverriddenTypoScriptFrontendController $tsfe
      * @see \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::checkEnableFields()
      */
     public function checkEnableFields(
@@ -112,7 +112,7 @@ class UserGroupDetector extends AbstractFrontendHelper implements
      * restrictions apply during page rendering.
      *
      * @param array $parameters Parameters from frontend
-     * @param TypoScriptFrontendController $parentObject TSFE object
+     * @param OverriddenTypoScriptFrontendController $parentObject TSFE object
      */
     public function deactivateTcaFrontendGroupEnableFields(
         /** @noinspection PhpUnusedParameterInspection */

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -27,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Access\RootlineElement;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**

--- a/Classes/PageDocumentPostProcessor.php
+++ b/Classes/PageDocumentPostProcessor.php
@@ -27,7 +27,7 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 
 /**
  * Page document post processor interface to handle page documents after they
@@ -43,11 +43,11 @@ interface PageDocumentPostProcessor
      * Can be used to trigger actions when all contextual variables of the pageDocument to be indexed are known
      *
      * @param \Apache_Solr_Document $pageDocument the generated page document
-     * @param TypoScriptFrontendController $page the page object with information about page id or language
+     * @param OverriddenTypoScriptFrontendController $page the page object with information about page id or language
      * @return void
      */
     public function postProcessPageDocument(
         \Apache_Solr_Document $pageDocument,
-        TypoScriptFrontendController $page
+        OverriddenTypoScriptFrontendController $page
     );
 }

--- a/Classes/System/Mvc/Frontend/Controller/OverriddenTypoScriptFrontendController.php
+++ b/Classes/System/Mvc/Frontend/Controller/OverriddenTypoScriptFrontendController.php
@@ -1,0 +1,66 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Exception\DocumentPreparationException;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Overrides TYPO3 CMS TypoScriptFrontendController TSFE to prevent PHP on indexing processes from dieing.
+ */
+class OverriddenTypoScriptFrontendController extends TypoScriptFrontendController
+{
+
+    /**
+     * Page unavailable handler for use in frontend plugins from extensions.
+     *
+     * @param string $reason Reason text
+     * @param string $header HTTP header to send
+     * @throws DocumentPreparationException
+     */
+    public function pageUnavailableAndExit($reason = '', $header = '')
+    {
+        if (!defined('EXT_SOLR_INDEXING_CONTEXT')) {
+            parent::pageUnavailableAndExit($reason = '', $header = '');
+        }
+        throw new DocumentPreparationException('Solr Document can not be prepared. The Reason: ' . $reason, 1517584040);
+    }
+
+    /**
+     * Page-not-found handler for use in frontend plugins from extensions.
+     *
+     * @param string $reason Reason text
+     * @param string $header HTTP header to send
+     * @throws DocumentPreparationException
+     */
+    public function pageNotFoundAndExit($reason = '', $header = '')
+    {
+        if (!defined('EXT_SOLR_INDEXING_CONTEXT')) {
+            parent::pageNotFoundAndExit($reason = '', $header = '');
+        }
+        throw new DocumentPreparationException('Solr Document can not be prepared. The Reason: ' . $reason, 1517584045);
+    }
+
+}

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -27,15 +27,14 @@ namespace ApacheSolrForTypo3\Solr;
 use Apache_Solr_Document;
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
-use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\FieldProcessor\Service;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Page Indexer to index TYPO3 pages used by the Index Queue.
@@ -74,7 +73,7 @@ class Typo3PageIndexer
     /**
      * Frontend page object (TSFE).
      *
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $page = null;
     /**
@@ -120,9 +119,9 @@ class Typo3PageIndexer
     /**
      * Constructor
      *
-     * @param TypoScriptFrontendController $page The page to index
+     * @param OverriddenTypoScriptFrontendController $page The page to index
      */
-    public function __construct(TypoScriptFrontendController $page)
+    public function __construct(OverriddenTypoScriptFrontendController $page)
     {
         $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -24,21 +24,18 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -319,7 +316,7 @@ class Util
         if (!isset($tsfeCache[$cacheId]) || !$useCache) {
             GeneralUtility::_GETset($language, 'L');
 
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
+            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(OverriddenTypoScriptFrontendController::class,
                 $GLOBALS['TYPO3_CONF_VARS'], $pageId, 0);
 
             // for certain situations we need to trick TSFE into granting us
@@ -450,10 +447,10 @@ class Util
      * Resolves the configured absRefPrefix to a valid value and resolved if absRefPrefix
      * is set to "auto".
      *
-     * @param TypoScriptFrontendController $TSFE
+     * @param OverriddenTypoScriptFrontendController $TSFE
      * @return string
      */
-    public static function getAbsRefPrefixFromTSFE(TypoScriptFrontendController $TSFE)
+    public static function getAbsRefPrefixFromTSFE(OverriddenTypoScriptFrontendController $TSFE)
     {
         $absRefPrefix = '';
         if (empty($TSFE->config['config']['absRefPrefix'])) {

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -14,7 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 
 
 /**
@@ -33,7 +33,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     protected $tagName = 'form';
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $frontendController;
 

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -27,10 +27,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -48,7 +48,7 @@ class RelationTest extends IntegrationTest
     public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn($fixtureName)
     {
         $this->importDataSetFromFixture($fixtureName);
-        $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TSFE'] = $this->getMockBuilder(OverriddenTypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
         $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
         /* @var ContentObjectRenderer $contentObjectRenderer */
         $contentObjectRendererMock = $this->getMockBuilder(ContentObjectRenderer::class)->setConstructorArgs([$GLOBALS['TSFE']])->getMock();

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -97,11 +97,13 @@ class IndexServiceTest extends IntegrationTest
             ]
         ];
     }
+
     /**
-     *
      * @dataProvider canResolveAbsRefPrefixDataProvider
      * @param string $absRefPrefix
      * @param string $expectedUrl
+     * @throws \ApacheSolrForTypo3\Solr\System\Environment\WebRootAllReadyDefinedException
+     * @throws \TYPO3\CMS\Core\Tests\Exception
      * @test
      */
     public function canResolveAbsRefPrefix($absRefPrefix, $expectedUrl)

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+    </sys_language>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_mode = strict
+
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello solr</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestPostProcessor.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestPostProcessor.php
@@ -2,7 +2,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\PageDocumentPostProcessor;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 
 class TestPostProcessor implements PageDocumentPostProcessor{
 
@@ -11,10 +11,10 @@ class TestPostProcessor implements PageDocumentPostProcessor{
      * Can be used to trigger actions when all contextual variables of the pageDocument to be indexed are known
      *
      * @param \Apache_Solr_Document $pageDocument the generated page document
-     * @param TypoScriptFrontendController $page the page object with information about page id or language
+     * @param OverriddenTypoScriptFrontendController $page the page object with information about page id or language
      * @return void
      */
-    public function postProcessPageDocument(\Apache_Solr_Document $pageDocument, TypoScriptFrontendController $page)
+    public function postProcessPageDocument(\Apache_Solr_Document $pageDocument, OverriddenTypoScriptFrontendController $page)
     {
         $pageDocument->addField('postProcessorField_stringS','postprocessed');
     }

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 
 use ApacheSolrForTypo3\Solr\Util;
@@ -34,7 +35,6 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageGenerator;
 use TYPO3\CMS\Frontend\Utility\EidUtility;
 use TYPO3\CMS\Install\Service\SqlExpectedSchemaService;
@@ -243,12 +243,13 @@ abstract class IntegrationTest extends FunctionalTestCase
     }
 
     /**
-     * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+     * @return OverriddenTypoScriptFrontendController
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
      */
     protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $config = [])
     {
-        /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
-        $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
+        /** @var $TSFE OverriddenTypoScriptFrontendController */
+        $TSFE = GeneralUtility::makeInstance(OverriddenTypoScriptFrontendController::class,
             $TYPO3_CONF_VARS, $id, $type, $no_cache, $cHash, $_2, $MP, $RDCT);
 
 
@@ -387,7 +388,8 @@ abstract class IntegrationTest extends FunctionalTestCase
     /**
      * @param integer $pageId
      * @param array $feUserGroupArray
-     * @return TypoScriptFrontendController
+     * @return OverriddenTypoScriptFrontendController
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
      */
     protected function fakeTSFE($pageId, $feUserGroupArray = [0])
     {

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -40,7 +41,7 @@ class TypoScriptConfigurationTest extends IntegrationTest
      * @return void
      */
     public function setUp() {
-        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $tsfe = $this->getMockBuilder(OverriddenTypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
         $tsfe->cObjectDepthCounter = 50;
         $GLOBALS['TSFE'] = $tsfe;
         parent::setUp();

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\SystemLanguage\SystemLanguageRepository;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
@@ -76,7 +77,7 @@ class ConnectionManagerTest extends UnitTest
      */
     public function setUp()
     {
-        $TSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $TSFE = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $GLOBALS['TSFE'] = $TSFE;
 
         /** @var $GLOBALS ['TSFE']->tmpl  \TYPO3\CMS\Core\TypoScript\TemplateService */

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ContentObject\Classification;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -77,7 +78,7 @@ class ClassificationTest extends UnitTest
             Classification::class
         ];
 
-        $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);
+        $GLOBALS['TSFE'] = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
 
         $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
             ->setMethods(['getResourceFactory', 'getEnvironmentVariable'])

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -93,7 +94,7 @@ class MultivalueTest extends UnitTest
             Multivalue::class
         ];
 
-        $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);
+        $GLOBALS['TSFE'] = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
 
         $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
             ->setMethods(['getResourceFactory', 'getEnvironmentVariable'])

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
 use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -79,7 +80,7 @@ class BuilderTest extends UnitTest
      */
     public function canBuildApacheSolrDocumentFromEmptyPage()
     {
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakePage = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
         $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
 
@@ -99,7 +100,7 @@ class BuilderTest extends UnitTest
      */
     public function canSetKeywordsForApacheSolrDocument()
     {
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakePage = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
         $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
 
@@ -118,7 +119,7 @@ class BuilderTest extends UnitTest
      */
     public function canSetEndtimeForApacheSolrDocument()
     {
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakePage = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
         $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
 
@@ -137,7 +138,7 @@ class BuilderTest extends UnitTest
      */
     public function canSetTagFieldsForApacheSolrDocument()
     {
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakePage = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
         $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
 

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -27,9 +27,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\FrequentSearches;
 use ApacheSolrForTypo3\Solr\Domain\Search\FrequentSearches\FrequentSearchesService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Core\Cache\Frontend\AbstractFrontend;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class FrequentSearchesServiceTest extends UnitTest
 {
@@ -39,7 +39,7 @@ class FrequentSearchesServiceTest extends UnitTest
     protected $frequentSearchesService;
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $tsfeMock;
 
@@ -63,7 +63,7 @@ class FrequentSearchesServiceTest extends UnitTest
      */
     public function setUp()
     {
-        $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
+        $this->tsfeMock = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $this->statisticsRepositoryMock = $this->getDumbMock(StatisticsRepository::class );
         $this->cacheMock = $this->getDumbMock(AbstractFrontend::class);
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -35,8 +35,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -49,7 +49,7 @@ class SuggestServiceTest extends UnitTest
     protected $suggestService;
 
     /**
-     * @var TypoScriptFrontendController
+     * @var OverriddenTypoScriptFrontendController
      */
     protected $tsfeMock;
 
@@ -78,7 +78,7 @@ class SuggestServiceTest extends UnitTest
      */
     public function setUp()
     {
-        $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
+        $this->tsfeMock = $this->getDumbMock(OverriddenTypoScriptFrontendController::class);
         $this->searchResultSetServiceMock = $this->getDumbMock(SearchResultSetService::class);
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);


### PR DESCRIPTION

add IndexingException, DocumentPreparationException to handle errors from TYPO3 CMS side properly
add OverriddenTypoScriptFrontendController extended from CMS::TypoScriptFrontendController
use allways OverriddenTypoScriptFrontendController instead of CMS::TypoScriptFrontendController
set constant EXT_SOLR_INDEXING_CONTEXT on __construct of IndexService to handle indexing process properly

Fixes: #1658