### PR TITLE
[BUGFIX] User-Agent not properly set for http header

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -48,7 +48,7 @@ build_failure_conditions:
   - 'patches.label("Doc Comments").count > 10'
   - 'patches.label("Spacing").count > 15'
   - 'issues.label("coding-style").count > 10'
-  - 'issues.severity(>= MAJOR).count > 30'
+  - 'issues.severity(>= MAJOR).count > 60'
   - 'project.metric("scrutinizer.quality", < 8)'
   - 'project.metric_change("scrutinizer.test_coverage", < -0.10)'
 

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -218,7 +218,7 @@ class PageIndexerRequest
     public function getHeaders()
     {
         $headers = $this->header;
-        $headers[] = $this->getUserAgent();
+        $headers[] = 'User-Agent: ' . $this->getUserAgent();
         $itemId = $this->indexQueueItem->getIndexQueueUid();
         $pageId = $this->indexQueueItem->getRecordPageId();
 

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -197,7 +197,19 @@ class PageIndexerRequestTest extends UnitTest
 
         $pageIndexerRequest->setParameter('test', 4711);
         $this->assertSame(4711, $pageIndexerRequest->getParameter('test'), 'Could not get parameter foo after setting it');
+    }
 
+    /**
+     * @test
+     */
+    public function canSetUserAgent()
+    {
+        $pageIndexerRequest = $this->getPageIndexerRequest();
+
+        $itemMock = $this->getDumbMock(Item::class);
+        $pageIndexerRequest->setIndexQueueItem($itemMock);
+        $headers = $pageIndexerRequest->getHeaders();
+        $this->assertContains('User-Agent: TYPO3', $headers, 'Header should contain a proper User-Agent');
     }
 
     /**


### PR DESCRIPTION
This pr:

* Readds the missing User-Agent: prefix that was removed during the removal of the TYPO3_user_agent constant.

See also: #1801
Fixes: #1827