### PR TITLE
[TASK] Use Guzzle API for HTTP Crawling Requests

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -222,4 +222,15 @@ class SolrConnection
 
         return $service;
     }
+
+    /**
+     * Creates a string representation of the Solr connection. Specifically
+     * will return the Solr URL.
+     *
+     * @return string The Solr URL.
+     */
+    public function __toString()
+    {
+        return $this->scheme . '://' . $this->host . ':' . $this->port . $this->path;
+    }
 }


### PR DESCRIPTION
Use TYPO3 v8's included crawling functionality with Guzzle to support cURL-based requests.