### PR TITLE
[TASK] Limit pages to default language

### DIFF
--- a/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
+++ b/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
@@ -28,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\System\Records\SystemLanguage;
 use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -73,6 +74,7 @@ class SystemLanguageRepository extends AbstractRepository implements SingletonIn
         $languages = [0];
 
         $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(HiddenRestriction::class));
         $languageRecords = $queryBuilder->select('uid')
             ->from($this->table)
             ->execute()->fetchAll();


### PR DESCRIPTION
For TYPO3 v9, pages can have multiple languages.

If TYPO3 v9 has translated pages, the siteroot
is checked for that translated page as well.

Currently, solr fetches connections for all
is_siteroot pages, setting up too many connections.

Additionally, only fetch languages which are
not hidden in the system to create connections.