### PR TITLE
[TASK] Catch NoPidException in RecordMonitor

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -263,15 +263,19 @@ class RecordMonitor extends AbstractDataHandlerListener
             return;
         }
 
-        $recordPageId = $this->getRecordPageId($status, $recordTable, $recordUid, $uid, $fields, $tceMain);
+        try {
+            $recordPageId = $this->getRecordPageId($status, $recordTable, $recordUid, $uid, $fields, $tceMain);
 
-        // when a content element changes we need to updated the page instead
-        if ($recordTable === 'tt_content') {
-            $recordTable = 'pages';
-            $recordUid = $recordPageId;
+            // when a content element changes we need to updated the page instead
+            if ($recordTable === 'tt_content') {
+                $recordTable = 'pages';
+                $recordUid = $recordPageId;
+            }
+
+            $this->processRecord($recordTable, $recordPageId, $recordUid, $fields);
+        } catch (NoPidException $e) {
+            // do nothing
         }
-
-        $this->processRecord($recordTable, $recordPageId, $recordUid, $fields);
     }
 
     /**


### PR DESCRIPTION
To avoid exceptions shown to the user, this exection
must be caught.