### PR TITLE
[BUGFIX] SearchRequest::setGroupItemPage should be able to handle a solr group query as $groupItemValue

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -451,7 +451,8 @@ class SearchRequest
     public function setGroupItemPage(string $groupName, string $groupItemValue, int $page): SearchRequest
     {
         $this->stateChanged = true;
-        $path = $this->prefixWithNamespace('groupPage:' . $groupName . ':' . $groupItemValue);
+        $escapedValue = $this->getEscapedGroupItemValue($groupItemValue);
+        $path = $this->prefixWithNamespace('groupPage:' . $groupName . ':' . $escapedValue);
         $this->argumentsAccessor->set($path, $page);
         return $this;
     }
@@ -465,8 +466,20 @@ class SearchRequest
      */
     public function getGroupItemPage(string $groupName, string $groupItemValue): int
     {
-        $path = $this->prefixWithNamespace('groupPage:' . $groupName . ':' . $groupItemValue);
+        $escapedValue = $this->getEscapedGroupItemValue($groupItemValue);
+        $path = $this->prefixWithNamespace('groupPage:' . $groupName . ':' . $escapedValue);
         return max(1, (int)$this->argumentsAccessor->get($path));
+    }
+
+    /**
+     * Removes all non alphanumeric values from the groupItem value to have a valid array key.
+     *
+     * @param string $groupItemValue
+     * @return string
+     */
+    protected function getEscapedGroupItemValue(string $groupItemValue)
+    {
+        return preg_replace("/[^A-Za-z0-9]/", '', $groupItemValue);
     }
 
     /**

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -197,7 +197,6 @@ class SearchUriBuilder
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->setGroupItemPage($groupItem->getGroup()->getGroupName(), $groupItem->getGroupValue(), $page)
             ->getAsArray();
-
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $persistentAndFacetArguments);
     }

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -313,6 +313,18 @@ class SearchRequestTest extends UnitTest
     /**
      * @test
      */
+    public function canSetGroupItemPageForQuery()
+    {
+        $query = 'tx_solr%5Bq%5D=typo3';
+        $request = $this->getSearchRequestFromQueryString($query);
+        $request->setGroupItemPage('pidGroup', 'pid:[0 to 5]', 3);
+
+        $this->assertSame(3, $request->getGroupItemPage('pidGroup', 'pid:[0 to 5]'), 'Can not set and get groupItemPage for a query');
+    }
+
+    /**
+     * @test
+     */
     public function canResetAllGroupItemPages()
     {
         $query = 'tx_solr%5Bq%5D=typo3';


### PR DESCRIPTION
This pr:

* Allows to use solr queries as $groupItemValue and generate proper urls

Fixes: #1852