### PR TITLE
[TASK] sortBy should be a global grouping setting, not on a group base

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
@@ -240,6 +240,7 @@ class Grouping extends AbstractDeactivatableParameterBuilder implements Paramete
         $resultsPerGroup = $solrConfiguration->getSearchGroupingHighestGroupResultsLimit();
         $configuredGroups = $solrConfiguration->getSearchGroupingGroupsConfiguration();
         $numberOfGroups = $solrConfiguration->getSearchGroupingNumberOfGroups();
+        $sortBy = $solrConfiguration->getSearchGroupingSortBy();
 
         foreach ($configuredGroups as $groupName => $groupConfiguration) {
             if (isset($groupConfiguration['field'])) {
@@ -247,9 +248,10 @@ class Grouping extends AbstractDeactivatableParameterBuilder implements Paramete
             } elseif (isset($groupConfiguration['query'])) {
                 $queries[] = $groupConfiguration['query'];
             }
-            if (isset($groupConfiguration['sortBy'])) {
-                $sortings[] = $groupConfiguration['sortBy'];
-            }
+        }
+
+        if (!empty(trim($sortBy))) {
+            $sortings[] = $sortBy;
         }
 
         return new Grouping($isEnabled, $fields, $sortings, $queries, $numberOfGroups, $resultsPerGroup);

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -2279,6 +2279,19 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns the sortBy configuration for the grouping.
+     *
+     * plugin.tx_solr.search.grouping.sortBy
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+    public function getSearchGroupingSortBy($defaultIfEmpty = '')
+    {
+        return (string)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.grouping.sortBy', $defaultIfEmpty);
+    }
+
+    /**
      * Returns the highestValue of the numberOfResultsPerGroup configuration that is globally configured and
      * for each group.
      *

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Grouping;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class GroupingTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canBuildSortingFromConfiguration()
+    {
+        $typoScriptConfiguration = new TypoScriptConfiguration(
+            [
+                'plugin.' => [
+                    'tx_solr.' => [
+                        'search.' => [
+                            'grouping' => 1,
+                            'grouping.' => [
+                                'sortBy' => 'title desc'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
+        $grouping = Grouping::fromTypoScriptConfiguration($typoScriptConfiguration);
+        $this->assertSame(['title desc'], $grouping->getSortings(), 'Could not set sortings from TypoScriptConfiguration');
+    }
+
+}


### PR DESCRIPTION
This pr:

* Moves the setting from a grouped based setting to a global grouping setting, since the sorting can not be set on a group base in apache solr

Fixes: #1855