### PR TITLE
[BUGFIX] targetPageId is not used in SearchFormViewHelper

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -99,7 +99,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
             $pageUid = $this->getTypoScriptConfiguration()->getSearchTargetPage();
         }
 
-        $uri = $this->buildUriFromArguments();
+        $uri = $this->buildUriFromPageUidAndArguments($pageUid);
 
         $this->tag->addAttribute('action', trim($uri));
         if ($this->arguments['addSuggestUrl']) {
@@ -109,17 +109,25 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         $this->tag->addAttribute('accept-charset', $this->frontendController->metaCharset);
 
         // Get search term
-        $this->templateVariableContainer->add('q', $this->getQueryString());
-        $this->templateVariableContainer->add('pageUid', $pageUid);
-        $this->templateVariableContainer->add('languageUid', $this->frontendController->sys_language_uid);
+        $this->getTemplateVariableContainer()->add('q', $this->getQueryString());
+        $this->getTemplateVariableContainer()->add('pageUid', $pageUid);
+        $this->getTemplateVariableContainer()->add('languageUid', $this->frontendController->sys_language_uid);
         $formContent = $this->renderChildren();
-        $this->templateVariableContainer->remove('q');
-        $this->templateVariableContainer->remove('pageUid');
-        $this->templateVariableContainer->remove('languageUid');
+        $this->getTemplateVariableContainer()->remove('q');
+        $this->getTemplateVariableContainer()->remove('pageUid');
+        $this->getTemplateVariableContainer()->remove('languageUid');
 
         $this->tag->setContent($formContent);
 
         return $this->tag->render();
+    }
+
+    /**
+     * @return \TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface
+     */
+    protected function getTemplateVariableContainer()
+    {
+        return $this->templateVariableContainer;
     }
 
     /**
@@ -162,12 +170,13 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     }
 
     /**
+     * @param int|null $pageUid
      * @return string
      */
-    protected function buildUriFromArguments(): string
+    protected function buildUriFromPageUidAndArguments($pageUid): string
     {
         $uriBuilder = $this->getControllerContext()->getUriBuilder();
-        $uri = $uriBuilder->reset()->setTargetPageUid($this->arguments['pageUid'])->setTargetPageType($this->arguments['pageType'])->setNoCache($this->arguments['noCache'])->setUseCacheHash(!$this->arguments['noCacheHash'])->setArguments($this->arguments['additionalParams'])->setCreateAbsoluteUri($this->arguments['absolute'])->setAddQueryString($this->arguments['addQueryString'])->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString'])->setAddQueryStringMethod($this->arguments['addQueryStringMethod'])->setSection($this->arguments['section'])->build();
+        $uri = $uriBuilder->reset()->setTargetPageUid($pageUid)->setTargetPageType($this->arguments['pageType'])->setNoCache($this->arguments['noCache'])->setUseCacheHash(!$this->arguments['noCacheHash'])->setArguments($this->arguments['additionalParams'])->setCreateAbsoluteUri($this->arguments['absolute'])->setAddQueryString($this->arguments['addQueryString'])->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString'])->setAddQueryStringMethod($this->arguments['addQueryStringMethod'])->setSection($this->arguments['section'])->build();
         return $uri;
     }
 }

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -1,0 +1,128 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\ViewHelpers\Facet\Options\Group\Prefix;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\ViewHelpers\SearchFormViewHelper;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SearchFormViewHelperTest extends UnitTest
+{
+    /**
+     * @var SearchFormViewHelper
+     */
+    protected $viewHelper;
+
+    /**
+     * @var UriBuilder
+     */
+    protected $uriBuilderMock;
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $typoScriptConfigurationMock;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->uriBuilderMock = $this->getDumbMock(UriBuilder::class);
+        $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $controllerContextMock = $this->getDumbMock(ControllerContext::class);
+        $controllerContextMock->expects($this->once())->method('getUriBuilder')->willReturn($this->uriBuilderMock);
+
+        $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)->setMethods(['getControllerContext', 'getTypoScriptConfiguration', 'getTemplateVariableContainer', 'getSearchResultSet', 'renderChildren'])->getMock();
+        $this->viewHelper->expects($this->any())->method('getControllerContext')->willReturn($controllerContextMock);
+        $this->viewHelper->expects($this->any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
+        $this->viewHelper->expects($this->any())->method('getTemplateVariableContainer')->willReturn($this->getDumbMock(VariableProviderInterface::class));
+        $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn('');
+
+    }
+
+    /**
+     * @param integer $pageUid
+     */
+    protected function assertUriIsBuildForPageUid($pageUid)
+    {
+        $this->uriBuilderMock->expects($this->any())->method('reset')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setTargetPageUid')->with($pageUid)->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setTargetPageType')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setNoCache')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setUseCacheHash')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setArguments')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setCreateAbsoluteUri')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setArgumentsToBeExcludedFromQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setAddQueryStringMethod')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('setSection')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects($this->once())->method('build')->willReturn('index.php?id=' . $pageUid);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetTargetPageUidFromConfigurationWhenNullWasPassed()
+    {
+        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(888);
+        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->viewHelper->setArguments(['additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
+
+        $this->assertUriIsBuildForPageUid(888);
+        $this->viewHelper->render();
+    }
+
+    /**
+     * @test
+     */
+    public function canUsePassedPageUidWhenNoTargetPageIsConfigured()
+    {
+        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(0);
+        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->viewHelper->setArguments(['pageUid' => 4711, 'additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
+
+        $this->assertUriIsBuildForPageUid(4711);
+        $this->viewHelper->render();
+    }
+
+    /**
+     * @test
+     */
+    public function passedPageUidHasPriorityOverConfiguredTargetPageUid()
+    {
+        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(888);
+        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->viewHelper->setArguments(['pageUid' => 4711, 'additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
+
+        $this->assertUriIsBuildForPageUid(4711);
+        $this->viewHelper->render();
+    }
+}


### PR DESCRIPTION
This pr:

* Passes $pageUid after merging arguments and TypoScript configuration
* Add's a testcase for all scenarios

Fixes: #1860