### PR TITLE
[BUGFIX] PHP Warning in BE module "Index Queue"

### DIFF
--- a/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
@@ -73,6 +73,22 @@ class IfHasAccessToModuleViewHelper extends AbstractConditionViewHelper
         return $hasAccessToModule;
     }
 
+    /**
+     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+     *
+     * @todo This copy of the render method is just required for TYPO3 8 backwards compatibility, can be dropped when TYPO3 8 support is dropped.
+     *
+     * @param bool $condition View helper condition
+     * @return string the rendered string
+     */
+    public function render()
+    {
+        if (static::evaluateCondition($this->arguments)) {
+            return $this->renderThenChild();
+        }
+        return $this->renderElseChild();
+    }
+
     protected static function getModuleConfiguration(string $moduleSignature)
     {
         return $GLOBALS['TBE_MODULES']['_configuration'][$moduleSignature];


### PR DESCRIPTION
This pr:

* Add's a render method to IfHasAccessToModuleViewHelper to avoid a warning with TYPO3 8
* The method can be removed when TYPO3 8 support is dropped

Fixes: #1864