### PR TITLE
[TASK] do not die on indexing process

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -249,6 +249,8 @@ class IndexQueueModuleController extends AbstractModuleController
     /**
      * Indexes a few documents with the index service.
      * @return void
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\StopActionException
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\UnsupportedRequestTypeException
      */
     public function doIndexingRunAction()
     {

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -87,6 +87,7 @@ class IndexService
         $this->indexQueue = $queue ?? GeneralUtility::makeInstance(Queue::class);
         $this->signalSlotDispatcher = $dispatcher ?? GeneralUtility::makeInstance(Dispatcher::class);
         $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        define('EXT_SOLR_INDEXING_CONTEXT', true);
     }
 
     /**

--- a/Classes/Domain/Search/LastSearches/LastSearchesService.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesService.php
@@ -28,8 +28,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\LastSearches;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Generic\Session;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * The LastSearchesService is responsible to return the LastSearches from the session or database,

--- a/Classes/IndexQueue/Exception/DocumentPreparationException.php
+++ b/Classes/IndexQueue/Exception/DocumentPreparationException.php
@@ -1,0 +1,33 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\IndexQueue\Exception;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-eb-support@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Exception that is thrown on TYPO3 side in indexing process.
+ */
+class DocumentPreparationException extends IndexingException
+{
+}

--- a/Classes/IndexQueue/Exception/IndexingException.php
+++ b/Classes/IndexQueue/Exception/IndexingException.php
@@ -1,0 +1,34 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\IndexQueue\Exception;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-eb-support@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Exception that is thrown on indexing process. Does not matter on which side, TYPO3 or Apache.
+ * This exception should be used for any errors on indexing process.
+ */
+class IndexingException extends \Exception
+{
+}

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -27,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Access\RootlineElement;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**

--- a/Classes/System/Mvc/Frontend/Controller/OverriddenTypoScriptFrontendController.php
+++ b/Classes/System/Mvc/Frontend/Controller/OverriddenTypoScriptFrontendController.php
@@ -1,0 +1,64 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Exception\DocumentPreparationException;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Overrides TYPO3 CMS TypoScriptFrontendController TSFE to prevent PHP on indexing processes from dieing.
+ */
+class OverriddenTypoScriptFrontendController extends TypoScriptFrontendController
+{
+    /**
+     * Page unavailable handler for use in frontend plugins from extensions.
+     *
+     * @param string $reason Reason text
+     * @param string $header HTTP header to send
+     * @throws DocumentPreparationException
+     */
+    public function pageUnavailableAndExit($reason = '', $header = '')
+    {
+        if (!defined('EXT_SOLR_INDEXING_CONTEXT')) {
+            parent::pageUnavailableAndExit($reason, $header);
+        }
+        throw new DocumentPreparationException('Solr Document can not be prepared. The Reason: ' . $reason, 1517584040);
+    }
+
+    /**
+     * Page-not-found handler for use in frontend plugins from extensions.
+     *
+     * @param string $reason Reason text
+     * @param string $header HTTP header to send
+     * @throws DocumentPreparationException
+     */
+    public function pageNotFoundAndExit($reason = '', $header = '')
+    {
+        if (!defined('EXT_SOLR_INDEXING_CONTEXT')) {
+            parent::pageNotFoundAndExit($reason, $header);
+        }
+        throw new DocumentPreparationException('Solr Document can not be prepared. The Reason: ' . $reason, 1517584045);
+    }
+}

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -27,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr;
 use Apache_Solr_Document;
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
-use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\FieldProcessor\Service;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -24,22 +24,19 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -320,7 +317,7 @@ class Util
         if (!isset($tsfeCache[$cacheId]) || !$useCache) {
             GeneralUtility::_GETset($language, 'L');
 
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
+            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(OverriddenTypoScriptFrontendController::class,
                 $GLOBALS['TYPO3_CONF_VARS'], $pageId, 0);
 
             // for certain situations we need to trick TSFE into granting us
@@ -446,10 +443,10 @@ class Util
      * Resolves the configured absRefPrefix to a valid value and resolved if absRefPrefix
      * is set to "auto".
      *
-     * @param TypoScriptFrontendController $TSFE
+     * @param OverriddenTypoScriptFrontendController $TSFE
      * @return string
      */
-    public static function getAbsRefPrefixFromTSFE(TypoScriptFrontendController $TSFE)
+    public static function getAbsRefPrefixFromTSFE(OverriddenTypoScriptFrontendController $TSFE)
     {
         $absRefPrefix = '';
         if (empty($TSFE->config['config']['absRefPrefix'])) {

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -27,11 +27,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -52,7 +52,7 @@ class RelationTest extends IntegrationTest
             $this->markTestSkipped('This testcase is relevant for TYPO3 8 only');
         }
         $this->importDataSetFromFixture($fixtureName);
-        $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TSFE'] = $this->getMockBuilder(OverriddenTypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
         $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
         /* @var ContentObjectRenderer $contentObjectRenderer */
         $contentObjectRendererMock = $this->getMockBuilder(ContentObjectRenderer::class)->setConstructorArgs([$GLOBALS['TSFE']])->getMock();

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -97,11 +97,13 @@ class IndexServiceTest extends IntegrationTest
             ]
         ];
     }
+
     /**
-     *
      * @dataProvider canResolveAbsRefPrefixDataProvider
      * @param string $absRefPrefix
      * @param string $expectedUrl
+     * @throws \ApacheSolrForTypo3\Solr\System\Environment\WebRootAllReadyDefinedException
+     * @throws \TYPO3\CMS\Core\Tests\Exception
      * @test
      */
     public function canResolveAbsRefPrefix($absRefPrefix, $expectedUrl)

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <hidden>0</hidden>
+        <title>German</title>
+        <flag>de</flag>
+        <language_isocode>de</language_isocode>
+        <static_lang_isocode>0</static_lang_isocode>
+    </sys_language>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.sys_language_mode = strict
+
+                config.sys_language_uid = 0
+                config.linkVars = L
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello solr</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -25,15 +25,19 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Exception\DocumentPreparationException;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Testcase to check if we can index page documents using the PageIndexer
@@ -313,6 +317,52 @@ class PageIndexerTest extends IntegrationTest
     }
 
     /**
+     * This Test should tests, that TYPO3 CMS on FE does not die if page is not available.
+     * If something goes wrong the exception must be thrown instead of dieing, to make marking the items as failed possible.
+     *
+     * @test
+     */
+    public function phpProcessDoesNotDieIfPageIsNotAvailable() {
+        $this->applyXClassOverriddenTypoScriptFrontendController();
+        $this->applyUsingErrorControllerForCMS9andAbove();
+        $this->registerShutdownFunctionToPrintExplanationOf404HandlingOnCMSIfDieIsCalled();
+
+        if(Util::getIsTYPO3VersionBelow9()) {
+            $this->expectException(DocumentPreparationException::class);
+        } else {
+            $this->expectException(PageNotFoundException::class);
+        }
+
+        $this->importDataSetFromFixture('does_not_die_if_page_not_available.xml');
+        define('EXT_SOLR_INDEXING_CONTEXT', true);
+        $this->executePageIndexer(null, null, null, null, null, null, null, null, 3, ['sys_language_mode' => 'strict']);
+    }
+
+    /**
+     * Registers shutdown function to print proper information about TYPO3 CMS behaviour on unavailable pages.
+     */
+    protected function registerShutdownFunctionToPrintExplanationOf404HandlingOnCMSIfDieIsCalled()
+    {
+        register_shutdown_function(function() {
+            // prompt only after phpProcessDoesNotDieIfPageIsNotAvailable() test case
+            if ($this->getName() !== 'phpProcessDoesNotDieIfPageIsNotAvailable') {
+                return;
+            }
+
+            // don't show HTML or other stuff from CMS in output
+            ob_clean();
+
+            $message = PHP_EOL . PHP_EOL . PHP_EOL .
+                'Note: This test case kills whole PHPUnit process on failing, which is expected behaviour, because TYPO3 CMS uses die() function in cases if page or record is not available.';
+            $message .= PHP_EOL . PHP_EOL . 'TYPO3 CMS API for registering shutdown callbacks for handling of unavailable pages is changed.' . PHP_EOL .
+                'TypoScriptFrontendController::pageUnavailableAndExit() is not called anymore.' . PHP_EOL .
+                'Please refer to the TYPO3 CMS documentation and use new API for this functionality.';
+
+            printf(PHP_EOL . PHP_EOL . "\033[01;31m%s\033[0m", $message);
+        });
+    }
+
+    /**
      * @param array $typo3ConfVars
      * @param int $pageId
      * @param int $type
@@ -322,20 +372,22 @@ class PageIndexerTest extends IntegrationTest
      * @param string $MP
      * @param string $RDCT
      * @param int $languageId
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
      */
-    protected function executePageIndexer($typo3ConfVars = [], $pageId = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $languageId = 0)
+    protected function executePageIndexer($typo3ConfVars = [], $pageId = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $languageId = 0, $additionalConfigs = [])
     {
         GeneralUtility::_GETset($languageId, 'L');
         $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
 
         $config = [
-            'config' => [
+            'config' => array_merge([
                 'index_enable' => 1,
                 'sys_language_uid' => $languageId
-            ]
+            ], $additionalConfigs)
         ];
 
         unset($GLOBALS['TSFE']);
+
         $TSFE = $this->getConfiguredTSFE($typo3ConfVars, $pageId, $type, $no_cache, $cHash, $_2, $MP, $RDCT, $config);
         $TSFE->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $GLOBALS['TSFE'] = $TSFE;
@@ -343,6 +395,7 @@ class PageIndexerTest extends IntegrationTest
         /** @var $request \ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest */
         $request = GeneralUtility::makeInstance(PageIndexerRequest::class);
         $request->setParameter('item', 4711);
+
         /** @var $request \ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse */
         $response = GeneralUtility::makeInstance(PageIndexerResponse::class);
 
@@ -351,5 +404,26 @@ class PageIndexerTest extends IntegrationTest
         $pageIndexer->activate();
         $pageIndexer->processRequest($request, $response);
         $pageIndexer->hook_indexContent($TSFE);
+    }
+
+    /**
+     * Simulates loading in ext_localconf.php loaded XClass for TSFE.
+     */
+    private function applyXClassOverriddenTypoScriptFrontendController()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TypoScriptFrontendController::class] = array(
+            'className' => OverriddenTypoScriptFrontendController::class
+        );
+    }
+
+    /**
+     * Applies in CMS 9.2 introduced error handling.
+     */
+    private function applyUsingErrorControllerForCMS9andAbove()
+    {
+        if(Util::getIsTYPO3VersionBelow9()) {
+            return;
+        }
+        $GLOBALS['TYPO3_REQUEST'] = new ServerRequest();
     }
 }

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -40,7 +41,7 @@ class TypoScriptConfigurationTest extends IntegrationTest
      * @return void
      */
     public function setUp() {
-        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $tsfe = $this->getMockBuilder(OverriddenTypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
         $tsfe->cObjectDepthCounter = 50;
         $GLOBALS['TSFE'] = $tsfe;
         parent::setUp();

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -37,7 +37,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,6 +16,13 @@ if (!function_exists('strptime')) {
 // registering Index Queue page indexer helpers
 
 if (TYPO3_MODE == 'FE' && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])) {
+
+    // prevent indexing process from die() if page does not exist to be able to log errors properly.
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class] = array(
+        'className' => \ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController::class
+    );
+    define('EXT_SOLR_INDEXING_CONTEXT', true);
+
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/index_ts.php']['preprocessRequest']['ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequestHandler'] = \ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequestHandler::class . '->run';
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer'] = \ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer::class;
 


### PR DESCRIPTION

* add IndexingException, DocumentPreparationException to handle errors on Indexing process properly
* add OverriddenTypoScriptFrontendController extended from CMS::TypoScriptFrontendController
  * use it in Util and in ext_localconf.php if Frontend-Helping things are triggered
  * define EXT_SOLR_INDEXING_CONTEXT on indexing processes and handle then differently
  * on __construct of IndexService and in ext_localconf
* add test case with dieing part of TYPO3 CMS for pages indexing

Fixes: #1658
