### PR TITLE
[TASK] Reduce complexity of search method in SearchResultSetService

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -125,6 +125,11 @@ class SearchResultSet
     protected $correctedQueryString = '';
 
     /**
+     * @var bool
+     */
+    protected $hasSearched = false;
+
+    /**
      * @return \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet
      */
     public function __construct()
@@ -412,5 +417,19 @@ class SearchResultSet
         $this->correctedQueryString = $correctedQueryString;
     }
 
+    /**
+     * @return boolean
+     */
+    public function getHasSearched(): bool
+    {
+        return $this->hasSearched;
+    }
 
+    /**
+     * @param boolean $hasSearched
+     */
+    public function setHasSearched(bool $hasSearched)
+    {
+        $this->hasSearched = $hasSearched;
+    }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SearchResultSetServiceTest extends UnitTest
+{
+    /**
+     * @var SearchResultSetService
+     */
+    protected $searchResultSetService;
+
+    /**
+     * @var TypoScriptConfiguration
+     */
+    protected $configurationMock;
+
+    /**
+     * @var Search
+     */
+    protected $searchMock;
+
+    /**
+     * @var SolrLogManager
+     */
+    protected $logManagerMock;
+
+    /**
+     * @var SearchResultBuilder
+     */
+    protected $searchResultBuilderMock;
+
+    /**
+     * @var QueryBuilder
+     */
+    protected $queryBuilderMock;
+
+    public function setUp()
+    {
+        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $this->searchMock = $this->getDumbMock(Search::class);
+        $this->searchResultBuilderMock = $this->getDumbMock(SearchResultBuilder::class);
+        $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
+        $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock);
+    }
+
+    /**
+     * @test
+     */
+    public function searchIsNotTriggeredWhenEmptySearchDisabledAndEmptyQueryWasPassed()
+    {
+        $searchRequest = new SearchRequest();
+        $searchRequest->setRawQueryString(null);
+        $this->assertAllInitialSearchesAreDisabled();
+        $resultSet = $this->searchResultSetService->search($searchRequest);
+        $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
+    }
+
+    /**
+     * @test
+     */
+    public function searchIsNotTriggeredWhenEmptyQueryWasPassedAndEmptySearchWasDisabled()
+    {
+        $searchRequest = new SearchRequest();
+        $searchRequest->setRawQueryString("");
+        $this->configurationMock->expects($this->once())->method('getSearchQueryAllowEmptyQuery')->willReturn(false);
+        $resultSet = $this->searchResultSetService->search($searchRequest);
+        $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertAllInitialSearchesAreDisabled()
+    {
+        $this->configurationMock->expects($this->any())->method('getSearchInitializeWithEmptyQuery')->willReturn(false);
+        $this->configurationMock->expects($this->any())->method('getSearchShowResultsOfInitialEmptyQuery')->willReturn(false);
+        $this->configurationMock->expects($this->any())->method('getSearchInitializeWithQuery')->willReturn(false);
+        $this->configurationMock->expects($this->any())->method('getSearchShowResultsOfInitialQuery')->willReturn(false);
+    }
+}


### PR DESCRIPTION
The "search" method in the SearchResultSetService is very long an complex and could be split into multiple methods.

This pr:

* Splits the method into multiple methods
* Add's unit tests for several use cases

Fixes: #1871