### PR TITLE
[TASK] Move Sorting to Domain/Search/ResultSet/Sorting/SortingHelper

### DIFF
--- a/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
+++ b/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015-2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Class SortingHelper
+ */
+class SortingHelper {
+
+    /**
+     * @var array
+     */
+    protected $configuration = [];
+
+    /**
+     * Constructor
+     *
+     * @param array $sortingConfiguration Raw configuration from plugin.tx_solr.search.sorting.options
+     */
+    public function __construct(array $sortingConfiguration)
+    {
+        $this->configuration = $sortingConfiguration;
+    }
+
+    /**
+     * Gets a list of configured sorting fields.
+     *
+     * @deprecated Since 8.1 will be removed in EXT:solr 9.0
+     * @return array Array of (resolved) sorting field names.
+     */
+    public function getSortFields()
+    {
+        trigger_error('SortingHelper::getSortFields is deprecated please use the sorting of the SearchResultSet now or retrieve it on your own.', E_USER_DEPRECATED);
+        $sortFields = [];
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+        foreach ($this->configuration as $optionName => $optionConfiguration) {
+            $fieldName = $contentObject->stdWrap(
+                $optionConfiguration['field'],
+                $optionConfiguration['field.']
+            );
+
+            $sortFields[] = $fieldName;
+        }
+
+        return $sortFields;
+    }
+
+    /**
+     * Takes the tx_solr[sort] URL parameter containing the option names and
+     * directions to sort by and resolves it to the actual sort fields and
+     * directions as configured through TypoScript. Makes sure that only
+     * configured sorting options get applied to the query.
+     *
+     * @param string $urlParameters tx_solr[sort] URL parameter.
+     * @return string The actual index field configured to sort by for the given sort option name
+     * @throws \InvalidArgumentException if the given sort option is not configured
+     */
+    public function getSortFieldFromUrlParameter($urlParameters)
+    {
+        $sortFields = [];
+        $sortParameters = GeneralUtility::trimExplode(',', $urlParameters);
+
+        $removeTsKeyDot = function($sortingKey) { return trim($sortingKey, '.'); };
+        $configuredSortingName = array_map($removeTsKeyDot, array_keys($this->configuration));
+
+        foreach ($sortParameters as $sortParameter) {
+            list($sortOption, $sortDirection) = explode(' ', $sortParameter);
+
+            if (!in_array($sortOption, $configuredSortingName)) {
+                throw new \InvalidArgumentException('No sorting configuration found for option name ' . $sortOption, 1316187644);
+            }
+
+            $sortField = $this->configuration[$sortOption . '.']['field'];
+            $sortFields[] = $sortField . ' ' . $sortDirection;
+        }
+
+        return implode(', ', $sortFields);
+    }
+
+    /**
+     * Gets the sorting options with resolved field names in case stdWrap was
+     * used to define them.
+     *
+     * @deprecated Since 8.1 will be removed in EXT:solr 9.0
+     * @return array The sorting options with resolved field names.
+     */
+    public function getSortOptions()
+    {
+        trigger_error('SortingHelper::getSortOptions is deprecated please use the sorting of the SearchResultSet now or retrieve it on your own.', E_USER_DEPRECATED);
+
+        $sortOptions = [];
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+        foreach ($this->configuration as $optionName => $optionConfiguration) {
+            $optionField = $contentObject->stdWrap(
+                $optionConfiguration['field'],
+                $optionConfiguration['field.']
+            );
+
+            $optionLabel = $contentObject->stdWrap(
+                $optionConfiguration['label'],
+                $optionConfiguration['label.']
+            );
+
+            $optionName = substr($optionName, 0, -1);
+            $sortOptions[$optionName] = [
+                'field' => $optionField,
+                'label' => $optionLabel,
+                'defaultOrder' => $optionConfiguration['defaultOrder']
+            ];
+            if (isset($optionConfiguration['fixedOrder'])) {
+                $sortOptions[$optionName]['fixedOrder'] = $optionConfiguration['fixedOrder'];
+            }
+        }
+
+        return $sortOptions;
+    }
+}

--- a/Classes/Search/SortingComponent.php
+++ b/Classes/Search/SortingComponent.php
@@ -25,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Search;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\SortingHelper;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
-use ApacheSolrForTypo3\Solr\Sorting;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -56,30 +56,31 @@ class SortingComponent extends AbstractComponent implements QueryAware, SearchRe
      * Initializes the search component.
      *
      * Sets the sorting query parameters
-     *
      */
     public function initializeSearchComponent()
     {
         if (!empty($this->searchConfiguration['query.']['sortBy'])) {
-            $this->query->addQueryParameter('sort',
-                $this->searchConfiguration['query.']['sortBy']);
+            $this->query->addQueryParameter('sort', $this->searchConfiguration['query.']['sortBy']);
         }
 
         $arguments = $this->searchRequest->getArguments();
 
-        if (!empty($this->searchConfiguration['sorting'])
-            && !empty($arguments['sort'])
-            && preg_match('/^([a-z0-9_]+ (asc|desc)[, ]*)*([a-z0-9_]+ (asc|desc))+$/i',
-                $arguments['sort'])
-        ) {
-            $sortHelper = GeneralUtility::makeInstance(
-                Sorting::class,
-                $this->searchConfiguration['sorting.']['options.']
-            );
+        if (!empty($this->searchConfiguration['sorting']) && $this->hasValidSorting($arguments)) {
+            $sortHelper = GeneralUtility::makeInstance(SortingHelper::class, $this->searchConfiguration['sorting.']['options.']);
             $sortField = $sortHelper->getSortFieldFromUrlParameter($arguments['sort']);
-
             $this->query->setSorting($sortField);
         }
+    }
+
+    /**
+     * Checks if the arguments array has a valid sorting.
+     *
+     * @param array $arguments
+     * @return bool
+     */
+    protected function hasValidSorting(array $arguments)
+    {
+        return !empty($arguments['sort']) && preg_match('/^([a-z0-9_]+ (asc|desc)[, ]*)*([a-z0-9_]+ (asc|desc))+$/i', $arguments['sort']);
     }
 
     /**
@@ -99,5 +100,4 @@ class SortingComponent extends AbstractComponent implements QueryAware, SearchRe
     {
         $this->searchRequest = $searchRequest;
     }
-
 }

--- a/Classes/Sorting.php
+++ b/Classes/Sorting.php
@@ -25,17 +25,15 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\SortingHelper;
 
 /**
  * Utility class for sorting.
  *
  * @author Stefan Sprenger <stefan.sprenger@dkd.de>
  */
-class Sorting
+class Sorting extends SortingHelper
 {
-    protected $configuration;
 
     /**
      * Constructor
@@ -44,97 +42,7 @@ class Sorting
      */
     public function __construct(array $sortingConfiguration)
     {
-        $this->configuration = $sortingConfiguration;
-    }
-
-    /**
-     * Gets a list of configured sorting fields.
-     *
-     * @return array Array of (resolved) sorting field names.
-     */
-    public function getSortFields()
-    {
-        $sortFields = [];
-        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-
-        foreach ($this->configuration as $optionName => $optionConfiguration) {
-            $fieldName = $contentObject->stdWrap(
-                $optionConfiguration['field'],
-                $optionConfiguration['field.']
-            );
-
-            $sortFields[] = $fieldName;
-        }
-
-        return $sortFields;
-    }
-
-    /**
-     * Takes the tx_solr[sort] URL parameter containing the option names and
-     * directions to sort by and resolves it to the actual sort fields and
-     * directions as configured through TypoScript. Makes sure that only
-     * configured sorting options get applied to the query.
-     *
-     * @param string $urlParameters tx_solr[sort] URL parameter.
-     * @return string The actual index field configured to sort by for the given sort option name
-     * @throws \InvalidArgumentException if the given sort option is not configured
-     */
-    public function getSortFieldFromUrlParameter($urlParameters)
-    {
-        $sortFields = [];
-        $sortParameters = GeneralUtility::trimExplode(',', $urlParameters);
-        $availableSortOptions = $this->getSortOptions();
-
-        foreach ($sortParameters as $sortParameter) {
-            list($sortOption, $sortDirection) = explode(' ', $sortParameter);
-
-            if (!array_key_exists($sortOption, $availableSortOptions)) {
-                throw new \InvalidArgumentException(
-                    'No sorting configuration found for option name ' . $sortOption,
-                    1316187644
-                );
-            }
-
-            $sortField = $availableSortOptions[$sortOption]['field'];
-            $sortFields[] = $sortField . ' ' . $sortDirection;
-        }
-
-        return implode(', ', $sortFields);
-    }
-
-    /**
-     * Gets the sorting options with resolved field names in case stdWrap was
-     * used to define them.
-     *
-     * @return array The sorting options with resolved field names.
-     */
-    public function getSortOptions()
-    {
-        $sortOptions = [];
-        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-
-        foreach ($this->configuration as $optionName => $optionConfiguration) {
-            $optionField = $contentObject->stdWrap(
-                $optionConfiguration['field'],
-                $optionConfiguration['field.']
-            );
-
-            $optionLabel = $contentObject->stdWrap(
-                $optionConfiguration['label'],
-                $optionConfiguration['label.']
-            );
-
-            $optionName = substr($optionName, 0, -1);
-            $sortOptions[$optionName] = [
-                'field' => $optionField,
-                'label' => $optionLabel,
-                'defaultOrder' => $optionConfiguration['defaultOrder']
-            ];
-            if (isset($optionConfiguration['fixedOrder'])) {
-                $sortOptions[$optionName]['fixedOrder'] = $optionConfiguration['fixedOrder'];
-            }
-        }
-
-        return $sortOptions;
+        trigger_error('ApacheSolrForTypo3\Solr\Sorting is deprecated please use ApacheSolrForTypo3\Domain\Search\ResultsSet\Sorting\SortingHelper now', E_USER_DEPRECATED);
+        parent::__construct($sortingConfiguration);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Sorting;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\SortingHelper;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Class SortingHelperTest
+ */
+class SortingHelperTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function canGetSortFieldFromUrlParameter()
+    {
+        $sortConfiguration = [
+            'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
+            'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
+            'type.' => ['field' => 'type', 'label' => 'Type']
+        ];
+        $sorting = new SortingHelper($sortConfiguration);
+        $sortField = $sorting->getSortFieldFromUrlParameter('title asc');
+        $this->assertSame('sortTitle asc', $sortField);
+
+        $sortField = $sorting->getSortFieldFromUrlParameter('title desc');
+        $this->assertSame('sortTitle desc', $sortField);
+
+        $sortField = $sorting->getSortFieldFromUrlParameter('title desc,type asc');
+        $this->assertSame('sortTitle desc, type asc', $sortField);
+    }
+
+    /**
+     * @test
+     */
+    public function canThrowExceptionForUnconfiguredSorting()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No sorting configuration found for option name unconfigured');
+        $sorting = new SortingHelper([]);
+        $sorting->getSortFieldFromUrlParameter('unconfigured asc');
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet;
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Sorting;
 
 /***************************************************************
  *  Copyright notice

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -1,0 +1,117 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Search;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Search\SortingComponent;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcase for SortingComponent
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SortingComponentTest extends UnitTest
+{
+
+    /**
+     * @var Query
+     */
+    protected $query;
+
+    /**
+     * @var SearchRequest
+     */
+    protected $searchRequestMock;
+
+    /**
+     * @var SortingComponent
+     */
+    protected $sortingComponent;
+
+    /**
+     * SortingComponentTest constructor.
+     */
+    public function setUp()
+    {
+        $this->query = new Query('');
+        $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
+
+        $this->sortingComponent = new SortingComponent();
+        $this->sortingComponent->setQuery($this->query);
+        $this->sortingComponent->setSearchRequest($this->searchRequestMock);
+    }
+
+    /**
+     * @test
+     */
+    public function sortingFromUrlIsNotAppliedWhenSortingIsDisabled()
+    {
+        $this->searchRequestMock->expects($this->once())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->sortingComponent->initializeSearchComponent();
+        $this->assertNull($this->query->getQueryParameter('sort'), 'No sorting should be present in query');
+    }
+
+    /**
+     * @test
+     */
+    public function validSortingFromUrlIsApplied()
+    {
+        $this->sortingComponent->setSearchConfiguration([
+            'sorting' => 1,
+            'sorting.' => [
+                'options.' => [
+                    'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
+                    'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
+                    'type.' => ['field' => 'type', 'label' => 'Type']
+                ]
+            ]
+        ]);
+        $this->searchRequestMock->expects($this->once())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->sortingComponent->initializeSearchComponent();
+        $this->assertSame('sortTitle asc', $this->query->getQueryParameter('sort'), 'Sorting was not applied in the query as expected');
+    }
+
+    /**
+     * @test
+     */
+    public function invalidSortingFromUrlIsNotApplied()
+    {
+        $this->sortingComponent->setSearchConfiguration([
+            'sorting' => 1,
+            'sorting.' => [
+                'options.' => [
+                    'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
+                    'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
+                    'type.' => ['field' => 'type', 'label' => 'Type']
+                ]
+            ]
+        ]);
+        $this->searchRequestMock->expects($this->once())->method('getArguments')->willReturn(['sort' => 'title INVALID']);
+        $this->sortingComponent->initializeSearchComponent();
+        $this->assertNull($this->query->getQueryParameter('sort'), 'No sorting should be present in query');
+    }
+}


### PR DESCRIPTION
This pr:

* Moves the logic fom ApacheSolrForTypo3\Solr\Sorting to ApacheSolrForTypo3\Solr\Domain\Search\ResultsSet\Sorting\SortingHelper
* Deprecated the methods getSortFields and getSortOptions since they are not used anymore

Fixes: #1872