### PR TITLE
[BUGFIX] Ensure AjaxController returns a response (#1875)

### DIFF
--- a/Classes/Controller/Backend/AjaxController.php
+++ b/Classes/Controller/Backend/AjaxController.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Http\Response;
 
 /**
  * Handling of Ajax requests
@@ -71,10 +72,12 @@ class AjaxController
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function updateConnections(ServerRequestInterface $request, ResponseInterface $response)
+    public function updateConnections(ServerRequestInterface $request): ResponseInterface
     {
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $connectionManager->updateConnections();
+        // Currently no return value from connection manager
+        return new Response();
     }
 
 }


### PR DESCRIPTION
* [BUGFIX] Ensure AjaxController returns a response

In TYPO3 v9, all Routes should return a PSR-7 compatible Response object.

However "updateConnections"  does not do so, resulting in a PHP error.

* Return an empty Response object for ClearCacheMenu item