### PR TITLE
[TASK] Groups should be respected in suggest as well

### DIFF
--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -106,6 +106,14 @@ class SearchResult extends \Apache_Solr_Document
     }
 
     /**
+     * @return bool
+     */
+    public function getHasGroupItem()
+    {
+        return $this->groupItem !== null;
+    }
+
+    /**
      * @param GroupItem $group
      */
     public function setGroupItem(GroupItem $group)

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -232,6 +232,7 @@ class SuggestService {
             'type' => $document->getField('type_stringS') ? $document->getField('type_stringS')['value'] : $document->getType(),
             'title' => $document->getTitle(),
             'content' => $document->getContent(),
+            'group' => $document->getHasGroupItem() ? $document->getGroupItem()->getGroupValue() : '',
             'previewImage' => $document->getField('previewImage_stringS') ? $document->getField('previewImage_stringS')['value'] : '',
         ];
     }

--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -57,7 +57,15 @@ function SuggestController() {
 
                     $.each(response.documents, function (key, value) {
                         var dataObject = value;
-                        dataObject.category = $form.data('suggest-header') ? $form.data('suggest-header') : 'Top results';
+
+                        var defaultGroup = $form.data('suggest-header') ? $form.data('suggest-header') : 'Top results';
+                        dataObject.category = defaultGroup;
+
+                        // if a group is set we try to get a label
+                        if(dataObject.group) {
+                            dataObject.category = $form.data('suggest-header-' + dataObject.group) ? $form.data('suggest-header-' + dataObject.group) : dataObject.group;
+                        }
+
                         result.suggestions.push(
                             {
                                 value: firstSuggestion,


### PR DESCRIPTION
This pr:

* Adapts the SuggestService to render the grouping value
* Set the category from the group in the suggest_controller.js
* This allows to render groups in the suggest as well when solrfluidgrouping is installed

Fixes: #1881