### PR TITLE
[BUGFIX] prevent CURLE_BAD_CONTENT_ENCODING

### DIFF
--- a/Classes/IndexQueue/PageIndexerResponse.php
+++ b/Classes/IndexQueue/PageIndexerResponse.php
@@ -110,10 +110,8 @@ class PageIndexerResponse
      */
     public function sendHeaders()
     {
-        // This overwrites the "Content-Encoding: gzip" header that is usually sent by TYPO3 by default. This header
-        // would require that the content really is gzip-ed (which it is not). This lets e.g. Varnish 3.0
-        // fail when trying to decode the response.
-        header('Content-Encoding: none');
+        // set content type header to prevent problems with Content-Encoding
+        header('Content-Type: application/json');
 
         header('Content-Length: ' . strlen($this->getContent()));
     }


### PR DESCRIPTION
When using an nginx server and libcurl 7.57.0 indexing did not work with libcurl error 61. This was because Content-Encoding "gzip" was requested but "normal" was returned. To prevent this I changed the header to send a Content-Type instead of Content-Encoding. This also works with apache. It should also work behind Varnish, but this needs to be tested.