### PR TITLE
[BUGFIX] Use bash_source instead of $0

### DIFF
--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+SCRIPTPATH=$( cd $(dirname ${BASH_SOURCE[0]}) ; pwd -P )
 EXTENSION_ROOTPATH="$SCRIPTPATH/../../"
 SOLR_INSTALL_PATH="/opt/solr-tomcat/"
 


### PR DESCRIPTION
This pr:

* Uses bash_source instead $0 to be able to bootstrap also when $0 is not set (e.g. docker)

Fixes: #1898