### PR TITLE
[BUGFIX] SearchRequest::getHighestGroupPage should return 1 even when group was passed

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -491,7 +491,7 @@ class SearchRequest
     {
         $max = 1;
         $path = $this->prefixWithNamespace('groupPage');
-        $groupPages = $this->argumentsAccessor->get($path);
+        $groupPages = $this->argumentsAccessor->get($path, []);
         foreach ($groupPages as $groups) {
             if (!is_array($groups)) continue;
             foreach ($groups as $groupItemPage) {

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -301,6 +301,24 @@ class SearchRequestTest extends UnitTest
     /**
      * @test
      */
+    public function canGetHighestGroupItemPageWhenNoPageWasPassed()
+    {
+        $request = $this->getSearchRequestFromQueryString('');
+        $this->assertSame(1, $request->getHighestGroupPage(), 'Can not get highest group item page when no group page was passed');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetInitialGroupItemPage()
+    {
+        $request = $this->getSearchRequestFromQueryString('');
+        $this->assertSame(1, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not get initial group item page');
+    }
+
+    /**
+     * @test
+     */
     public function canSetGroupItemPage()
     {
         $query = 'tx_solr%5Bq%5D=typo3';


### PR DESCRIPTION
* Add's a testcase and fixes the bug

Fixes: #1903