### PR TITLE
[TASK] Make find/delete/count of queue items more flexible

### DIFF
--- a/Classes/Site.php
+++ b/Classes/Site.php
@@ -282,4 +282,20 @@ class Site
 
         return $this->sysLanguageMode;
     }
+
+    /**
+     * Retrieves the rootPageIds as an array from a set of sites.
+     *
+     * @param array $sites
+     * @return array
+     */
+    public static function getRootPageIdsFromSites(array $sites): array
+    {
+        $rootPageIds = [];
+        foreach ($sites as $site) {
+            $rootPageIds[] = (int)$site->getRootPageId();
+        }
+
+        return $rootPageIds;
+    }
 }

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/can_count_items.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/can_count_items.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>3</root>
+        <item_type>pages</item_type>
+        <item_uid>3</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>4</root>
+        <item_type>pages</item_type>
+        <item_uid>4</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <!-- News Records that should stay untouched -->
+    <tx_solr_indexqueue_item>
+        <uid>4715</uid>
+        <root>2</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4716</uid>
+        <root>3</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/can_delete_item_by_type.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/can_delete_item_by_type.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>3</root>
+        <item_type>pages</item_type>
+        <item_uid>3</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>4</root>
+        <item_type>pages</item_type>
+        <item_uid>4</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <!-- News Records that should stay untouched -->
+    <tx_solr_indexqueue_item>
+        <uid>4715</uid>
+        <root>2</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4716</uid>
+        <root>3</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/can_delete_item_by_type_and_uid.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/can_delete_item_by_type_and_uid.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>3</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <!-- News Records that should stay untouched -->
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>1</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4715</uid>
+        <root>2</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4716</uid>
+        <root>3</root>
+        <item_type>tx_news_domain_model_news</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>news</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+</dataset>

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/can_find_items.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/can_find_items.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+    </pages>
+    <pages>
+        <uid>2</uid>
+    </pages>
+    <pages>
+        <uid>3</uid>
+    </pages>
+    <pages>
+        <uid>4</uid>
+
+    </pages>
+
+    <tx_solr_indexqueue_item>
+        <uid>4711</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+    <tx_solr_indexqueue_item>
+        <uid>4712</uid>
+        <root>2</root>
+        <item_type>pages</item_type>
+        <item_uid>2</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4713</uid>
+        <root>3</root>
+        <item_type>pages</item_type>
+        <item_uid>3</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+    <tx_solr_indexqueue_item>
+        <uid>4714</uid>
+        <root>4</root>
+        <item_type>pages</item_type>
+        <item_uid>4</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+
+
+</dataset>


### PR DESCRIPTION
This pr:

* Add's a new method deleteItems to the QueueItemRepository class
* Uses this method internally when it is possible
* Add's testcases for uncovered parts

Fixes: #1918