### PR TITLE
[TASK] Use additional class for focus on search query input

### DIFF
--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -10,7 +10,7 @@
 				<input type="hidden" name="L" value="{languageUid}" />
 				<input type="hidden" name="id" value="{pageUid}" />
 
-				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest form-control" name="{pluginNamespace}[q]" value="{q}" />
+				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
 				<span class="input-group-btn">
 					<button class="btn btn-default tx-solr-submit" type="submit">
 						<span class=" glyphicon glyphicon-search"></span>

--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -5,7 +5,7 @@ function SuggestController() {
         jQuery('form[data-suggest]').each(function () {
             var $form = $(this), $searchBox = $form.find('.tx-solr-suggest');
 
-            $form.find('.tx-solr-suggest').focus();
+            $form.find('.tx-solr-suggest-focus').focus();
 
             jQuery.ajaxSetup({jsonp: "tx_solr[callback]"})
 


### PR DESCRIPTION
Using an additional class makes it possible to disable setting the
focus without using a own copy of the suggest javascript.

Resolves: #1922