### PR TITLE
[TASK] Check why release-8.0.x build is broken with TYPO3 9 (#1930)

### DIFF
--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -55,6 +55,9 @@ echo "Using web path $TYPO3_PATH_WEB"
 
 # Install TYPO3 sources
 if [[ $TYPO3_VERSION = *"9."* ]]; then
+    # only needed until https://github.com/symfony/symfony/issues/26757 is resolved
+    composer require --dev symfony/finder:4.0.6
+
     composer require --dev typo3/cms-backend="$TYPO3_VERSION"
     composer require --dev typo3/cms-core="$TYPO3_VERSION"
     composer require --dev typo3/cms-fluid="$TYPO3_VERSION"


### PR DESCRIPTION
This pr:

* Installs symfony/finder:4.0.6 when TYPO9 is installed

Fixes: #1929