### PR TITLE
[TASK] Fix build against TYPO3 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ matrix:
       env: TYPO3_VERSION="^9.1"
     - php: 7.1
       env: TYPO3_VERSION="^9.1"
-  allow_failures:
-    - env: TYPO3_VERSION="^9.1"
-      php: 7.2
 
 before_install:
   - composer self-update

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -14,8 +14,10 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelper as CoreTranslateViewHelper;
-use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 
 /**
  * Class TranslateViewHelper
@@ -32,23 +34,51 @@ class TranslateViewHelper extends CoreTranslateViewHelper
     protected $escapeChildren = true;
 
     /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
+     * @return string|null
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $arguments['extensionName'] = $arguments['extensionName'] === null ? 'Solr' : $arguments['extensionName'];
-        $result = parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
-
+        $result = parent::render();
         $result = self::replaceTranslationPrefixesWithAtWithStringMarker($result);
-        if (trim($result) === '') {
-            $result = $arguments['default'] !== null ? $arguments['default'] : $renderChildrenClosure();
-        }
+        $result = vsprintf($result, $this->arguments['arguments']);
+        return $result;
+    }
 
+    /**
+     * Wrapper call to static LocalizationUtility
+     *
+     * @param string $id Translation Key compatible to TYPO3 Flow
+     * @param string $extensionName UpperCamelCased extension key (for example BlogExample)
+     * @param array $arguments Arguments to be replaced in the resulting string
+     * @param string $languageKey Language key to use for this translation
+     * @param string[] $alternativeLanguageKeys Alternative language keys if no translation does exist
+     *
+     * @return string|null
+     */
+    public static function translateAndReplaceMarkers($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys)
+    {
+        $result = LocalizationUtility::translate($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys);
+        $result = self::replaceTranslationPrefixesWithAtWithStringMarker($result);
         $result = vsprintf($result, $arguments['arguments']);
         return $result;
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return sprintf(
+            '\\%1$s::translateAndReplaceMarkers(%2$s[\'key\'] ?? %2$s[\'id\'], %2$s[\'extensionName\'] ?? $renderingContext->getControllerContext()->getRequest()->getControllerExtensionName(), %2$s[\'arguments\'], %2$s[\'languageKey\'], %2$s[\'alternativeLanguageKeys\']) ?? %2$s[\'default\'] ?? %3$s()',
+            static::class,
+            $argumentsName,
+            $closureName
+        );
     }
 
     /**

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -28,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -47,6 +48,9 @@ class RelationTest extends IntegrationTest
      */
     public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn($fixtureName)
     {
+        if (!Util::getIsTYPO3VersionBelow9()) {
+            $this->markTestSkipped('This testcase is relevant for TYPO3 8 only');
+        }
         $this->importDataSetFromFixture($fixtureName);
         $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
         $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -214,7 +215,8 @@ class GarbageCollectorTest extends IntegrationTest
         $items = $this->indexQueue->getItems('pages', 1);
 
         // we index this item
-        $this->indexPageIds($items);
+        $itemIds = $this->getItemPageIds($items);
+        $this->indexPageIds($itemIds);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -262,8 +264,10 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
 
+        $itemIds = $this->getItemPageIds($items);
+
         // we index this item
-        $this->indexPageIds($items);
+        $this->indexPageIds($itemIds);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -314,8 +318,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
 
+        $itemIds = $this->getItemPageIds($items);
         // we index this item
-        $this->indexPageIds($items);
+        $this->indexPageIds($itemIds);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -367,7 +372,8 @@ class GarbageCollectorTest extends IntegrationTest
         $items = $this->indexQueue->getItems('pages', 1);
 
         // we index this item
-        $this->indexPageIds($items);
+        $itemIds = $this->getItemPageIds($items);
+        $this->indexPageIds($itemIds);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -418,7 +424,8 @@ class GarbageCollectorTest extends IntegrationTest
         $items = $this->indexQueue->getItems('pages', 1);
 
         // we index this item
-        $this->indexPageIds($items);
+        $itemIds = $this->getItemPageIds($items);
+        $this->indexPageIds($itemIds);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -530,5 +537,19 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertNotContains('will be removed!', $solrContent, 'solr did not remove content from deleted page');
         $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
         $this->assertContains('"numFound":1', $solrContent, 'Expected to have two documents in the index');
+    }
+
+    /**
+     * @param $items
+     * @return array
+     */
+    protected function getItemPageIds($items):array
+    {
+        $itemIds = [];
+        foreach ($items as $item) {
+            /** @var $item Item */
+            $itemIds[] = $item->getRecordPageId();
+        }
+        return $itemIds;
     }
 }

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mulitple_mm_relations.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_mulitple_mm_relations.v9.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"1|1";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_de/";s:8:"language";i:1;s:5:"label";s:73:"Congratulations (pid: 1, language: german) - localhost:8999/solr/core_de/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+
+                config.sys_language_mode = ignore
+                config.sys_language_uid = 0
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+
+                                fields {
+                                    title = title
+                                    tags_stringM = SOLR_RELATION
+                                    tags_stringM {
+                                        localField = tags
+                                        enableRecursiveValueResolution = 1
+                                        multiValue = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <l10n_parent>1</l10n_parent>
+        <sys_language_uid>1</sys_language_uid>
+        <doktype>1</doktype>
+    </pages>
+    <tx_fakeextension_domain_model_bar>
+        <uid>88</uid>
+        <pid>1</pid>
+        <title>the document</title>
+    </tx_fakeextension_domain_model_bar>
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>8</uid_foreign>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+    <tx_fakeextension_domain_model_related_mm>
+        <uid_local>88</uid_local>
+        <uid_foreign>9</uid_foreign>
+        <tablenames>tx_fakeextension_domain_model_mmrelated</tablenames>
+    </tx_fakeextension_domain_model_related_mm>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>8</uid>
+        <pid>1</pid>
+        <tag>the tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+
+    <tx_fakeextension_domain_model_mmrelated>
+        <uid>9</uid>
+        <pid>1</pid>
+        <tag>the second tag</tag>
+    </tx_fakeextension_domain_model_mmrelated>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/queue_entry_stays_when_overlay_set_to_hidden.v9.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/queue_entry_stays_when_overlay_set_to_hidden.v9.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"2";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <pid>0</pid>
+        <title>Rootpage</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <l10n_parent>1</l10n_parent>
+        <doktype>1</doktype>
+        <sys_language_uid>1</sys_language_uid>
+        <title>Translated Rootpage</title>
+    </pages>
+    <tx_solr_indexqueue_item>
+        <uid>1</uid>
+        <root>1</root>
+        <item_type>pages</item_type>
+        <item_uid>1</item_uid>
+        <indexing_configuration>pages</indexing_configuration>
+        <has_indexing_properties>0</has_indexing_properties>
+        <indexing_priority>0</indexing_priority>
+        <changed>1449151778</changed>
+        <indexed>0</indexed>
+        <errors></errors>
+        <pages_mountidentifier></pages_mountidentifier>
+    </tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -30,8 +30,10 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Charset\CharsetConverter;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Lang\LanguageService;
 
@@ -70,6 +72,15 @@ class IndexerTest extends IntegrationTest
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $languageService->csConvObj = GeneralUtility::makeInstance(CharsetConverter::class);
         $GLOBALS['LANG'] = $languageService;
+
+        //@todo when TYPO3 8 support is dropped we need to refactor the tests to bootstrap the middleware stack with 9 LTS core components
+        if (!Util::getIsTYPO3VersionBelow9()) {
+            $_SERVER['HTTP_HOST'] = 'test.local.typo3.org';
+            $request = ServerRequestFactory::fromGlobals();
+            $handlerMock = $this->getMockBuilder( \Psr\Http\Server\RequestHandlerInterface::class)->getMock();
+            $normalizer = new \TYPO3\CMS\Core\Middleware\NormalizedParamsAttribute();
+            $normalizer->process($request, $handlerMock);
+        }
     }
 
     /**


### PR DESCRIPTION
This pr:

* Skips the test RelationTest::canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn in TYPO3 9 since it is not required for TYPO3 9, because pages_language_overlay is dropped and therefore the TCA for that is allways not defined
* Make the TranslateViewHelper compatible for the optimizations that have been introduced with: https://github.com/TYPO3/TYPO3.CMS/commit/e6f470ebd2ddac7f0c864fd7c18c3d12a9009c30
* Fixes some GarbageCollector tests that pass an instance of Item instead of the pageId to the TSFE initialization

Fixes: #1953