### PR TITLE
[TASK] Allow to flush queue errors by site in the API

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -110,14 +110,40 @@ class QueueItemRepository extends AbstractRepository
     public function flushAllErrors() : int
     {
         $queryBuilder = $this->getQueryBuilder();
-        $affectedRows = $queryBuilder
+        $affectedRows = $this->getPreparedFlushErrorQuery($queryBuilder)->execute();
+        return $affectedRows;
+    }
+
+    /**
+     * Flushes the errors for a single site.
+     *X
+     * @param Site $site
+     * @return int
+     */
+    public function flushErrorsBySite(Site $site) : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $affectedRows = $this->getPreparedFlushErrorQuery($queryBuilder)
+            ->andWhere(
+                $queryBuilder->expr()->eq('root', (int)$site->getRootPageId())
+            )
+            ->execute();
+        return $affectedRows;
+    }
+
+    /**
+     * Initializes the QueryBuilder with a query the resets the error field for items that have an error.
+     *
+     * @return QueryBuilder
+     */
+    private function getPreparedFlushErrorQuery(QueryBuilder $queryBuilder)
+    {
+        return $queryBuilder
             ->update($this->table)
             ->set('errors', '')
             ->where(
                 $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter(''))
-            )
-            ->execute();
-        return $affectedRows;
+            );
     }
 
     /**

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -289,6 +289,17 @@ class Queue
     }
 
     /**
+     * Resets the errors in the index queue for a specific site
+     *
+     * @param Site $site
+     * @return mixed
+     */
+    public function resetErrorsBySite(Site $site)
+    {
+        return $this->queueItemRepository->flushErrorsBySite($site);
+    }
+
+    /**
      * Adds an item to the index queue.
      *
      * Not meant for public use.

--- a/Tests/Integration/IndexQueue/Fixtures/can_flush_errors.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_flush_errors.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+	<sys_registry>
+		<uid>4711</uid>
+		<entry_namespace>tx_solr</entry_namespace>
+		<entry_key>servers</entry_key>
+		<entry_value>a:2:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}s:3:"1|1";a:9:{s:13:"connectionKey";s:3:"2|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"2";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:1;s:5:"label";s:74:"Congratulations (pid: 2, language: english) - localhost:8999/solr/core_en/";}}</entry_value>
+	</sys_registry>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+	</pages>
+
+	<pages>
+		<uid>2</uid>
+		<is_siteroot>1</is_siteroot>
+	</pages>
+
+	<tx_solr_indexqueue_item>
+		<uid>4711</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<indexed>1489507500</indexed>
+		<errors></errors>
+	</tx_solr_indexqueue_item>
+
+	<tx_solr_indexqueue_item>
+		<uid>4712</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<indexed>0</indexed>
+		<errors>something very bad happenend on site 1</errors>
+	</tx_solr_indexqueue_item>
+
+	<tx_solr_indexqueue_item>
+		<uid>4713</uid>
+		<root>2</root>
+		<item_type>pages</item_type>
+		<indexed>1489507800</indexed>
+		<errors>something bad happpend on site 2</errors>
+	</tx_solr_indexqueue_item>
+
+	<tx_solr_indexqueue_item>
+		<uid>4714</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<indexed>1489507800</indexed>
+		<errors>another error in site 1</errors>
+	</tx_solr_indexqueue_item>
+</dataset>


### PR DESCRIPTION
This pr:

* Add's a method flushErrorsBySite to the QueueItemRepository
* Add's a method resetErrorsBySite to the Queue
* Refactors QueueItemRepository:flushAllErrors to use the same logic as QueueItemRepository::flushErrorsBySite

Fixes: #1953