### PR TITLE
[BUGFIX] Remove jQuery ui related information from autosuggest documentation

### DIFF
--- a/Documentation/Frontend/Autosuggest.rst
+++ b/Documentation/Frontend/Autosuggest.rst
@@ -17,7 +17,10 @@ This feature can be easily configured with the following typoscript setting:
         }
     }
 
-Beside the server related part solrfluid ships the jQueryUi autocomplete implementation to show the suggest results.
+Beside the server related part EXT:solr ships the jQuery autocomplete implementation to show the suggest results.
+
+The suggest implementation uses the devbridge/jQuery-Autocomplete library(https://github.com/devbridge/jQuery-Autocomplete) to render the autocomplete.
+
 If you want to configure an the autosuggest by example, you can include the typoscript example template **"(Example) Suggest/autocomplete with jquery"**.
 
 When everything is configured the frontend will show you a drop down of suggestions when you are typing in the search field:


### PR DESCRIPTION
This pr:

* Removes the jQueryUi information from the Autosuggest.rst since it is not used anymore

Fixes: #1917