### PR TITLE
[TASK] Change type of fileSize to long

### DIFF
--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -49,7 +49,7 @@ class SchemaStatus extends AbstractSolrStatus
      *
      * @var string
      */
-    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-8-1-0--20180409';
+    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-8-1-0--20180423';
 
     /**
      * Compiles a collection of schema version checks against each configured

--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -48,7 +48,7 @@ class SolrConfigStatus extends AbstractSolrStatus
      *
      * @var string
      */
-    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-8-1-0--20180409';
+    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-8-1-0--20180423';
 
     /**
      * Compiles a collection of solrconfig version checks against each configured

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/arabic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/armenian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/basque/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/bulgarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/burmese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/catalan/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/chinese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/czech/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/galician/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/general_schema_fields.xml
@@ -154,7 +154,7 @@
 	<field name="fileRelativePathOnly"    type="string"  indexed="true"  stored="true" />
 	<field name="fileSha1"                type="string"  indexed="false" stored="true" />
 	<field name="fileStorage"             type="integer" indexed="true"  stored="true" docValues="true" />
-	<field name="fileSize"                type="integer" indexed="true"  stored="true" />
+	<field name="fileSize"                type="long" indexed="true"  stored="true" />
 	<field name="fileUid"                 type="integer" indexed="true"  stored="true" />
 	<field name="filePublicUrl"           type="string"  indexed="true"  stored="true" />
 

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/generic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/greek/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hindi/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/indonesian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/irish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/japanese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/khmer/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/korean/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/lao/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/latvia/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/latvia/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/persian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/romanian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/russian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/serbian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/solrconfig.xml
@@ -1,4 +1,4 @@
-<config name="tx_solr-8-1-0--20180409">
+<config name="tx_solr-8-1-0--20180423">
 
 	<luceneMatchVersion>6.6.0</luceneMatchVersion>
 

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/thai/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/ukrainian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180409" version="1.6" >
+<schema name="tx_solr-8-1-0--20180423" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should


### PR DESCRIPTION
The filesize is saved in bytes and could be to small for very large files(e.g. 2gb).
Therefore the type of the fileSize field is changed to "long"

Fixes: #1691