### PR TITLE
[TASK] Move Util::isLocalizedRecord to TCAService

### DIFF
--- a/Classes/System/TCA/TCAService.php
+++ b/Classes/System/TCA/TCAService.php
@@ -198,6 +198,56 @@ class TCAService
     }
 
     /**
+     * @param string $table
+     * @param array $record
+     * @return mixed
+     */
+    public function getTranslationOriginalUid($table, array $record)
+    {
+        return $record[$this->tca[$table]['ctrl']['transOrigPointerField']];
+    }
+
+    /**
+     * Retrieves the uid that as marked as original if the record is a translation if not it returns the
+     * originalUid.
+     *
+     * @param $table
+     * @param array $record
+     * @param $originalUid
+     * @return integer
+     */
+    public function getTranslationOriginalUidIfTranslated($table, array $record, $originalUid)
+    {
+        if (!$this->isLocalizedRecord($table, $record)) {
+            return $originalUid;
+        }
+
+        return $this->getTranslationOriginalUid($table, $record);
+    }
+
+    /**
+     * Checks whether a record is a localization overlay.
+     *
+     * @param string $tableName The record's table name
+     * @param array $record The record to check
+     * @return bool TRUE if the record is a language overlay, FALSE otherwise
+     */
+    public function isLocalizedRecord($tableName, array $record)
+    {
+        $translationUid = $this->getTranslationOriginalUid($tableName, $record);
+        if (is_null($translationUid)) {
+            return false;
+        }
+
+        $hasTranslationReference = $translationUid > 0;
+        if (!$hasTranslationReference) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Compiles a list of visibility affecting fields of a table so that it can
      * be used in SQL queries.
      *

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -33,6 +33,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
@@ -393,21 +394,16 @@ class Util
      *
      * @param string $tableName The record's table name
      * @param array $record The record to check
+     * @deprecated Since 8.1.0 will be removed in 9.0.0. Use TCAService::isLocalizedRecord instead.
      * @return bool TRUE if the record is a language overlay, FALSE otherwise
      */
     public static function isLocalizedRecord($tableName, array $record)
     {
-        $isLocalizedRecord = false;
+        trigger_error('Call deprecated method Util::isLocalizedRecord, use TCAService::isLocalizedRecord instead, deprecated since 8.1.0 will be removed in 9.0.0', E_USER_DEPRECATED);
 
-        if (isset($GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'])) {
-            $translationOriginalPointerField = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'];
-
-            if ($record[$translationOriginalPointerField] > 0) {
-                $isLocalizedRecord = true;
-            }
-        }
-
-        return $isLocalizedRecord;
+        /** @var $tcaService TCAService */
+        $tcaService = GeneralUtility::makeInstance(TCAService::class);
+        return $tcaService->isLocalizedRecord($tableName, $record);
     }
 
     /**

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -377,4 +377,95 @@ class TCAServiceTest extends UnitTest
         $visibilityFields = $tcaService->getVisibilityAffectingFieldsByTable('tx_domain_model_faketable');
         $this->assertContains('fe_groups', $visibilityFields, 'The field fe_groups should be retrieved as visbility affecting field');
     }
+
+    /**
+     * @test
+     */
+    public function getTranslationOriginalUid()
+    {
+        $fakeTCA = [
+            'tx_domain_model_faketable' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l10n_parent'
+                ]
+            ]
+        ];
+
+        $tcaService = new TCAService($fakeTCA);
+        $fakeRecord = ['l10n_parent' => 999];
+
+        $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
+        $this->assertSame(999, $l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+    }
+
+    /**
+     * @test
+     */
+    public function getTranslationOriginalUidReturnsNullWhenFieldIsEmpty()
+    {
+        $fakeTCA = [
+            'tx_domain_model_faketable' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l10n_parent'
+                ]
+            ]
+        ];
+
+        $tcaService = new TCAService($fakeTCA);
+        $fakeRecord = [];
+
+        $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
+        $this->assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+    }
+
+    /**
+     * @test
+     */
+    public function getTranslationOriginalUidReturnsNullWhenPointerFieldIsNotConfigured()
+    {
+        $tcaService = new TCAService([]);
+        $fakeRecord = [];
+        $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
+        $this->assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+    }
+
+    /**
+     * @test
+     */
+    public function isLocalizedRecord()
+    {
+        $fakeTCA = [
+            'tx_domain_model_faketable' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l10n_parent'
+                ]
+            ]
+        ];
+
+        $tcaService = new TCAService($fakeTCA);
+
+        $this->assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 0]), 'Item with l10n_parent => 0 should not be indicated as translation');
+        $this->assertTrue($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 9999]), 'Item with l10n_parent => 9999 should be indicated as translation');
+        $this->assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999]), 'Item without tca should not be indicated as translation');
+    }
+
+    /**
+     * @test
+     */
+    public function getTranslationOriginalUidIfTranslated()
+    {
+        $fakeTCA = [
+            'tx_domain_model_faketable' => [
+                'ctrl' => [
+                    'transOrigPointerField' => 'l10n_parent'
+                ]
+            ]
+        ];
+
+        $tcaService = new TCAService($fakeTCA);
+
+        $this->assertSame(4711, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 0], 4711), 'No translation, original uid should be returned');
+        $this->assertSame(9999, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 9999], 4711), 'Valid translation, uid of parent should be returned');
+        $this->assertSame(4711,$tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999], 4711), 'No translation, original uid should be returned');
+    }
 }


### PR DESCRIPTION
This pr:

* Moves the method Util::isLocalizedRecord to the TCAService
* Add's tests for those methods
* Refactors the RecordMonitor to use these methods of the TCAService

Fixes: #1978