### PR TITLE
[BUGFIX] Add setting to be able to add additional persistent arguments

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -118,6 +118,15 @@ class SearchRequest
         }
 
         $this->persistentArgumentsPaths = [$this->argumentNameSpace . ':q', $this->argumentNameSpace . ':filter', $this->argumentNameSpace . ':sort', $this->argumentNameSpace . ':groupPage'];
+
+        if (!is_null($typoScriptConfiguration)) {
+            $additionalPersistentArgumentsNames = $typoScriptConfiguration->getSearchAdditionalPersistentArgumentNames();
+            foreach ($additionalPersistentArgumentsNames as $additionalPersistentArgumentsName) {
+                $this->persistentArgumentsPaths[] = $this->argumentNameSpace . ':' . $additionalPersistentArgumentsName;
+            }
+            $this->persistentArgumentsPaths = array_unique($this->persistentArgumentsPaths);
+        }
+
         $this->reset();
     }
 

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -2252,6 +2252,26 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns the argument names, that should be added to the persistent arguments, as array.
+     *
+     * plugin.tx_solr.search.additionalPersistentArgumentNames
+     *
+     * @param array $defaultIfEmpty
+     * @return array
+     */
+    public function getSearchAdditionalPersistentArgumentNames($defaultIfEmpty = [])
+    {
+        $additionalPersistentArgumentNames = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.additionalPersistentArgumentNames', $defaultIfEmpty);
+
+        if ($additionalPersistentArgumentNames === '') {
+            return $defaultIfEmpty;
+        }
+
+        return GeneralUtility::trimExplode(',', $additionalPersistentArgumentNames, true);
+
+    }
+
+    /**
      * Method to check if grouping was enabled with typoscript.
      *
      * plugin.tx_solr.search.grouping

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -95,6 +95,17 @@ ignoreGlobalQParameter
 
 In some cases you want EXT:solr to react on the parameter "q" in the url. Normally plugins are bounded to a namespace to allow multiple instances of the search on the same page. In this case you might want to disable this and let EXT:solr only react on the namespaced query parameter (tx_solr[q] by default).
 
+additionalPersistentArgumentNames
+---------------------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.search.additionalPersistentArgumentNames
+:Since: 8.0
+
+Comma-separated list of additional argument names, that should be added to the persistent arguments that are kept for sub request, like the facet and sorting urls. Hard coded argument names are q, filter and sort.
+
+Till solr version 6.5.x all parameters of the plugin namespace was added to the url again. With this setting you could enable this behavior again, but only with a whitelist of argument names.
+
 query
 -----
 


### PR DESCRIPTION
Till solr version 6.5.x all parameters of the plugin namespace was
added to the facet or sorting url again.
This patch adds a setting to be able to enable this behavior again,
but only with a whitelist of argument names.

Resolves: #1984