### PR TITLE
[TASK] Remove setting search.spellchecking.wrap

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1765,19 +1765,6 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Returns the wrap that should be used for spellchecking
-     *
-     * plugin.tx_solr.search.spellchecking.wrap
-     *
-     * @param string $defaultIfEmpty
-     * @return string
-     */
-    public function getSearchSpellcheckingWrap($defaultIfEmpty = '')
-    {
-        return (string)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.spellchecking.wrap', $defaultIfEmpty);
-    }
-
-    /**
      * Returns the numberOfSuggestionsToTry that should be used for the spellchecking.
      *
      * plugin.tx_solr.search.spellchecking.numberOfSuggestionsToTry

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -584,16 +584,6 @@ spellchecking
 
 Set `plugin.tx_solr.search.spellchecking = 1` to enable spellchecking / did you mean.
 
-spellchecking.wrap
-~~~~~~~~~~~~~~~~~~
-
-:Type: String
-:TS Path: plugin.tx_solr.search.spellchecking.wrap
-:Since: 1.0
-:Default: \|<div class="spelling-suggestions">###LLL:didYouMean### \|</div>\|
-
-This can be used to configure a custom wrap for your did you mean rendering.
-
 spellchecking.searchUsingSpellCheckerSuggestion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This setting is not used anymore. It was replaced by a label in fluid in
version 7.

Resolves: #1970