### PR TITLE
[BUGFIX] 1991 Use andWhere 

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -593,7 +593,7 @@ class TypoScriptConfiguration
             return '';
         }
 
-        return ' AND ' . $initialPagesAdditionalWhereClause;
+        return $initialPagesAdditionalWhereClause;
     }
 
     /**

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -211,7 +211,7 @@ class PagesRepository extends AbstractRepository
         }
 
         if (!empty($initialPagesAdditionalWhereClause)) {
-            $queryBuilder->add('where', $initialPagesAdditionalWhereClause, true);
+            $queryBuilder->andWhere($initialPagesAdditionalWhereClause);
         }
 
         $resultSet = $queryBuilder->execute();


### PR DESCRIPTION
Use andWhere instead of add since this method seems to be broken. In addition adjusted method that constructs initialPagesAdditionalWhereClause