### PR TITLE
[TASK] Fix warnings in tests for SearchRequest

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -121,7 +121,7 @@ class SearchRequest
 
         if (!is_null($typoScriptConfiguration)) {
             $additionalPersistentArgumentsNames = $typoScriptConfiguration->getSearchAdditionalPersistentArgumentNames();
-            foreach ($additionalPersistentArgumentsNames as $additionalPersistentArgumentsName) {
+            foreach ($additionalPersistentArgumentsNames ?? [] as $additionalPersistentArgumentsName) {
                 $this->persistentArgumentsPaths[] = $this->argumentNameSpace . ':' . $additionalPersistentArgumentsName;
             }
             $this->persistentArgumentsPaths = array_unique($this->persistentArgumentsPaths);


### PR DESCRIPTION
This pr:

* Uses an empty array when the configured fields are null

Fixes: #1994