### PR TITLE
[TASK] Set mm.autoRelax to true

### DIFF
--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -49,7 +49,7 @@ class SchemaStatus extends AbstractSolrStatus
      *
      * @var string
      */
-    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-8-1-0--20180423';
+    const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-8-1-0--20180615';
 
     /**
      * Compiles a collection of schema version checks against each configured

--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -48,7 +48,7 @@ class SolrConfigStatus extends AbstractSolrStatus
      *
      * @var string
      */
-    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-8-1-0--20180423';
+    const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-8-1-0--20180615';
 
     /**
      * Compiles a collection of solrconfig version checks against each configured

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/arabic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/armenian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/basque/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/bulgarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/burmese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/catalan/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/chinese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/czech/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/galician/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/generic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/greek/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hindi/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/indonesian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/irish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/japanese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/khmer/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/korean/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/lao/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/latvia/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/latvia/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/persian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/romanian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/russian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/serbian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/solrconfig.xml
@@ -1,4 +1,4 @@
-<config name="tx_solr-8-1-0--20180423">
+<config name="tx_solr-8-1-0--20180615">
 
 	<luceneMatchVersion>6.6.0</luceneMatchVersion>
 
@@ -169,6 +169,7 @@
 			<int name="ps">15</int>
 
 			<str name="mm">2&lt;-35%</str>
+			<str name="mm.autoRelax">true</str>
 
 			<str name="hl.fl">title,content</str>
 			<int name="hl.snippets">3</int>

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/thai/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/ukrainian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_8_1_0/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-8-1-0--20180423" version="1.6" >
+<schema name="tx_solr-8-1-0--20180615" version="1.6" >
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should


### PR DESCRIPTION
When terms get removed because they are stopwords this might have an
unwanted impact when the mm condition is evaluated. Setting mm.autoRelax to true
fixes this.

This pr:

* Set's mm.autoRelax = true

Fixes: #1891