### PR TITLE
[TASK] Remove option fixedOrder

### DIFF
--- a/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
+++ b/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
@@ -135,9 +135,6 @@ class SortingHelper {
                 'label' => $optionLabel,
                 'defaultOrder' => $optionConfiguration['defaultOrder']
             ];
-            if (isset($optionConfiguration['fixedOrder'])) {
-                $sortOptions[$optionName]['fixedOrder'] = $optionConfiguration['fixedOrder'];
-            }
         }
 
         return $sortOptions;

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1377,21 +1377,6 @@ class TypoScriptConfiguration
     }
 
     /**
-     * Returns the configured fixedOrder, if nothing configured defaultIfEmpty will be returned.
-     *
-     * plugin.tx_solr.search.sorting.options.<sortOptionName>.fixedOrder
-     *
-     * @param string $sortOptionName
-     * @param string $defaultIfEmpty
-     * @return string
-     */
-    public function getSearchSortingFixedOrderBySortOptionName($sortOptionName = '', $defaultIfEmpty = '')
-    {
-        $fixedOrder = 'plugin.tx_solr.search.sorting.options.' . $sortOptionName . '.fixedOrder';
-        return mb_strtolower($this->getValueByPathOrDefaultValue($fixedOrder, $defaultIfEmpty));
-    }
-
-    /**
      * Returns the trusted fields configured for the search that do not need to be escaped.
      *
      * @param array $defaultIfEmpty

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -783,18 +783,6 @@ sorting.options.[optionName].defaultOrder
 
 Sets the default sort order for a particular sort option.
 
-sorting.options.[optionName].fixedOrder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Type: String
-:TS Path: plugin.tx_solr.search.sorting.options.[optionName].fixedOrder
-:Since: 2.2
-:Default: asc
-:Options: asc, desc
-
-Sets a fixed sort order for a particular sort option that can not be changed.
-
-
 faceting
 --------
 


### PR DESCRIPTION
This option has no effect since version 7 (fluid rewrite)

It can be achieved by adapting the partial for one particular sorting and or using the option defaultOrder.

Resolves: #1968