### PR TITLE
[TASK] Allow basic usage with TYPO3 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,15 @@ env:
   matrix:
     - TYPO3_VERSION="^8.7"
     - TYPO3_VERSION="8.x-dev"
-    - TYPO3_VERSION="^9.1"
+    - TYPO3_VERSION="^9.3"
 
 matrix:
   fast_finish: true
   exclude:
     - php: 7.0
-      env: TYPO3_VERSION="^9.1"
+      env: TYPO3_VERSION="^9.3"
     - php: 7.1
-      env: TYPO3_VERSION="^9.1"
+      env: TYPO3_VERSION="^9.3"
 
 before_install:
   - composer self-update

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -160,7 +160,11 @@ class RootPageResolver implements SingletonInterface
             /* @var $pageSelect PageRepository */
             $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
 
-            $rootLineArray = $pageSelect->getRootLine($pageId, $mountPointIdentifier, true);
+            try {
+                $rootLineArray = $pageSelect->getRootLine($pageId, $mountPointIdentifier);
+            } catch (\RuntimeException $e) {
+                $rootLineArray = [];
+            }
             $rootLine->setRootLineArray($rootLineArray);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "typo3/cms-core": "^8.7.0 || ^9.1",
-    "typo3/cms-backend": "^8.7.0 || ^9.1",
-    "typo3/cms-extbase": "^8.7.0 || ^9.1",
-    "typo3/cms-frontend": "^8.7.0 || ^9.1",
-    "typo3/cms-fluid": "^8.7.0 || ^9.1",
-    "typo3/cms-reports": "^8.7.0 || ^9.1",
-    "typo3/cms-scheduler": "^8.7.0 || ^9.1",
-    "typo3/cms-tstemplate": "^8.7.0 || ^9.1"
+    "typo3/cms-core": "^8.7.0 || ^9.3",
+    "typo3/cms-backend": "^8.7.0 || ^9.3",
+    "typo3/cms-extbase": "^8.7.0 || ^9.3",
+    "typo3/cms-frontend": "^8.7.0 || ^9.3",
+    "typo3/cms-fluid": "^8.7.0 || ^9.3",
+    "typo3/cms-reports": "^8.7.0 || ^9.3",
+    "typo3/cms-scheduler": "^8.7.0 || ^9.3",
+    "typo3/cms-tstemplate": "^8.7.0 || ^9.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
This pr:

* Fixes errors during indexing in TYPO3 9.3
* Additional changes are required when TYPO3 8.7 compatibility will be dropped