### PR TITLE
[FEATURE] Update Item changed timestamp when value changed during indexing

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -193,12 +193,20 @@ class IndexService
         // Remember original http host value
         $originalHttpHost = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
 
+        $itemChangedDate = $item->getChanged();
+        $itemChangedDateAfterIndex = 0;
+
         $this->initializeHttpServerEnvironment($item);
         $itemIndexed = $indexer->index($item);
 
         // update IQ item so that the IQ can determine what's been indexed already
         if ($itemIndexed) {
             $this->indexQueue->updateIndexTimeByItem($item);
+            $itemChangedDateAfterIndex = $item->getChanged();
+        }
+
+        if ($itemChangedDateAfterIndex > $itemChangedDate && $itemChangedDateAfterIndex > time()) {
+            $this->indexQueue->setForcedChangeTimeByItem($item, $itemChangedDateAfterIndex);
         }
 
         if (!is_null($originalHttpHost)) {

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -770,6 +770,23 @@ class QueueItemRepository extends AbstractRepository
     }
 
     /**
+     * Sets the change timestamp of an item.
+     *
+     * @param Item $item
+     * @param int $changedTime
+     * @return int affected rows
+     */
+    public function updateChangedTimeByItem(Item $item, int $changedTime) : int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        return (int)$queryBuilder
+            ->update($this->table)
+            ->set('changed', $changedTime)
+            ->where($queryBuilder->expr()->eq('uid', $item->getIndexQueueUid()))
+            ->execute();
+    }
+
+    /**
      * Initializes Queue by given sql
      *
      * Note: Do not use platform specific functions!

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -604,4 +604,15 @@ class Queue
     {
         $this->queueItemRepository->updateIndexTimeByItem($item);
     }
+
+    /**
+     * Sets the change timestamp of an item.
+     *
+     * @param Item $item
+     * @param int $forcedChangeTime The change time for the item
+     */
+    public function setForcedChangeTimeByItem(Item $item, $forcedChangeTime)
+    {
+        $this->queueItemRepository->updateChangedTimeByItem($item, $forcedChangeTime);
+    }
 }


### PR DESCRIPTION
With this PR the IndexService takes care of updating the item queue
record when the value of the changed property changed during indexing.

Now an indexer could force the indexing queue to index an item at
a future timestamp again.

Resolves: #2018