### PR TITLE
[TASK] Allow to install with TYPO3 9.3

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '8.7.0-9.0.99'
+            'typo3' => '8.7.0-9.3.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
This pr:

* Allows to install with TYPO3 9.3
* Just for development and testing TYPO3 9 is not officially supported yet.