### PR TITLE
[BUGFIX] Download of stopwords and synonyms not working

### DIFF
--- a/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
+++ b/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
@@ -303,7 +303,22 @@ class CoreOptimizationModuleController extends AbstractModuleController
             $coreAdmin->getCoreName() . '.' . $fileExtension,
             true
         );
-        return $content;
+
+        $this->response->setContent($content);
+        $this->sendFileResponse();
+    }
+
+    /**
+     * This method send the headers and content and does an exit, since without the exit TYPO3 produces and error.
+     * @return void
+     */
+    protected function sendFileResponse()
+    {
+        $this->response->sendHeaders();
+        $this->response->shutdown();
+        $this->response->send();
+
+        exit();
     }
 
     /**


### PR DESCRIPTION
This pr:

* Fixes the downloads of synonyms and stopwords by sending, contents and headers and doing an exit afterwards

Fixes: #2016