### PR TITLE
[!!!][WIP][TASK] Unify filter handling in suggest

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -43,9 +43,10 @@ class SuggestController extends AbstractBaseController
      *
      * @param string $queryString
      * @param string $callback
+     * @param array $additionalFilters
      * @return string
      */
-    public function suggestAction($queryString, $callback)
+    public function suggestAction($queryString, $callback, $additionalFilters = [])
     {
         $jsonPCallback = htmlspecialchars($callback);
         // Get suggestions
@@ -58,11 +59,12 @@ class SuggestController extends AbstractBaseController
                 /** @scrutinizer ignore-type */ $this->typoScriptFrontendController,
                 /** @scrutinizer ignore-type */ $this->searchService,
                 /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
-            $additionalFilters = htmlspecialchars(GeneralUtility::_GET('filters'));
 
+            $additionalFilters = is_array($additionalFilters) ? array_map("htmlspecialchars", $additionalFilters) : [];
             $pageId = $this->typoScriptFrontendController->getRequestedId();
             $languageId = $this->typoScriptFrontendController->sys_language_uid;
             $arguments = (array)$this->request->getArguments();
+
             $searchRequest = $this->getSearchRequestBuilder()->buildForSuggest($arguments, $rawQuery, $pageId, $languageId);
             $result = $suggestService->getSuggestions($searchRequest, $additionalFilters);
         } catch (SolrUnavailableException $e) {

--- a/Classes/Domain/Search/Query/ParameterBuilder/Filters.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Filters.php
@@ -90,6 +90,23 @@ class Filters implements ParameterBuilder
     }
 
     /**
+     * Add's multiple filters to the filter collection.
+     *
+     * @param array $filterArray
+     * @return Filters
+     */
+    public function addMultiple($filterArray)
+    {
+        foreach($filterArray as $key => $value) {
+            if (!$this->hasWithName($key)) {
+                $this->add($value, $key);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @return bool
      */

--- a/Classes/Domain/Search/Query/Query.php
+++ b/Classes/Domain/Search/Query/Query.php
@@ -446,6 +446,19 @@ class Query
     }
 
     /**
+     * @param Filters $filtersToAdd
+     * @return Filters
+     */
+    public function addFilters(Filters $filtersToAdd)
+    {
+        foreach($filtersToAdd->getValues() as $key => $value) {
+            $this->getFilters()->add($value, $key);
+        }
+
+        return $this->filters;
+    }
+
+    /**
      * @param ReturnFields $returnFields
      */
     public function setReturnFields(ReturnFields $returnFields)

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -189,7 +189,7 @@ class SearchResultSetService
             return $resultSet;
         }
 
-        $query = $this->queryBuilder->buildSearchQuery($searchRequest->getRawUserQuery(), (int)$searchRequest->getResultsPerPage());
+        $query = $this->queryBuilder->buildSearchQuery($searchRequest->getRawUserQuery(), (int)$searchRequest->getResultsPerPage(), $searchRequest->getAdditionalFilters());
         $this->initializeRegisteredSearchComponents($query, $searchRequest);
         $resultSet->setUsedQuery($query);
 

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -609,6 +609,32 @@ class SearchRequest
     }
 
     /**
+     * Allows to set additional filters that are used on time and not transported during the request.
+     *
+     * @param array $additionalFilters
+     * @return SearchRequest
+     */
+    public function setAdditionalFilters($additionalFilters)
+    {
+        $path = $this->prefixWithNamespace('additionalFilters');
+        $this->argumentsAccessor->set($path, $additionalFilters);
+        $this->stateChanged = true;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the addtional filters that have been set
+     *
+     * @return array
+     */
+    public function getAdditionalFilters()
+    {
+        $path = $this->prefixWithNamespace('additionalFilters');
+        return $this->argumentsAccessor->get($path, []);
+    }
+
+    /**
      * @return int
      */
     public function getContextSystemLanguageUid()

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -85,10 +85,10 @@ class SuggestService {
      * Build an array structure of the suggestions.
      *
      * @param SearchRequest $searchRequest
-     * @param string $additionalFilters
+     * @param array $additionalFilters
      * @return array
      */
-    public function getSuggestions(SearchRequest $searchRequest, $additionalFilters) : array
+    public function getSuggestions(SearchRequest $searchRequest, array $additionalFilters = []) : array
     {
         $requestId = (int)$this->tsfe->getRequestedId();
         $groupList = (string)$this->tsfe->gr_list;
@@ -108,7 +108,7 @@ class SuggestService {
             return $this->getResultArray($searchRequest, $suggestions, [], false);
         }
 
-        return $this->addTopResultsToSuggestions($searchRequest, $suggestions);
+        return $this->addTopResultsToSuggestions($searchRequest, $suggestions, $additionalFilters);
     }
 
     /**
@@ -116,14 +116,16 @@ class SuggestService {
      *
      * @param SearchRequest $searchRequest
      * @param array $suggestions
+     * @param array $additionalFilters
      * @return array
      */
-    protected function addTopResultsToSuggestions(SearchRequest $searchRequest, $suggestions) : array
+    protected function addTopResultsToSuggestions(SearchRequest $searchRequest, $suggestions, array $additionalFilters) : array
     {
         $maxDocuments = $this->typoScriptConfiguration->getSuggestNumberOfTopResults();
 
         // perform the current search.
         $searchRequest->setResultsPerPage($maxDocuments);
+        $searchRequest->setAdditionalFilters($additionalFilters);
 
         $didASecondSearch = false;
         $documents = [];
@@ -139,6 +141,7 @@ class SuggestService {
         $bestSuggestionRequest = $searchRequest->getCopyForSubRequest();
         $bestSuggestionRequest->setRawQueryString($bestSuggestion);
         $bestSuggestionRequest->setResultsPerPage($maxDocuments);
+        $bestSuggestionRequest->setAdditionalFilters($additionalFilters);
 
         // No results found, use first proposed suggestion to perform the search
         if (count($documents) === 0 && !empty($suggestions) && ($searchResultSet = $this->doASearch($bestSuggestionRequest)) && count($searchResultSet->getSearchResults()) > 0) {

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -171,7 +171,7 @@ class QueryBuilderTest extends UnitTest
         $this->configurationMock->expects($this->any())->method('getSearchQueryFilterConfiguration')->willReturn(['noPage' => '-type:pages']);
         $query = $this->builder->buildSearchQuery('applies configured filters');
 
-        $filterValues = $query->getFilters()->getValues();
+        $filterValues = $query->getQueryParameter('fq');
         $this->assertCount(1, $filterValues, 'Unpexcted amount of filters for query');
         $this->assertSame('-type:pages', $filterValues[0], 'First filter has unexpected value');
     }
@@ -1608,7 +1608,7 @@ class QueryBuilderTest extends UnitTest
             ->setMethods(['useSiteHashFromTypoScript'])
             ->getMock();
 
-        $suggestQuery = $this->builder->buildSuggestQuery('foo', '', 3232, '');
+        $suggestQuery = $this->builder->buildSuggestQuery('foo', [], 3232, '');
         $queryParameters = $suggestQuery->getQueryParameters();
         $this->assertSame('foo', $queryParameters['facet.prefix'], 'Passed query string is not used as facet.prefix argument');
     }
@@ -1624,7 +1624,7 @@ class QueryBuilderTest extends UnitTest
                                 ->setMethods(['useSiteHashFromTypoScript'])
                                 ->getMock();
 
-        $suggestQuery = $this->builder->buildSuggestQuery('bar', '', 3232, '');
+        $suggestQuery = $this->builder->buildSuggestQuery('bar', [], 3232, '');
         $this->assertSame('*:*', $suggestQuery->getAlternativeQuery(), 'Alterntive query is not set to wildcard query by default');
     }
 }

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -118,7 +118,7 @@ class SuggestServiceTest extends UnitTest
             'typo'
         ]));
 
-        $suggestions = $this->suggestService->getSuggestions($fakeRequest, '');
+        $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
         $expectedSuggestions = [
             'suggestions' => ['type', 'typo'],
@@ -141,7 +141,7 @@ class SuggestServiceTest extends UnitTest
         $fakeRequest = $this->getFakedSearchRequest('ty');
 
         $this->suggestService->expects($this->once())->method('getSolrSuggestions')->will($this->returnValue([]));
-        $suggestions = $this->suggestService->getSuggestions($fakeRequest, '');
+        $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
         $expectedSuggestions = ['status' => false];
         $this->assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
@@ -176,7 +176,7 @@ class SuggestServiceTest extends UnitTest
         $this->searchResultSetServiceMock->expects($this->once())->method('search')->will($this->returnValue($fakeTopResults));
 
 
-        $suggestions = $this->suggestService->getSuggestions($fakeRequest, '');
+        $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
         $this->assertCount(2, $suggestions['documents'], 'Expected to have two top results');
         $this->assertSame('pages', $suggestions['documents'][0]['type'],'The first top result has an unexpected type');


### PR DESCRIPTION
This pr:

* Moves the addtional filters that have been passed as global argument "filters" before as tx_solr[additionalFilters]
* Makes sure that these filters get applied in addition to the filters that have been configured in (plugin.tx_solr.search.query.filters) to the suggestions and topResults

Impact: If you have passed the "filters" arguments somewhere from your own code, you now need to use tx_solr[additionalFilters] now.

Fixes: #2025
Fixes: #1885
Fixes: #1884