### PR TITLE
[TASK] Deprecate Search::getHasSearched and SearchResultSetService::getHasSearched

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -106,7 +106,8 @@ class SearchController extends AbstractBaseController
             $this->controllerContext->setSearchResultSet($searchResultSet);
 
             $values = [
-                'hasSearched' => $this->searchService->getHasSearched(),
+                /** @deprecated The option hasSearched is deprecated no, use resultSet.hasSearched in the templates instead, can be moved in EXT:solr 9.0.0 */
+                'hasSearched' => $searchResultSet->getHasSearched(),
                 'additionalFilters' => $this->searchService->getAdditionalFilters(),
                 'resultSet' => $searchResultSet,
                 'pluginNamespace' => $this->typoScriptConfiguration->getSearchPluginNamespace()
@@ -152,7 +153,8 @@ class SearchController extends AbstractBaseController
         $this->controllerContext->setSearchResultSet($searchResultSet);
 
         $values = [
-            'hasSearched' => $this->searchService->getHasSearched(),
+            /** @deprecated The option hasSearched is deprecated no, use resultSet.hasSearched in the templates instead, can be moved in EXT:solr 9.0.0 */
+            'hasSearched' => $searchResultSet->getHasSearched(),
             'additionalFilters' => $this->searchService->getAdditionalFilters(),
             'resultSet' => $searchResultSet
         ];

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -122,10 +122,13 @@ class SearchResultSetService
     }
 
     /**
+     * @deprecated Since 8.1.0 will be removed in 9.0.0. This method is deprecated. Use SearchResultSet::getHasSearched instead.
      * @return bool
      */
     public function getHasSearched()
     {
+        trigger_error('Call deprecated method SearchResultSetService::getHasSearched, deprecated since 8.1.0 will be removed in 9.0.0 use SearchResultSet::getHasSearched instead', E_USER_DEPRECATED);
+
         return $this->search->hasSearched();
     }
 

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -65,6 +65,7 @@ class Search
     /**
      * Flag for marking a search
      *
+     * @deprecated will be removed in EXT:solr 9.0.0 use SearchResultSet::getHasSearched instead
      * @var bool
      */
     protected $hasSearched = false;
@@ -184,6 +185,8 @@ class Search
         }
 
         $this->response = $response;
+
+        //@todo can be dropped in EXT:solr 9.0.0
         $this->hasSearched = true;
 
         return $this->response;
@@ -222,12 +225,15 @@ class Search
     }
 
     /**
-     * checks whether a search has been executed
+     * checks whether a search has been executed.
      *
+     * @deprecated Since 8.1.0 will be removed in 9.0.0. This method is deprecated. Use SearchResultSet::getHasSearched instead.
      * @return bool    TRUE if there was a search, FALSE otherwise (if the user just visited the search page f.e.)
      */
     public function hasSearched()
     {
+        trigger_error('Call deprecated method Search::hasSearched, deprecated since 8.1.0 will be removed in 9.0.0 use SearchResultSet::getHasSearched instead', E_USER_DEPRECATED);
+
         return $this->hasSearched;
     }
 

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -14,7 +14,7 @@
 
 			<div class="tx-solr-search-form col-lg-2 hidden-xs">&nbsp;</div>
 			<div class="col-lg-2 hidden-xs">
-				<f:if condition="{hasSearched}">
+				<f:if condition="{resultSet.hasSearched}">
 					<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchSorting}">
 						<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
 					</f:if>
@@ -87,7 +87,7 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<f:if condition="{hasSearched}">
+				<f:if condition="{resultSet.hasSearched}">
 					<s:widget.resultPaginate resultSet="{resultSet}">
 						<div data-start="{pagination.resultCountStart}" class="results-list list-group">
 							<f:for each="{documents}" as="document">
@@ -104,7 +104,7 @@
 
 <f:section name="extra">
 	<div id="tx-solr-search-functions">
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:if condition="{resultSet.usedSearchRequest.contextTypoScriptConfiguration.searchFaceting}">
 				<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
 			</f:if>

--- a/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
+++ b/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
@@ -40,7 +40,7 @@
 			</span>
 		</f:if>
 
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:if condition="{resultSet.usedSearch.numberOfResults}">
 				<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 			</f:if>
@@ -56,7 +56,7 @@
 </f:section>
 <f:section name="extra">
 	<div id="tx-solr-search-functions">
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
 			<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
 		</f:if>

--- a/Tests/Integration/Controller/Fixtures/customTemplates/Search/Results.html
+++ b/Tests/Integration/Controller/Fixtures/customTemplates/Search/Results.html
@@ -40,7 +40,7 @@
 			</span>
 		</f:if>
 
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:if condition="{resultSet.usedSearch.numberOfResults}">
 				<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 			</f:if>
@@ -57,7 +57,7 @@
 </f:section>
 <f:section name="extra">
 	<div id="tx-solr-search-functions">
-		<f:if condition="{hasSearched}">
+		<f:if condition="{resultSet.hasSearched}">
 			<f:render partial="Result/Sorting" section="Sorting" arguments="{resultSet:resultSet}" />
 			<f:render partial="Result/Facets" section="Facets" arguments="{resultSet:resultSet}" />
 		</f:if>


### PR DESCRIPTION
This pr:

* Deprecates the methods Search::getHasSearched and SearchResultSetService::getHasSearched
* Deprecates the global template variable hasSearch

Impact:

* Use SearchResultSet::getHasSearched instead or resultSet.hasSearched in the template
* Will be removed in EXT:solr 9.0.0

Fixes: #2031