### PR TITLE
[FEATURE] Allow open query in the DateRangeFacet

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
@@ -56,12 +56,19 @@ class DateRangeUrlDecoder implements FacetUrlDecoderInterface
     {
         list($dateRangeStart, $dateRangeEnd) = explode(self::DELIMITER, $dateRange);
 
-        $dateRangeEnd .= '59'; // adding 59 seconds
-
         $formatService = GeneralUtility::makeInstance(FormatService::class);
-        $dateRangeFilter = '[' . $formatService->timestampToIso(strtotime($dateRangeStart));
-        $dateRangeFilter .= ' TO ';
-        $dateRangeFilter .= $formatService->timestampToIso(strtotime($dateRangeEnd)) . ']';
+        $fromPart = '*';
+        if($dateRangeStart !== ''){
+            $fromPart = $formatService->timestampToIso(strtotime($dateRangeStart));
+        }
+
+        $toPart = '*';
+        if($dateRangeEnd !== ''){
+            $dateRangeEnd .= '59'; // adding 59 seconds
+            $toPart = $formatService->timestampToIso(strtotime($dateRangeEnd));
+        }
+
+        $dateRangeFilter = '[' . $fromPart . ' TO ' . $toPart . ']';
         return $dateRangeFilter;
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -56,4 +56,24 @@ class DateRangeUrlEncoderTest extends UnitTest
         $actual = $this->rangeParser->decode('201001010000-201001312359');
         $this->assertEquals($expected, $actual);
     }
+    
+    /**
+     * @test
+     */
+    public function canParseMinOpenDateRangeQuery()
+    {
+        $expected = '[* TO 2010-01-31T23:59:59Z]';
+        $actual = $this->rangeParser->decode('-201001312359');
+        $this->assertEquals($expected, $actual);
+    }
+    
+    /**
+     * @test
+     */
+    public function canParseMaxOpenDateRangeQuery()
+    {
+        $expected = '[2010-01-01T00:00:00Z TO *]';
+        $actual = $this->rangeParser->decode('201001010000-');
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This change allows to use the DateRangeFacet with an open end or open begin like:

?tx_solr[q]=*&tx_solr[filter][0]=created:-201701010000
?tx_solr[q]=*&tx_solr[filter][0]=created:201701010000-

Fixes: #2041