### PR TITLE
[BUGFIX] Warning in TranslateViewHelper

### DIFF
--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -15,8 +15,8 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
  */
 
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
-use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelper as CoreTranslateViewHelper;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 
 /**


### PR DESCRIPTION
This pr:

* Uses the new ViewHelperNode class from the new namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree

Fixes: #2043