### PR TITLE
[BUGFIX] Use copy instead of reference

### DIFF
--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -381,9 +381,9 @@ lib.solr_extbase_bootstrap {
 	userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
 	vendorName = ApacheSolrForTypo3
 	extensionName = Solr
-	settings =< plugin.tx_solr.settings
-	persistence =< plugin.tx_solr.persistence
-	view =< plugin.tx_solr.view
+	settings < plugin.tx_solr.settings
+	persistence < plugin.tx_solr.persistence
+	view < plugin.tx_solr.view
 }
 
 plugin.tx_solr_PiResults_Results < lib.solr_extbase_bootstrap


### PR DESCRIPTION
This pr:

* Changes "lib.solr_extbase_bootstrap" to use a copy for settings, persistence and view since they are no TypoScript objects

Fixes: #2040