### PR TITLE
[!!!][TASK] Make RelevanceViewHelper compatible for solrfluidgrouping

### DIFF
--- a/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
@@ -54,7 +54,7 @@ class GroupItem
     /**
      * @var float
      */
-    protected $maxScore = 0;
+    protected $maximumScore = 0;
 
     /**
      * @var SearchResultCollection
@@ -79,7 +79,7 @@ class GroupItem
         $this->groupValue = $groupValue;
         $this->numFound = $numFound;
         $this->start = $start;
-        $this->maxScore = $maxScore;
+        $this->maximumScore = $maxScore;
         $this->searchResults = new SearchResultCollection();
     }
 
@@ -118,10 +118,23 @@ class GroupItem
      *
      * @return float
      */
+    public function getMaximumScore()
+    {
+        return $this->maximumScore;
+    }
+
+    /**
+     * Get maxScore
+     *
+     * @deprecated Deprecated since EXT:solr 9.0.0 will be removed in EXT:solr 10.0.0
+     * @return float
+     */
     public function getMaxScore()
     {
-        return $this->maxScore;
+        trigger_error('GroupItem::getMaxScore is deprecated please use GroupItem::getMaximumScore now', E_USER_DEPRECATED);
+        return $this->getMaximumScore();
     }
+
 
     /**
      * @return SearchResultCollection

--- a/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/AbstractResultParser.php
@@ -62,7 +62,7 @@ abstract class AbstractResultParser {
     /**
      * @param SearchResultSet $resultSet
      * @param bool $useRawDocuments
-     * @return SearchResultCollection
+     * @return SearchResultSet
      */
     abstract public function parse(SearchResultSet $resultSet, bool $useRawDocuments = true);
 

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
@@ -40,7 +40,7 @@ class DefaultResultParser extends AbstractResultParser {
     /**
      * @param SearchResultSet $resultSet
      * @param bool $useRawDocuments
-     * @return SearchResultCollection|array|object
+     * @return SearchResultSet
      */
     public function parse(SearchResultSet $resultSet, bool $useRawDocuments = true)
     {
@@ -60,7 +60,10 @@ class DefaultResultParser extends AbstractResultParser {
             $searchResults[] = $searchResultObject;
         }
 
-        return $searchResults;
+        $resultSet->setSearchResults($searchResults);
+        $resultSet->setMaximumScore($parsedData->response->maxScore ?? 0.0);
+
+        return $resultSet;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -91,6 +91,11 @@ class SearchResultSet
     protected $allResultCount = 0;
 
     /**
+     * @var float
+     */
+    protected $maximumScore = 0.0;
+
+    /**
      * @var Suggestion[]
      */
     protected $spellCheckingSuggestions = [];
@@ -197,6 +202,22 @@ class SearchResultSet
     public function addFacet(AbstractFacet $facet)
     {
         $this->facets->addFacet($facet);
+    }
+
+    /**
+     * @return float
+     */
+    public function getMaximumScore()
+    {
+        return $this->maximumScore;
+    }
+
+    /**
+     * @param float $maximumScore
+     */
+    public function setMaximumScore($maximumScore)
+    {
+        $this->maximumScore = $maximumScore;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -198,7 +198,9 @@ class SearchResultSetService
 
         $resultSet->setHasSearched(true);
         $resultSet->setResponse($response);
-        $resultSet->setSearchResults($this->getParsedSearchResults($resultSet));
+
+        $this->getParsedSearchResults($resultSet);
+
         $resultSet->setUsedAdditionalFilters($this->queryBuilder->getAdditionalFilters());
 
         /** @var $variantsProcessor VariantsProcessor */
@@ -222,15 +224,13 @@ class SearchResultSetService
      * Uses the configured parser and retrieves the parsed search resutls.
      *
      * @param SearchResultSet $resultSet
-     * @return Result\SearchResultCollection
      */
-    protected function getParsedSearchResults($resultSet): SearchResultCollection
+    protected function getParsedSearchResults($resultSet)
     {
         /** @var ResultParserRegistry $parserRegistry */
         $parserRegistry = GeneralUtility::makeInstance(ResultParserRegistry::class, /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
         $useRawDocuments = (bool)$this->typoScriptConfiguration->getValueByPathOrDefaultValue('plugin.tx_solr.features.useRawDocuments', false);
-        $searchResults = $parserRegistry->getParser($resultSet)->parse($resultSet, $useRawDocuments);
-        return $searchResults;
+        $parserRegistry->getParser($resultSet)->parse($resultSet, $useRawDocuments);
     }
 
     /**

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -283,8 +283,13 @@ class Search
         return $this->response->response->start;
     }
 
+    /**
+     * @deprecated Since 9.0.0 will be removed in 10.0.0. Please use SearchResultSet::getMaxScore now.
+     * @return mixed
+     */
     public function getMaximumResultScore()
     {
+        trigger_error('Search::getMaximumResultScore is deprecated please use SearchResultSet::getMaximumScore now', E_USER_DEPRECATED);
         return $this->response->response->maxScore;
     }
 

--- a/Classes/ViewHelpers/Document/RelevanceViewHelper.php
+++ b/Classes/ViewHelpers/Document/RelevanceViewHelper.php
@@ -38,6 +38,7 @@ class RelevanceViewHelper extends AbstractSolrFrontendViewHelper
         parent::initializeArguments();
         $this->registerArgument('resultSet', SearchResultSet::class, 'The context searchResultSet', true);
         $this->registerArgument('document', \Apache_Solr_Document::class, 'The document to highlight', true);
+        $this->registerArgument('maximumScore', 'float', 'The maximum score that should be used for percentage calculation, if nothing is passed the maximum from the resultSet is used', false);
     }
 
     /**
@@ -54,7 +55,7 @@ class RelevanceViewHelper extends AbstractSolrFrontendViewHelper
             /** @var $resultSet SearchResultSet */
         $resultSet = $arguments['resultSet'];
 
-        $maximumScore = $document->__solr_grouping_groupMaximumScore ?: $resultSet->getUsedSearch()->getMaximumResultScore();
+        $maximumScore = $arguments['maximumScore'] ?? $resultSet->getMaximumScore();
         $content = 0;
 
         if ($maximumScore <= 0) {

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -59,9 +59,9 @@ class GroupItemTest extends UnitTest
     /**
      * @test
      */
-    public function canGetMaxScore()
+    public function canGetMaximumScore()
     {
-        $this->assertSame(99, $this->groupItem->getMaxScore(), 'Unexpected maxScore');
+        $this->assertSame(99, $this->groupItem->getMaximumScore(), 'Unexpected maximumScore');
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -58,7 +58,7 @@ class DefaultParserTest extends UnitTest
      */
     public function parseWillCreateResultCollectionFromSolrResponse()
     {
-        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
 
         $fakedSolrResponse = $this->getFixtureContentByName('fakeResponse.json');
         $fakeHttpResponse = $this->getDumbMock(\Apache_Solr_HttpTransport_Response::class);
@@ -66,8 +66,25 @@ class DefaultParserTest extends UnitTest
         $fakeResponse = new \Apache_Solr_Response($fakeHttpResponse);
 
         $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
-        $collection = $this->parser->parse($fakeResultSet, true);
-        $this->assertCount(3, $collection);
+        $parsedResultSet = $this->parser->parse($fakeResultSet, true);
+        $this->assertCount(3, $parsedResultSet->getSearchResults());
+    }
+
+    /**
+     * @test
+     */
+    public function parseWillSetMaximumScore()
+    {
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
+
+        $fakedSolrResponse = $this->getFixtureContentByName('fakeResponse.json');
+        $fakeHttpResponse = $this->getDumbMock(\Apache_Solr_HttpTransport_Response::class);
+        $fakeHttpResponse->expects($this->once())->method('getBody')->will($this->returnValue($fakedSolrResponse));
+        $fakeResponse = new \Apache_Solr_Response($fakeHttpResponse);
+
+        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $parsedResultSet = $this->parser->parse($fakeResultSet, true);
+        $this->assertSame(3.1, $parsedResultSet->getMaximumScore());
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fakeResponse.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fakeResponse.json
@@ -53,7 +53,7 @@
     "response": {
         "numFound": 8,
         "start": 5,
-        "maxScore": 1.0,
+        "maxScore": 3.1,
         "docs": [
             {
                 "id": "23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/6/0/0/0",
@@ -79,7 +79,7 @@
                 "url": "http:///.Build/bin/phpunit",
                 "_version_": 1527228677005246464,
                 "indexed": "2016-02-26T09:26:04Z",
-                "score": 1.0,
+                "score": 3.1,
                 "isElevated": false
             },
             {

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -42,10 +42,8 @@ class RelevanceViewHelperTest extends UnitTest
      */
     public function canCalculateRelevance()
     {
-        $searchMock = $this->getDumbMock(Search::class);
-        $searchMock->expects($this->once())->method('getMaximumResultScore')->will($this->returnValue(5.5));
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $resultSetMock->expects($this->any())->method('getUsedSearch')->will($this->returnValue($searchMock));
+        $resultSetMock->expects($this->any())->method('getMaximumScore')->will($this->returnValue(5.5));
 
         $documentMock = $this->getDumbMock(SearchResult::class);
         $documentMock->expects($this->once())->method('getScore')->will($this->returnValue(0.55));
@@ -58,5 +56,27 @@ class RelevanceViewHelperTest extends UnitTest
         $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
 
         $this->assertEquals(10.0, $score, 'Unexpected score');
+    }
+
+    /**
+     * @test
+     */
+    public function canCalculateRelevanceFromPassedMaximumScore()
+    {
+        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock->expects($this->never())->method('getMaximumScore');
+
+        $documentMock = $this->getDumbMock(SearchResult::class);
+        $documentMock->expects($this->once())->method('getScore')->will($this->returnValue(0.55));
+
+        $arguments = [
+            'resultSet' => $resultSetMock,
+            'document' => $documentMock,
+            'maximumScore' => 11
+        ];
+        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
+
+        $this->assertEquals(5.0, $score, 'Unexpected score');
     }
 }


### PR DESCRIPTION
By now the maximumScore is not calculated over all groups, when solrfluidgrouping is active.

To change this, some changes in the API are required:

* A ResultParser now get's the SearchResultSet passed and also retrieves it.
* The ResultParser is responsible to, parse the search results and the maximum score.
* SearchResultSet::getMaximumScore can be used to retrieve the maximum score
* The RelevanceViewHelper uses SearchResultSet::getMaximumScore to calculate the percentage in relation to the maximum score of all results. In addition the argument "maximumScore" can be used to overwrite that, e.g. to use the maximum score from the group.

Deprecations:

* Search::getMaximumResultScore is deprecated, use SearchResultSet::getMaximumScore now. The parsers for default and grouped results are responsible to set that value correctly
* GroupItem::getMaxScore is deprecated, use GroupItem::getMaximumScore now. This was changed to have a consistent naming in SearchResultSet and GroupItem

Fixes: #2056