### PR TITLE
[!!!][TASK] Use SearchResultSet::getAllResultCount instead of Search:::getNumberOfResults

### DIFF
--- a/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
@@ -44,7 +44,7 @@ class GroupItem
     /**
      * @var int
      */
-    protected $numFound = 0;
+    protected $allResultCount = 0;
 
     /**
      * @var int
@@ -77,7 +77,7 @@ class GroupItem
     {
         $this->group = $group;
         $this->groupValue = $groupValue;
-        $this->numFound = $numFound;
+        $this->allResultCount = $numFound;
         $this->start = $start;
         $this->maximumScore = $maxScore;
         $this->searchResults = new SearchResultCollection();
@@ -98,9 +98,21 @@ class GroupItem
      *
      * @return int
      */
+    public function getAllResultCount()
+    {
+        return $this->allResultCount;
+    }
+
+    /**
+     * Get numFound
+     *
+     * @deprecated Deprecated since EXT:solr 9.0.0 will be removed in EXT:solr 10.0.0 use getAllResultCount now
+     * @return int
+     */
     public function getNumFound()
     {
-        return $this->numFound;
+        trigger_error('GroupItem::getNumFound is deprecated please use GroupItem::getAllResultCount now', E_USER_DEPRECATED);
+        return $this->getAllResultCount();
     }
 
     /**
@@ -126,7 +138,7 @@ class GroupItem
     /**
      * Get maxScore
      *
-     * @deprecated Deprecated since EXT:solr 9.0.0 will be removed in EXT:solr 10.0.0
+     * @deprecated Deprecated since EXT:solr 9.0.0 will be removed in EXT:solr 10.0.0 getMaximumScore now
      * @return float
      */
     public function getMaxScore()

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
@@ -46,8 +46,12 @@ class DefaultResultParser extends AbstractResultParser {
     {
         $searchResults = GeneralUtility::makeInstance(SearchResultCollection::class);
         $parsedData = $resultSet->getResponse()->getParsedData();
+
+        $resultSet->setMaximumScore($parsedData->response->maxScore ?? 0.0);
+        $resultSet->setAllResultCount($parsedData->response->numFound ?? 0);
+
         if (!is_array($parsedData->response->docs)) {
-            return $searchResults;
+            return $resultSet;
         }
 
         $documents = $parsedData->response->docs;
@@ -61,8 +65,6 @@ class DefaultResultParser extends AbstractResultParser {
         }
 
         $resultSet->setSearchResults($searchResults);
-        $resultSet->setMaximumScore($parsedData->response->maxScore ?? 0.0);
-
         return $resultSet;
     }
 

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -79,28 +79,12 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             return $resultSet;
         }
 
-        $resultSet = $this->parseResultCount($resultSet);
         $resultSet = $this->parseSpellCheckingResponseIntoObjects($resultSet);
         $resultSet = $this->parseSortingIntoObjects($resultSet);
 
         // here we can reconstitute other domain objects from the solr response
         $resultSet = $this->parseFacetsIntoObjects($resultSet);
 
-        return $resultSet;
-    }
-
-    /**
-     * @param SearchResultSet $resultSet
-     * @return SearchResultSet
-     */
-    protected function parseResultCount(SearchResultSet $resultSet)
-    {
-        $response = $resultSet->getResponse();
-        $solrResponse = $response->__get('response');
-        if (!isset($solrResponse->numFound)) {
-            return $resultSet;
-        }
-        $resultSet->setAllResultCount($solrResponse->numFound);
         return $resultSet;
     }
 

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -268,8 +268,13 @@ class Search
         return $this->getResponseHeader()->params->rows;
     }
 
+    /**
+     * @deprecated Since 9.0.0 will be removed in 10.0.0. Please use SearchResultSet::getAllResultCount now
+     * @return int
+     */
     public function getNumberOfResults()
     {
+        trigger_error('Search::getNumberOfResults is deprecated please use SearchResultSet::getAllResultCount now', E_USER_DEPRECATED);
         return $this->response->response->numFound;
     }
 

--- a/Classes/ViewHelpers/Widget/Controller/GroupItemPaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/GroupItemPaginateController.php
@@ -49,7 +49,7 @@ class GroupItemPaginateController extends AbstractPaginateWidgetController
         $this->groupItem = $this->widgetConfiguration['groupItem'];
         $this->configuration['itemsPerPage'] = $this->getItemsPerPage();
 
-        $this->numberOfPages = (int)ceil($this->groupItem->getNumFound() / $this->configuration['itemsPerPage']);
+        $this->numberOfPages = (int)ceil($this->groupItem->getAllResultCount() / $this->configuration['itemsPerPage']);
     }
 
     /**

--- a/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/ResultPaginateController.php
@@ -42,7 +42,7 @@ class ResultPaginateController extends AbstractPaginateWidgetController
         $this->resultSet = $this->widgetConfiguration['resultSet'];
         $this->configuration['itemsPerPage'] = $this->getItemsPerPage();
 
-        $this->numberOfPages = (int)ceil($this->resultSet->getUsedSearch()->getNumberOfResults() / $this->configuration['itemsPerPage']);
+        $this->numberOfPages = (int)ceil($this->resultSet->getAllResultCount() / $this->configuration['itemsPerPage']);
     }
 
     /**

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -62,14 +62,14 @@
 					</f:then>
 				</f:if>
 
-				<f:if condition="{resultSet.usedSearch.numberOfResults}">
+				<f:if condition="{resultSet.allResultCount}">
 					<span class="result-found">
-						<f:if condition="{resultSet.usedSearch.numberOfResults} == 1">
+						<f:if condition="{resultSet.allResultCount} == 1">
 							<f:then>
 								<s:translate key="results_found.singular" arguments="{0:resultSet.usedSearch.queryTime}">Found 1 result in %d seconds</s:translate>
 							</f:then>
 							<f:else>
-								<s:translate key="results_found" arguments="{0:resultSet.usedSearch.numberOfResults, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
+								<s:translate key="results_found" arguments="{0:resultSet.allResultCount, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
 							</f:else>
 						</f:if>
 					</span>
@@ -79,7 +79,7 @@
 						</s:pageBrowserRange>
 					</span>
 				</f:if>
-				<f:if condition="{resultSet.usedSearch.numberOfResults}">
+				<f:if condition="{resultSet.allResultCount}">
 					<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 				</f:if>
 			</div>

--- a/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
+++ b/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
@@ -28,9 +28,9 @@
 			</f:then>
 		</f:if>
 
-		<f:if condition="{resultSet.usedSearch.numberOfResults}">
+		<f:if condition="{resultSet.allResultCount}">
 			<span class="result-found">
-				<s:translate key="results_found" arguments="{0:resultSet.usedSearch.numberOfResults, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
+				<s:translate key="results_found" arguments="{0:resultSet.allResultCount, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
 			</span>
 
 			<span class="result-range">
@@ -41,7 +41,7 @@
 		</f:if>
 
 		<f:if condition="{resultSet.hasSearched}">
-			<f:if condition="{resultSet.usedSearch.numberOfResults}">
+			<f:if condition="{resultSet.allResultCount}">
 				<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 			</f:if>
 			<s:widget.resultPaginate resultSet="{resultSet}">

--- a/Tests/Integration/Controller/Fixtures/customTemplates/Search/Results.html
+++ b/Tests/Integration/Controller/Fixtures/customTemplates/Search/Results.html
@@ -28,9 +28,9 @@
 			</f:then>
 		</f:if>
 
-		<f:if condition="{resultSet.usedSearch.numberOfResults}">
+		<f:if condition="{resultSet.allResultCount}">
 			<span class="result-found">
-				<s:translate key="results_found" arguments="{0:resultSet.usedSearch.numberOfResults, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
+				<s:translate key="results_found" arguments="{0:resultSet.allResultCount, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
 			</span>
 
 			<span class="result-range">
@@ -41,7 +41,7 @@
 		</f:if>
 
 		<f:if condition="{resultSet.hasSearched}">
-			<f:if condition="{resultSet.usedSearch.numberOfResults}">
+			<f:if condition="{resultSet.allResultCount}">
 				<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 			</f:if>
 			<s:widget.resultPaginate resultSet="{resultSet}">

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -77,7 +77,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetNumFound()
     {
-        $this->assertSame(12, $this->groupItem->getNumFound(), 'Unexpected numFound');
+        $this->assertSame(12, $this->groupItem->getAllResultCount(), 'Unexpected numFound');
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -73,6 +73,23 @@ class DefaultParserTest extends UnitTest
     /**
      * @test
      */
+    public function returnsResultSetWithResultCount()
+    {
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
+
+        $fakedSolrResponse = $this->getFixtureContentByName('fake_solr_response_with_query_fields_facets.json');
+        $fakeHttpResponse = $this->getDumbMock(\Apache_Solr_HttpTransport_Response::class);
+        $fakeHttpResponse->expects($this->once())->method('getBody')->will($this->returnValue($fakedSolrResponse));
+        $fakeResponse = new \Apache_Solr_Response($fakeHttpResponse);
+
+        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $parsedResultSet = $this->parser->parse($fakeResultSet, true);
+        $this->assertSame(10, $parsedResultSet->getAllResultCount());
+    }
+
+    /**
+     * @test
+     */
     public function parseWillSetMaximumScore()
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
@@ -114,5 +131,6 @@ class DefaultParserTest extends UnitTest
         $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(false));
         $this->assertTrue($this->parser->canParse($fakeResultSet));
     }
+
 
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fake_solr_response_with_query_fields_facets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/Fixtures/fake_solr_response_with_query_fields_facets.json
@@ -1,0 +1,97 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 11,
+    "params": {
+      "spellcheck": "true",
+      "facet": "true",
+      "enableElevation": "false",
+      "hl.tag.post": "</em>",
+      "spellcheck.maxCollationTries": "5",
+      "q.alt": "*:*",
+      "hl": "true",
+      "echoParams": "all",
+      "debugQuery": "true",
+      "fl": "*,score",
+      "bf": "recip(ms(NOW,filter_dateS),3.16e-11,1,1)^20.0",
+      "facet.query": [
+        "created:[NOW/DAY-7DAYS TO *]",
+        "created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]",
+        "created:[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]",
+        "created:[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]",
+        "created:[* TO NOW/DAY-1YEAR]"
+      ],
+      "facet.field": [
+        "type",
+        "category_stringM"
+      ],
+      "fq": [
+        "siteHash:\"73f9dbeae83ff400a97eedfb88e33a5a9d9f58fe\"",
+        "{!typo3access}-2,0,1"
+      ],
+      "hl.fragsize": "100",
+      "facet.mincount": "1",
+      "qf": "content^10.0 title^12.0 category_textM^2.0",
+      "hl.tag.pre": "<em class=\"match\">",
+      "hl.fl": "content",
+      "json.nl": "map",
+      "spellcheck.collate": "true",
+      "wt": "json",
+      "rows": "10",
+      "hl.useFastVectorHighlighter": "true",
+      "start": "0",
+      "facet.sort": "count",
+      "q": "",
+      "hl.requireFieldMatch": "true",
+      "mm": "2<-35%",
+      "indent": "true",
+      "spellcheck.extendedResults": "false",
+      "hl.mergeContiguous": "true",
+      "f.content.hl.maxAlternateFieldLength": "200",
+      "spellcheck.onlyMorePopular": "false",
+      "defType": "edismax",
+      "pf": "content^2.0",
+      "df": "content",
+      "hl.snippets": "3",
+      "f.content.hl.alternateField": "content",
+      "spellcheck.dictionary": [
+        "default",
+        "wordbreak"
+      ],
+      "spellcheck.count": "1",
+      "ps": "15"
+    }
+  },
+  "response": {
+    "numFound": 10,
+    "start": 0,
+    "maxScore": 1.0868415
+  },
+  "facet_counts": {
+    "facet_queries": {
+      "created:[NOW/DAY-7DAYS TO *]": 0,
+      "created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]": 3,
+      "created:[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]": 27,
+      "created:[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]": 0,
+      "created:[* TO NOW/DAY-1YEAR]": 17
+    },
+    "facet_fields": {
+      "type_stringS": {
+        "page": 31,
+        "event": 7,
+        "news": 6,
+        "protocol": 3
+      },
+      "category_stringM": {
+        "Cat 1": 3,
+        "Cat 2": 2,
+        "Cat 3": 2,
+        "Cat 4": 1,
+        "Cat 5": 1
+      }
+    },
+    "facet_dates": {},
+    "facet_ranges": {},
+    "facet_intervals": {}
+  }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -1053,21 +1053,6 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     /**
      * @test
      */
-    public function returnsResultSetWithResultCount()
-    {
-        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
-
-        $configuration = [];
-
-        $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
-        $processor->process($searchResultSet);
-
-        $this->assertEquals(10, $searchResultSet->getAllResultCount(), 'Unexpected all result count');
-    }
-
-    /**
-     * @test
-     */
     public function canReturnSortingsAndMarkedSelectedAsActive()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');


### PR DESCRIPTION
This pr:

* Changes the default templates to use resultSet.allResultCount instead of resultSet.usedSearch.numberOfResults
* Moves the parsing of all allResultCount to the default parser
* Changes the method GroupItem::getNumFound to GroupItem::getAllResultCount to be consistent with SearchResultSet
* Use getAllResultCount where previously getNumberOfResults was used
* Deprecate GroupItem::getNumFound
* Deprecate Search::getNumberOfResults

Deprecations:

* GroupItem::getNumFound is deprecated now, please use GroupItem::getAllResultCount now, will be removed in EXT:solr 10
* Search::getNumberOfResults is deprecated now, please use SearchResultSet::getAllResutCount now, will be removed in EXT:solr 10

Fixes: #2057