### PR TITLE
[TASK] Fix deprecations from Apache Solr 7.4

### DIFF
--- a/Documentation/Appendix/DynamicFieldTypes.rst
+++ b/Documentation/Appendix/DynamicFieldTypes.rst
@@ -33,36 +33,28 @@ Extension               Type                                 Multivalue  Comment
 \*_binM                 binary                               Yes         Stored but not indexed
 \*_boolS                Boolean                              No
 \*_boolM                Boolean                              Yes
-\*_intS                 Integer                              No          deprecated use _tIntS now
-\*_intM                 Integer                              Yes         deprecated use _tIntM now
-\*_sIntS                Sortable        Integer              No          not available use _tIntS now
-\*_sIntM                Sortable        Integer              Yes         not available use _tIntM now
-\*_tIntS                Trie Integer                         No
-\*_tIntM                Trie Integer                         Yes
-\*_longS                Long                                 No          deprecated use _tLongS now
-\*_longM                Long                                 Yes         deprecated use _tLongM now
-\*_sLongS               Sortable Long                        No          not available use _tLongS now
-\*_sLongM               Sortable Long                        Yes         not available use _tLongM now
-\*_tLongS               Trie Long                            No
-\*_tLongM               Trie Long                            Yes
-\*_floatS               Float                                No          deprecated use _tFloatS now
-\*_floatM               Float                                Yes         deprecated use _tFloatM now
-\*_sFloatS              Sortable Float                       No          not available use _tFloatS now
-\*_sFloatM              Sortable Float                       Yes         not available use _tFloatM now
-\*_tFloatS              Trie Float                           No
-\*_tFloatM              Trie Float                           Yes
-\*_doubleS              Double                               No          deprecated use _tDoubleS now
-\*_doubleM              Double                               Yes         deprecated use _tDoubleM now
-\*_sDoubleS             Sortable Double                      No          not available use _tDoubleS now
-\*_sDoubleM             Sortable Double                      Yes         not available use _tDoubleM now
-\*_tDoubleS             Trie Double                          No
-\*_tDoubleM             Trie Double                          Yes
-\*_tDouble4S            Trie Double with Precision Step 4    No
-\*_tDouble4M            Trie Double with Precision Step 4    Yes
-\*_dateS                Date                                 No          deprecated use _tDateS now
-\*_dateM                Date                                 Yes         deprecated use _tDateM now
-\*_tDateS               Trie Date                            No
-\*_tDateM               Trie Date                            Yes
+\*_intS                 Integer                              No
+\*_intM                 Integer                              Yes
+\*_tIntS                Integer                              No          Deprecated use _intS removed in EXT:solr 10
+\*_tIntM                Integer                              Yes         Deprecated use _intM removed in EXT:solr 10
+\*_longS                Long                                 No
+\*_longM                Long                                 Yes
+\*_tLongS               Long                                 No          Deprecated use _longS removed in EXT:solr 10
+\*_tLongM               Long                                 Yes         Deprecated use _longM removed in EXT:solr 10
+\*_floatS               Float                                No
+\*_floatM               Float                                Yes
+\*_tFloatS              Float                                No          Deprecated use _floatS removed in EXT:solr 10
+\*_tFloatM              Float                                Yes         Deprecated use _floatM removed in EXT:solr 10
+\*_doubleS              Double                               No
+\*_doubleM              Double                               Yes
+\*_tDoubleS             Double                               No          Deprecated use _doubleS removed in EXT:solr 10
+\*_tDoubleM             Double                               Yes         Deprecated use _doubleS removed in EXT:solr 10
+\*_tDouble4S            Double                               No          Deprecated use _double4S removed in EXT:solr 10
+\*_tDouble4M            Double                               Yes         Deprecated use _double4M removed in EXT:solr 10
+\*_dateS                Date                                 No
+\*_dateM                Date                                 Yes
+\*_tDateS               Date                                 No          Deprecated use _dateS removed in EXT:solr 10
+\*_tDateM               Date                                 Yes         Deprecated use _dateM removed in EXT:solr 10
 \*_random               Random                               No
 \*_textS                Text                                 No
 \*_textM                Text                                 Yes

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/arabic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/arabic/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,9 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -69,7 +71,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +83,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
@@ -95,10 +97,10 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -109,7 +111,33 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+
+			<filter class="solr.KeywordMarkerFilterFactory" protected="arabic/protwords.txt"/>
+			<filter class="solr.ArabicStemFilterFactory"/>
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="arabic/protwords.txt"
+			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="arabic/protwords.txt"/>
@@ -123,11 +151,24 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -151,7 +192,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="arabic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="arabic"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="arabic"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/armenian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/armenian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -57,17 +57,16 @@
 				protected="armenian/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
-
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
-
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -77,12 +76,9 @@
 				preserveOriginal="1"
 				protected="armenian/protwords.txt"
 			/>
-
 			<filter class="solr.LowerCaseFilterFactory"/>
-
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
-
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -92,10 +88,10 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -105,10 +101,27 @@
 				protected="armenian/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
-
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="armenian/protwords.txt"
+			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Armenian" protected="armenian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -118,11 +131,18 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
-
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -132,20 +152,16 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
-
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
-
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory" />
-
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="armenian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="armenian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="armenian"/>
-
 			<filter class="solr.StandardFilterFactory" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/basque/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/basque/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -112,17 +114,47 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
+			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="basque/protwords.txt"
+			/>
+
+			<filter class="solr.SnowballPorterFilterFactory" language="Basque" protected="basque/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -145,7 +177,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="basque"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="basque" />
 			<filter class="solr.ManagedStopFilterFactory" managed="basque"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/brazilian_portuguese/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,9 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
@@ -68,7 +70,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +82,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
@@ -93,14 +95,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -114,17 +117,47 @@
 			<filter class="solr.BrazilianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
+			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="brazilian_portuguese/protwords.txt"
+			/>
+
+			<filter class="solr.KeywordMarkerFilterFactory" protected="brazilian_portuguese/protwords.txt"/>
+			<filter class="solr.BrazilianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -147,7 +180,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="brazilian-portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="brazilian-portuguese"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/bulgarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/bulgarian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
@@ -93,10 +94,10 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -107,7 +108,29 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+
+			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
+			<filter class="solr.BulgarianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="bulgarian/protwords.txt"
+			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="bulgarian/protwords.txt"/>
@@ -120,11 +143,20 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -148,7 +180,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="bulgarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="bulgarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="bulgarian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/burmese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/burmese/schema.xml
@@ -45,11 +45,12 @@
 	<fieldType name="text" class="solr.TextField" positionIncrementGap="100">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
 		</analyzer>
 	</fieldType>
 
@@ -57,9 +58,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
 		</analyzer>
 	</fieldType>
 
@@ -67,11 +73,20 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="burmese"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="burmese"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -81,11 +96,12 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="burmese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="burmese" />
 		</analyzer>
 	</fieldType>
 

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/catalan/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/catalan/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
@@ -91,14 +92,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -110,20 +112,49 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
+			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="catalan/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Catalan" protected="catalan/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
+			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -143,7 +174,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="catalan"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="catalan" />
 			<filter class="solr.ManagedStopFilterFactory" managed="catalan"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/chinese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/chinese/schema.xml
@@ -47,13 +47,14 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
 		</analyzer>
 	</fieldType>
 
@@ -61,11 +62,18 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
 		</analyzer>
 	</fieldType>
 
@@ -73,10 +81,17 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -87,14 +102,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="chinese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="chinese" />
 		</analyzer>
 	</fieldType>
-
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/czech/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/czech/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 
 			<filter class="solr.CzechStemFilterFactory"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 
 			<filter class="solr.CzechStemFilterFactory"/>
@@ -92,15 +93,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -112,17 +114,46 @@
 			<filter class="solr.CzechStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
+			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="czech/protwords.txt"
+			/>
+			<filter class="solr.CzechStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -144,7 +175,7 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="czech"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="czech" />
 			<filter class="solr.ManagedStopFilterFactory" managed="czech"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/danish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
@@ -92,15 +93,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -113,17 +115,47 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="danish/protwords.txt"
+			/>
+
+			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -146,7 +178,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="danish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="danish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="danish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/dutch/schema.xml
@@ -47,7 +47,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -60,7 +60,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
@@ -69,7 +70,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -82,7 +83,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
@@ -94,14 +95,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -114,17 +116,46 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
+			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="dutch/protwords.txt"
+			/>
+
+			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -147,7 +178,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="dutch"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="dutch" />
 			<filter class="solr.ManagedStopFilterFactory" managed="dutch"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/english/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1"
+			<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
 				catenateNumbers="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
@@ -91,10 +92,10 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -105,7 +106,29 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
+
+			<filter class="solr.EnglishPossessiveFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="english/protwords.txt"
+			/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -118,11 +141,20 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -145,7 +177,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="english"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="english" />
 			<filter class="solr.ManagedStopFilterFactory" managed="english"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/finnish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +82,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
@@ -93,15 +94,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -113,17 +115,46 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="finnish/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -146,7 +177,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="finnish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="finnish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="finnish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/french/schema.xml
@@ -47,7 +47,7 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.ElisionFilterFactory"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -57,8 +57,12 @@
 				preserveOriginal="1"
 				protected="french/protwords.txt"
 			/>
-			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -66,7 +70,7 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.ElisionFilterFactory"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -78,7 +82,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
@@ -89,16 +93,18 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
 
 			<filter class="solr.ElisionFilterFactory"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -110,17 +116,47 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
+			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+
+			<filter class="solr.ElisionFilterFactory"/>
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="french/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -141,7 +177,7 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="french"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="french" />
 			<filter class="solr.ManagedStopFilterFactory" managed="french"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/galician/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/galician/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
@@ -93,15 +94,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -114,17 +116,47 @@
 			<filter class="solr.GalicianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
+			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="galician/protwords.txt"
+			/>
+			<filter class="solr.KeywordMarkerFilterFactory" protected="galician/protwords.txt"/>
+			<filter class="solr.GalicianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -148,7 +180,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="galician"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="galician" />
 			<filter class="solr.ManagedStopFilterFactory" managed="galician"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/general_schema_fields.xml
@@ -191,33 +191,39 @@
 	<dynamicField name="*_binS"      type="binary"    indexed="false" stored="true" multiValued="false" />
 	<dynamicField name="*_binM"      type="binary"    indexed="false" stored="true" multiValued="true" />
 
+	<!--
+		Numeric point fields
+	-->
 	<dynamicField name="*_intS"      type="integer"   indexed="true" stored="true" docValues="true" multiValued="false" />
 	<dynamicField name="*_intM"      type="integer"   indexed="true" stored="true" docValues="true" multiValued="true" />
-	<dynamicField name="*_tIntS"     type="tint"      indexed="true" stored="true" docValues="true" multiValued="false" />
-	<dynamicField name="*_tIntM"     type="tint"      indexed="true" stored="true" docValues="true" multiValued="true" />
-
 	<dynamicField name="*_longS"     type="long"      indexed="true" stored="true" docValues="true" multiValued="false" />
 	<dynamicField name="*_longM"     type="long"      indexed="true" stored="true" docValues="true" multiValued="true" />
-	<dynamicField name="*_tLongS"    type="tlong"     indexed="true" stored="true" docValues="true" multiValued="false" />
-	<dynamicField name="*_tLongM"    type="tlong"     indexed="true" stored="true" docValues="true" multiValued="true" />
-
 	<dynamicField name="*_floatS"    type="float"     indexed="true" stored="true" docValues="true" multiValued="false"/>
 	<dynamicField name="*_floatM"    type="float"     indexed="true" stored="true" docValues="true" multiValued="true"/>
-	<dynamicField name="*_tFloatS"   type="tfloat"    indexed="true" stored="true" docValues="true" multiValued="false"/>
-	<dynamicField name="*_tFloatM"   type="tfloat"    indexed="true" stored="true" docValues="true" multiValued="true"/>
-
 	<dynamicField name="*_doubleS"   type="double"    indexed="true" stored="true" docValues="true" multiValued="false" />
 	<dynamicField name="*_doubleM"   type="double"    indexed="true" stored="true" docValues="true" multiValued="true" />
-	<dynamicField name="*_tDoubleS"  type="tdouble"   indexed="true" stored="true" docValues="true" multiValued="false" />
-	<dynamicField name="*_tDoubleM"  type="tdouble"   indexed="true" stored="true" docValues="true" multiValued="true" />
-	<dynamicField name="*_tDouble4S" type="tdouble4"  indexed="true" stored="true" docValues="true" multiValued="false" />
-	<dynamicField name="*_tDouble4M" type="tdouble4"  indexed="true" stored="true" docValues="true" multiValued="true" />
-
-
 	<dynamicField name="*_dateS"     type="date"      indexed="true" stored="true" docValues="true" multiValued="false" />
 	<dynamicField name="*_dateM"     type="date"      indexed="true" stored="true" docValues="true" multiValued="true" />
-	<dynamicField name="*_tDateS"    type="tdate"     indexed="true" stored="true" docValues="true" multiValued="false" />
-	<dynamicField name="*_tDateM"    type="tdate"     indexed="true" stored="true" docValues="true" multiValued="true" />
+
+
+	<!--
+		These fields are deprecated and only kept for backwards compatibility:
+	-->
+	<dynamicField name="*_tIntS"      type="integer"   indexed="true" stored="true" docValues="true" multiValued="false" />
+	<dynamicField name="*_tIntM"      type="integer"   indexed="true" stored="true" docValues="true" multiValued="true" />
+	<dynamicField name="*_tLongS"     type="long"      indexed="true" stored="true" docValues="true" multiValued="false" />
+	<dynamicField name="*_tLongM"     type="long"      indexed="true" stored="true" docValues="true" multiValued="true" />
+	<dynamicField name="*_tFloatS"    type="float"     indexed="true" stored="true" docValues="true" multiValued="false"/>
+	<dynamicField name="*_tFloatM"    type="float"     indexed="true" stored="true" docValues="true" multiValued="true"/>
+	<dynamicField name="*_tDoubleS"   type="double"    indexed="true" stored="true" docValues="true" multiValued="false" />
+	<dynamicField name="*_tDoubleM"   type="double"    indexed="true" stored="true" docValues="true" multiValued="true" />
+	<dynamicField name="*_tDouble4S"  type="double"    indexed="true" stored="true" docValues="true" multiValued="false" />
+	<dynamicField name="*_tDouble4M"  type="double"    indexed="true" stored="true" docValues="true" multiValued="true" />
+	<dynamicField name="*_tDateS"     type="date"      indexed="true" stored="true" docValues="true" multiValued="false" />
+	<dynamicField name="*_tDateM"     type="date"      indexed="true" stored="true" docValues="true" multiValued="true" />
+	<!--
+		End of deprecated fields
+	-->
 
 	<dynamicField name="*_textS"      type="text"      indexed="true" stored="true" multiValued="false" />
 	<dynamicField name="*_textM"      type="text"      indexed="true" stored="true" multiValued="true" />
@@ -242,21 +248,16 @@
 
 	<dynamicField name="*_phoneticS" type="phonetic"  indexed="true" stored="true" multiValued="false" />
 	<dynamicField name="*_phoneticM" type="phonetic"  indexed="true" stored="true" multiValued="true" />
-
-
 	<dynamicField name="*_random"    type="random"    indexed="true" stored="true" multiValued="false" />
 
 
 	<dynamicField name="*_point"       type="point"       indexed="true" stored="true" multiValued="false" />
-	<dynamicField name="*_location"    type="location"    indexed="true" stored="true" multiValued="false" />
+	<dynamicField name="*_location"    type="location"    indexed="true" stored="true" docValues="true" multiValued="false" />
 	<!-- Type used to index the lat and lon components for the "location" field type -->
 	<dynamicField name="*_coordinate"  type="double"      indexed="true" stored="false" />
 	<dynamicField name="*_locationRpt" type="locationRpt" indexed="true" stored="true" multiValued="false" />
 
-
 	<dynamicField name="*_currency"  type="currency"  indexed="true" stored="true" multiValued="false" />
-
-
 
 	<!--
 		The following causes solr to ignore any fields that don't already

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/general_schema_types.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/general_schema_types.xml
@@ -39,27 +39,10 @@
 	<!--
 		Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
 	-->
-	<fieldType name="integer" class="solr.TrieIntField"    precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
-	<fieldType name="float"   class="solr.TrieFloatField"  precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
-	<fieldType name="long"    class="solr.TrieLongField"   precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
-	<fieldType name="double"  class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0" omitNorms="true" useDocValuesAsStored="false" />
-
-	<!--
-		Numeric field types that index each value at various levels of precision
-		to accelerate range queries when the number of values between the range
-		endpoints is large. See the javadoc for NumericRangeQuery for internal
-		implementation details.
-
-		Smaller precisionStep values (specified in bits) will lead to more tokens
-		indexed per value, slightly larger index size, and faster range queries.
-		A precisionStep of 0 disables indexing at different precision levels.
-	-->
-	<fieldType name="tint"     class="solr.TrieIntField"    precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
-	<fieldType name="tfloat"   class="solr.TrieFloatField"  precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
-	<fieldType name="tlong"    class="solr.TrieLongField"   precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
-	<fieldType name="tdouble"  class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
-
-	<fieldType name="tdouble4" class="solr.TrieDoubleField" precisionStep="4" positionIncrementGap="0" omitNorms="true" indexed="true" stored="false" useDocValuesAsStored="false" />
+	<fieldType name="integer" class="solr.IntPointField"    omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="float"   class="solr.FloatPointField"  omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="long"    class="solr.LongPointField"   omitNorms="true" useDocValuesAsStored="false" />
+	<fieldType name="double"  class="solr.DoublePointField" omitNorms="true" useDocValuesAsStored="false" />
 
 	<!--
 		The format for this date field is of the form 1995-12-31T23:59:59Z, and
@@ -84,11 +67,7 @@
 
 		Note: For faster range queries, consider the tdate type
 	-->
-	<fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0" sortMissingLast="true" omitNorms="true" useDocValuesAsStored="false" />
-
-	<!-- A Trie based date field for faster date range queries and date faceting. -->
-	<fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0" omitNorms="true" />
-
+	<fieldType name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true" useDocValuesAsStored="false" />
 
 	<!-- solr.TextField allows the specification of custom text analyzers
 		specified as a tokenizer and a list of token filters. Different
@@ -213,7 +192,7 @@
 	<fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_doubleS" />
 
 	<!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-	<fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate" />
+	<fieldType name="location" class="solr.LatLonPointSpatialField" />
 
 	<!--
 		An alternative geospatial field type. It supports multiValued and polygon shapes.
@@ -222,7 +201,7 @@
 	<fieldType name="locationRpt" class="solr.SpatialRecursivePrefixTreeFieldType"
 			   geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees"  />
 
-	<fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
+	<fieldType name="currency" class="solr.CurrencyFieldType" amountLongSuffix="_longS" codeStrSuffix="_stringS" defaultCurrency="USD" currencyConfig="currency.xml" />
 
 
 	<!-- since fields of this type are by default not stored or indexed, any data added to

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/generic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/generic/schema.xml
@@ -42,7 +42,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -55,7 +55,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
 
 			<!-- no stemming -->
@@ -64,7 +65,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1"
+			<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
 				catenateNumbers="0"
@@ -76,7 +77,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
 
 			<!-- no stemming -->
@@ -89,15 +90,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1" catenateNumbers="1"
@@ -109,17 +111,46 @@
 			<!-- no stemming -->
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
+			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1" catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="generic/protwords.txt"
+			/>
+
+			<!-- no stemming -->
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -142,7 +173,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="generic"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="generic" />
 			<filter class="solr.ManagedStopFilterFactory" managed="generic"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/german/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
 				dictionary="german/german-common-nouns.txt"
@@ -76,7 +77,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -88,7 +89,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
 
 			<filter class="solr.GermanNormalizationFilterFactory"/>
@@ -101,11 +102,13 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+
 			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
 				dictionary="german/german-common-nouns.txt"
 				minWordSize="5"
@@ -115,7 +118,7 @@
 			/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -128,17 +131,53 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
+			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
+					dictionary="german/german-common-nouns.txt"
+					minWordSize="5"
+					minSubwordSize="4"
+					maxSubwordSize="15"
+					onlyLongestMatch="false"
+			/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="german/protwords.txt"
+			/>
+			<filter class="solr.GermanNormalizationFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -168,7 +207,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="german"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="german" />
 			<filter class="solr.ManagedStopFilterFactory" managed="german"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/greek/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/greek/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
@@ -93,15 +94,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -115,17 +117,48 @@
 			<filter class="solr.GreekStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
+			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="greek/protwords.txt"
+			/>
+
+			<filter class="solr.KeywordMarkerFilterFactory" protected="greek/protwords.txt"/>
+			<filter class="solr.GreekStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -148,7 +181,7 @@
 
 			<filter class="solr.GreekLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="greek"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="greek" />
 			<filter class="solr.ManagedStopFilterFactory" managed="greek"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/hindi/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/hindi/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
@@ -70,7 +71,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -82,7 +83,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
@@ -97,14 +98,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -119,17 +121,48 @@
 			<filter class="solr.HindiNormalizationFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
+			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="hindi/protwords.txt"
+			/>
+			<filter class="solr.KeywordMarkerFilterFactory" protected="hindi/protwords.txt"/>
+			<filter class="solr.HindiStemFilterFactory"/>
+			<filter class="solr.IndicNormalizationFilterFactory"/>
+			<filter class="solr.HindiNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -154,7 +187,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hindi"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hindi" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hindi"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/hungarian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1" generateNumberParts="1"
 				catenateWords="1"
 				catenateNumbers="1"
@@ -57,7 +57,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
@@ -65,7 +66,7 @@
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -77,7 +78,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
@@ -89,15 +90,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -109,17 +111,46 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="hungarian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="index">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -142,7 +173,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="hungarian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="hungarian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="hungarian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/indonesian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/indonesian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
@@ -93,14 +94,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -113,17 +115,46 @@
 			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="indonesian/protwords.txt"
+			/>
+			<filter class="solr.KeywordMarkerFilterFactory" protected="indonesian/protwords.txt"/>
+			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -147,7 +178,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="indonesian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="indonesian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="indonesian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/irish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.IrishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="irish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory" generateWordParts="1"
+			<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
 				catenateNumbers="0"
@@ -78,7 +79,7 @@
 			/>
 			<filter class="solr.IrishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="irish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
@@ -90,10 +91,10 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -104,7 +105,28 @@
 			/>
 			<filter class="solr.IrishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="irish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
+
+			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="irish/protwords.txt"
+			/>
+			<filter class="solr.IrishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
@@ -116,11 +138,20 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="irish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -143,7 +174,7 @@
 
 			<filter class="solr.IrishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="irish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="irish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="irish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/italian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +82,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
@@ -93,15 +94,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -113,17 +115,46 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="italian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -146,7 +177,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="italian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="italian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="italian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/japanese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/japanese/schema.xml
@@ -47,13 +47,14 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
 		</analyzer>
 	</fieldType>
 
@@ -61,11 +62,18 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
 		</analyzer>
 	</fieldType>
 
@@ -73,10 +81,17 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -87,13 +102,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="japanese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="japanese" />
 		</analyzer>
 	</fieldType>
 

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/khmer/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/khmer/schema.xml
@@ -45,11 +45,12 @@
 	<fieldType name="text" class="solr.TextField" positionIncrementGap="100">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
 		</analyzer>
 	</fieldType>
 
@@ -57,9 +58,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
 		</analyzer>
 	</fieldType>
 
@@ -67,10 +73,17 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -79,11 +92,10 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="khmer"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="khmer" />
 		</analyzer>
 	</fieldType>
 

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/korean/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/korean/schema.xml
@@ -47,13 +47,14 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
 		</analyzer>
 	</fieldType>
 
@@ -61,11 +62,18 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
 		</analyzer>
 	</fieldType>
 
@@ -73,10 +81,17 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -87,13 +102,12 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 			<filter class="solr.CJKWidthFilterFactory"/>
 			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="korean"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="korean" />
 		</analyzer>
 	</fieldType>
 

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/lao/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/lao/schema.xml
@@ -45,11 +45,12 @@
 	<fieldType name="text" class="solr.TextField" positionIncrementGap="100">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
 		</analyzer>
 	</fieldType>
 
@@ -57,9 +58,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
 		</analyzer>
 	</fieldType>
 
@@ -67,10 +73,17 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -79,11 +92,10 @@
 	<fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
 		<analyzer type="index">
 			<tokenizer class="solr.ICUTokenizerFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.ICUTokenizerFactory" />
-			<filter class="solr.ManagedSynonymFilterFactory" managed="lao"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="lao" />
 		</analyzer>
 	</fieldType>
 

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/latvia/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/latvia/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="latvia"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
 
 			<filter class="solr.LatvianStemFilterFactory"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="latvia"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
 			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
 
 			<filter class="solr.LatvianStemFilterFactory"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="latvia"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -111,17 +113,46 @@
 			<filter class="solr.LatvianStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
+			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="latvia/protwords.txt"
+			/>
+			<filter class="solr.LatvianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="latvia"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
 			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -144,7 +175,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="latvia"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="latvia" />
 			<filter class="solr.ManagedStopFilterFactory" managed="latvia"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/norwegian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -111,17 +113,47 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="norwegian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -144,7 +176,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="norwegian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="norwegian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="norwegian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/persian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/persian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
@@ -69,7 +70,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +82,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
@@ -95,13 +96,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -115,20 +117,50 @@
 			<filter class="solr.ArabicNormalizationFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="persian/protwords.txt"
+			/>
+			<filter class="solr.KeywordMarkerFilterFactory" protected="persian/protwords.txt"/>
+			<filter class="solr.PersianNormalizationFilterFactory"/>
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -150,7 +182,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="persian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="persian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="persian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/polish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
@@ -92,15 +93,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -112,17 +114,47 @@
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="polish/protwords.txt"
+			/>
+			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -146,7 +178,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="polish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="polish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="polish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/portuguese/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -111,17 +113,44 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
+			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="portuguese/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
-
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -144,7 +173,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="portuguese"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="portuguese" />
 			<filter class="solr.ManagedStopFilterFactory" managed="portuguese"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/romanian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/romanian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
@@ -91,13 +92,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -109,17 +111,44 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="romanian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Romanian" protected="romanian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -142,7 +171,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="romanian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="romanian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="romanian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/russian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/russian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +82,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
@@ -93,14 +94,15 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -112,20 +114,49 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="russian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="russian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -145,7 +176,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="russian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="russian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="russian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/serbian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="serbian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="serbian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -91,16 +92,38 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="serbian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+				generateWordParts="0"
+				generateNumberParts="0"
+				catenateWords="1"
+				catenateNumbers="1"
+				catenateAll="0"
+				preserveOriginal="1"
+				protected="serbian/protwords.txt"
+			/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -118,11 +141,20 @@
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="serbian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -147,7 +179,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="serbian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="serbian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="serbian"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/spanish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -81,7 +82,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
@@ -92,15 +93,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -112,20 +114,51 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="spanish/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -145,7 +178,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="spanish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="spanish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="spanish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/swedish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -58,7 +58,8 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
@@ -67,7 +68,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -111,20 +113,50 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="swedish/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -144,7 +176,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="swedish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="swedish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="swedish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/thai/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/thai/schema.xml
@@ -48,7 +48,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
@@ -60,7 +61,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
@@ -73,32 +74,56 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.ThaiTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 
 			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
 			<filter class="solr.PorterStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ThaiTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
+			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+
+			<filter class="solr.KeywordMarkerFilterFactory" protected="thai/protwords.txt"/>
+			<filter class="solr.PorterStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
+			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+
 	</fieldType>
 
 	<!-- Setup simple analysis for spell checking -->
@@ -118,7 +143,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="thai"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="thai" />
 			<filter class="solr.ManagedStopFilterFactory" managed="thai"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/turkish/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
@@ -68,7 +69,7 @@
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -80,7 +81,7 @@
 			/>
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
@@ -92,13 +93,14 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -110,17 +112,45 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
+			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="turkish/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -143,7 +173,7 @@
 
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="turkish"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="turkish" />
 			<filter class="solr.ManagedStopFilterFactory" managed="turkish"/>
 
 			<filter class="solr.StandardFilterFactory" />

--- a/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/ukrainian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_9_0_0/conf/ukrainian/schema.xml
@@ -46,7 +46,7 @@
 		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="1"
@@ -59,7 +59,8 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
@@ -67,7 +68,7 @@
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="1"
 				generateNumberParts="1"
 				catenateWords="0"
@@ -79,7 +80,7 @@
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
@@ -91,15 +92,16 @@
 	<!-- Less flexible matching, but less false matches.	Probably not ideal for product names,
 		but may be good for SKUs.	Can insert dashes in the wrong place and still match. -->
 	<fieldType name="textTight" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
 
-			<filter class="solr.WordDelimiterFilterFactory"
+			<filter class="solr.WordDelimiterGraphFilterFactory"
 				generateWordParts="0"
 				generateNumberParts="0"
 				catenateWords="1"
@@ -111,17 +113,46 @@
 			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
+			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+
+			<filter class="solr.WordDelimiterGraphFilterFactory"
+					generateWordParts="0"
+					generateNumberParts="0"
+					catenateWords="1"
+					catenateNumbers="1"
+					catenateAll="0"
+					preserveOriginal="1"
+					protected="ukrainian/protwords.txt"
+			/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Russian" protected="ukrainian/protwords.txt"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
 	</fieldType>
 
 	<!-- Exact matching of words like textWhiteSpaceTokenized,
 		but with enabled Synonym and Stop Filter
 	 -->
 	<fieldType name="textExact" class="solr.TextField" positionIncrementGap="100" >
-		<analyzer>
+		<analyzer type="index">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
-			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -144,7 +175,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedSynonymFilterFactory" managed="ukrainian"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="ukrainian" />
 			<filter class="solr.ManagedStopFilterFactory" managed="ukrainian"/>
 
 			<filter class="solr.StandardFilterFactory" />


### PR DESCRIPTION
This pr:

* Uses CurrencyFieldType instead of CurrencyField
* Uses DatePointField instead of TrieDateField
* Uses DoublePointField instead of TrieDoubleField
* Uses FloatPointField instead of TrieFloatField
* Uses LongPointField instead of TrieLongField
* Uses WordDelimiterGraphFilterFactory instead of WordDelimiterFilterFactory
* Uses WordDelimiterGraphFilterFactory instead of WordDelimiterFilterFactory
* Use ManagedSynonymGraphFilterFactory and FlattenGraphFilterFactory for text* types on indexing
* Use ManagedSynonymGraphFilterFactory for text* tyes on querytime

Fixes: #2064