### PR TITLE
[BUGFIX] Can not parse non default language from schema

### DIFF
--- a/Classes/System/Solr/Parser/SchemaParser.php
+++ b/Classes/System/Solr/Parser/SchemaParser.php
@@ -71,7 +71,6 @@ class SchemaParser
     protected function parseLanguage(\stdClass $schema)
     {
         $language = 'english';
-
         if (!is_object($schema) || !isset($schema->fieldTypes)) {
             return $language;
         }
@@ -82,7 +81,7 @@ class SchemaParser
             }
             // we have a text field
             foreach ($fieldType->queryAnalyzer->filters as $filter) {
-                if ($filter->class === 'solr.ManagedSynonymFilterFactory') {
+                if ($filter->class === 'solr.ManagedSynonymGraphFilterFactory') {
                     $language = $filter->managed;
                 }
             }

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -188,4 +188,17 @@ class SolrAdminServiceTest extends IntegrationTest
         $result = $this->solrAdminService->requestServlet('/solr/core_en/admin/ping');
         $this->assertSame('OK', $result->status, 'Unexpected servlet response');
     }
+
+    /**
+     * @test
+     */
+    public function canParseLanguageFromSchema()
+    {
+        $client = new Client(['adapter' => 'Solarium\Core\Client\Adapter\Guzzle']);
+        $client->clearEndpoints();
+        $client->createEndpoint(['host' => 'localhost', 'port' => 8999, 'path' => '/solr', 'core' => 'core_de', 'key' => 'admin'] , true);
+
+        $this->solrAdminService = GeneralUtility::makeInstance(SolrAdminService::class, $client);
+        $this->assertSame("german", $this->solrAdminService->getSchema()->getLanguage(), "Could not get language from core in non default language");
+    }
 }

--- a/Tests/Unit/System/Solr/Parser/Fixtures/schema.json
+++ b/Tests/Unit/System/Solr/Parser/Fixtures/schema.json
@@ -142,7 +142,7 @@
             {
               "class":"solr.LowerCaseFilterFactory"},
             {
-              "class":"solr.ManagedSynonymFilterFactory",
+              "class":"solr.ManagedSynonymGraphFilterFactory",
               "managed":"german"},
             {
               "class":"solr.ManagedStopFilterFactory",
@@ -171,7 +171,7 @@
             {
               "class":"solr.LowerCaseFilterFactory"},
             {
-              "class":"solr.ManagedSynonymFilterFactory",
+              "class":"solr.ManagedSynonymGraphFilterFactory",
               "managed":"german"},
             {
               "class":"solr.ManagedStopFilterFactory",
@@ -222,7 +222,7 @@
           "filters":[{
               "class":"solr.LowerCaseFilterFactory"},
             {
-              "class":"solr.ManagedSynonymFilterFactory",
+              "class":"solr.ManagedSynonymGraphFilterFactory",
               "managed":"german"},
             {
               "class":"solr.ManagedStopFilterFactory",
@@ -250,7 +250,7 @@
             {
               "class":"solr.LowerCaseFilterFactory"},
             {
-              "class":"solr.ManagedSynonymFilterFactory",
+              "class":"solr.ManagedSynonymGraphFilterFactory",
               "managed":"german"},
             {
               "class":"solr.ManagedStopFilterFactory",


### PR DESCRIPTION
This pr:

* Fixes the bug by changing the classname that is used for parsing to ManagedSynonymGraphFilterFactory

Fixes: #2071