### PR TITLE
[BUGFIX] String representation of SolrConnection does not contain core

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -290,7 +290,7 @@ class SolrConnection
      */
     public function __toString()
     {
-        return $this->scheme . '://' . $this->host . ':' . $this->port . $this->path;
+        return $this->scheme . '://' . $this->host . ':' . $this->port . $this->path . $this->core . '/';
     }
 
     /**

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -131,4 +131,14 @@ class SolrConnectionTest extends UnitTest
         $solrService = new SolrConnection('localhost','8080','/solr/','http', '', '', $configuration);
         $this->assertSame(99, $solrService->getReadService()->getPrimaryEndpoint()->getTimeout(), 'Default timeout was not set from configuration');
     }
+
+    /**
+     * @test
+     */
+    public function toStringContainsAllSegments()
+    {
+        $configuration = new TypoScriptConfiguration([]);
+        $solrService = new SolrConnection('localhost','8080','/solr/core_de/','http', '', '', $configuration);
+        $this->assertSame('http://localhost:8080/solr/core_de/', (string) $solrService, 'Could not get string representation of connection');
+    }
 }


### PR DESCRIPTION
This pr:

* Adjust the __toString method of the SolrConnection to contain the core.

Fixes: #2083