### PR TITLE
[BUGFIX] Do not throw exception when unexsting field is retrieved from documents

### DIFF
--- a/Classes/System/Solr/Document/Document.php
+++ b/Classes/System/Solr/Document/Document.php
@@ -18,12 +18,7 @@ class Document extends SolariumDocument {
         if (substr($name, 0, 3) == 'get') {
             $field = substr($name, 3);
             $field = strtolower($field[0]) . substr($field, 1);
-
-            if (!isset($this->fields[$field])) {
-                throw new RuntimeException('Tried to access non-existent field "' . $field . '".', 1311006894);
-            }
-
-            return $this->fields[$field];
+            return $this->fields[$field] ?? null;
         } else {
             throw new RuntimeException('Call to undefined method. Supports magic getters only.', 1311006605);
         }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -108,4 +108,12 @@ class SearchResultTest extends UnitTest
     {
         $this->assertSame(true, $this->searchResult->getIsElevated(), 'Could not get isElevated from searchResult');
     }
+
+    /**
+     * @test
+     */
+    public function getOnUnexistingFieldReturnsNull()
+    {
+        $this->assertNull($this->searchResult->getUnexistingField(), 'Calling getter for unexisting field does not return null');
+    }
 }


### PR DESCRIPTION
This pr:

* When an unexisting field is requested from the solr document, no exception is throwen anymore and instead "null" is returned.

Fixes: #2082