### PR TITLE
[BUGFIX] Execution time of query not shown

### DIFF
--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -143,6 +143,7 @@ class QueryBuilder extends AbstractQueryBuilder {
                 ->usePhraseFieldsFromTypoScript()
                 ->useBigramPhraseFieldsFromTypoScript()
                 ->useTrigramPhraseFieldsFromTypoScript()
+                ->useOmitHeader(false)
                 ->getQuery();
     }
 

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -118,6 +118,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
         $result = $this->searchResponse->getContent();
 
+        $this->assertRegExp('/Found [0-9]+ results in [0-9]+ milliseconds/i',$result);
         $this->assertContains('pages/3/0/0/0', $result, 'Could not find page 3 in result set');
         $this->assertContains('pages/2/0/0/0', $result, 'Could not find page 2 in result set');
     }


### PR DESCRIPTION
This pr:

* Set's the required parameter omitHeaders to false to include the timing information in the response
* Add's an assertion to the integration tests

Fixes: #2086