### PR TITLE
[BUGFIX] Wrong root pid in statistics table

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
@@ -75,7 +76,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
         $ipMaskLength = (int)$configuration->getStatisticsAnonymizeIP();
 
         $TSFE = $this->getTSFE();
-        $root_pid = $this->determineSearchRoot($TSFE);
+        $root_pid = GeneralUtility::makeInstance(SiteRepository::class)->getSiteByPageId($TSFE->id)->getRootPageId();
         $statisticData = [
             'pid' => $TSFE->id,
             'root_pid' => $root_pid,
@@ -117,28 +118,6 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
         return $keywords;
     }
 
-    /**
-     * @param $TSFE
-     * @return null | integer
-     * @throws \Exception
-     */
-    protected function determineSearchRoot($TSFE)
-    {
-        $root_pid = null;
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites']) &&
-            count($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites']) > 0
-        ) {
-            $sites = array_keys($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites']);
-            foreach ($TSFE->tmpl->rootLine as $pageInRootline) {
-                if (in_array ($pageInRootline['uid'], $sites)){
-                    $root_pid = $pageInRootline['uid'];
-                }
-            }
-        } else {
-            $root_pid = $TSFE->tmpl->rootLine[0]['uid'];
-        }
-        return $root_pid;
-    }
     /**
      * Sanitizes a string
      *

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -31,7 +31,6 @@ use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Writes statistics after searches have been conducted.
@@ -48,11 +47,17 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
     protected $statisticsRepository;
 
     /**
+     * @var SiteRepository
+     */
+    protected $siteRepository;
+
+    /**
      * @param StatisticsRepository $statisticsRepository
      */
     public function __construct(StatisticsRepository $statisticsRepository = null)
     {
         $this->statisticsRepository = $statisticsRepository ?? GeneralUtility::makeInstance(StatisticsRepository::class);
+        $this->siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
     }
 
     /**
@@ -76,7 +81,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
         $ipMaskLength = (int)$configuration->getStatisticsAnonymizeIP();
 
         $TSFE = $this->getTSFE();
-        $root_pid = GeneralUtility::makeInstance(SiteRepository::class)->getSiteByPageId($TSFE->id)->getRootPageId();
+        $root_pid = $this->siteRepository->getSiteByPageId($TSFE->id)->getRootPageId();
         $statisticData = [
             'pid' => $TSFE->id,
             'root_pid' => $root_pid,

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -46,6 +47,11 @@ class StatisticsWriterProcessorTest extends UnitTest
      * @var StatisticsRepository|PHPUnit_Framework_MockObject_MockObject
      */
     protected $statisticsRepositoryMock;
+
+    /**
+     * @var SiteRepository|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $siteRepositoryMock;
 
     /**
      * @var StatisticsWriterProcessor|PHPUnit_Framework_MockObject_MockObject
@@ -75,6 +81,7 @@ class StatisticsWriterProcessorTest extends UnitTest
         $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
         $this->queryMock = $this->getDumbMock(Query::class);
+        $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
     }
 
     /**
@@ -85,7 +92,7 @@ class StatisticsWriterProcessorTest extends UnitTest
         $fakeTSFE = $this->getDumbMock(TypoScriptFrontendController::class);
         $fakeTime = 100;
         $fakeIP = '192.168.2.22';
-        
+
         $this->processor->expects($this->once())->method('getTSFE')->will($this->returnValue($fakeTSFE));
         $this->processor->expects($this->once())->method('getUserIp')->will($this->returnValue($fakeIP));
         $this->processor->expects($this->once())->method('getTime')->will($this->returnValue($fakeTime));


### PR DESCRIPTION
The root_pid in the statistcs table is always the root_pid on the search page. There are secenarios where this is not appropriate. This patch resolves the 'root_pid' according to the configuration.

Resolves: #2088 