### PR TITLE
[BUGFIX] Determine root_pid depending on the configuration

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -46,11 +47,18 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
     protected $statisticsRepository;
 
     /**
-     * @param StatisticsRepository $statisticsRepository
+     * @var SiteRepository
      */
-    public function __construct(StatisticsRepository $statisticsRepository = null)
+    protected $siteRepository;
+
+    /**
+     * @param StatisticsRepository $statisticsRepository
+     * @param SiteRepository $siteRepository
+     */
+    public function __construct(StatisticsRepository $statisticsRepository = null, SiteRepository $siteRepository = null)
     {
         $this->statisticsRepository = $statisticsRepository ?? GeneralUtility::makeInstance(StatisticsRepository::class);
+        $this->siteRepository = $siteRepository ?? GeneralUtility::makeInstance(SiteRepository::class);
     }
 
     /**
@@ -74,9 +82,10 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
         $ipMaskLength = (int)$configuration->getStatisticsAnonymizeIP();
 
         $TSFE = $this->getTSFE();
+        $root_pid = $this->siteRepository->getSiteByPageId($TSFE->id)->getRootPageId();
         $statisticData = [
             'pid' => $TSFE->id,
-            'root_pid' => $TSFE->tmpl->rootLine[0]['uid'],
+            'root_pid' => $root_pid,
             'tstamp' => $this->getTime(),
             'language' => $TSFE->sys_language_uid,
             'num_found' => isset($response->response->numFound) ? (int)$response->response->numFound : 0,

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -30,6 +30,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -46,6 +48,11 @@ class StatisticsWriterProcessorTest extends UnitTest
      * @var StatisticsRepository|PHPUnit_Framework_MockObject_MockObject
      */
     protected $statisticsRepositoryMock;
+
+    /**
+     * @var SiteRepository|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $siteRepositoryMock;
 
     /**
      * @var StatisticsWriterProcessor|PHPUnit_Framework_MockObject_MockObject
@@ -71,7 +78,9 @@ class StatisticsWriterProcessorTest extends UnitTest
     {
         parent::setUp();
         $this->statisticsRepositoryMock = $this->getMockBuilder(StatisticsRepository::class)->setMethods(['saveStatisticsRecord'])->getMock();
-        $this->processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setConstructorArgs([$this->statisticsRepositoryMock])->setMethods(['getTSFE', 'getTime', 'getUserIp'])->getMock();
+
+        $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
+        $this->processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setConstructorArgs([$this->statisticsRepositoryMock, $this->siteRepositoryMock])->setMethods(['getTSFE', 'getTime', 'getUserIp'])->getMock();
         $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
         $this->queryMock = $this->getDumbMock(Query::class);
@@ -83,9 +92,14 @@ class StatisticsWriterProcessorTest extends UnitTest
     public function canWriteExpectedStatisticsData()
     {
         $fakeTSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakeTSFE->id = 888;
         $fakeTime = 100;
         $fakeIP = '192.168.2.22';
-        
+
+        $fakeSite = $this->getDumbMock(Site::class);
+        $fakeSite->expects($this->once())->method('getRootPageId')->willReturn(4711);
+        $this->siteRepositoryMock->expects($this->once())->method('getSiteByPageId')->with(888)->willReturn($fakeSite);
+
         $this->processor->expects($this->once())->method('getTSFE')->will($this->returnValue($fakeTSFE));
         $this->processor->expects($this->once())->method('getUserIp')->will($this->returnValue($fakeIP));
         $this->processor->expects($this->once())->method('getTime')->will($this->returnValue($fakeTime));
@@ -102,6 +116,7 @@ class StatisticsWriterProcessorTest extends UnitTest
         $this->statisticsRepositoryMock->expects($this->any())->method('saveStatisticsRecord')->will($this->returnCallback(function($statisticData) use ($self) {
             $this->assertSame('my search', $statisticData['keywords'], 'Unexpected keywords given');
             $this->assertSame('192.168.2.22', $statisticData['ip'], 'Unexpected ip given');
+            $this->assertSame(4711, $statisticData['root_pid'], 'Unexpected root pid given');
         }));
 
         $this->processor->process($resultSetMock);


### PR DESCRIPTION
The root_pid in the statistics table was always set to the root page of
the current search page. If the search configuration is below that page in
the page tree, statistics are not shown.

This pr:

* Uses the siteRepository to get the related site and rootPageId

Fixes: #2088