### PR TITLE
[BUGFIX] Limit argument in Search::search not evaluated

### DIFF
--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -135,8 +135,8 @@ class Search
     {
         $this->query = $query;
 
-        if (empty($limit)) {
-            $limit = $query->getRows();
+        if (!empty($limit)) {
+            $query->setRows($limit);
         }
         $query->setStart($offset);
 
@@ -161,7 +161,7 @@ class Search
                         'exception' => $e->__toString(),
                         'query' => (array)$query,
                         'offset' => $offset,
-                        'limit' => $limit
+                        'limit' => $query->getRows()
                     ]
                 );
             }

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery;
+use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrReadService;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+
+class SearchTest extends UnitTest
+{
+
+    /**
+     * @var SolrConnection
+     */
+    protected $solrConnectionMock;
+
+    /**
+     * @var SolrReadService
+     */
+    protected $solrReadServiceMock;
+
+    /**
+     * @var Search
+     */
+    protected $search;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->solrReadServiceMock = $this->getDumbMock(SolrReadService::class);
+        $this->solrConnectionMock = $this->getDumbMock(SolrConnection::class);
+        $this->solrConnectionMock->expects($this->any())->method('getReadService')->willReturn($this->solrReadServiceMock);
+        $this->search = new Search($this->solrConnectionMock);
+    }
+
+    /**
+     * @test
+     */
+    public function canPassLimit()
+    {
+        $query = new SearchQuery();
+        $limit = 99;
+        $this->solrReadServiceMock->expects($this->once())->method('search')->willReturnCallback(
+            function($query) use ($limit) {
+                $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
+            }
+        );
+
+        $this->search->search($query, 0, $limit);
+    }
+
+    /**
+     * @test
+     */
+    public function canKeepLimitWhenNullWasPassedAsLimit()
+    {
+        $query = new SearchQuery();
+        $limit = 99;
+        $query->setRows($limit);
+
+        $this->solrReadServiceMock->expects($this->once())->method('search')->willReturnCallback(
+            function($query) use ($limit) {
+                $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
+            }
+        );
+
+        $this->search->search($query, 0, null);
+    }
+
+}


### PR DESCRIPTION
This pr:

* Fixes the bug and add's a testcase

Fixes: #2098