### PR TITLE
[BUGFIX] Improve solr backend message for sites without solr connection

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -141,6 +141,12 @@ abstract class AbstractModuleController extends ActionController
     protected function initializeView(ViewInterface $view)
     {
         parent::initializeView($view);
+        /* @var SiteRepository $siteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $sites = $siteRepository->getAvailableSites();
+
+        $selectOtherPage = count($sites) > 0 || $this->selectedPageUID < 1;
+        $this->view->assign('showSelectOtherPage', $selectOtherPage);
         $this->view->assign('pageUID', $this->selectedPageUID);
         if ($view instanceof NotFoundView || $this->selectedPageUID < 1) {
             return;

--- a/Resources/Private/Partials/Backend/NoSiteAvailable.html
+++ b/Resources/Private/Partials/Backend/NoSiteAvailable.html
@@ -1,4 +1,4 @@
-<f:if condition="{pageUID} < 1">
+<f:if condition="{showSelectOtherPage}">
 	<f:then>
 		<f:be.infobox title="No site could be found." state="3">
 			<p>Please choose other page in the page tree, which has solr configured.</p>


### PR DESCRIPTION
By now you get the message that no solr site is configured when you select e.g. a sysfolder in the pagetree outside a site, even when other sites exists

This pr:

* When no sites exis on the system => show the setup instructions
* When you are on the root page or on a page where no sites exists but there are sites in the system => show message to select another site in the pagetree

Fixes: #2095