### PR TITLE
[TASK] Move manipulateCacheActionsHook to seperate class

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -56,9 +56,16 @@ build_failure_conditions:
 build:
   environment:
     php:
-      version: 7.0.20
+      version: 7.1.21
   nodes:
     analysis:
+      dependencies:
+        after:
+          - composer require --dev squizlabs/php_codesniffer:3.1.1
       tests:
         override:
           - php-scrutinizer-run
+        override:
+          -
+            command: phpcs-run
+            use_website_config: false

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -348,11 +348,15 @@ class ConnectionManager implements SingletonInterface, ClearCacheActionsHookInte
     /**
      * Adds a menu entry to the clear cache menu to detect Solr connections.
      *
+     * @deprecated deprecated since 9.0.0 will we removed in 10.0.0 still in place to prevent errors from cached localconf.php
+     * @todo this method and the implementation of the ClearCacheActionsHookInterface can be removed in EXT:solr 10
      * @param array $cacheActions Array of CacheMenuItems
      * @param array $optionValues Array of AccessConfigurations-identifiers (typically  used by userTS with options.clearCache.identifier)
      */
     public function manipulateCacheActions(&$cacheActions, &$optionValues)
     {
+        trigger_error('ConnectionManager::manipulateCacheActions is deprecated please use ClearCacheActionsHook::manipulateCacheActions now', E_USER_DEPRECATED);
+
         if ($GLOBALS['BE_USER']->isAdmin()) {
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
             $optionValues[] = 'clearSolrConnectionCache';

--- a/Classes/System/Hooks/Backend/Toolbar/ClearCacheActionsHook.php
+++ b/Classes/System/Hooks/Backend/Toolbar/ClearCacheActionsHook.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\System\Hooks\Backend\Toolbar;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2018 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Toolbar\ClearCacheActionsHookInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class ClearCacheActionsHook
+ * @package ApacheSolrForTypo3\Solr\System\Hooks\Backend\Toolbar
+ */
+class ClearCacheActionsHook implements ClearCacheActionsHookInterface
+{
+
+    /**
+     * @var UriBuilder
+     */
+    protected $uriBuilder;
+
+    /**
+     * @var BackendUserAuthentication
+     */
+    protected $backendUser;
+
+    /**
+     * ClearCacheActionsHook constructor.
+     * @param UriBuilder|null $uriBuilder
+     * @param BackendUserAuthentication|null $backendUser
+     */
+    public function __construct(UriBuilder $uriBuilder = null, BackendUserAuthentication $backendUser = null)
+    {
+        $this->uriBuilder = $uriBuilder ??  GeneralUtility::makeInstance(UriBuilder::class);
+        $this->backendUser = $backendUser ?? $GLOBALS['BE_USER'];
+    }
+
+    /**
+     * Adds a menu entry to the clear cache menu to detect Solr connections.
+     *
+     * @param array $cacheActions Array of CacheMenuItems
+     * @param array $optionValues Array of AccessConfigurations-identifiers (typically  used by userTS with options.clearCache.identifier)
+     */
+    public function manipulateCacheActions(&$cacheActions, &$optionValues)
+    {
+        if (!$this->backendUser->isAdmin()) {
+            return;
+        }
+
+        $href = $this->uriBuilder->buildUriFromRoute('ajax_solr_updateConnections');
+        $optionValues[] = 'clearSolrConnectionCache';
+        $cacheActions[] = [
+            'id' => 'clearSolrConnectionCache',
+            'title' => 'LLL:EXT:solr/Resources/Private/Language/locallang.xlf:cache_initialize_solr_connections',
+            'href' => $href,
+            'iconIdentifier' => 'extensions-solr-module-initsolrconnections'
+        ];
+    }
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -122,7 +122,7 @@ if (TYPO3_MODE == 'BE') {
     ];
 
     // register Clear Cache Menu hook
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['clearSolrConnectionCache'] = \ApacheSolrForTypo3\Solr\ConnectionManager::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['clearSolrConnectionCache'] = \ApacheSolrForTypo3\Solr\System\Hooks\Backend\Toolbar\ClearCacheActionsHook::class;
 }
 
 if ((TYPO3_MODE === 'BE') || (TYPO3_MODE === 'FE' && isset($_POST['TSFE_EDIT']))) {


### PR DESCRIPTION
This pr:

* Moves the manipulateCacheActions hook to a seperate class and deprecates the old method

Fixes: #1471