### PR TITLE
[BUGFIX] Sort facet options by metric is not working

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
+++ b/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
@@ -61,7 +61,8 @@ class SortingExpression
      */
     public function getForJsonFacet($sorting, $direction)
     {
-        $expression = $this->getForFacet($sorting);
+        $isMetricSorting = strpos($sorting, 'metrics_') === 0;
+        $expression = $isMetricSorting ? $sorting : $this->getForFacet($sorting);
         $direction = strtolower($direction);
         if (!empty($direction) && in_array($direction, ['asc', 'desc'])) {
             $expression .= ' ' . $direction;

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1063,7 +1063,22 @@ faceting.facets.[facetName].sortBy
 Sets how a single facet's options are sorted, by default they are sorted by number of results, highest on top.
 Facet options can also be sorted alphabetically by setting the option to alpha.
 
-Note: Since 8.0 sortBy for option facets can also be a function applied on the faceted documents (e.g. avg(price_floatS)).
+Note: Since 9.0.0 it is possible to sort a facet by a function. This can be done be defining a metric and use that metric in the sortBy configuration. As sorting name you then need to use by convention "metrics_<metricName>"
+
+Example:
+
+.. code-block:: typoscript
+
+    pid {
+        label = Content Type
+        field = pid
+        metrics {
+           newest = max(created)
+        }
+        sortBy = metrics_newest desc
+    }
+
+
 
 faceting.facets.[facetName].manualSortOrder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Integration/Controller/Fixtures/can_sort_by_metric.xml
+++ b/Tests/Integration/Controller/Fixtures/can_sort_by_metric.xml
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:9:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:10:"solrScheme";s:4:"http";s:8:"solrHost";s:9:"localhost";s:8:"solrPort";s:4:"8999";s:8:"solrPath";s:14:"/solr/core_en/";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                config.disableAllHeaderCode = 1
+                config.tx_extbase {
+                	mvc {
+
+                	}
+
+                    features {
+                        requireCHashArgumentForActionArguments = 0
+                        useRawDocuments = 1
+                    }
+                }
+
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                page.10.wrap = <!--TYPO3SEARCH_begin--><html><body>|</body></html><!--TYPO3SEARCH_end-->
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    enableDebugMode = 0
+
+                    general {
+                        dateFormat.date = d.m.Y H:i
+                        baseWrap {
+                            value = <div class="baseWrap">|</div>
+                        }
+                    }
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8999
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        additionalFields {
+
+                        }
+
+                        // assigns processing instructions to Solr fields during indexing, Solr field = processing instruction
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                            category_stringM = categoryUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7,4
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR doktype=4 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                //exclude some html parts inside TYPO3SEARCH markers by classname (comma list)
+                                excludeContentByClass = typo3-search-exclude
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+
+                                    category_stringM = SOLR_RELATION
+                                    category_stringM {
+                                        localField = categories
+                                        foreignLabelField = uid
+                                        multiValue = 1
+                                    }
+                                 }
+                            }
+
+                        }
+                    }
+
+                    search {
+                        // fields that are allowed to contain html and should be skipped during escaping after retrieval from Solr
+                        // by default all fields expect url get escaped, you might need to add other url fields here as well because of &
+                        // characters in the url.
+                        trustedFields = url
+
+                        targetPage = {$plugin.tx_solr.search.targetPage}
+
+                        initializeWithEmptyQuery = 0
+                        showResultsOfInitialEmptyQuery = 0
+
+                        initializeWithQuery =
+                        showResultsOfInitialQuery = 0
+
+                        keepExistingParametersForNewSearches = 1
+
+                        query {
+                            allowEmptyQuery = 1
+
+                            allowedSites = __solr_current_site
+
+                            // qf parameter http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29
+                            queryFields = content^40.0, title^5.0, keywords^2.0, tagsH1^5.0, tagsH2H3^3.0, tagsH4H5H6^2.0, tagsInline^1.0, description^4.0, abstract^1.0, subtitle^1.0, navtitle^1.0, author^1.0
+
+                            // fl parameter http://wiki.apache.org/solr/CommonQueryParameters#fl
+                            returnFields = *, score
+
+                            // see http://wiki.apache.org/solr/DisMaxRequestHandler#mm_.28Minimum_.27Should.27_Match.29
+                            minimumMatch =
+
+                            // see http://wiki.apache.org/solr/DisMaxRequestHandler#bf_.28Boost_Functions.29
+                            boostFunction =
+
+                            // see http://wiki.apache.org/solr/DisMaxQParserPlugin#bq_.28Boost_Query.29
+                            boostQuery =
+
+                            filter {
+
+                            }
+
+                            sortBy =
+                        }
+
+                        results {
+                            resultsHighlighting = 1
+                            resultsHighlighting {
+                                 // can be used to increase the highlighting performance requires the field is termVectors=on,
+                                 // termPositions=on and termOffsets=on which is set for content. NOTE: fragmentSize needs to be larger
+                                 // then 18
+                                useFastVectorHighlighter = 0
+                                highlightFields = content
+                                fragmentSize = 20
+                                fragmentSeparator = [...]
+
+                                wrap = <span class="results-highlight">|</span>
+                            }
+                            siteHighlighting = 0
+
+                            resultsPerPage = 5
+                            resultsPerPageSwitchOptions = 5, 10, 25, 50
+
+                            pagebrowser {
+                                enabled = 1
+
+                                pagesBefore = 3
+                                pagesAfter = 3
+
+                                enableMorePages = 1
+                                enableLessPages = 1
+                            }
+
+                            showDocumentScoreAnalysis = 1
+                        }
+
+                        spellchecking = 1
+                        spellchecking {
+                            wrap = |<div class="spelling-suggestions">###LLL:didYouMean### |</div>|
+                            searchUsingSpellCheckerSuggestion = 0
+                            numberOfSuggestionsToTry = 0
+                        }
+
+                        lastSearches = 1
+                        lastSearches {
+                            limit = 10
+                            // tracking mode "user" or "global"
+                            mode = user
+                        }
+
+                        frequentSearches = 1
+                        frequentSearches {
+                            useLowercaseKeywords = 0
+
+                            minSize = 15
+                            maxSize = 40
+                            limit = 20
+
+                            select {
+                                SELECT = keywords as search_term, count(*) as hits
+                                FROM = tx_solr_statistics
+                                ADD_WHERE =
+                                GROUP_BY = keywords
+                                ORDER_BY = hits DESC, search_term ASC
+                                checkRootPageId = 0
+                                checkLanguage = 0
+                            }
+
+                            // cache lifetime in seconds (default is 86400s = 24h)
+                            cacheLifetime = 0
+                        }
+
+                        sorting = 1
+                        sorting {
+                            defaultOrder = asc
+
+                            options {
+                                relevance {
+                                    field = relevance
+                                    label = Relevance
+                                }
+
+                                title {
+                                    field = sortTitle
+                                    label = Title
+                                }
+
+                                type {
+                                    field = type
+                                    label = Type
+                                }
+
+                                author {
+                                    field = sortAuthor
+                                    label = Author
+                                }
+
+                                created {
+                                    field = created
+                                    label = Creation Date
+                                }
+                            }
+                        }
+
+                        faceting = 1
+                        faceting {
+                            minimumCount = 1
+                            sortBy = count
+                            limit = 10
+                            singleFacetMode = 0
+                            showEmptyFacets = 0
+                            keepAllFacetsOnSelection = 0
+
+                            facetLinkUrlParameters = &foo=bar
+
+                            facets {
+                                pid {
+                                    label = Content Type
+                                    field = pid
+                                    metrics {
+                                        newest = max(created)
+                                    }
+                                    sortBy = metrics_newest desc
+                                }
+                            }
+
+                            showAllLink.wrap = <li>|</li>
+                        }
+
+                        elevation = 1
+                        elevation {
+                            markElevatedResults = 1
+                            forceElevation = 1
+                        }
+
+                    }
+
+                    suggest = 1
+                    suggest {
+                        numberOfSuggestions = 10
+                        suggestField = spell
+                        forceHttps = 0
+                    }
+
+                    statistics = 1
+                    statistics {
+                        anonymizeIP = 0
+                    }
+
+                    logging {
+                        exceptions = 1
+
+                        indexing {
+                            indexQueueInitialization = 0
+                            missingTypo3SearchMarkers = 1
+                            pageIndexed = 0
+
+                            queue {
+                                pages = 0
+                            }
+                        }
+
+                        query {
+                            filters = 0
+                            searchWords = 0
+                            queryString = 0
+                            rawPost = 0
+                            rawGet = 0
+                            rawDelete = 0
+                        }
+                    }
+
+            }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+        <static_file_mode>0</static_file_mode>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Products</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Socks</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Jeans</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <pages>
+        <uid>4</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Shoes</title>
+        <subtitle>Woman</subtitle>
+    </pages>
+    <pages>
+        <uid>5</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>T-Shirts</title>
+        <subtitle>Woman</subtitle>
+    </pages>
+    <pages>
+        <uid>6</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>T-Shirts</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <pages>
+        <uid>7</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sweatshirts</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <pages>
+        <uid>8</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Sweatshirts</title>
+        <subtitle>Woman</subtitle>
+    </pages>
+    <pages>
+        <uid>9</uid>
+        <pid>2</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>T-Shirts</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <!-- This is the page with the highest creation date, therefore pid 2 should be on the first position -->
+    <pages>
+        <uid>10</uid>
+        <pid>2</pid>
+        <crdate>1535717680</crdate>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>T-Shirts</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <pages>
+        <uid>11</uid>
+        <pid>3</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>T-Shirts</title>
+        <subtitle>Men</subtitle>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>2</pid>
+        <CType>text</CType>
+        <bodytext>Our awesome new sock products prices starting at 10 euro</bodytext>
+        <colPos>0</colPos>
+    </tt_content>
+
+    <tt_content>
+        <uid>2</uid>
+        <pid>3</pid>
+        <CType>text</CType>
+        <bodytext>Our awesome men jeans products prices starting at 50 euro</bodytext>
+        <colPos>0</colPos>
+    </tt_content>
+
+    <tx_solr_statistics>
+        <pid>1</pid>
+        <num_found>100</num_found>
+        <keywords>shoes</keywords>
+    </tx_solr_statistics>
+</dataset>

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -940,6 +940,33 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     /**
      * @test
      */
+    public function canSortByMetric()
+    {
+        $this->importDataSetFromFixture('can_sort_by_metric.xml');
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+
+        $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        $pid1Option = urlencode('tx_solr[filter][0]') . '=' . urlencode('pid:1');
+        $pid2Option = urlencode('tx_solr[filter][0]') . '=' . urlencode('pid:2');
+
+        //not in the content but we expect to get shoes suggested
+        $_GET['q'] = '*';
+        $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
+
+        $content = $this->searchResponse->getContent();
+        $pid1OptionPosition = strpos($content, $pid1Option);
+        $pid2OptionPosition = strpos($content, $pid2Option);
+
+        $this->assertGreaterThan(0, $pid1OptionPosition, 'Pid 1 option does not appear in the content');
+        $this->assertGreaterThan(0, $pid2OptionPosition, 'Pid 2 option does not appear in the content');
+        $isPid2OptionBefore1Option = $pid2OptionPosition < $pid1OptionPosition;
+        $this->assertTrue($isPid2OptionBefore1Option);
+    }
+
+    /**
+     * @test
+     */
     public function formActionIsRenderingTheForm()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -76,6 +76,9 @@ class SortingExpressionTest extends UnitTest
             'byCountJson' => ['sorting' => 'count', 'direction' => '', 'isJson' => true, 'expectedResult' => 'count'],
             'byCountJsonSortAsc' => ['sorting' => 'count', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'count asc'],
             'byCountJsonSortDesc' => ['sorting' => 'count', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'count desc'],
+
+            'byMetricJsonSortAsc' => ['sorting' => 'metrics_neweset', 'direction' => 'asc', 'isJson' => true, 'expectedResult' => 'metrics_neweset asc'],
+            'byMetricJsonSortDesc' => ['sorting' => 'metrics_neweset', 'direction' => 'desc', 'isJson' => true, 'expectedResult' => 'metrics_neweset desc'],
         ];
     }
 


### PR DESCRIPTION
With the introduction of json faceting you should be able to sort facet options by a metric:

```
pid {
    label = Content Type
    field = pid
    metrics {
       newest = max(created)
    }
    sortBy = metrics_newest desc
}
```

This is not working because the sortingName is filtered out.

This pr:

* Fixes the bug and add's a test for it.

Fixes: #2109