### PR TITLE
[BUGFIX] The resetting of the index queue from the queue module is not working

### DIFF
--- a/Classes/ViewHelpers/Backend/IsTYPO3VersionBelow9ViewHelper.php
+++ b/Classes/ViewHelpers/Backend/IsTYPO3VersionBelow9ViewHelper.php
@@ -1,0 +1,62 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\ViewHelpers\Backend;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+
+/**
+ * Check if the system is below TYPO3 9
+ *
+ * @todo This ViewHelper and all usages can be dropped when TYPO3 8 support is dropped.
+ */
+class IsTYPO3VersionBelow9ViewHelper extends AbstractConditionViewHelper
+{
+
+    /**
+     * @param null $arguments
+     * @return bool
+     */
+    protected static function evaluateCondition($arguments = null)
+    {
+        return Util::getIsTYPO3VersionBelow9();
+    }
+
+    /**
+     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+     *
+     * @todo This copy of the render method is just required for TYPO3 8 backwards compatibility, can be dropped when TYPO3 8 support is dropped.
+     *
+     * @param bool $condition View helper condition
+     * @return string the rendered string
+     */
+    public function render()
+    {
+        if (static::evaluateCondition($this->arguments)) {
+            return $this->renderThenChild();
+        }
+        return $this->renderElseChild();
+    }
+}

--- a/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
@@ -128,13 +128,32 @@
 
 			<div class="row section-with-header">
 				<div class="col-md-3">
-                    <f:comment><!-- This is the dirty hack to make it possible to call actions between backend modules. --></f:comment>
-					<f:form addQueryString="1" addQueryStringMethod="POST" fieldNamePrefix="tx_solr_searchbackend_solrindexadministration"
-                            additionalParams="{M: 'searchbackend_SolrIndexadministration', id: '{pageUID}', tx_solr_searchbackend_solrindexadministration:{controller: 'Backend\\Search\\IndexAdministrationModule', action: 'clearIndexQueue'}}">
-						<f:form.submit class="btn btn-sm btn-default btn-danger t3js-modal-formsubmit-trigger"
-									   data="{title: 'Please confirm', content: 'Are you sure you want to clear the Index Queue?', severity: 'warning'}"
-									   value="{f:translate(key:'solr.backend.index_queue_module.button.clear_index_queue')}"/>
-					</f:form>
+					<f:comment>
+					<!--
+						This is the dirty hack to make it possible to call actions between backend modules.
+						When TYPO3 8 support is dropped we should drop the special generation for TYPO3 8
+					-->
+					</f:comment>
+
+					<solr:backend.isTYPO3VersionBelow9>
+						<f:then>
+							<f:form addQueryString="1" addQueryStringMethod="POST" fieldNamePrefix="tx_solr_searchbackend_solrindexadministration"
+									additionalParams="{M: 'searchbackend_SolrIndexadministration', id: '{pageUID}', tx_solr_searchbackend_solrindexadministration:{controller: 'Backend\\Search\\IndexAdministrationModule', action: 'clearIndexQueue', fromQueue: 'true'}}">
+								<f:form.submit class="btn btn-sm btn-default btn-danger t3js-modal-formsubmit-trigger"
+											   data="{title: 'Please confirm', content: 'Are you sure you want to clear the Index Queue?', severity: 'warning'}"
+											   value="{f:translate(key:'solr.backend.index_queue_module.button.clear_index_queue')}"/>
+							</f:form>
+						</f:then>
+						<f:else>
+							<f:form addQueryString="1" addQueryStringMethod="POST"
+									additionalParams="{route: '/searchbackend/SolrIndexadministration/', tx_solr_searchbackend_solrindexadministration:{controller: 'Backend\\Search\\IndexAdministrationModule', action: 'clearIndexQueue', id: '{pageUID}', fromQueue: 'true'}}">
+								<f:form.submit class="btn btn-sm btn-default btn-danger t3js-modal-formsubmit-trigger"
+											   data="{title: 'Please confirm', content: 'Are you sure you want to clear the Index Queue?', severity: 'warning'}"
+											   value="{f:translate(key:'solr.backend.index_queue_module.button.clear_index_queue')}"/>
+							</f:form>
+						</f:else>
+					</solr:backend.isTYPO3VersionBelow9>
+
 				</div>
 				<div class="col-md-9 action-description">
 					<h3>
@@ -150,5 +169,4 @@
 			</div>
 		</f:then>
 	</solr:backend.security.ifHasAccessToModule>
-
 </f:section>


### PR DESCRIPTION
The resetting of the index queue (in the admin module) from the index queue module is not working since the link to the other module does not work.

This pr:

* Add's a compatible form for TYPO3 9 and the redirect back to the index queue module.

Fixes: #2021