### PR TITLE
[BUGFIX] ReQueue from index inspector not working in TYPO3 9.4

### DIFF
--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -306,15 +306,19 @@
                                                 <core:icon identifier="actions-document-view" />
                                             </f:link.action>
                                         </span>
-
+                                        <f:comment>
+                                            <!-- The additionalPrams M:'...' can be removed whe TYPO3 8 support will be dropped. -->
+                                        </f:comment>
                                         <solr:backend.security.ifHasAccessToModule extension="Solr" main="searchbackend" sub="indexqueue">
                                             <span class="btn btn-default">
+
                                                 <f:link.action action="requeueDocument" arguments="{uid: document.uid, type: document.type}"
                                                                controller="Backend\Search\IndexQueueModule"
                                                                pluginName="searchbackend_SolrIndexqueue"
-                                                               additionalParams="{M:'searchbackend_SolrIndexqueue'}" title="ReQueue for all languages">
+                                                               additionalParams="{M:'searchbackend_SolrIndexqueue',route: 'searchbackend_SolrIndexqueue'}" title="ReQueue for all languages">
                                                     <core:icon identifier="actions-refresh" />
                                                 </f:link.action>
+
                                             </span>
                                         </solr:backend.security.ifHasAccessToModule>
                                     </td>


### PR DESCRIPTION
This pr:

* Fixes the ReQueue link by adding the route

Fixes: #2121