### PR TITLE
[BUGFIX] Excludetags not properly generated for json faceting

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -82,7 +82,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
 
         if ($isKeepAllOptionsActiveForSingleFacet || $isKeepAllOptionsActiveGlobalsAndCountsEnabled) {
             return $facetConfiguration['field'];
-        } else {
+        } elseif($configuration->getSearchFacetingKeepAllFacetsOnSelection()) {
             // keepAllOptionsOnSelection globally active
             $facets = [];
             foreach ($configuration->getSearchFacetingFacets() as $facet) {
@@ -90,6 +90,8 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
             }
             return implode(',', $facets);
         }
+
+        return '';
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\DefaultFacetQueryBuilder;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Class DefaultFacetQueryBuilderTest
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class DefaultFacetQueryBuilderTest extends UnitTest
+{
+    /**
+     * Whe nothing is set, no exclude tags should be set.
+     *
+     * faceting {
+     *    facets {
+     *       type {
+     *          field = type
+     *       }
+     *       color {
+     *          field = color
+     *       }
+     *    }
+     * }
+     *
+     * @test
+     */
+    public function testWhenKeepAllOptionsOnSelectionIsNotConfiguredNoExcludeTagIsAdded()
+    {
+        $fakeConfigurationArray = [];
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
+            'type.' => [
+                'field' => 'type',
+            ],
+            'color.' => [
+                'field' => 'color',
+            ]
+        ];
+        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $defaultQueryBuilder = new DefaultFacetQueryBuilder();
+        $result = $defaultQueryBuilder->build('color', $fakeConfiguration);
+
+        $this->assertNotContains('{!ex', $result['facet.field'][0]);
+    }
+
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\OptionBase\Options;
 
 /***************************************************************
  *  Copyright notice
@@ -55,9 +55,6 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
         );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
-        );
 
         $builder = new OptionsFacetQueryBuilder();
         $facetParameters = $builder->build('category', $configurationMock);
@@ -93,9 +90,6 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
         );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
-        );
 
         $builder = new OptionsFacetQueryBuilder();
         $facetParameters = $builder->build('category', $configurationMock);
@@ -128,9 +122,7 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
         );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
-        );
+
         $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->will(
             $this->returnValue(15)
         );
@@ -167,9 +159,6 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
         );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
-        );
 
         $builder = new OptionsFacetQueryBuilder();
         $facetParameters = $builder->build('category', $configurationMock);
@@ -202,9 +191,7 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
         );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
-        );
+
         $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->will(
             $this->returnValue(5)
         );
@@ -244,9 +231,6 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
             $this->returnValue($fakeFacetConfiguration)
-        );
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacets')->will(
-            $this->returnValue([])
         );
 
         $builder = new OptionsFacetQueryBuilder();

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -105,7 +105,7 @@ class FacetingTest extends UnitTest
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
         $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
 
-        $expectedJsonFacet = '{"type":{"type":"terms","field":"type","limit":100,"mincount":1,"domain":{"excludeTags":"type"}}}';
+        $expectedJsonFacet = '{"type":{"type":"terms","field":"type","limit":100,"mincount":1}}';
         $this->assertSame($expectedJsonFacet,  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
@@ -217,6 +217,48 @@ class FacetingTest extends UnitTest
         $jsonData = \json_decode($queryParameter['json.facet']);
         $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
         $this->assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+    }
+
+    /**
+     * Whe nothing is set, no exclude tags should be set.
+     *
+     * faceting {
+     *    facets {
+     *       type {
+     *          field = type
+     *       }
+     *       color {
+     *          field = color
+     *       }
+     *    }
+     * }
+     *
+     * @test
+     */
+    public function testExcludeTagsAreEmptyWhenKeepAllFacetsOnSelectionIsNotSet()
+    {
+        $fakeConfigurationArray = [];
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
+            'type.' => [
+                'field' => 'type',
+            ],
+            'color.' => [
+                'field' => 'color',
+            ]
+        ];
+        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+
+        $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+        $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+
+        $jsonData = \json_decode($queryParameter['json.facet']);
+        $this->assertEmpty($jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEmpty($jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
     }
 
     /**


### PR DESCRIPTION
Exclude tags should only be added when keepAllFacetsOnSelection and/or keepAllOptionsOnSelection is configured.

This pr:

* Fixes makes sure that exclude tags are only added when keepAllOptionsOnSelection or keepAllFacetsOnSelection is active

Resolves: #2127 