### PR TITLE
[BUGFIX] Allow global minimumCount configuration of 0 for facets

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -103,7 +103,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
     {
         if (isset($facetConfiguration['facetLimit'])) {
             return (int)$facetConfiguration['facetLimit'];
-        } elseif ($configuration->getSearchFacetingFacetLimit() > 0) {
+        } elseif (!is_null($configuration->getSearchFacetingFacetLimit()) && $configuration->getSearchFacetingFacetLimit() >= 0) {
             return $configuration->getSearchFacetingFacetLimit();
         } else {
             return -1;
@@ -119,7 +119,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
     {
         if (isset($facetConfiguration['minimumCount'])) {
             return (int)$facetConfiguration['minimumCount'];
-        } elseif ($configuration->getSearchFacetingMinimumCount() > 0) {
+        } elseif (!is_null($configuration->getSearchFacetingMinimumCount()) && (int)$configuration->getSearchFacetingMinimumCount() >= 0) {
             return $configuration->getSearchFacetingMinimumCount();
         } else {
             return 1;

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -177,9 +177,23 @@ class OptionsFacetQueryBuilderTest extends UnitTest
     }
 
     /**
+     * @return array
+     */
+    public function getGlobalMinimumCountValue()
+    {
+        return [
+            ['configuredMinimumCount' => 5, 'expectedMinimumCount' => 5],
+            ['configuredMinimumCount' => 0, 'expectedMinimumCount' => 0],
+            ['configuredMinimumCount' => null, 'expectedMinimumCount' => 1],
+
+        ];
+    }
+
+    /**
+     * @dataProvider getGlobalMinimumCountValue
      * @test
      */
-    public function canBuildMincountParameterFromGlobalSetting()
+    public function canBuildMincountParameterFromGlobalSetting($configuredMinimumCount, $expectedMinimumCount)
     {
         /**
          * mincount = 2
@@ -193,7 +207,7 @@ class OptionsFacetQueryBuilderTest extends UnitTest
         );
 
         $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->will(
-            $this->returnValue(5)
+            $this->returnValue($configuredMinimumCount)
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -204,7 +218,7 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'type' => 'terms',
                     'field' => 'category',
                     'limit' => -1,
-                    'mincount' => 5,
+                    'mincount' => $expectedMinimumCount,
                 ],
             ]
         ];


### PR DESCRIPTION
This pr:

* Allows to configure "minumCount" to 0 for all facets
* Add's testcases for that usecase

Fixes: #2128