### PR TITLE
[BUGFIX] Response Adapter need to implement Countable interface

### DIFF
--- a/Classes/System/Solr/ResponseAdapter.php
+++ b/Classes/System/Solr/ResponseAdapter.php
@@ -1,6 +1,7 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\System\Solr;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
+use Countable;
 
 /**
  * In EXT:solr 9 we have switched from the SolrPhpClient to the solarium api.
@@ -27,7 +28,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
  * @property \stdClass index
  * @property \stdClass fields
  */
-class ResponseAdapter
+class ResponseAdapter implements Countable
 {
     /**
      * @var string
@@ -35,9 +36,9 @@ class ResponseAdapter
     protected $responseBody;
 
     /**
-     * @var array
+     * @var \stdClass
      */
-    protected $data = [];
+    protected $data = null;
 
     /**
      * @var int
@@ -132,5 +133,13 @@ class ResponseAdapter
     public function getHttpStatusMessage(): string
     {
         return $this->httpStatusMessage;
+    }
+
+    /**
+     * Counts the elements of
+     */
+    public function count()
+    {
+        return count(get_object_vars($this->data));
     }
 }

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -66,6 +66,15 @@ abstract class IntegrationTest extends FunctionalTestCase
     ];
 
     /**
+     * @var array
+     */
+    protected $configurationToUseInTestInstance = [
+       'SYS' =>  [
+           'exceptionalErrors' =>  E_WARNING | E_RECOVERABLE_ERROR | E_DEPRECATED | E_USER_DEPRECATED
+       ]
+    ];
+
+    /**
      * @return void
      */
     public function setUp()

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -192,6 +192,16 @@ class SolrAdminServiceTest extends IntegrationTest
     /**
      * @test
      */
+    public function canGetPluginsInformation()
+    {
+        $result = $this->solrAdminService->getPluginsInformation();
+        $this->assertSame(0, $result->responseHeader->status);
+        $this->assertSame(2, count($result));
+    }
+
+    /**
+     * @test
+     */
     public function canParseLanguageFromSchema()
     {
         $client = new Client(['adapter' => 'Solarium\Core\Client\Adapter\Guzzle']);


### PR DESCRIPTION
The ResponseAdapter need to implement the Countable interface for backwards compatibility.

This pr:

* Add's the implementation of the Countable interface
* Add's a testcase the reproduces the error from the reports

Resolves: #2125