### PR TITLE
Use package typo3/cms-core instead of typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "typo3/cms": ">=8.7.0"
+    "typo3/cms-core": ">=8.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",


### PR DESCRIPTION
A TYPO3 extension should not require `typo3/cms`.
See: https://insight.helhum.io/post/148886148725/composerjson-specification-for-typo3-extensions