### PR TITLE
[BUGFIX:PORT] fields in flex forms filter are not available on duplicate facets label

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -23,6 +23,7 @@ namespace ApacheSolrForTypo3\Solr\System\UserFunctions;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * This class contains all user functions for flexforms.
@@ -74,14 +75,22 @@ class FlexFormUserFunctions
             if (!empty($configuredFacets)) {
                 $configuredFacet = array_values($configuredFacets);
                 $label = $configuredFacet[0]['label'];
+                // try to translate LLL: label or leave it unchanged
+                if (GeneralUtility::isFirstPartOfStr($label, 'LLL:') && LocalizationUtility::translate($label) != '') {
+                    $label = LocalizationUtility::translate($label);
+                } elseif (!GeneralUtility::isFirstPartOfStr($label, 'LLL:') && $configuredFacet[0]['label.']) {
+                    $label = sprintf('cObject[...faceting.facets.%slabel]', array_keys($configuredFacets)[0]);
+                }
+                $label = sprintf('%s (Facet Label: "%s")', $value, $label);
             }
 
-            $newItems[$label] = [$label, $value];
+            $newItems[$value] = [$label, $value];
         }, $this->getFieldNamesFromSolrMetaDataForPage($pageRecord));
 
         ksort($newItems, SORT_NATURAL);
         return $newItems;
     }
+
     /**
      * Retrieves the configured facets for a page.
      *

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -959,6 +959,7 @@ faceting.facets.[facetName].label
 :Required: yes
 
 Used as a headline or title to describe the options of a facet.
+Used in flex forms of plugin for filter labels. Can be translated with LLL: and consumed and translated in Partial/Facets/* with f:translate ViewHelper.
 
 faceting.facets.[facetName].excludeValues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* use field name as array key in flex form select items
* use new presentation format for options labels in select flex form
`field_name (Facet Label: "usedLabelOrLLLTranslationLabel")`
`field_name (Facet Label: "cObject[...faceting.facets.someFacet.label]")`
* implement tests for this case

Fixes: #2156