### PR TITLE
[TASK] Handle bad gateway as not available

### DIFF
--- a/Classes/System/Solr/Service/SolrReadService.php
+++ b/Classes/System/Solr/Service/SolrReadService.php
@@ -101,7 +101,7 @@ class SolrReadService extends AbstractSolrService
         $message = $exception->getStatusMessage();
         $solrRespone = new ResponseAdapter($exception->getBody());
 
-        if ($status === 0) {
+        if ($status === 0 || $status === 502) {
             $e = new SolrUnavailableException('Solr Server not available: ' . $message, 1505989391);
             $e->setSolrResponse($solrRespone);
             throw $e;


### PR DESCRIPTION
If solr runs behind a proxy and solr is down the proxy returns status
"502 Bad Gateway".

Instead of having the thrown SolrCommunicationException uncaught
throw a SolrUnavailableException in this case.

Resolves: #2186