### PR TITLE
[TASK] Handle bad gateway as not available

### DIFF
--- a/Classes/System/Solr/Service/SolrReadService.php
+++ b/Classes/System/Solr/Service/SolrReadService.php
@@ -110,7 +110,7 @@ class SolrReadService extends AbstractSolrService
         $status = $response->getHttpStatus();
         $message = $response->getHttpStatusMessage();
 
-        if ($status === 0) {
+        if ($status === 0 || $status === 502) {
             $e = new SolrUnavailableException('Solr Server not available: ' . $message, 1505989391);
             $e->setSolrResponse($response);
             throw $e;


### PR DESCRIPTION
If solr runs behind a proxy and solr is down the proxy returns status
"502 Bad Gateway".

Instead of having the thrown SolrCommunicationException uncaught
throw a SolrUnavailableException in this case.

Resolves: #2186