### PR TITLE
[FEATURE] More flexible facet uri viewhelpers with optional facet object

### DIFF
--- a/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
@@ -16,6 +16,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\AbstractUriViewHelper;
 
 /**
@@ -33,9 +34,11 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('facet', AbstractFacet::class, 'The facet', true);
+        $this->registerArgument('facet', AbstractFacet::class, 'The facet', false, null);
+        $this->registerArgument('facetName', 'string', 'The facet name', false, null);
         $this->registerArgument('facetItem', AbstractFacetItem::class, 'The facet item', false, null);
         $this->registerArgument('facetItemValue', 'string', 'The facet item', false, null);
+        $this->registerArgument('resultSet', SearchResultSet::class, 'The result set', false, null);
     }
 
     /**
@@ -56,5 +59,45 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
         }
 
         return $facetValue;
+    }
+
+    /**
+     * @param $arguments
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected static function getNameFromArguments($arguments)
+    {
+        if (isset($arguments['facet'])) {
+            /** @var  $facet AbstractFacet */
+            $facet = $arguments['facet'];
+            $facetName = $facet->getName();
+        } elseif (isset($arguments['facetName'])) {
+            $facetName = $arguments['facetName'];
+        } else {
+            throw new \InvalidArgumentException('No facet was passed, please pass either facet or facetName');
+        }
+
+        return $facetName;
+    }
+
+    /**
+     * @param $arguments
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected static function getResultSetFromArguments($arguments)
+    {
+        if (isset($arguments['facet'])) {
+            /** @var  $facet AbstractFacet */
+            $facet = $arguments['facet'];
+            $resultSet = $facet->getResultSet();
+        } elseif (isset($arguments['facetName'])) {
+            $resultSet = $arguments['resultSet'];
+        } else {
+            throw new \InvalidArgumentException('No facet was passed, please pass either facet or resultSet');
+        }
+
+        return $resultSet;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
@@ -14,7 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -35,11 +35,12 @@ class AddFacetItemViewHelper extends AbstractValueViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        /** @var  $facet AbstractFacet */
-        $facet = $arguments['facet'];
+        /** @var  $resultSet SearchResultSet */
+        $name = self::getNameFromArguments($arguments);
         $itemValue = self::getValueFromArguments($arguments);
-        $previousRequest = $facet->getResultSet()->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getAddFacetValueUri($previousRequest, $facet->getName(), $itemValue);
+        $resultSet = self::getResultSetFromArguments($arguments);
+        $previousRequest = $resultSet->getUsedSearchRequest();
+        $uri = self::getSearchUriBuilder()->getAddFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
@@ -14,7 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -36,11 +36,12 @@ class RemoveFacetItemViewHelper extends AbstractValueViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        /** @var  $facet AbstractFacet */
-        $facet = $arguments['facet'];
+        /** @var  $resultSet SearchResultSet */
+        $name = self::getNameFromArguments($arguments);
         $itemValue = self::getValueFromArguments($arguments);
-        $previousRequest = $facet->getResultSet()->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getRemoveFacetValueUri($previousRequest, $facet->getName(), $itemValue);
+        $resultSet = self::getResultSetFromArguments($arguments);
+        $previousRequest = $resultSet->getUsedSearchRequest();
+        $uri = self::getSearchUriBuilder()->getRemoveFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
@@ -14,7 +14,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -36,11 +36,12 @@ class SetFacetItemViewHelper extends AbstractValueViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        /** @var  $facet AbstractFacet */
-        $facet = $arguments['facet'];
+        /** @var  $resultSet SearchResultSet */
+        $name = self::getNameFromArguments($arguments);
         $itemValue = self::getValueFromArguments($arguments);
-        $previousRequest = $facet->getResultSet()->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getSetFacetValueUri($previousRequest, $facet->getName(), $itemValue);
+        $resultSet = self::getResultSetFromArguments($arguments);
+        $previousRequest = $resultSet->getUsedSearchRequest();
+        $uri = self::getSearchUriBuilder()->getSetFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }


### PR DESCRIPTION
You could create now a facet item link (add, set, remove) somewhere else
in the results view where no facet object is available.

Beside {s:uri.facet.setFacetItem(facet: facet, facetItem: option)}
you could create a set link now with this vh arguments:
{s:uri.facet.setFacetItem(facetName: 'type', facetItemValue: 'pages',
resultSet: resultSet)}

Resolves: #2191