### PR TITLE
[TASK] Adapt version constraint to allow installation with 9 LTS

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '8.7.0-9.4.99'
+            'typo3' => '8.7.0-9.5.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
This pr:

* Adapts the version constraint to allow an installation with TYPO3 9 LTS

Fixes: #2203