### PR TITLE
[TASK] pretify search url by removing id and L from it

### DIFF
--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -7,9 +7,6 @@
 	<div class="tx-solr-search-form">
 		<s:searchForm id="tx-solr-search-form-pi-results" additionalFilters="{additionalFilters}" suggestHeader="{s:translate(key:'suggest_header',default:'Top Results')}">
 			<div class="input-group">
-				<input type="hidden" name="L" value="{languageUid}" />
-				<input type="hidden" name="id" value="{pageUid}" />
-
 				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
 				<span class="input-group-btn">
 					<button class="btn btn-default tx-solr-submit" type="submit">


### PR DESCRIPTION
These parameters are not needed in the form because they are handled by the URL.

Fixes: #2217