### PR TITLE
[BUGFIX] Do not render id and L param for form for sites managed with site management

### DIFF
--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -7,8 +7,10 @@
 	<div class="tx-solr-search-form">
 		<s:searchForm id="tx-solr-search-form-pi-results" additionalFilters="{additionalFilters}" suggestHeader="{s:translate(key:'suggest_header',default:'Top Results')}">
 			<div class="input-group">
-				<input type="hidden" name="L" value="{languageUid}" />
-				<input type="hidden" name="id" value="{pageUid}" />
+				<f:if condition="{addPageAndLanguageId}">
+					<input type="hidden" name="L" value="{languageUid}" />
+					<input type="hidden" name="id" value="{pageUid}" />
+				</f:if>
 
 				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
 				<span class="input-group-btn">

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -59,11 +59,12 @@ class SearchFormViewHelperTest extends UnitTest
         $controllerContextMock = $this->getDumbMock(ControllerContext::class);
         $controllerContextMock->expects($this->once())->method('getUriBuilder')->willReturn($this->uriBuilderMock);
 
-        $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)->setMethods(['getControllerContext', 'getTypoScriptConfiguration', 'getTemplateVariableContainer', 'getSearchResultSet', 'renderChildren'])->getMock();
+        $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)->setMethods(['getControllerContext', 'getTypoScriptConfiguration', 'getTemplateVariableContainer', 'getSearchResultSet', 'renderChildren', 'getIsSiteManagedSite'])->getMock();
         $this->viewHelper->expects($this->any())->method('getControllerContext')->willReturn($controllerContextMock);
         $this->viewHelper->expects($this->any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
         $this->viewHelper->expects($this->any())->method('getTemplateVariableContainer')->willReturn($this->getDumbMock(VariableProviderInterface::class));
         $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn('');
+        $this->viewHelper->expects($this->once())->method('getIsSiteManagedSite')->willReturn(false);
 
     }
 


### PR DESCRIPTION
When the pageId and the languageId is encoded in the path segment of the url e.g. "/en/search", there is no need,
to keep the in the form as hidden arguments. Nevertheless we need to make sure that they are added when no speaking urls are used (e.g. in a 8 LTS default environment).

This pr:

* Add's variable(addPageAndLanguageId) to the form that indicates if the L and id parameter are required as hidden fields
* The variable is set to false when we have a site in TYPO3 9 LTS managed with the site management because then these arguments are encoded in the path segment of the url

Fixes: #2217