### PR TITLE
[BUGFIX] Filters in autosuggest get added twice

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -106,7 +106,7 @@ class SearchController extends AbstractBaseController
             $this->controllerContext->setSearchResultSet($searchResultSet);
 
             $values = [
-                'additionalFilters' => $this->searchService->getAdditionalFilters(),
+                'additionalFilters' => $this->getAdditionalFilters(),
                 'resultSet' => $searchResultSet,
                 'pluginNamespace' => $this->typoScriptConfiguration->getSearchPluginNamespace()
             ];
@@ -127,7 +127,7 @@ class SearchController extends AbstractBaseController
 
         $values = [
             'search' => $this->searchService->getSearch(),
-            'additionalFilters' => $this->searchService->getAdditionalFilters(),
+            'additionalFilters' => $this->getAdditionalFilters(),
             'pluginNamespace' => $this->typoScriptConfiguration->getSearchPluginNamespace()
         ];
         $values = $this->emitActionSignal(__CLASS__, __FUNCTION__, [$values]);
@@ -151,7 +151,7 @@ class SearchController extends AbstractBaseController
         $this->controllerContext->setSearchResultSet($searchResultSet);
 
         $values = [
-            'additionalFilters' => $this->searchService->getAdditionalFilters(),
+            'additionalFilters' => $this->getAdditionalFilters(),
             'resultSet' => $searchResultSet
         ];
         $values = $this->emitActionSignal(__CLASS__, __FUNCTION__, [$values]);
@@ -194,5 +194,16 @@ class SearchController extends AbstractBaseController
     {
         parent::handleSolrUnavailable();
         $this->forward('solrNotAvailable');
+    }
+
+    /**
+     * This method can be overwritten to add additionalFilters for the autosuggest.
+     * By default the suggest controller will apply the configured filters from the typoscript configuration.
+     *
+     * @return array
+     */
+    protected function getAdditionalFilters()
+    {
+        return [];
     }
 }

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -280,10 +280,15 @@ class SearchResultSetService
     /**
      * Retrieves the configuration filters from the TypoScript configuration, except the __pageSections filter.
      *
+     * @deprecated Since the suggest controller is a controller with a pagetype there is no need to pass around
+     * the filters that are configured in TypoScript. Therefore this method is not required anymore since the suggest
+     * controller retrieves the configured filters directly from the typoscript. Nevertheless you can pass view specific
+     * additionFilters to you search view when needed and they will still be evaluated. Depreacted since EXT:solr 9 will be removed in EXT:solr 10
      * @return array
      */
     public function getAdditionalFilters()
     {
+        trigger_error('Additional filters in the suggest are now retrieved from typoscript directly and there is no need to keep this. Will be removed in EXT:solr 10.', E_USER_DEPRECATED);
         return $this->queryBuilder->getAdditionalFilters();
     }
 


### PR DESCRIPTION
The filters in the autosuggest currently get added twice. Once from TypoScript and once
from the passed additionalFilters (That originally also come from the TypoScript of the previous request).

Since we can access the TypoScript from the suggest controller as well we should not pass those filters as additionalFilters.

Nevertheless we should keep the evaluation of additionalFilters to allow additionalFilters on a view base.

Related: #2212 