### PR TITLE
[BUGFIX] Ignore filter when it was passed twice with the same name

### DIFF
--- a/Classes/Domain/Search/Query/AbstractQueryBuilder.php
+++ b/Classes/Domain/Search/Query/AbstractQueryBuilder.php
@@ -351,6 +351,11 @@ abstract class AbstractQueryBuilder {
     public function useFilter($filterString, $filterName = '')
     {
         $filterName = $filterName === '' ? $filterString : $filterName;
+
+        $nameWasPassedAndFilterIsAllreadySet = $filterName !== '' && $this->queryToBuild->getFilterQuery($filterName) !== null;
+        if($nameWasPassedAndFilterIsAllreadySet) {
+            return $this;
+        }
         $this->queryToBuild->addFilterQuery(['key' => $filterName, 'query' => $filterString]);
         return $this;
     }

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -1045,6 +1045,20 @@ class QueryBuilderTest extends UnitTest
     /**
      * @test
      */
+    public function canUseFilterIgnoreSecondePassedFilterWithSameKey()
+    {
+        $fakeConfiguration = new TypoScriptConfiguration([]);
+        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
+
+        // we add a filter with the same key twice and expect that only the first one is kept and not overwritten
+        $this->builder->startFrom($query)->useFilter('foo:bar', 'test')->useFilter('foo:bla', 'test');
+        $parameters = $this->getAllQueryParameters($query);
+        $this->assertSame('foo:bar', $parameters['fq'], 'Unexpected filter query was added');
+    }
+
+    /**
+     * @test
+     */
     public function canSetAndUnSetQueryType()
     {
         $query = $this->getInitializedTestSearchQuery('test');


### PR DESCRIPTION
When a filter is passed twice (e.g. by passing it as additional filter), it should be ignored.

This pr:

* Ignores a filter when it is passed twice and keeps the filter that was passed first.

Related: #2212