### PR TITLE
[TASK] Remove singleFacetMode from fixtures and code

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1961,11 +1961,14 @@ class TypoScriptConfiguration
      *
      * plugin.tx_solr.search.faceting.singleFacetMode
      *
+     * @deprecated singleFacetMode is not supported anymore with TypoScript. If you need this behaviour please use the partialName=OptionsSinglemode for that
      * @param bool $defaultIfEmpty
      * @return bool
      */
     public function getSearchFacetingSingleFacetMode($defaultIfEmpty = false)
     {
+        trigger_error('TypoScriptConfiguration::getSearchFacetingSingleFacetMode is deprecated please use partialName=OptionsSinglemode typoscript configuration for that. Will be removed in EXT:solr 10', E_USER_DEPRECATED);
+
         $singleFacetMode = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.faceting.singleFacetMode', $defaultIfEmpty);
         return $this->getBool($singleFacetMode);
     }

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -271,7 +271,6 @@ plugin.tx_solr {
 			minimumCount = 1
 			sortBy = count
 			limit = 10
-			singleFacetMode = 0
 			showEmptyFacets = 0
 			keepAllFacetsOnSelection = 0
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -842,19 +842,6 @@ faceting.facetLimit
 Number of options of a facet returned from solr.
 
 
-faceting.singleFacetMode
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Type: Boolean
-:TS Path: plugin.tx_solr.search.faceting.singleFacetMode
-:Since: 1.2, 2.0
-:Default: 0
-:Options: 0, 1
-
-If enabled, the user can only select an option from one facet at a time.
-
-Lets say you have two facets configured, type and author. If the user selects a facet option from type its filter is added to the query. Normally when selecting another option from the other facet - the author facet - this would lead to having two facet filters applied to the query. When this option is activated the option from the author facet will simply replace the first option from the type facet.
-
 faceting.keepAllFacetsOnSelection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
@@ -231,7 +231,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_render_path_facet_with_search_controller.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_path_facet_with_search_controller.xml
@@ -158,7 +158,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_render_search_controller.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_controller.xml
@@ -267,7 +267,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_customTemplate.xml
@@ -257,7 +257,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_render_search_customTemplateFromTs.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_search_customTemplateFromTs.xml
@@ -249,7 +249,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_render_suggest_controller.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_suggest_controller.xml
@@ -267,7 +267,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 

--- a/Tests/Integration/Controller/Fixtures/can_sort_by_metric.xml
+++ b/Tests/Integration/Controller/Fixtures/can_sort_by_metric.xml
@@ -267,7 +267,6 @@
                             minimumCount = 1
                             sortBy = count
                             limit = 10
-                            singleFacetMode = 0
                             showEmptyFacets = 0
                             keepAllFacetsOnSelection = 0
 


### PR DESCRIPTION
The TypoScript setting "singleFacetMode", was removed and could be replaced by rendering a facet with the partial "OptionsSinglemode".

This pr:

* Removes the left settings in fixtures and default configuration
* Deprecates the method TypoScriptConfiguration::getSearchFacetingSingleFacetMode

Fixes: #2189