### PR TITLE
[BUGFIX] Fix backend info module with missing core

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -32,6 +32,7 @@ use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -105,6 +106,8 @@ class Repository implements SingletonInterface
             $response = $this->search->search($pageQuery, 0, 10000);
         } catch (NoSolrConnectionFoundException $exception) {
             return [];
+        } catch (SolrCommunicationException $exception) {
+            return [];
         }
         $data = $response->getParsedData();
         return $this->documentEscapeService->applyHtmlSpecialCharsOnAllFields($data->response->docs ?? []);
@@ -124,6 +127,8 @@ class Repository implements SingletonInterface
             $recordQuery = $this->queryBuilder->buildRecordQuery($type, $uid, $pageId);
             $response = $this->search->search($recordQuery, 0, 10000);
         } catch (NoSolrConnectionFoundException $exception) {
+            return [];
+        } catch (SolrCommunicationException $exception) {
             return [];
         }
         $data = $response->getParsedData();

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -314,7 +314,12 @@ abstract class AbstractSolrService {
      */
     public function ping($useCache = true)
     {
-        $httpResponse = $this->performPingRequest($useCache);
+        try {
+            $httpResponse = $this->performPingRequest($useCache);
+        } catch (HttpException $exception) {
+            return false;
+        }
+
         return ($httpResponse->getHttpStatus() === 200);
     }
 


### PR DESCRIPTION
When a core is unavailable this should not prevent the backend module from rendering.

This pr:

* Catches a SolrCommunicationException in the document repository as well
* Makes sure that "ping" returns false for an unconfigured core by catching the HttpException thrown by Solarium

Fixes: #2220