### PR TITLE
[BUGFIX] Catch solarium HttpExceptions

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -33,6 +33,7 @@ use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
+use Solarium\Exception\HttpException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
@@ -142,7 +143,11 @@ class IndexService
         if ($enableCommitsSetting && count($itemsToIndex) > 0) {
             $solrServers = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionsBySite($this->site);
             foreach ($solrServers as $solrServer) {
-                $solrServer->getWriteService()->commit(false, false, false);
+                try {
+                    $solrServer->getWriteService()->commit(false, false, false);
+                } catch (HttpException $e) {
+                    $errors++;
+                }
             }
         }
 

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -35,6 +35,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Util;
+use Solarium\Exception\HttpException;
 use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
@@ -172,9 +173,13 @@ class Indexer extends AbstractIndexer
         $documents = $this->processDocuments($item, $documents);
         $documents = $this->preAddModifyDocuments($item, $language, $documents);
 
-        $response = $this->solr->getWriteService()->addDocuments($documents);
-        if ($response->getHttpStatus() == 200) {
-            $itemIndexed = true;
+        try {
+            $response = $this->solr->getWriteService()->addDocuments($documents);
+            if ($response->getHttpStatus() == 200) {
+                $itemIndexed = true;
+            }
+        } catch (HttpException $e) {
+            $response = new ResponseAdapter($e->getBody(), $httpStatus = 500, $e->getStatusMessage());
         }
 
         $this->log($item, $documents, $response);


### PR DESCRIPTION
During indexing we should catch solarium HttpException's on several places in order to proceed the indexing process.

Fixes: #2233 