### PR TITLE
[TASK] Prepare different url generation when site management is active

### DIFF
--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types = 1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerDataUrlModifier;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Implementations of this class are able to build an indexing url for solr page indexing.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder
+ */
+abstract class AbstractUriStrategy
+{
+    /**
+     * @var SolrLogManager|null|object
+     */
+    protected $logger;
+
+    /**
+     * AbstractUriStrategy constructor.
+     * @param SolrLogManager|null $logger
+     */
+    public function __construct(SolrLogManager $logger = null)
+    {
+        $this->logger = $logger ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+    }
+
+    /**
+     * @param UrlHelper $urlHelper
+     * @param array $overrideConfiguration
+     * @return UrlHelper
+     */
+    protected function applyTypoScriptOverridesOnIndexingUrl(UrlHelper $urlHelper, array $overrideConfiguration = []): UrlHelper
+    {
+        // check whether we should use ssl / https
+        if (!empty($overrideConfiguration['scheme'])) {
+            $urlHelper->setScheme($overrideConfiguration['scheme']);
+        }
+
+        // overwriting the host
+        if (!empty($overrideConfiguration['host'])) {
+            $urlHelper->setHost($overrideConfiguration['host']);
+        }
+
+        // setting a path if TYPO3 is installed in a sub directory
+        if (!empty($overrideConfiguration['path'])) {
+            $urlHelper->setPath($overrideConfiguration['path']);
+        }
+
+        return $urlHelper;
+    }
+
+    /**
+     * @param Item $item
+     * @param int $language
+     * @param string $mountPointParameter
+     * @param array $options
+     * @return string
+     */
+    public function getPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0, string $mountPointParameter = '', $options = []): string
+    {
+        $pageIndexUri = $this->buildPageIndexingUriFromPageItemAndLanguageId($item, $language, $mountPointParameter);
+        $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $pageIndexUri);
+        $overrideConfiguration = is_array($options['frontendDataHelper.']) ? $options['frontendDataHelper.'] : [];
+        $urlHelper = $this->applyTypoScriptOverridesOnIndexingUrl($urlHelper, $overrideConfiguration);
+        $dataUrl = $urlHelper->getUrl();
+
+        if (!GeneralUtility::isValidUrl($dataUrl)) {
+            $this->logger->log(
+                SolrLogManager::ERROR,
+                'Could not create a valid URL to get frontend data while trying to index a page.',
+                [
+                    'item' => (array)$item,
+                    'constructed URL' => $dataUrl,
+                    'scheme' => $urlHelper->getScheme(),
+                    'host' => $urlHelper->getHost(),
+                    'path' => $urlHelper->getPath(),
+                    'page ID' => $item->getRecordUid(),
+                    'indexer options' => $options
+                ]
+            );
+
+            throw new \RuntimeException(
+                'Could not create a valid URL to get frontend data while trying to index a page. Created URL: ' . $dataUrl,
+                1311080805
+            );
+        }
+
+
+        return $this->applyDataUrlModifier($item, $language, $dataUrl, $urlHelper);
+    }
+
+    /**
+     * @param Item $item
+     * @param int $language
+     * @param string $mountPointParameter
+     * @return mixed
+     */
+    abstract protected function buildPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0, string $mountPointParameter = '');
+
+    /**
+     * @param Item $item
+     * @param int $language
+     * @param string $dataUrl
+     * @param UrlHelper $urlHelper
+     * @return string
+     */
+    protected function applyDataUrlModifier(Item $item, int $language, $dataUrl, UrlHelper $urlHelper):string
+    {
+        if (empty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'])) {
+            return $dataUrl;
+        }
+
+        $dataUrlModifier = GeneralUtility::makeInstance($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier']);
+        if (!$dataUrlModifier instanceof PageIndexerDataUrlModifier) {
+            throw new \RuntimeException($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'] . ' is not an implementation of ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerDataUrlModifier', 1290523345);
+        }
+
+        return $dataUrlModifier->modifyDataUrl($dataUrl,
+            [
+                'item' => $item, 'scheme' => $urlHelper->getScheme(), 'host' => $urlHelper->getHost(),
+                'path' => $urlHelper->getPath(), 'pageId' => $item->getRecordUid(), 'language' => $language
+            ]
+        );
+    }
+}

--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/SolrSiteStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/SolrSiteStrategy.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+
+/**
+ * This class is used to build the indexing url based on the EXT:solr site.
+ *
+ * The EXT:solr site is the TYPO3 site where the domain record is located or an EXT:solr specific domain configuration
+ * is located. EXT:solr uses this term "site" several years for the entry point.
+ *
+ * In TYPO3 9 "site's" have been introduced in TYPO3 and are managed with the "site management" for those sites
+ * we build the indexing url in a different way since they have the pageId and languageId encoded in the speaking url by the core.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder
+ */
+class SolrSiteStrategy extends AbstractUriStrategy
+{
+    /**
+     * @param Item $item
+     * @param int $language
+     * @param string $mountPointParameter
+     * @return string
+     */
+    protected function buildPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0, string $mountPointParameter  = '')
+    {
+        $scheme = 'http';
+        $host = $item->getSite()->getDomain();
+        $path = '/';
+        $pageId = $item->getRecordUid();
+
+        $pageIndexUri = $scheme . '://' . $host . $path . 'index.php?id=' . $pageId;
+        $pageIndexUri .= ($mountPointParameter !== '') ? '&MP=' . $mountPointParameter : '';
+        $pageIndexUri .= '&L=' . $language;
+
+        return $pageIndexUri;
+    }
+}

--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * This class is used to build the indexing url for a TYPO3 site that is managed with the TYPO3 site management.
+ *
+ * These sites have the pageId and language information encoded in the speaking url.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder
+ */
+class TYPO3SiteStrategy extends AbstractUriStrategy
+{
+    /**
+     * @var SiteFinder
+     */
+    protected $siteFinder = null;
+
+    /**
+     * TYPO3SiteStrategy constructor.
+     * @param SolrLogManager|null $logger
+     * @param SiteFinder|null $siteFinder
+     */
+    public function __construct(SolrLogManager $logger = null, SiteFinder $siteFinder = null)
+    {
+        parent::__construct($logger);
+        $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
+    }
+
+    /**
+     * @param Item $item
+     * @param int $language
+     * @param string $mountPointParameter
+     * @return string
+     */
+    protected function buildPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0,  string $mountPointParameter = '')
+    {
+        $site = $this->siteFinder->getSiteByPageId($item->getRecordUid());
+        $parameters = [];
+
+        if ($language > 0) {
+            $parameters['_language'] = $language;
+        };
+
+        if ($mountPointParameter !== '') {
+            $parameters['MP'] = $mountPointParameter;
+        }
+
+        $pageIndexUri = (string)$site->getRouter()->generateUri($item->getRecord(), $parameters);
+        return $pageIndexUri;
+    }
+}

--- a/Classes/Domain/Index/PageIndexer/Helper/UriStrategyFactory.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriStrategyFactory.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\AbstractUriStrategy;
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\SolrSiteStrategy;
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\TYPO3SiteStrategy;
+use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * This class is responsible to retrieve an "UriStrategy" the can build uri's for the site where the
+ * passed page belongs to.
+ *
+ * This can be:
+ * * A TYPO3 site managed with site management
+ * * A TYPO3 site without site management where the url is build by EXT:solr with L and id param and information from the domain
+ * record or solr specific configuration.
+ *
+ * @package ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper
+ */
+class UriStrategyFactory
+{
+    /**
+     * @param integer $pageId
+     * @oaram array $overrideConfiguration
+     * @return AbstractUriStrategy
+     */
+    public function getForPageId(int $pageId): AbstractUriStrategy
+    {
+        // @todo by now using the site urls leads to problems
+        // since e.g. fallbacks do not work and urls could be indexed that lead to a 404 error
+        // when this is resolved we could generate the urls with the router of the site for indexing with solr
+        // if (SiteUtility::getIsSiteManagedSite($pageId)) {
+        //    return GeneralUtility::makeInstance(TYPO3SiteStrategy::class);
+        // }
+
+        return GeneralUtility::makeInstance(SolrSiteStrategy::class);
+    }
+}

--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -48,6 +48,7 @@ class UrlHelper {
     public function __construct($url)
     {
         $this->initialUrl = $url;
+        $this->parseInitialUrl();
     }
 
     /**
@@ -70,15 +71,85 @@ class UrlHelper {
     }
 
     /**
+     * @param string $part
+     * @param mixed $value
+     */
+    protected function setUrlPart($part, $value)
+    {
+        $this->urlParts[$part] = $value;
+    }
+
+    /**
+     * @param $path
+     * @return mixed
+     */
+    protected function getUrlPart($path)
+    {
+        return $this->urlParts[$path];
+    }
+
+    /**
+     * @param string $host
+     * @return UrlHelper
+     */
+    public function setHost(string $host)
+    {
+        $this->setUrlPart('host', $host);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHost(): string
+    {
+        return $this->getUrlPart('host');
+    }
+
+    /**
+     * @param string $scheme
+     * @return UrlHelper
+     */
+    public function setScheme(string $scheme)
+    {
+        $this->setUrlPart('scheme', $scheme);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScheme(): string
+    {
+        return $this->getUrlPart('scheme');
+    }
+
+    /**
+     * @param string $path
+     * @return UrlHelper
+     */
+    public function setPath($path)
+    {
+        $this->setUrlPart('path', $path);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->getUrlPart('path');
+    }
+
+    /**
      * @param string $parameterName
      * @throws \InvalidArgumentException
      * @return UrlHelper
      */
     public function removeQueryParameter(string $parameterName): UrlHelper
     {
-        $this->parseInitialUrl();
         unset($this->queryParts[$parameterName]);
-
         return $this;
     }
 
@@ -90,9 +161,7 @@ class UrlHelper {
      */
     public function addQueryParameter(string $parameterName, $value): UrlHelper
     {
-        $this->parseInitialUrl();
         $this->queryParts[$parameterName] = $value;
-
         return $this;
     }
 
@@ -101,28 +170,24 @@ class UrlHelper {
      */
     public function getUrl(): string
     {
-        $this->parseInitialUrl();
         $this->urlParts['query'] = http_build_query($this->queryParts);
-
-        return $this->unparse_url($this->urlParts);
+        return $this->unparseUrl();
     }
 
     /**
-     * @param array $parsed_url
      * @return string
      */
-    protected function unparse_url(array $parsed_url): string
+    protected function unparseUrl(): string
     {
-        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
-        $host     = $parsed_url['host'] ?? '';
-        $port     = $parsed_url['port'] ?? '';
-        $user     = $parsed_url['user'] ?? '';
-        $pass     = $parsed_url['pass'] ?? '';
+        $scheme   = isset($this->urlParts['scheme']) ? $this->urlParts['scheme'] . '://' : '';
+        $host     = $this->urlParts['host'] ?? '';
+        $port     = $this->urlParts['port'] ?? '';
+        $user     = $this->urlParts['user'] ?? '';
+        $pass     = $this->urlParts['pass'] ?? '';
         $pass     = ($user || $pass) ? "$pass@" : '';
-        $path     = $parsed_url['path'] ?? '';
-        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
-        $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+        $path     = $this->urlParts['path'] ?? '';
+        $query    = isset($this->urlParts['query']) && !empty($this->urlParts['query']) ? '?' . $this->urlParts['query'] : '';
+        $fragment = isset($this->urlParts['fragment']) ? '#' . $this->urlParts['fragment'] : '';
         return $scheme . $user . $pass . $host . $port . $path . $query . $fragment;
     }
-
 }

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -1,0 +1,58 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Util;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * This class contains related functions for the new site management that was introduced with TYPO3 9.
+ *
+ * @package ApacheSolrForTypo3\Solr\System\Util
+ */
+class SiteUtility
+{
+
+    /**
+     * Determines if the site where the page belongs to is managed with the TYPO3 site management.
+     *
+     * @return boolean
+     */
+    public static function getIsSiteManagedSite($pageId)
+    {
+        if (Util::getIsTYPO3VersionBelow9()) {
+            return false;
+        }
+
+        $siteFinder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Site\SiteFinder::class);
+        try {
+            $site = $siteFinder->getSiteByPageId($pageId);
+        } catch (\TYPO3\CMS\Core\Exception\SiteNotFoundException $e) {
+            return false;
+        }
+
+        return $site instanceof \TYPO3\CMS\Core\Site\Entity\Site;
+    }
+}

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -15,6 +15,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
  */
 
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
+use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -117,7 +118,6 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         $this->getTemplateVariableContainer()->add('pageUid', $pageUid);
         $this->getTemplateVariableContainer()->add('languageUid', $this->frontendController->sys_language_uid);
 
-        // @todo when TYPO3 8 support is dropped we can remove this property and remove
         $this->getTemplateVariableContainer()->add('addPageAndLanguageId', !$this->getIsSiteManagedSite($pageUid));
         $formContent = $this->renderChildren();
         $this->getTemplateVariableContainer()->remove('addPageAndLanguageId');
@@ -135,25 +135,11 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
      * When no speaking urls are active (e.g. with TYPO3 8 and no realurl) this information is passed as query parameter
      * and would get lost when it is only part of the query arguments in the action parameter of the form.
      *
-     * Therefore we check if we have a TYPO3 9 system with active site management and then do not render these arguments in the form.
-     *
      * @return boolean
      */
     protected function getIsSiteManagedSite($pageId)
     {
-        if (!class_exists('\TYPO3\CMS\Core\Site\SiteFinder')) {
-           return false;
-        }
-
-        //we have a TYPO3 9 System
-        $siteFinder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Site\SiteFinder::class);
-        try {
-            $site = $siteFinder->getSiteByPageId($pageId);
-        } catch (\TYPO3\CMS\Core\Exception\SiteNotFoundException $e) {
-            return false;
-        }
-
-        return $site instanceof \TYPO3\CMS\Core\Site\Entity\Site;
+        return SiteUtility::getIsSiteManagedSite($pageId);
     }
 
     /**

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/SolrSiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/SolrSiteStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\SolrSiteStrategy;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\Site;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class SolrSiteStrategyTest
+ * @package ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index
+ */
+class SolrSiteStrategyTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function testPageIndexingUriFromPageItemAndLanguageId()
+    {
+        $itemMock = $this->getMockedItemWithSite(55, 'www.site.de');
+
+        /** @var SolrSiteStrategy $strategy */
+        $strategy = GeneralUtility::makeInstance(SolrSiteStrategy::class);
+        $uri = $strategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'xx');
+        $this->assertSame('http://www.site.de/index.php?id=55&MP=xx&L=2', $uri, 'Solr site strategy generated unexpected uri');
+    }
+
+    /**
+     * @test
+     */
+    public function canOverrideHost()
+    {
+        $itemMock = $this->getMockedItemWithSite(55, 'www.site.de');
+        /** @var SolrSiteStrategy $strategy */
+        $strategy = GeneralUtility::makeInstance(SolrSiteStrategy::class);
+        $uri = $strategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'xx', ['frontendDataHelper.' => ['host' => 'www.secondsite.de']]);
+        $this->assertSame('http://www.secondsite.de/index.php?id=55&MP=xx&L=2', $uri, 'Solr site strategy generated unexpected uri');
+    }
+
+    /**
+     * @test
+     */
+    public function canOverrideScheme()
+    {
+        $itemMock = $this->getMockedItemWithSite(55, 'www.site.de');
+        /** @var SolrSiteStrategy $strategy */
+        $strategy = GeneralUtility::makeInstance(SolrSiteStrategy::class);
+        $uri = $strategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'xx', ['frontendDataHelper.' => ['scheme' => 'https']]);
+        $this->assertSame('https://www.site.de/index.php?id=55&MP=xx&L=2', $uri, 'Solr site strategy generated unexpected uri');
+    }
+
+    /**
+     * @param int $pageId
+     * @param string $domain
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockedItemWithSite($pageId, $domain)
+    {
+        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock->expects($this->once())->method('getDomain')->willReturn($domain);
+
+        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock->expects($this->any())->method('getSite')->willReturn($siteMock);
+        $itemMock->expects($this->any())->method('getRecordUid')->willReturn($pageId);
+
+        return $itemMock;
+    }
+
+}

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\TYPO3SiteStrategy;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Util;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Routing\RouterInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class SolrSiteStrategyTest
+ * @package ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index
+ */
+class TYPO3SiteStrategyTest extends UnitTest
+{
+
+    /**
+     * @test
+     */
+    public function testPageIndexingUriFromPageItemAndLanguageId()
+    {
+        // @todo this check can be dropped when TYPO3 8 compatibility is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $this->markTestSkipped('SiteFinder is only available with TYPO3 9');
+        }
+
+        $pageRecord = ['uid' => 55];
+        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock->expects($this->any())->method('getRecord')->willReturn($pageRecord);
+        $itemMock->expects($this->any())->method('getRecordUid')->willReturn(55);
+
+            /** @var $loggerMock SolrLogManager */
+        $loggerMock = $this->getDumbMock(SolrLogManager::class);
+
+        $uriMock = $this->getDumbMock(UriInterface::class);
+        $uriMock->expects($this->any())->method('__toString')->willReturn('http://www.site.de/en/test');
+
+        $routerMock = $this->getDumbMock(RouterInterface::class);
+        $routerMock->expects($this->once())->method('generateUri')->with($pageRecord, ['_language' => 2, 'MP' => 'foo'])
+            ->willReturn($uriMock);
+
+        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock->expects($this->once())->method('getRouter')->willReturn($routerMock);
+
+        /** @var SiteFinder $siteFinderMock */
+        $siteFinderMock = $this->getDumbMock(SiteFinder::class);
+        $siteFinderMock->expects($this->once())->method('getSiteByPageId')->willReturn($siteMock);
+
+
+        $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
+        $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo');
+    }
+}

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\AbstractUriStrategy;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
@@ -33,6 +34,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\Site;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 
@@ -68,6 +70,11 @@ class PageIndexerTest extends UnitTest
      */
     protected $pageIndexerRequestMock;
 
+    /**
+     * @var AbstractUriStrategy
+     */
+    protected $uriStrategyMock;
+
     public function setUp()
     {
         $this->pagesRepositoryMock = $this->getDumbMock(PagesRepository::class);
@@ -75,6 +82,7 @@ class PageIndexerTest extends UnitTest
         $this->solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
         $this->connectionManagerMock = $this->getDumbMock(ConnectionManager::class);
         $this->pageIndexerRequestMock = $this->getDumbMock(PageIndexerRequest::class);
+        $this->uriStrategyMock = $this->getDumbMock(AbstractUriStrategy::class);
     }
 
     /**
@@ -92,9 +100,10 @@ class PageIndexerTest extends UnitTest
                     $this->solrLogManagerMock,
                     $this->connectionManagerMock
                 ])
-            ->setMethods(['getPageIndexerRequest', 'getSystemLanguages', 'getAccessRootlineByPageId'])
+            ->setMethods(['getPageIndexerRequest', 'getSystemLanguages', 'getAccessRootlineByPageId', 'getUriStrategy'])
             ->getMock();
         $pageIndexer->expects($this->any())->method('getPageIndexerRequest')->willReturn($this->pageIndexerRequestMock);
+        $pageIndexer->expects($this->any())->method('getUriStrategy')->willReturn($this->uriStrategyMock);
         return $pageIndexer;
     }
 
@@ -107,9 +116,12 @@ class PageIndexerTest extends UnitTest
             ['rootPageUid' => 88, 'language' => 0]
         ]);
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getDomain')->willReturn('myfrontendurl.de');
         $siteMock->expects($this->any())->method('getRootPageId')->willReturn(88);
         $siteMock->expects($this->any())->method('getRootPage')->willReturn(['l18n_cfg' => 0, 'title' => 'mysiteroot']);
+
+        $urlHelperMock = $this->getDumbMock(UrlHelper::class);
+        $testUri = 'http://myfrontendurl.de/index.php?id=4711&L=0';
+        $this->uriStrategyMock->expects($this->any())->method('getPageIndexingUriFromPageItemAndLanguageId')->willReturn($testUri);
 
             /** @var $item Item */
         $item = $this->getDumbMock(Item::class);

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -91,7 +91,6 @@ class UrlHelperTest extends UnitTest
     }
 
     /**
-     *
      * @dataProvider getUrl
      * @test
      * @param string $inputUrl
@@ -101,5 +100,53 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper($inputUrl);
         $this->assertSame($expectedOutputUrl, $urlHelper->getUrl(), 'Can not get expected output url');
+    }
+
+    /**
+     * @test
+     */
+    public function testSetHost()
+    {
+        $urlHelper = new UrlHelper('http://www.google.de/test/index.php?foo=bar');
+        $urlHelper->setHost('www.test.de');
+        $this->assertSame('http://www.test.de/test/index.php?foo=bar', $urlHelper->getUrl());
+    }
+
+    /**
+     * @test
+     */
+    public function testSetScheme()
+    {
+        $urlHelper = new UrlHelper('http://www.google.de/test/index.php?foo=bar');
+        $urlHelper->setScheme('https');
+        $this->assertSame('https://www.google.de/test/index.php?foo=bar', $urlHelper->getUrl());
+    }
+
+    /**
+     * @test
+     */
+    public function testSetPath()
+    {
+        $urlHelper = new UrlHelper('http://www.google.de/one/two?foo=bar');
+        $urlHelper->setPath('/one/two');
+        $this->assertSame('http://www.google.de/one/two?foo=bar', $urlHelper->getUrl());
+    }
+
+    public function unmodifiedUrl()
+    {
+        return [
+            'noQuery' => ['http://www.site.de/en/test'],
+            'withQuery' => ['http://www.site.de/en/test?id=1'],
+            'withQueries' => ['http://www.site.de/en/test?id=1&L=2']
+
+        ];
+    }
+    /**
+     * @dataProvider unmodifiedUrl
+     */
+    public function testGetUnmodifiedUrl($uri)
+    {
+        $urlHelper = new UrlHelper($uri);
+        $this->assertSame($uri, $urlHelper->getUrl(), 'Could not get unmodified url');
     }
 }


### PR DESCRIPTION
When the site management in TYPO3 9 is used, the language and pageId parameter are part of the encoded url. In previous versions of EXT:solr we build the frontend url by our own by adding the id, L and MP parameter.

This pr:
    
* Refactors the url generation by extracting the code into strategy classes
* Implements a SolrSiteStrategy that is able to build the indexing uri as before with index.php?id=xx&L=yy
* Implements a TYPO3SiteStrategy that uses the router to build the indexing uri
* Prepares a different indexing url handling with site management
    
**Important**: By now the old urls with id and L parameter are used also when site management is active since the urls that are generated by the router could produce urls that lead to a 404 error.
    
Related: #2234