### PR TITLE
[BUGFIX] KeepAllFacetsOnSelection is not evaluated when KeepAllOptionsOnSelection is used.

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -76,22 +76,25 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildExcludeTagsForJson(array $facetConfiguration, TypoScriptConfiguration $configuration)
     {
-        $isKeepAllOptionsActiveForSingleFacet = $facetConfiguration['keepAllOptionsOnSelection'] == 1;
-        $isKeepAllOptionsActiveGlobalsAndCountsEnabled = $configuration->getSearchFacetingKeepAllFacetsOnSelection()
-            && $configuration->getSearchFacetingCountAllFacetsForSelection();
+        $excludeFields = [];
 
-        if ($isKeepAllOptionsActiveForSingleFacet || $isKeepAllOptionsActiveGlobalsAndCountsEnabled) {
-            return $facetConfiguration['field'];
-        } elseif($configuration->getSearchFacetingKeepAllFacetsOnSelection()) {
-            // keepAllOptionsOnSelection globally active
-            $facets = [];
-            foreach ($configuration->getSearchFacetingFacets() as $facet) {
-                $facets[] = $facet['field'];
+        if ($configuration->getSearchFacetingKeepAllFacetsOnSelection()) {
+            if (!$configuration->getSearchFacetingCountAllFacetsForSelection()) {
+                // keepAllOptionsOnSelection globally active
+                foreach ($configuration->getSearchFacetingFacets() as $facet) {
+                    $excludeFields[] = $facet['field'];
+                }
+            } else {
+                $excludeFields[] = $facetConfiguration['field'];
             }
-            return implode(',', $facets);
         }
 
-        return '';
+        $isKeepAllOptionsActiveForSingleFacet = $facetConfiguration['keepAllOptionsOnSelection'] == 1;
+        if ($isKeepAllOptionsActiveForSingleFacet) {
+            $excludeFields[] = $facetConfiguration['field'];
+        }
+
+        return implode(',', array_unique($excludeFields));
     }
 
     /**

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -853,6 +853,25 @@ faceting.keepAllFacetsOnSelection
 
 When enabled selecting an option from a facet will not reduce the number of options available in other facets.
 
+faceting.countAllFacetsForSelection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.faceting.countAllFacetsForSelection
+:Since: 8.0
+:Default: 0
+:Options: 0, 1
+
+When ```keepAllFacetsOnSelection``` is active the count of a facet do not get reduced. You can use ```countAllFacetsForSelection``` to achieve that.
+
+The following example shows how to keep all options of all facets by keeping the real document count, even when it has zero options:
+
+```
+plugin.tx_solr.search.faceting.keepAllFacetsOnSelection = 1
+plugin.tx_solr.search.faceting.countAllFacetsForSelection = 1
+plugin.tx_solr.search.faceting.minimumCount = 0
+```
+
 faceting.showAllLink.wrap
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -306,6 +306,82 @@ class FacetingTest extends UnitTest
     }
 
     /**
+     * @test
+     */
+    public function testCanHandleCombinationOfKeepAllFacetsOnSelectionAndKeepAllOptionsOnSelection()
+    {
+        $fakeConfigurationArray = [];
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['keepAllFacetsOnSelection'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
+            'type.' => [
+                'field' => 'type',
+                'keepAllOptionsOnSelection' => 1
+            ],
+            'color.' => [
+                'field' => 'color',
+            ]
+        ];
+        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+
+        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
+        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+
+        $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+        $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+
+        $jsonData = \json_decode($queryParameter['json.facet']);
+
+        $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
+
+        $this->assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
+    }
+
+    /**
+     * @test
+     */
+    public function testCanHandleCombinationOfKeepAllFacetsOnSelectionAndKeepAllOptionsOnSelectionAndCountAllFacetsForSelection()
+    {
+        $fakeConfigurationArray = [];
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['keepAllFacetsOnSelection'] = 1;
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['countAllFacetsForSelection'] = 1;
+
+        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
+            'type.' => [
+                'field' => 'type',
+                'keepAllOptionsOnSelection' => 1
+            ],
+            'color.' => [
+                'field' => 'color',
+            ]
+        ];
+        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+
+        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
+        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+
+        $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
+        $this->assertContains('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+
+        $jsonData = \json_decode($queryParameter['json.facet']);
+
+        $this->assertEquals('type', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
+
+        $this->assertEquals('color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+        $this->assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
+    }
+
+    /**
      *
      * @test
      */


### PR DESCRIPTION
# What this pr does

Add's the excludeTags for both cases. This is required when both is activated at the same time.

# How to test

Enable both at the same time and check that the options and counts stay for the facets when you select an option.

Fixes: #2244

