### PR TITLE
[FEATURE] Individual additional exclude tags for facets

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -94,6 +94,10 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
             $excludeFields[] = $facetConfiguration['field'];
         }
 
+        if (!empty($facetConfiguration['additionalExcludeTags'])) {
+            $excludeFields[] = $facetConfiguration['additionalExcludeTags'];
+        }
+
         return implode(',', array_unique($excludeFields));
     }
 

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -171,7 +171,7 @@ class Faceting implements Modifier, SearchRequestAware
     protected function getFilterTag($facetConfiguration, $keepAllFacetsOnSelection)
     {
         $tag = '';
-        if ($facetConfiguration['keepAllOptionsOnSelection'] == 1 || $keepAllFacetsOnSelection) {
+        if ($facetConfiguration['keepAllOptionsOnSelection'] == 1 || $facetConfiguration['addFieldAsTag'] == 1 || $keepAllFacetsOnSelection) {
             $tag = '{!tag=' . addslashes($facetConfiguration['field']) . '}';
         }
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -946,6 +946,33 @@ A facet will use the values of a configured index field to offer these values as
 
 To configure a facet you only need to provide the label and field configuration options, all other configuration options are optional.
 
+
+faceting.facets.[facetName].additionalExcludeTags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].additionalExcludeTags
+:Since: 9.0
+:Required: no
+
+The settings ``keepAllOptionsOnSelection``` and ``keepAllFacetsOnSelection``` are used internally to build exclude tags for facets in order to exclude the filters from the facet counts.
+This helps to keep the counts of a facet as expected by the user, in some usecases (Read also: http://yonik.com/multi-select-faceting/).
+
+With the setting ``additionalExcludeTags``` you can add tags of factes that should be excluded from the counts as well.
+
+**Note:** This setting is only available for option facets by now.
+
+faceting.facets.[facetName].addFieldAsTag
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].addFieldAsTag
+:Since: 9.0
+:Required: no
+:Default: false
+
+When you want to add fields as ```additionalExcludeTags``` for a facet a tag for this facet needs to exist. You can use this setting to force the creation of a tag for this facet in the solr query.
+
 faceting.facets.[facetName].field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Releases/solr-release-9-0.rst
+++ b/Documentation/Releases/solr-release-9-0.rst
@@ -154,13 +154,26 @@ Thanks to Marc Bastian Heinrichs for creating a patch for that.
 
 * https://github.com/TYPO3-Solr/ext-solr/pull/2194
 
+
+Allow to configure additionalExcludeTags for option facets
+----------------------------------------------------------
+
+When you want to exclude facets from the counts of another facets, Apache Solr uses tags and excludeTags to realize that.
+
+With the setting ```additionalExcludeTags``` you can add custom exclude tags for a facet and ```addFieldAsTag``` allows you, to force the creation of a tag for a certain facet.
+
+Thanks to Marc Bastian Heinrichs for creating a patch for that and to in2code for paying for the finalization and documentation.
+
+* https://github.com/TYPO3-Solr/ext-solr/issues/2195
+
+
 Bugfixes
 ========
 
 * https://github.com/TYPO3-Solr/ext-solr/pull/2048 Fixes a warning in the TranslateViewHelper
 * https://github.com/TYPO3-Solr/ext-solr/pull/2052 Use copy instead of reference in the TypoScript template
 * https://github.com/TYPO3-Solr/ext-solr/pull/2053 Unify multiple whitespaces to a single whitespace
-
+* https://github.com/TYPO3-Solr/ext-solr/pull/2245 KeepAllFacetsOnSelection is not evaluated when KeepAllOptionsOnSelection is used
 
 Migration from EXT:solr 8.1.0 to EXT:solr 9.0.0
 ===============================================


### PR DESCRIPTION
# What this pr does

* Add's the setting ```additionalExcludeTags``` to a facet to exclude custom tags from the count of that facet
* Add's the setting ```addFieldAsTag``` to a facet to force the creation of a tag for that facet

# How to test

Configure ```addFieldAsTag``` for the tagged facet and add that field with ```addtionalExcludeTags``` to a facet and see if the exclude tag will be applied

Fixes: #2195 