### PR TITLE
[BACKPORT][BUGFIX] A new created page is not added to the queue in TYPO3 9 LTS

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -451,7 +451,7 @@ class RecordMonitor extends AbstractDataHandlerListener
      */
     protected function getRecordPageId($status, $recordTable, $recordUid, $originalUid, array $fields, DataHandler $tceMain)
     {
-        if ($recordTable === 'pages' && isset($fields['l10n_parent'])) {
+        if ($recordTable === 'pages' && isset($fields['l10n_parent']) && intval($fields['l10n_parent']) > 0) {
             return $fields['l10n_parent'];
         }
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_create_new_page.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_create_new_page.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:7:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+				plugin.tx_solr {
+					enabled = 1
+
+					solr {
+						scheme = http
+						host   = localhost
+						port   = 8999
+						path   = /solr/core_en/
+					}
+
+					index {
+
+						queue {
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+								allowedPageTypes = 1,7,4
+								indexingPriority = 0
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+								additionalWhereClause = (doktype = 1 OR doktype=4 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+								fields {
+									sortSubTitle_stringS = subtitle
+								}
+							}
+						}
+					}
+				}
+			]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Solr</title>
+    </pages>
+
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>1st Subpage</title>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -909,4 +909,42 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->assertIndexQueueContainsItemAmount(1);
     }
+
+    /**
+     * This testcase checks if we can create a new testpage on the root level without any errors.
+     *
+     * @test
+     */
+    public function canCreateSiteOneRootLevel()
+    {
+        $this->importDataSetFromFixture('can_create_new_page.xml');
+        $this->setUpBackendUserFromFixture(1);
+
+        $this->assertIndexQueueContainsItemAmount(0);
+        $dataHandler = $this->getDataHandler();
+        $dataHandler->start(['pages' => ['NEW' => ['hidden' => 0]]], []);
+        $dataHandler->process_datamap();
+
+        // the item is outside a siteroot so we should not have any queue entry
+        $this->assertIndexQueueContainsItemAmount(0);
+    }
+
+    /**
+     * This testcase checks if we can create a new testpage on the root level without any errors.
+     *
+     * @test
+     */
+    public function canCreateSubPageBelowSiteRoot()
+    {
+        $this->importDataSetFromFixture('can_create_new_page.xml');
+        $this->setUpBackendUserFromFixture(1);
+
+        $this->assertIndexQueueContainsItemAmount(0);
+        $dataHandler = $this->getDataHandler();
+        $dataHandler->start(['pages' => ['NEW' => ['hidden' => 0, 'pid' => 1]]], []);
+        $dataHandler->process_datamap();
+
+        // we should have one item in the solr queue
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
 }

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -31,7 +31,10 @@ use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use TYPO3\CMS\Core\Charset\CharsetConverter;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Lang\LanguageService;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -432,5 +435,18 @@ abstract class IntegrationTest extends FunctionalTestCase
             return;
         }
         $GLOBALS['TYPO3_REQUEST'] = new ServerRequest();
+    }
+
+    /**
+     * Returns the data handler
+     *
+     * @return \TYPO3\CMS\Core\DataHandling\DataHandler
+     */
+    protected function getDataHandler()
+    {
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
+        $csConf = GeneralUtility::makeInstance(CharsetConverter::class);
+        $GLOBALS['LANG']->csConvObj = $csConf;
+        return GeneralUtility::makeInstance(DataHandler::class);
     }
 }


### PR DESCRIPTION
# What this pr does

* Fixes the bug by return only l10n_parent when it is greater then zero and add's a test case for that.

# How to test

* Create a new, unhidden page in TYPO3 9 LTS and check if it get's queued in the index queue when a proper configuration is in place.

Fixes: #2248

