### PR TITLE
[BACKPORT][BUGFIX] Deprecated method getPath called in default template

### DIFF
--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -249,7 +249,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h3 class="panel-title">
-                        <a href="#panel-group3document-core-{currentCore.index}" data-toggle="collapse">{indexInspectorDocumentsByType.core.path}</a>
+                        <a href="#panel-group3document-core-{currentCore.index}" data-toggle="collapse">{indexInspectorDocumentsByType.core.corepath}</a>
                         <a href="#panel-group3document-core-{currentCore.index}" title="Collapse table" class="pull-right" data-toggle="collapse">
                             <core:icon identifier="actions-view-list-expand" size="small"/><f:comment><!-- @todo: make Icon toggable between actions-view-list-collapse/actions-view-list-expand --></f:comment>
                         </a>


### PR DESCRIPTION
# What this pr does

* Uses the new method getCorePath instead of getPath to avoid the deprecation error.

# How to test

Go to the info module and check the error log for that error. Should be gone with new default partial

Fixes: #2247
