### PR TITLE
[BUGFIX] Restrict used solarium version to 4.2.x

### DIFF
--- a/Resources/Private/Php/ComposerLibraries/composer.json
+++ b/Resources/Private/Php/ComposerLibraries/composer.json
@@ -7,6 +7,6 @@
     "prepend-autoloader": false
   },
   "require": {
-    "solarium/solarium": "^4.2.0"
+    "solarium/solarium": "~4.2.0"
   }
 }

--- a/Resources/Private/Php/ComposerLibraries/composer.lock
+++ b/Resources/Private/Php/ComposerLibraries/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad853db0661d152a88b87f2b462480c3",
+    "content-hash": "f90f4df5f1b6e811cfd729013235904f",
     "packages": [
         {
             "name": "solarium/solarium",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "typo3/cms-reports": "^9.5.0",
     "typo3/cms-scheduler": "^9.5.0",
     "typo3/cms-tstemplate": "^9.5.0",
-    "solarium/solarium": "^4.2.0"
+    "solarium/solarium": "~4.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
# What this pr does

* Updates the composer.json file and the bundled TER libraries to 4.2.x

# How to test

* After running ```composer update``` version 4.2.x of solarium should be kept

Fixes: #2260
