### PR TITLE
[TASK] Split patterns into matchPatterns and unmatchPatterns

### DIFF
--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -100,15 +100,21 @@ class Classification
     {
         $classifications = [];
         foreach ($configuredMappedClasses as $class) {
-            if (empty($class['patterns']) || empty($class['class'])) {
+            if ( (empty($class['patterns']) && empty($class['matchPatterns'])) || empty($class['class'])) {
                 throw new \InvalidArgumentException('A class configuration in SOLR_CLASSIFCATION needs to have a pattern and a class configured. Given configuration: ' . serialize($class));
             }
 
-            $patterns = GeneralUtility::trimExplode(',', $class['patterns']);
+                // @todo deprecate patterns configuration
+            $patterns = empty($class['patterns']) ? [] : GeneralUtility::trimExplode(',', $class['patterns']);
+            $matchPatterns = empty($class['matchPatterns']) ? [] : GeneralUtility::trimExplode(',', $class['matchPatterns']);
+            $matchPatterns = $matchPatterns + $patterns;
+            $unMatchPatters = empty($class['unmatchPatterns']) ? [] : GeneralUtility::trimExplode(',', $class['unmatchPatterns']);
+
             $className = $class['class'];
             $classifications[] = GeneralUtility::makeInstance(
                 ClassificationItem::class,
-                /** @scrutinizer ignore-type */ $patterns,
+                /** @scrutinizer ignore-type */ $matchPatterns,
+                /** @scrutinizer ignore-type */ $unMatchPatters,
                 /** @scrutinizer ignore-type */ $className
             );
         }

--- a/Classes/Domain/Index/Classification/Classification.php
+++ b/Classes/Domain/Index/Classification/Classification.php
@@ -39,17 +39,43 @@ class Classification {
     protected $matchPatterns = [];
 
     /**
+     * Array of regular expressions
+     * @var array
+     */
+    protected $unMatchPatterns = [];
+
+    /**
      * @var string
      */
     protected $mappedClass = '';
 
     /**
      * Classification constructor.
+     * @param array $matchPatterns
+     * @param array $unMatchPatterns
+     * @param string $mappedClass
      */
-    public function __construct(array $matchPatterns = [], string $mappedClass = '')
+    public function __construct(array $matchPatterns = [], array $unMatchPatterns = [],string $mappedClass = '')
     {
         $this->matchPatterns = $matchPatterns;
+        $this->unMatchPatterns = $unMatchPatterns;
         $this->mappedClass = $mappedClass;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnMatchPatterns(): array
+    {
+        return $this->unMatchPatterns;
+    }
+
+    /**
+     * @param array $unMatchPatterns
+     */
+    public function setUnMatchPatterns(array $unMatchPatterns)
+    {
+        $this->unMatchPatterns = $unMatchPatterns;
     }
 
     /**

--- a/Classes/Domain/Index/Classification/ClassificationService.php
+++ b/Classes/Domain/Index/Classification/ClassificationService.php
@@ -1,28 +1,28 @@
 <?php declare(strict_types = 1);
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
 
-/***************************************************************
- *  Copyright notice
- *
- *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
- *  All rights reserved
- *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+    /***************************************************************
+     *  Copyright notice
+     *
+     *  (c) 2010-2017 dkd Internet Service GmbH <solr-support@dkd.de>
+     *  All rights reserved
+     *
+     *  This script is part of the TYPO3 project. The TYPO3 project is
+     *  free software; you can redistribute it and/or modify
+     *  it under the terms of the GNU General Public License as published by
+     *  the Free Software Foundation; either version 3 of the License, or
+     *  (at your option) any later version.
+     *
+     *  The GNU General Public License can be found at
+     *  http://www.gnu.org/copyleft/gpl.html.
+     *
+     *  This script is distributed in the hope that it will be useful,
+     *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+     *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     *  GNU General Public License for more details.
+     *
+     *  This copyright notice MUST APPEAR in all copies of the script!
+     ***************************************************************/
 
 /**
  * Class ClassificationService
@@ -39,13 +39,47 @@ class ClassificationService {
     {
         $matchingClassification = [];
         foreach ($classifications as $classification) {
-            /** @var $classification Classification */
-            foreach ($classification->getMatchPatterns() as $matchPattern)
-            {
-                if (preg_match_all('~' . $matchPattern . '~ims', $stringToMatch) > 0) {
-                    $matchingClassification[] = $classification->getMappedClass();
-                    // if we found one match, we do not need to check the other patterns
-                    break;
+            $matchingClassification = $this->applyMatchPatterns($stringToMatch, $classification, $matchingClassification);
+            $matchingClassification = $this->applyUnMatchPatterns($stringToMatch, $classification, $matchingClassification);
+        }
+
+        return array_values($matchingClassification);
+    }
+
+    /**
+     * @param string $stringToMatch
+     * @param Classification $classification
+     * @param $matchingClassification
+     * @return array
+     */
+    protected function applyMatchPatterns(string $stringToMatch, $classification, $matchingClassification): array
+    {
+        /** @var $classification Classification */
+        foreach ($classification->getMatchPatterns() as $matchPattern) {
+            if (preg_match_all('~' . $matchPattern . '~ims', $stringToMatch) > 0) {
+                $matchingClassification[] = $classification->getMappedClass();
+                // if we found one match, we do not need to check the other patterns
+                break;
+            }
+        }
+        return array_unique($matchingClassification);
+    }
+
+    /**
+     * @param string $stringToMatch
+     * @param Classification $classification
+     * @param $matchingClassification
+     * @param $messages
+     * @return array
+     */
+    protected function applyUnMatchPatterns(string $stringToMatch, $classification, $matchingClassification): array
+    {
+        foreach ($classification->getUnMatchPatterns() as $unMatchPattern) {
+            if (preg_match_all('~' . $unMatchPattern . '~ims', $stringToMatch) > 0) {
+                // if we found one match, we do not need to check the other patterns
+                $position = array_search($classification->getMappedClass(), $matchingClassification);
+                if ($position !== false) {
+                    unset($matchingClassification[$position]);
                 }
             }
         }

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -674,19 +674,32 @@ Example:
         field = __solr_content
         classes {
             programming {
-                patterns = php, java, javascript, go
+                matchPatterns = php, java, javascript, go
                 class = programming
             }
             cms {
-                patterns = TYPO3, joomla
+                matchPatterns = TYPO3, joomla
                 class = cms
             }
             database {
-                patterns = mysql, MariaDB, postgreSQL
+                matchPatterns = mysql, MariaDB, postgreSQL
                 class = database
             }
         }
     }
+
+
+The ```matchPatterns`` can be used to configure pattern that can occure in the content to add that class. In addition ```unmatchPatterns```can be configured to define patterns that should not occure in the content.
+
+Patterns are regular expressions. You configure everything that is possible with regular expressions.
+
+Example:s
+
+The pattern ```\ssmart[a-z]*\s``` will match everything, that starts with a **space** followed by **smart** ending with any lowercase letter and ending by **space**. This would match e.g. smartphone, smarthome and every other word that starts with ```smart```.
+
+**Note**:
+
+* The configuration ```patterns``` is deprecated with 10.0.0 and will be removed in EXT:solr 11. Please use ```matchPatterns``` and ```unmatchPatterns`` now.
 
 
 **field**

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -69,6 +69,48 @@ class ClassificationTest extends UnitTest
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @return array
+     */
+    public function excludePatternDataProvider()
+    {
+        return [
+            'excludePatternShouldLeadToUnassignedClass' => [
+                'input' => 'from the beach i can see the waves',
+                'expectedOutput' => []
+            ],
+            'noMatchingExlucePatternLeadsToExpectedClass' => [
+                'input' => 'i saw a shark between the waves',
+                'expectedOutput' => ['ocean']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider excludePatternDataProvider
+     * @test
+     */
+    public function canExcludePatterns($input, $expectedOutput)
+    {
+        $GLOBALS['TSFE']->cObjectDepthCounter = 2;
+        $this->contentObject->start(['content' => $input]);
+
+        $configuration = [
+            'field' => 'content',
+            'classes.' => [
+                [
+                    'matchPatterns' => 'waves',
+                    'unmatchPatterns' => 'beach',
+                    'class' => 'ocean'
+                ]
+            ]
+        ];
+
+        $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
+        $expected = serialize($expectedOutput);
+        $this->assertEquals($expected, $actual);
+    }
+
     protected function setUp()
     {
         // fake a registered hook

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -37,15 +37,16 @@ class ClassificationServiceTest extends UnitTest
     /**
      * @test
      */
-    public function canGetMatchingClassifications() {
-
+    public function canGetMatchingClassifications()
+    {
         $matchPatterns = ['smartphones', 'handy', 'smartphone', 'mobile', 'mobilephone'];
+        $unMatchPatterns = [];
         $mappedClass = 'mobilephone';
-        $mobilePhoneClassification = new Classification($matchPatterns, $mappedClass);
+        $mobilePhoneClassification = new Classification($matchPatterns, $unMatchPatterns, $mappedClass);
 
         $matchPatterns = ['clock', 'watch', 'watches'];
         $mappedClass = 'watch';
-        $watchClassification = new Classification($matchPatterns, $mappedClass);
+        $watchClassification = new Classification($matchPatterns, $unMatchPatterns, $mappedClass);
 
         $service = new ClassificationService();
         $matches = $service->getMatchingClassNames('I have a smartphone in my hand.', [$mobilePhoneClassification, $watchClassification]);
@@ -59,6 +60,38 @@ class ClassificationServiceTest extends UnitTest
 
         $matches = $service->getMatchingClassNames('I like my SMARTPHONE.', [$mobilePhoneClassification, $watchClassification]);
         $this->assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
+    }
 
+    /**
+     * @test
+     */
+    public function canMatchWildCards()
+    {
+        $matchPatterns = ['\ssmart[a-z]*\s'];
+        $unMatchPatterns = ['home'];
+        $mappedClass = 'mobilephone';
+        $mobilePhoneClassification = new Classification($matchPatterns, $unMatchPatterns, $mappedClass);
+
+        $service = new ClassificationService();
+        $matches = $service->getMatchingClassNames('', [$mobilePhoneClassification]);
+        $this->assertSame([], $matches, 'Nothing should match');
+
+        $matches = $service->getMatchingClassNames('I have a smartphone in my hand.', [$mobilePhoneClassification]);
+        $this->assertSame(['mobilephone'], $matches, 'Wildcard not detected');
+
+        $matches = $service->getMatchingClassNames('smarthome is the future.', [$mobilePhoneClassification]);
+        $this->assertSame([], $matches, 'Unmatch pattern should remove assigned class');
+
+        $matchPatterns = ['\sh.nd\s'];
+        $unMatchPatterns = [];
+        $mappedClass = 'test';
+        $testClassification = new Classification($matchPatterns, $unMatchPatterns, $mappedClass);
+
+        $matches = $service->getMatchingClassNames('ein hund spring', [$testClassification]);
+        $this->assertSame(['test'], $matches, 'test class should assign');
+        $matches = $service->getMatchingClassNames('eine hand klatscht', [$testClassification]);
+        $this->assertSame(['test'], $matches, 'test class should assign');
+        $matches = $service->getMatchingClassNames('die hunde bellen', [$testClassification]);
+        $this->assertSame([], $matches, 'test class should assign');
     }
 }


### PR DESCRIPTION
# What this pr does

* Splits the patterns into ```matchPatterns``` and ```unmatchPatterns``` to allow the removal of classs by an unmatch pattern
* Keeps the ```patterns``` configuration for backwards compatibility

# How to test

* Check if the old classification configuration still works
* Configure a ```matchPatterns``` with an ```unmatchPatterns``` configuration and make sure classes with matching ```unmatchPatterns``` are not assigned to the document.

Fixes: #2265
