### PR TITLE
[BUGFIX] Use domain from Site object instead of allways first domain record

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -293,8 +293,7 @@ class IndexService
         $hostFound = !empty($hosts[$rootpageId]);
 
         if (!$hostFound) {
-            $host = $this->getHostByRootPageId($rootpageId);
-            $hosts[$rootpageId] = $host;
+            $hosts[$rootpageId] = $item->getSite()->getDomain();
         }
 
         $_SERVER['HTTP_HOST'] = $hosts[$rootpageId];
@@ -316,16 +315,5 @@ class IndexService
 
         // needed since TYPO3 7.5
         GeneralUtility::flushInternalRuntimeCaches();
-    }
-
-    /**
-     * @param $rootpageId
-     * @return string
-     */
-    protected function getHostByRootPageId($rootpageId)
-    {
-        $rootline = BackendUtility::BEgetRootLine($rootpageId);
-        $host = BackendUtility::firstDomainRecord($rootline);
-        return $host;
     }
 }


### PR DESCRIPTION
# What this pr does

* Uses the domain from the site instead from the first domain record. In case when you use domain records this is the same,
but when domains are configure with ```$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][$rootPageId]['domains']``` instead the correct domain is used then.

# How to test

* Check if domains are configured with ```$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites'][$rootPageId]['domains']``` i if domain is set correct in IndexService

Fixes: #2275
