### PR TITLE
[BUGFIX] Exclude logger from serialize on save for scheduler task

### DIFF
--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -94,8 +94,8 @@ abstract class AbstractSolrTask extends AbstractTask {
     public function __sleep()
     {
         $properties = get_object_vars($this);
-        // avoid serialization if the site object
-        unset($properties['site']);
+        // avoid serialization if the site and logger object
+        unset($properties['site'], $properties['logger']);
         return array_keys($properties);
     }
 }

--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -94,7 +94,7 @@ abstract class AbstractSolrTask extends AbstractTask {
     public function __sleep()
     {
         $properties = get_object_vars($this);
-        // avoid serialization if the site and logger object
+        // avoid serialization of the site and logger object
         unset($properties['site'], $properties['logger']);
         return array_keys($properties);
     }


### PR DESCRIPTION

Exclusion of the logger instance from the record during save to database.
Prevent hard-coded logfile paths in database record.
Set the logger at runtime if the task is executed.



Fixes: #2279
