### PR TITLE
[BUGFIX] Fix composer deprecation message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
 before_install:
   - composer self-update
   - composer --version
+  - composer validate --no-check-lock
 
 install:
   - Build/Test/bootstrap.sh

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     "nimut/testing-framework": "^4.0.0"
   },
   "replace": {
-    "solr": "self.version",
     "typo3-ter/solr": "self.version",
     "apache-solr-for-typo3/solrfluid": "*"
   },


### PR DESCRIPTION
# What this pr does

* Removes the replace section for the package name "solr" since packages without a vendor are not supported anymore
* Executes composer validate --no-check-lock in .travis.yml

# How to test

Check that EXT:solr can be installed with composer without a deprecation warning

Fixes: #2253
