### PR TITLE
[BUGFIX] Remove usage of deprecated method getCoreName in IndexAdministrationModuleController

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -96,6 +96,14 @@ abstract class AbstractModuleController extends ActionController
     protected $moduleDataStorageService = null;
 
     /**
+     * @param Site $selectedSite
+     */
+    public function setSelectedSite(Site $selectedSite)
+    {
+        $this->selectedSite = $selectedSite;
+    }
+
+    /**
      * Initializes the controller and sets needed vars.
      */
     protected function initializeAction()

--- a/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
@@ -53,6 +53,14 @@ class IndexAdministrationModuleController extends AbstractModuleController
     protected $solrConnectionManager = null;
 
     /**
+     * @param ConnectionManager $solrConnectionManager
+     */
+    public function setSolrConnectionManager(ConnectionManager $solrConnectionManager)
+    {
+        $this->solrConnectionManager = $solrConnectionManager;
+    }
+
+    /**
      * Initializes the controller before invoking an action method.
      */
     protected function initializeAction()
@@ -91,9 +99,10 @@ class IndexAdministrationModuleController extends AbstractModuleController
                 /* @var $solrServer SolrConnection */
                 $writeService->deleteByQuery('siteHash:' . $siteHash);
                 $writeService->commit(false, false, false);
-                $affectedCores[] = $writeService->getCorePath();
+                $affectedCores[] = $writeService->getPrimaryEndpoint()->getCore();
             }
-            $this->addFlashMessage(LocalizationUtility::translate('solr.backend.index_administration.index_emptied_all', 'Solr', [$this->selectedSite->getLabel(), implode(', ', $affectedCores)]));
+            $message = LocalizationUtility::translate('solr.backend.index_administration.index_emptied_all', 'Solr', [$this->selectedSite->getLabel(), implode(', ', $affectedCores)]);
+            $this->addFlashMessage($message);
         } catch (\Exception $e) {
             $this->addFlashMessage(LocalizationUtility::translate('solr.backend.index_administration.error.on_empty_index', 'Solr', [$e->__toString()]), '', FlashMessage::ERROR);
         }
@@ -131,8 +140,8 @@ class IndexAdministrationModuleController extends AbstractModuleController
             /* @var $solrServer SolrConnection */
             $coreAdmin = $solrServer->getAdminService();
             $coreReloaded = $coreAdmin->reloadCore()->getHttpStatus() === 200;
-            $coreName = $coreAdmin->getCorePath();
 
+            $coreName = $coreAdmin->getPrimaryEndpoint()->getCore();
             if (!$coreReloaded) {
                 $coresReloaded = false;
 

--- a/Tests/Integration/Controller/Backend/Search/Fixtures/can_reload_index_configuration.xml
+++ b/Tests/Integration/Controller/Backend/Search/Fixtures/can_reload_index_configuration.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+	<sys_registry>
+		<uid>4711</uid>
+		<entry_namespace>tx_solr</entry_namespace>
+		<entry_key>servers</entry_key>
+		<entry_value>a:1:{s:3:"1|0";a:7:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}}</entry_value>
+	</sys_registry>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+	</pages>
+	<pages>
+		<uid>2</uid>
+		<pid>1</pid>
+	</pages>
+	<sys_domain>
+		<uid>1</uid>
+		<pid>1</pid>
+		<domainName>my-database-domain.de</domainName>
+	</sys_domain>
+
+</dataset>

--- a/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Search;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Controller\Backend\Search\IndexAdministrationModuleController;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class IndexAdministrationModuleControllerTest
+ * @package ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Search
+ */
+class IndexAdministrationModuleControllerTest extends IntegrationTest
+{
+
+    /**
+     * @var ConnectionManager
+     */
+    protected $connectionManager;
+
+    /**
+     * @var IndexAdministrationModuleController
+     */
+    protected $controller;
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+
+        $this->controller = $this->getMockBuilder(IndexAdministrationModuleController::class)->setMethods(['addFlashMessage', 'redirect'])->getMock();
+        $this->controller->setSolrConnectionManager($this->connectionManager);
+    }
+
+
+    /**
+     * @test
+     */
+    public function testReloadIndexConfigurationAction()
+    {
+        $this->importDataSetFromFixture('can_reload_index_configuration.xml');
+
+        /** @var SiteRepository $siteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $selectedSite = $siteRepository->getFirstAvailableSite();
+        $this->controller->setSelectedSite($selectedSite);
+        $this->controller->expects($this->exactly(1))
+            ->method('addFlashMessage')
+            ->with('Core configuration reloaded (core_en).','',FlashMessage::OK);
+        $this->controller->reloadIndexConfigurationAction();
+    }
+
+    /**
+     * @test
+     */
+    public function testEmptyIndexAction()
+    {
+        $this->importDataSetFromFixture('can_reload_index_configuration.xml');
+
+        /** @var SiteRepository $siteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $selectedSite = $siteRepository->getFirstAvailableSite();
+        $this->controller->setSelectedSite($selectedSite);
+        $this->controller->expects($this->exactly(1))
+            ->method('addFlashMessage')
+            ->with('Index emptied for Site ", Root Page ID: 1" (core_en).','',FlashMessage::OK);
+        $this->controller->emptyIndexAction();
+    }
+}

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Controller\Backend\Search\IndexAdministrationModuleController;
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
+use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use Solarium\Core\Client\Endpoint;
+
+
+/**
+ * Testcase for IndexQueueModuleController
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class IndexAdministrationModuleControllerTest extends UnitTest
+{
+
+    /**
+     * @var IndexAdministrationModuleController
+     */
+    protected $controller;
+
+    /**
+     * @var ConnectionManager
+     */
+    protected $connectionManagerMock;
+
+    /**
+     * @var Site
+     */
+    protected $selectedSiteMock;
+
+    /**
+     *
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->connectionManagerMock = $this->getDumbMock(ConnectionManager::class);
+        $this->selectedSiteMock = $this->getDumbMock(Site::class);
+
+        $this->controller = $this->getMockBuilder(IndexAdministrationModuleController::class)->setMethods(['addFlashMessage', 'redirect'])->getMock();
+        $this->controller->setSolrConnectionManager($this->connectionManagerMock);
+        $this->controller->setSelectedSite($this->selectedSiteMock);
+    }
+
+    /**
+     * @test
+     */
+    public function testReloadIndexConfigurationAction()
+    {
+        $responseMock = $this->getDumbMock(ResponseAdapter::class);
+        $responseMock->expects($this->once())->method('getHttpStatus')->willReturn(200);
+
+        $writeEndpointMock = $this->getDumbMock(Endpoint::class);
+        $adminServiceMock = $this->getDumbMock(SolrAdminService::class);
+        $adminServiceMock->expects($this->once())->method('reloadCore')->willReturn($responseMock);
+        $adminServiceMock->expects($this->once())->method('getPrimaryEndpoint')->willReturn($writeEndpointMock);
+
+        $solrConnection = $this->getDumbMock(SolrConnection::class);
+        $solrConnection->expects($this->once())->method('getAdminService')->willReturn($adminServiceMock);
+
+        $fakeConnections = [$solrConnection];
+        $this->connectionManagerMock->expects($this->once())
+            ->method('getConnectionsBySite')
+            ->with($this->selectedSiteMock)
+            ->willReturn($fakeConnections);
+        $this->controller->reloadIndexConfigurationAction();
+    }
+}


### PR DESCRIPTION
# What this pr does

* Replaces the usage of the deprecated method ```getCoreName()``` with ```getPrimaryEndpont()->getCore()```

# How to test

No deprecation notice is triggered anymore. When a core is reloaded or an index is emptied.

Fixes: #2286
