### PR TITLE
[WIP][FEATURE] Use TYPO3 site configuration for solr connection info

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -259,7 +259,7 @@ class InfoModuleController extends AbstractModuleController
         $documentsByCoreAndType = [];
         foreach ($solrCoreConnections as $languageId => $solrCoreConnection) {
             $coreAdmin = $solrCoreConnection->getAdminService();
-            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->requestedPageUID, $languageId);
+            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->selectedPageUID, $languageId);
 
             $documentsByType = [];
             foreach ($documents as $document) {
@@ -271,7 +271,7 @@ class InfoModuleController extends AbstractModuleController
         }
 
         $this->view->assignMultiple([
-            'pageId' => $this->requestedPageUID,
+            'pageId' => $this->selectedPageUID,
             'indexInspectorDocumentsByLanguageAndType' => $documentsByCoreAndType
         ]);
     }

--- a/Classes/Domain/Site/LegacySite.php
+++ b/Classes/Domain/Site/LegacySite.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/*
+ * This source file is proprietary property of Beech Applications B.V.
+ * Date: 13-3-19
+ * All code (c) Beech Applications B.V. all rights reserved
+ */
+
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class LegacySite extends Site
+{
+    /**
+     * The site's sys_language_mode
+     *
+     * @var string
+     */
+    protected $sysLanguageMode = null;
+
+    /**
+     * Constructor.
+     *
+     * @param TypoScriptConfiguration $configuration
+     * @param array $page Site root page ID (uid). The page must be marked as site root ("Use as Root Page" flag).
+     * @param string $domain The domain record used by this Site
+     * @param string $siteHash The site hash used by this site
+     * @param PagesRepository $pagesRepository
+     * @param int $defaultLanguageId
+     * @param int[] $availableLanguageIds
+     */
+    public function __construct(TypoScriptConfiguration $configuration, array $page, $domain, $siteHash, PagesRepository $pagesRepository = null, $defaultLanguageId = 0, $availableLanguageIds = [])
+    {
+        $this->configuration = $configuration;
+        $this->rootPage = $page;
+        $this->domain = $domain;
+        $this->siteHash = $siteHash;
+        $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
+        $this->defaultLanguageId = $defaultLanguageId;
+        $this->availableLanguageIds = $availableLanguageIds;
+    }
+
+    /**
+     * Gets the site's config.sys_language_mode setting
+     *
+     * @param int $languageUid
+     *
+     * @return string The site's config.sys_language_mode
+     */
+    public function getSysLanguageMode($languageUid = 0)
+    {
+        if ($this->sysLanguageMode === null) {
+            return $this->sysLanguageMode;
+        }
+
+        try {
+            Util::initializeTsfe($this->getRootPageId(), $languageUid);
+            $this->sysLanguageMode = $GLOBALS['TSFE']->sys_language_mode;
+            return $this->sysLanguageMode;
+
+        } catch (\TYPO3\CMS\Core\Error\Http\ServiceUnavailableException $e) {
+            // when there is an error during initialization we return the default sysLanguageMode
+            return $this->sysLanguageMode;
+        }
+    }
+
+    /**
+     * @param int $language
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getSolrConnectionConfiguration(int $language = 0): array {
+        $connectionKey = $this->getRootPageId() . '|' . $language;
+        $solrConfiguration = $this->getSolrConnectionConfigFromRegistry($connectionKey);
+
+        if (!is_array($solrConfiguration)) {
+            /* @var $noSolrConnectionException NoSolrConnectionFoundException */
+            $noSolrConnectionException = GeneralUtility::makeInstance(
+                NoSolrConnectionFoundException::class,
+                /** @scrutinizer ignore-type */  'Could not find a Solr connection for root page [' . $this->getRootPageId() . '] and language [' . $language . '].',
+                /** @scrutinizer ignore-type */ 1275396474
+            );
+            $noSolrConnectionException->setRootPageId($this->getRootPageId());
+            $noSolrConnectionException->setLanguageId($language);
+
+            throw $noSolrConnectionException;
+        }
+
+        return $solrConfiguration;
+    }
+
+    /**
+     * Gets all connection configurations found.
+     *
+     * @return array An array of connection configurations.
+     */
+    protected function getSolrConnectionConfigFromRegistry(string $connectionKey)
+    {
+        /** @var $registry Registry */
+        $registry = GeneralUtility::makeInstance(Registry::class);
+        $solrConfigurations = $registry->get('tx_solr', 'servers', []);
+
+        return $solrConfigurations[$connectionKey] ?? null;
+    }
+
+}

--- a/Classes/Domain/Site/SiteInterface.php
+++ b/Classes/Domain/Site/SiteInterface.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * This source file is proprietary property of Beech Applications B.V.
+ * Date: 13-3-19
+ * All code (c) Beech Applications B.V. all rights reserved
+ */
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
+
+interface SiteInterface
+{
+    /**
+     * Gets the site's root page ID (uid).
+     *
+     * @return int The site's root page ID.
+     */
+    public function getRootPageId();
+
+    /**
+     * Gets available language id's for this site
+     *
+     * @return int[] array or language id's
+     */
+    public function getAvailableLanguageIds(): array;
+
+    /**
+     * Gets the site's label. The label is build from the the site title and root
+     * page ID (uid).
+     *
+     * @return string The site's label.
+     */
+    public function getLabel();
+
+    /**
+     * Gets the site's Solr TypoScript configuration (plugin.tx_solr.*)
+     *
+     * @return  \ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration The Solr TypoScript configuration
+     */
+    public function getSolrConfiguration();
+
+    /**
+     * Gets the site's default language as configured in
+     * config.sys_language_uid. If sys_language_uid is not set, 0 is assumed to
+     * be the default.
+     *
+     * @return int The site's default language.
+     */
+    public function getDefaultLanguage();
+
+    /**
+     * Generates a list of page IDs in this site. Attention, this includes
+     * all page types! Deleted pages are not included.
+     *
+     * @param int|string $rootPageId Page ID from where to start collection sub pages
+     * @param int $maxDepth Maximum depth to descend into the site tree
+     * @return array Array of pages (IDs) in this site
+     */
+    public function getPages($rootPageId = 'SITE_ROOT', $maxDepth = 999);
+
+    /**
+     * Generates the site's unique Site Hash.
+     *
+     * The Site Hash is build from the site's main domain, the system encryption
+     * key, and the extension "tx_solr". These components are concatenated and
+     * sha1-hashed.
+     *
+     * @return string Site Hash.
+     */
+    public function getSiteHash();
+
+    /**
+     * Gets the site's main domain. More specifically the first domain record in
+     * the site tree.
+     *
+     * @return string The site's main domain.
+     */
+    public function getDomain();
+
+    /**
+     * Gets the site's root page.
+     *
+     * @return array The site's root page.
+     */
+    public function getRootPage();
+
+    /**
+     * Gets the site's root page's title.
+     *
+     * @return string The site's root page's title
+     */
+    public function getTitle();
+
+    /**
+     * Gets the site's config.sys_language_mode setting
+     *
+     * @param int $languageUid
+     *
+     * @return string The site's config.sys_language_mode
+     */
+    public function getSysLanguageMode($languageUid = 0);
+
+    /**
+     * @param int $language
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getSolrConnectionConfiguration(int $language = 0): array;
+
+    /**
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getAllSolrConnectionConfigurations(): array;
+}

--- a/Classes/Domain/Site/Typo3ManagedSite.php
+++ b/Classes/Domain/Site/Typo3ManagedSite.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/*
+ * This source file is proprietary property of Beech Applications B.V.
+ * Date: 13-3-19
+ * All code (c) Beech Applications B.V. all rights reserved
+ */
+
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Site\Entity\Site as Typo3Site;
+
+class Typo3ManagedSite extends Site
+{
+
+    /**
+     * @var Typo3Site
+     */
+    protected $typo3SiteObject;
+
+    
+    public function __construct(TypoScriptConfiguration $configuration, array $page, $domain, $siteHash, PagesRepository $pagesRepository = null, $defaultLanguageId = 0, $availableLanguageIds = [], Typo3Site $typo3SiteObject = null)
+    {
+        $this->configuration = $configuration;
+        $this->rootPage = $page;
+        $this->domain = $domain;
+        $this->siteHash = $siteHash;
+        $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
+        $this->defaultLanguageId = $defaultLanguageId;
+        $this->availableLanguageIds = $availableLanguageIds;
+        $this->typo3SiteObject = $typo3SiteObject;
+    }
+
+    public function getSysLanguageMode($languageUid = 0)
+    {
+        // TODO: Implement getSysLanguageMode() method.
+    }
+
+
+    public function getSolrConnectionConfiguration(int $language = 0): array
+    {
+        return ['read' => [], 'write' => []];
+//        $this->typo3SiteObject->getConfiguration()
+        // TODO: Implement getSolrConnectionConfiguration() method.
+    }
+}

--- a/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
+++ b/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
@@ -67,7 +67,7 @@ class SystemLanguageRepository extends AbstractRepository implements SingletonIn
     /**
      * Finds the system's configured languages.
      *
-     * @return array An array of language IDs
+     * @return array An array of language UIDs
      */
     public function findSystemLanguages()
     {

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\System\Util;
 
 /***************************************************************
@@ -54,5 +55,44 @@ class SiteUtility
         }
 
         return $site instanceof Site;
+    }
+
+    public static function getConnectionProperty(Site $typo3Site, $property, $languageId, $scope, $defaultValue = null): string
+    {
+
+        // convention kez solr_$property_$scope
+        $keyToCheck = 'solr_' . $property . '_' . $scope;
+
+        // convention fallback kez solr_$property_read
+        $fallbackKey = 'solr_' . $property . '_read';
+
+        // try to find language specific setting if found return it
+        $languageSpecificConfiguration = $typo3Site->getLanguageById($languageId)->toArray();
+        $value = self::getValueOrFallback($languageSpecificConfiguration, $keyToCheck, $fallbackKey);
+
+        if (!empty($value)) {
+            return $value;
+        }
+
+        // if not found check global configuration
+        $siteBaseConfiguration = $typo3Site->getConfiguration();
+
+        return self::getValueOrFallback($siteBaseConfiguration, $keyToCheck, $fallbackKey) ?: $defaultValue;
+    }
+
+    /**
+     * @param array $data
+     * @param string $keyToCheck
+     * @param string $fallbackKey
+     * @return string|null
+     */
+    protected static function getValueOrFallback(array $data, string $keyToCheck, string $fallbackKey)
+    {
+        $value = $data[$keyToCheck] ?? null;
+        if (!empty($value)) {
+            return $value;
+        }
+
+        return $data[$fallbackKey] ?? null;
     }
 }

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Global Solr Connection Settings
+ */
+// Configure a new simple required input field to site
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'] = [
+    'label' => 'Scheme',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'items' => [
+            ['http', 'http'],
+            ['https', 'https'],
+        ],
+        'size' => 1,
+        'minitems' => 0,
+        'maxitems' => 1
+    ],
+];
+
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = [
+    'label' => 'Use different write connection',
+    'onChange' => 'reload',
+    'config' => [
+        'type' => 'check',
+        'renderType' => 'checkboxToggle',
+        'default' => 0,
+        'items' => [
+            [
+                0 => '',
+                1 => ''
+            ]
+        ]
+    ],
+];
+
+
+// write TCA
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['config']['eval'] = 'optional';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read';
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write';
+
+$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = str_replace(
+    'base,',
+    'base, --palette--;Solr Configuration;solr_read, solr_use_write_connection, --palette--;Solr Write Configuration;solr_write,',
+    $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem']
+);
+
+
+/**
+ * Language specific core configuration
+ */
+$GLOBALS['SiteConfiguration']['site_language']['columns']['solr_core_read'] = [
+    'label' => 'Corename',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'optional',
+    ],
+];
+
+$GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(
+    'flag',
+    'flag, solr_core_read, ',
+    $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem']
+);

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -18,6 +18,13 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'] = [
         'maxitems' => 1
     ],
 ];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
+    'label' => 'Port',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'int,required',
+    ],
+];
 
 
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = [
@@ -39,11 +46,15 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = 
 
 // write TCA
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'];
-$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['config']['eval'] = 'optional';
+
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
 
-$GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read';
-$GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write']['config']['eval'] = '';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read, solr_port_read';
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write, solr_port_write';
 
 $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = str_replace(
     'base,',


### PR DESCRIPTION
# What this pr does

Add the option to configure your solr connection info through the TYPO3 site configuration instead of `typoscript` and/or `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['sites']....`

# How to test

Configure site with the `Site management tool` and check if cores can be found

Fixes: #2238


# Todo
- Check if we can hide "initialise conneciton" when site config is used
- Add missing fields to site configuration
- Add proper tests
- Fix solr core -> path resolving
- Cleanup todo in code (remove/deprecate unused methods)
- Think about how we handle username and password (site configuration could be public accessable)
- Documentation of Legacy and TYPO3Managed site mode