### PR TITLE
[FEATURE] Use TYPO3 site configuration for solr connection info

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -259,7 +259,7 @@ class InfoModuleController extends AbstractModuleController
         $documentsByCoreAndType = [];
         foreach ($solrCoreConnections as $languageId => $solrCoreConnection) {
             $coreAdmin = $solrCoreConnection->getAdminService();
-            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->requestedPageUID, $languageId);
+            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->selectedPageUID, $languageId);
 
             $documentsByType = [];
             foreach ($documents as $document) {
@@ -271,7 +271,7 @@ class InfoModuleController extends AbstractModuleController
         }
 
         $this->view->assignMultiple([
-            'pageId' => $this->requestedPageUID,
+            'pageId' => $this->selectedPageUID,
             'indexInspectorDocumentsByLanguageAndType' => $documentsByCoreAndType
         ]);
     }

--- a/Classes/Domain/Index/PageIndexer/Helper/UriStrategyFactory.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriStrategyFactory.php
@@ -57,9 +57,9 @@ class UriStrategyFactory
         // @todo by now using the site urls leads to problems
         // since e.g. fallbacks do not work and urls could be indexed that lead to a 404 error
         // when this is resolved we could generate the urls with the router of the site for indexing with solr
-        // if (SiteUtility::getIsSiteManagedSite($pageId)) {
-        //    return GeneralUtility::makeInstance(TYPO3SiteStrategy::class);
-        // }
+        if (SiteUtility::getIsSiteManagedSite($pageId)) {
+            return GeneralUtility::makeInstance(TYPO3SiteStrategy::class);
+        }
 
         return GeneralUtility::makeInstance(SolrSiteStrategy::class);
     }

--- a/Classes/Domain/Site/LegacySite.php
+++ b/Classes/Domain/Site/LegacySite.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Frans Saris <frans.saris@beech.it> & Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class LegacySite
+ *
+ * @deprecated This class is used for the old solr setup based on TypoScript and sys_registry records.
+ * @package ApacheSolrForTypo3\Solr\Domain\Site
+ */
+class LegacySite extends Site
+{
+    /**
+     * The site's sys_language_mode
+     *
+     * @var string
+     */
+    protected $sysLanguageMode = null;
+
+    /**
+     * Constructor.
+     *
+     * @param TypoScriptConfiguration $configuration
+     * @param array $page Site root page ID (uid). The page must be marked as site root ("Use as Root Page" flag).
+     * @param string $domain The domain record used by this Site
+     * @param string $siteHash The site hash used by this site
+     * @param PagesRepository $pagesRepository
+     * @param int $defaultLanguageId
+     * @param int[] $availableLanguageIds
+     */
+    public function __construct(TypoScriptConfiguration $configuration, array $page, $domain, $siteHash, PagesRepository $pagesRepository = null, $defaultLanguageId = 0, $availableLanguageIds = [])
+    {
+        $this->configuration = $configuration;
+        $this->rootPage = $page;
+        $this->domain = $domain;
+        $this->siteHash = $siteHash;
+        $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
+        $this->defaultLanguageId = $defaultLanguageId;
+        $this->availableLanguageIds = $availableLanguageIds;
+    }
+
+    /**
+     * Gets the site's config.sys_language_mode setting
+     *
+     * @param int $languageUid
+     *
+     * @return string The site's config.sys_language_mode
+     */
+    public function getSysLanguageMode($languageUid = 0)
+    {
+        if ($this->sysLanguageMode !== null) {
+            return $this->sysLanguageMode;
+        }
+
+        try {
+            Util::initializeTsfe($this->getRootPageId(), $languageUid);
+            $this->sysLanguageMode = $GLOBALS['TSFE']->sys_language_mode;
+            return $this->sysLanguageMode;
+
+        } catch (\TYPO3\CMS\Core\Error\Http\ServiceUnavailableException $e) {
+            // when there is an error during initialization we return the default sysLanguageMode
+            return $this->sysLanguageMode;
+        }
+    }
+
+    /**
+     * @param int $language
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getSolrConnectionConfiguration(int $language = 0): array {
+        $connectionKey = $this->getRootPageId() . '|' . $language;
+        $solrConfiguration = $this->getSolrConnectionConfigFromRegistry($connectionKey);
+
+        if (!is_array($solrConfiguration)) {
+            /* @var $noSolrConnectionException NoSolrConnectionFoundException */
+            $noSolrConnectionException = GeneralUtility::makeInstance(
+                NoSolrConnectionFoundException::class,
+                /** @scrutinizer ignore-type */  'Could not find a Solr connection for root page [' . $this->getRootPageId() . '] and language [' . $language . '].',
+                /** @scrutinizer ignore-type */ 1275396474
+            );
+            $noSolrConnectionException->setRootPageId($this->getRootPageId());
+            $noSolrConnectionException->setLanguageId($language);
+
+            throw $noSolrConnectionException;
+        }
+
+        return $solrConfiguration;
+    }
+
+    /**
+     * Gets all connection configurations found.
+     *
+     * @return array An array of connection configurations.
+     */
+    protected function getSolrConnectionConfigFromRegistry(string $connectionKey)
+    {
+        /** @var $registry Registry */
+        $registry = GeneralUtility::makeInstance(Registry::class);
+        $solrConfigurations = $registry->get('tx_solr', 'servers', []);
+
+        return $solrConfigurations[$connectionKey] ?? null;
+    }
+
+}

--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -25,7 +25,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -121,7 +120,7 @@ class SiteHashService
 
     /**
      * @param $pageId
-     * @return Site
+     * @return SiteInterface
      */
     protected function getSiteByPageId($pageId)
     {

--- a/Classes/Domain/Site/SiteInterface.php
+++ b/Classes/Domain/Site/SiteInterface.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Frans Saris <frans.saris@beech.it> & Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
+
+interface SiteInterface
+{
+    /**
+     * Gets the site's root page ID (uid).
+     *
+     * @return int The site's root page ID.
+     */
+    public function getRootPageId();
+
+    /**
+     * Gets available language id's for this site
+     *
+     * @return int[] array or language id's
+     */
+    public function getAvailableLanguageIds(): array;
+
+    /**
+     * Gets the site's label. The label is build from the the site title and root
+     * page ID (uid).
+     *
+     * @return string The site's label.
+     */
+    public function getLabel();
+
+    /**
+     * Gets the site's Solr TypoScript configuration (plugin.tx_solr.*)
+     *
+     * @return  \ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration The Solr TypoScript configuration
+     */
+    public function getSolrConfiguration();
+
+    /**
+     * Gets the site's default language as configured in
+     * config.sys_language_uid. If sys_language_uid is not set, 0 is assumed to
+     * be the default.
+     *
+     * @return int The site's default language.
+     */
+    public function getDefaultLanguage();
+
+    /**
+     * Generates a list of page IDs in this site. Attention, this includes
+     * all page types! Deleted pages are not included.
+     *
+     * @param int|string $rootPageId Page ID from where to start collection sub pages
+     * @param int $maxDepth Maximum depth to descend into the site tree
+     * @return array Array of pages (IDs) in this site
+     */
+    public function getPages($rootPageId = 'SITE_ROOT', $maxDepth = 999);
+
+    /**
+     * Generates the site's unique Site Hash.
+     *
+     * The Site Hash is build from the site's main domain, the system encryption
+     * key, and the extension "tx_solr". These components are concatenated and
+     * sha1-hashed.
+     *
+     * @return string Site Hash.
+     */
+    public function getSiteHash();
+
+    /**
+     * Gets the site's main domain. More specifically the first domain record in
+     * the site tree.
+     *
+     * @return string The site's main domain.
+     */
+    public function getDomain();
+
+    /**
+     * Gets the site's root page.
+     *
+     * @return array The site's root page.
+     */
+    public function getRootPage();
+
+    /**
+     * Gets the site's root page's title.
+     *
+     * @return string The site's root page's title
+     */
+    public function getTitle();
+
+    /**
+     * Gets the site's config.sys_language_mode setting
+     *
+     * @param int $languageUid
+     *
+     * @return string The site's config.sys_language_mode
+     */
+    public function getSysLanguageMode($languageUid = 0);
+
+    /**
+     * @param int $language
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getSolrConnectionConfiguration(int $language = 0): array;
+
+    /**
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getAllSolrConnectionConfigurations(): array;
+}

--- a/Classes/Domain/Site/Typo3ManagedSite.php
+++ b/Classes/Domain/Site/Typo3ManagedSite.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Site;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Frans Saris <frans.saris@beech.it> & Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Site\Entity\Site as Typo3Site;
+
+/**
+ * Class Typo3ManagedSite
+ * @package ApacheSolrForTypo3\Solr\Domain\Site
+ */
+class Typo3ManagedSite extends Site
+{
+
+    /**
+     * @var Typo3Site
+     */
+    protected $typo3SiteObject;
+
+    /**
+     * @var array
+     */
+    protected $solrConnectionConfigurations;
+
+
+    public function __construct(
+        TypoScriptConfiguration $configuration,
+        array $page, $domain, $siteHash, PagesRepository $pagesRepository = null, $defaultLanguageId = 0, $availableLanguageIds = [], array $solrConnectionConfigurations = [], Typo3Site $typo3SiteObject = null)
+    {
+        $this->configuration = $configuration;
+        $this->rootPage = $page;
+        $this->domain = $domain;
+        $this->siteHash = $siteHash;
+        $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
+        $this->defaultLanguageId = $defaultLanguageId;
+        $this->availableLanguageIds = $availableLanguageIds;
+        $this->solrConnectionConfigurations = $solrConnectionConfigurations;
+        $this->typo3SiteObject = $typo3SiteObject;
+    }
+
+    /**
+     * @param int $languageUid
+     * @return string
+     */
+    public function getSysLanguageMode($languageUid = 0)
+    {
+        return $this->typo3SiteObject->getLanguageById($languageUid)->getFallbackType();
+    }
+
+    /**
+     * @param int $language
+     * @return array
+     * @throws NoSolrConnectionFoundException
+     */
+    public function getSolrConnectionConfiguration(int $language = 0): array
+    {
+        if (!is_array($this->solrConnectionConfigurations[$language])) {
+            /* @var $noSolrConnectionException NoSolrConnectionFoundException */
+            $noSolrConnectionException = GeneralUtility::makeInstance(
+                NoSolrConnectionFoundException::class,
+                /** @scrutinizer ignore-type */  'Could not find a Solr connection for root page [' . $this->getRootPageId() . '] and language [' . $language . '].',
+                /** @scrutinizer ignore-type */ 1552491117
+            );
+            $noSolrConnectionException->setRootPageId($this->getRootPageId());
+            $noSolrConnectionException->setLanguageId($language);
+
+            throw $noSolrConnectionException;
+        }
+
+        return $this->solrConnectionConfigurations[$language];
+    }
+}

--- a/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
+++ b/Classes/System/Records/SystemLanguage/SystemLanguageRepository.php
@@ -67,7 +67,7 @@ class SystemLanguageRepository extends AbstractRepository implements SingletonIn
     /**
      * Finds the system's configured languages.
      *
-     * @return array An array of language IDs
+     * @return array An array of language UIDs
      */
     public function findSystemLanguages()
     {

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\System\Util;
 
 /***************************************************************
@@ -54,5 +55,64 @@ class SiteUtility
         }
 
         return $site instanceof Site;
+    }
+
+    /**
+     * This method is used to retrieve the connection configuration from the TYPO3 site configuration.
+     *
+     * The configuration is done in the globals configuration of a site, and be extended in the language specific configuration
+     * of a site.
+     *
+     * Typically everything except the core name is configured on the global level and the core name differs for each language.
+     *
+     * In addition every property can be defined for the ```read``` and ```write``` scope.
+     *
+     * The convension for propery keys is "solr_{propertyName}_{scope}". With the configuration "solr_host_read" you define the host
+     * for the solr read connection.
+     *
+     * @param Site $typo3Site
+     * @param $property
+     * @param $languageId
+     * @param $scope
+     * @param null $defaultValue
+     * @return string
+     */
+    public static function getConnectionProperty(Site $typo3Site, $property, $languageId, $scope, $defaultValue = null): string
+    {
+
+        // convention kez solr_$property_$scope
+        $keyToCheck = 'solr_' . $property . '_' . $scope;
+
+        // convention fallback key solr_$property_read
+        $fallbackKey = 'solr_' . $property . '_read';
+
+        // try to find language specific setting if found return it
+        $languageSpecificConfiguration = $typo3Site->getLanguageById($languageId)->toArray();
+        $value = self::getValueOrFallback($languageSpecificConfiguration, $keyToCheck, $fallbackKey);
+
+        if (!empty($value)) {
+            return $value;
+        }
+
+        // if not found check global configuration
+        $siteBaseConfiguration = $typo3Site->getConfiguration();
+
+        return self::getValueOrFallback($siteBaseConfiguration, $keyToCheck, $fallbackKey) ?: $defaultValue;
+    }
+
+    /**
+     * @param array $data
+     * @param string $keyToCheck
+     * @param string $fallbackKey
+     * @return string|null
+     */
+    protected static function getValueOrFallback(array $data, string $keyToCheck, string $fallbackKey)
+    {
+        $value = $data[$keyToCheck] ?? null;
+        if (!empty($value)) {
+            return $value;
+        }
+
+        return $data[$fallbackKey] ?? null;
     }
 }

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Global Solr Connection Settings
+ */
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'] = [
+    'label' => 'Scheme',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'items' => [
+            ['http', 'http'],
+            ['https', 'https'],
+        ],
+        'size' => 1,
+        'minitems' => 0,
+        'maxitems' => 1
+    ],
+];
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_host_read'] = [
+    'label' => 'Scheme',
+    'config' => [
+        'type' => 'input',
+        'default' => 'localhost',
+        'placeholder' => 'localhost',
+        'size' => 10
+    ],
+];
+
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
+    'label' => 'Port',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'int,required',
+        'size' => 5,
+        'default' => 8983
+    ],
+];
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'] = [
+    'label' => 'Path to cores (e.g. /solr/)',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'required',
+        'default' => '/solr/'
+    ],
+];
+
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = [
+    'label' => 'Use different write connection',
+    'onChange' => 'reload',
+    'config' => [
+        'type' => 'check',
+        'renderType' => 'checkboxToggle',
+        'default' => 0,
+        'items' => [
+            [
+                0 => '',
+                1 => ''
+            ]
+        ]
+    ],
+];
+
+
+// write TCA
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write']['config']['eval'] = '';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_port_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_host_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_host_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_host_write']['config']['eval'] = '';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_host_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_path_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'];
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_path_write']['config']['eval'] = '';
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_path_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
+
+
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read, solr_host_read, solr_port_read, solr_path_read';
+$GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write, solr_host_write, solr_port_write, solr_path_write';
+
+$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = str_replace(
+    'base,',
+    'base, --palette--;Solr Configuration;solr_read, solr_use_write_connection, --palette--;Solr Write Configuration;solr_write,',
+    $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem']
+);
+
+
+/**
+ * Language specific core configuration
+ */
+$GLOBALS['SiteConfiguration']['site_language']['columns']['solr_core_read'] = [
+    'label' => 'Corename',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'trim',
+        'valuePicker' => [
+            'items' => [
+                [ 'Arabic', 'core_ar'],
+                [ 'Armenian', 'core_hy'],
+                [ 'Basque', 'core_eu'],
+                [ 'Brazilian Portuguese', 'core_ptbr'],
+                [ 'Bulgarian', 'core_bg'],
+                [ 'Burmese', 'core_my'],
+                [ 'Catalan', 'core_ca'],
+                [ 'Chinese', 'core_zh'],
+                [ 'Czech', 'core_cs'],
+                [ 'Danish', 'core_da'],
+                [ 'Dutch', 'core_nl'],
+                [ 'English', 'core_en'],
+                [ 'Finnish', 'core_fi'],
+                [ 'French', 'core_fr'],
+                [ 'Galician', 'core_gl'],
+                [ 'German', 'core_de'],
+                [ 'Greek', 'core_el'],
+                [ 'Hinde', 'core_hi'],
+                [ 'Hungarian', 'core_hu'],
+                [ 'Indonesian', 'core_id'],
+                [ 'Irish', 'core_ie'],
+                [ 'Italian', 'core_it'],
+                [ 'Japanese', 'core_ja'],
+                [ 'Korean', 'core_km'],
+                [ 'Lao', 'core_lo'],
+                [ 'Latvia', 'core_lv'],
+                [ 'Norwegian', 'core_no'],
+                [ 'Persian', 'core_fa'],
+                [ 'Polish', 'core_pl'],
+                [ 'Portuguese', 'core_pt'],
+                [ 'Romanian', 'core_ro'],
+                [ 'Russian', 'core_ru'],
+                [ 'Serbian', 'core_rs'],
+                [ 'Spanish', 'core_es'],
+                [ 'Swedish', 'core_sv'],
+                [ 'Thai', 'core_th'],
+                [ 'Turkish', 'core_tr'],
+                [ 'Ukrainian', 'core_uk'],
+            ],
+        ],
+        'placeholder' => 'core_*',
+    ],
+];
+
+$GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(
+    'flag',
+    'flag, solr_core_read, ',
+    $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem']
+);

--- a/Resources/Private/Partials/Backend/NoSiteAvailable.html
+++ b/Resources/Private/Partials/Backend/NoSiteAvailable.html
@@ -10,6 +10,18 @@
 
 		<f:be.infobox title="There is no site configured for your solr extension!" state="3">
 			<p>Please check the following:</p>
+			<p>If you want to use solr with the TYPO3 site configuration:</p>
+
+			<ul>
+				<li>Your site has a page, marked as root page.</li>
+				<li>Configure EXT:solr with the TYPO3 site module.</li>
+				<li>Check the reports module if any solr error is shown.</li>
+			</ul>
+
+			<hr />
+			<p><strong>OR</strong></p>
+			<hr />
+			<p>If you want to use solr with the legacy configuration (domain record and typoscript of EXTCONF setup):</p>
 			<ul>
 				<li>Your site has a domain configured, please create a domain record on the root page, or configure it in "TYPO3_CONF_VARS|EXTCONF|solr|sites|###rootPageId###|domains"</li>
 				<li>Your site has a page, marked as root page.</li>

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -70,6 +71,11 @@ class ConnectionManagerTest extends UnitTest
     protected $pageRepositoryMock;
 
     /**
+     * @var SiteRepository
+     */
+    protected $siteRepositoryMock;
+
+    /**
      * Set up the connection manager test
      *
      * @return void
@@ -94,10 +100,11 @@ class ConnectionManagerTest extends UnitTest
         $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
         $this->languageRepositoryMock = $this->getDumbMock(SystemLanguageRepository::class);
         $this->pageRepositoryMock = $this->getDumbMock(PagesRepository::class);
+        $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
 
         $this->configurationManager = new ConfigurationManager();
         $this->connectionManager = $this->getMockBuilder(ConnectionManager::class)
-            ->setConstructorArgs([$this->languageRepositoryMock, $this->pageRepositoryMock, $this->logManagerMock])
+            ->setConstructorArgs([$this->languageRepositoryMock, $this->pageRepositoryMock, $this->siteRepositoryMock])
             ->setMethods(['getSolrConnectionForNodes'])
             ->getMock();
     }

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -154,7 +154,14 @@ class SiteRepositoryTest extends UnitTest
             '123|2' => ['rootPageUid' => 123],
             '234|0' => ['rootPageUid' => 234]
         ]);
-        $this->assertThatSitesAreCreatedWithPageIds([123,234]);
+        $this->assertThatSitesAreCreatedWithPageIds(
+            [123,234],
+            [
+                0 => ['language' => 0],
+                1 => ['language' => 1],
+                2 => ['language' => 2],
+            ]
+        );
 
         $siteOne = $this->siteRepository->getFirstAvailableSite();
         $languages = $this->siteRepository->getAllLanguages($siteOne);
@@ -179,16 +186,21 @@ class SiteRepositoryTest extends UnitTest
 
     /**
      * @param array $pageIds
+     * @param array $fakedConnectionConfiguration
      */
-    protected function assertThatSitesAreCreatedWithPageIds(array $pageIds)
+    protected function assertThatSitesAreCreatedWithPageIds(array $pageIds, array $fakedConnectionConfiguration = [])
     {
         $this->siteRepository->expects($this->any())->method('buildSite')->will(
-            $this->returnCallback(function($idToUse) use ($pageIds) {
+            $this->returnCallback(function($idToUse) use ($pageIds, $fakedConnectionConfiguration) {
                 if(in_array($idToUse, $pageIds)) {
                     $site = $this->getDumbMock(Site::class);
                     $site->expects($this->any())->method('getRootPageId')->will(
                         $this->returnValue($idToUse)
                     );
+
+                    $site->expects($this->any())
+                        ->method('getAllSolrConnectionConfigurations')
+                        ->willReturn($fakedConnectionConfiguration);
                     return $site;
                 }
             })

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Timo Hund <timo.hund@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
+/**
+ * Testcase for the SiteUtilityTest helper class.
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
+ */
+class SiteUtilityTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canFallbackToLanguageSpecificReadProperty()
+    {
+        $languageConfiguration = ['solr_core_read' => 'readcore'];
+        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+
+        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
+        $property = SiteUtility::getConnectionProperty($siteMock, 'core', 2, 'write');
+
+        $this->assertSame('readcore', $property, 'Can not fallback to read property when write property is undefined');
+    }
+
+    /**
+     * @test
+     */
+    public function canFallbackToGlobalPropertyWhenLanguageSpecificPropertyIsNotSet()
+    {
+        $languageConfiguration = ['solr_core_read' => 'readcore'];
+        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+
+        $globalConfiguration = ['solr_host_read' => 'readhost'];
+        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($globalConfiguration);
+        $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
+
+        $this->assertSame('readhost', $property, 'Can not fallback to read property when write property is undefined');
+    }
+
+    /**
+     * @test
+     */
+    public function canLanguageSpecificConfigurationOverwriteGlobalConfiguration()
+    {
+        $languageConfiguration = ['solr_host_read' => 'readhost.local.de'];
+        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+
+        $globalConfiguration = ['solr_host_read' => 'readhost.global.de'];
+        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($globalConfiguration);
+        $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
+
+        $this->assertSame('readhost.local.de', $property, 'Can not fallback to read property when write property is undefined');
+    }
+}


### PR DESCRIPTION
# What this pr does

With version 9 the concept of sites has been introduced in TYPO3. A site in TYPO3 can be used to configure everything that is related to domains and languages.

In the solr extension we also had a site concept before. The site concept in EXT:solr collects all connection information from the TypoScript configuration and stores that in the sys_registry. In addition the configuration ```$GLOBALS['TYPO3_CONF_VARS]['EXTCONF']['solr']['sites']```could be used to configure domains, when no TYPO3 domain record was configured.

Since the addtional domain record configuration was only developt because this was  not supported by the core, we should now get rid of that configuration. 

In addition the parsing the TypoScript and storing the connection information was only required to have a good performance (because TSFE needs to be instanciated from the backend). Therefore we should also remove the sys_registry approach and now configure everything that is Apache Solr related in the site configuration.

This pr:

* Refactors the SiteRepository to retrieve 
   * LegacySite for and old (TypoScript & EXTCONF & Domainrecord) 
   * Typo3ManagedSite for new sites managed by the TYPO3 site management
* Refactors the connection manager to remove the retrieval of the connection configuration to the site which allows us to use the old and new configuration handling of connection configuration
* Add's the configuration to the site configuration that allows to configure
   * Scheme, host, port and path at the global site level
   * Corename on the language level

# How to test

Configure site with the `Site management tool` and check if cores can be found

Fixes: #2238
