### PR TITLE
[BUGFIX] Do not quote integer values for flexform filters

### DIFF
--- a/Classes/System/Service/ConfigurationService.php
+++ b/Classes/System/Service/ConfigurationService.php
@@ -132,9 +132,12 @@ class ConfigurationService
 
             $fieldName = $filter['field'];
             $fieldValue = $filter['value'];
-            $quotedFieldValue = '"' . str_replace('"', '\"', $fieldValue) . '"';
 
-            $filterConfiguration[] =  $fieldName . ':' . $quotedFieldValue;
+            if (!is_numeric($fieldValue)) {
+                $fieldValue = '"' . str_replace('"', '\"', $fieldValue) . '"';
+            }
+
+            $filterConfiguration[] =  $fieldName . ':' . $fieldValue;
         }
         return $filterConfiguration;
     }

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -43,7 +43,7 @@ class ConfigurationServiceTest extends UnitTest
     public function overrideFilterDataProvider()
     {
         return [
-            'simpleInteger' => ['id', 4711, 'id:"4711"'],
+            'simpleInteger' => ['id', 4711, 'id:4711'],
             'escapedString' => ['id', 'foo"bar', 'id:"foo\"bar"']
         ];
     }


### PR DESCRIPTION
# What this pr does

* Removes the quoting if a numeric value for the filter was configured in the flexform.

# How to test

Configure a numeric filter in the flexform and check the frontend.

Fixes: #2293
