### PR TITLE
[BUGFIX] Correctly replace non breaking space entity

### DIFF
--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -82,17 +82,17 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
     public function excludeContentByClass($indexableContent)
     {
         if (empty(trim($indexableContent))) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $excludeClasses = $this->getConfiguration()->getIndexQueuePagesExcludeContentByClassArray();
         if (count($excludeClasses) === 0) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $isInContent = Util::containsOneOfTheStrings($indexableContent, $excludeClasses);
         if (!$isInContent) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $doc = new \DOMDocument('1.0', 'UTF-8');

--- a/Tests/Unit/HtmlContentExtractorTest.php
+++ b/Tests/Unit/HtmlContentExtractorTest.php
@@ -68,7 +68,11 @@ class HtmlContentExtractorTest extends UnitTest
             'decodeEntities' => [
                 'websiteContent' => 'B&auml;hm',
                 'exptectedIndexableContent' => 'Bähm'
-            ]
+            ],
+            'decodeSpaceEntities' => [
+                'websiteContent' => 'B&auml;hm&nbsp; Bum',
+                'exptectedIndexableContent' => 'Bähm Bum'
+            ],
         ];
     }
 

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -55,7 +55,7 @@ class Typo3PageContentExtractorTest extends UnitTest
     public function changesNbspToSpace()
     {
         $content = '<!-- TYPO3SEARCH_begin -->In Olten&nbsp;ist<!-- TYPO3SEARCH_end -->';
-        $expectedResult = 'In Olten ist';
+        $expectedResult = 'In Olten ist';
 
         $contentExtractor = GeneralUtility::makeInstance(Typo3PageContentExtractor::class, $content);
         $contentExtractor->setConfiguration($this->typoScripConfigurationMock);


### PR DESCRIPTION
In the process of extracting content from HTML, the &nbsp;
entity is being decoded into an UTF-8 char, which in the
end is destroyed with non unicode aware preg_replace calls
which finally leads to json_encode to fail due to encoding errors
and the page indexing fails.

To fix this, we remove unecessary decoding of entities early in the process
so that we later can cleanly remove &nbsp; with a space.