### PR TITLE
[TASK] migrate calls to PageRepository->getRootLine calls

### DIFF
--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -25,6 +25,7 @@ namespace ApacheSolrForTypo3\Solr\Access;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -143,7 +144,8 @@ class Rootline
 
         $pageSelector = GeneralUtility::makeInstance(PageRepository::class);
         $pageSelector->init(false);
-        $rootline = $pageSelector->getRootLine($pageId, $mountPointParameter);
+        $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $pageId, $mountPointParameter)->get();
+
         $rootline = array_reverse($rootline);
         // parent pages
         foreach ($rootline as $pageRecord) {

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -38,6 +38,7 @@ use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -127,11 +128,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function getConfigurationByPageId($pageId, $language = 0, $mount = '')
     {
-        // find the root page
-        $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-
         /** @var Rootline $rootLine */
-        $rootLine = GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $pageSelect->getRootLine($pageId, $mount));
+        $rootLine = GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ GeneralUtility::makeInstance(RootlineUtility::class, $pageId, $mount)->get());
         $siteRootPageId = $rootLine->getRootPageId();
 
         try {
@@ -381,7 +379,7 @@ class ConnectionManager implements SingletonInterface
         $connectionKey = $rootPage['uid'] . '|' . $languageId;
 
         $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-        $rootLine = $pageSelect->getRootLine($rootPage['uid']);
+        $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $rootPage['uid'])->get();
 
         $tmpl = GeneralUtility::makeInstance(ExtendedTemplateService::class);
         $tmpl->tt_track = false; // Do not log time-performance information

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -33,6 +33,7 @@ use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -250,8 +251,7 @@ class SiteRepository
         $siteService = GeneralUtility::makeInstance(SiteService::class);
         $domain = $siteService->getFirstDomainForRootPage($rootPageId);
         if ($domain === '') {
-            $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-            $rootLine = $pageSelect->getRootLine($rootPageId);
+            $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $rootPageId)->get();
             $domain = BackendUtility::firstDomainRecord($rootLine);
             return (string)$domain;
         }

--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\FieldProcessor;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -102,10 +103,7 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
     protected function buildPageIdRootline($pageId, $mountPoint = '')
     {
         $rootlinePageIds = [];
-
-            /** @var $pageSelector PageRepository */
-        $pageSelector = GeneralUtility::makeInstance(PageRepository::class);
-        $rootline = $pageSelector->getRootLine($pageId, (string)$mountPoint);
+        $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $pageId, (string)$mountPoint)->get();
 
         foreach ($rootline as $page) {
             if (Site::isRootPage($page)) {

--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -27,6 +27,7 @@ namespace ApacheSolrForTypo3\Solr\System\Configuration;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Records\SystemTemplate\SystemTemplateRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -104,7 +105,7 @@ class ConfigurationPageResolver
      */
     protected function calculateClosestPageIdWithActiveTemplate($startPageId)
     {
-        $rootLine = $this->pageRepository->getRootLine($startPageId);
+        $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $startPageId)->get();
         // when no rootline is present the startpage it's self is the closest page
         if (!is_array($rootLine)) {
             return $startPageId;

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -31,6 +31,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use ApacheSolrForTypo3\Solr\System\Mvc\Frontend\Controller\OverriddenTypoScriptFrontendController;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -258,7 +259,7 @@ class Util
 
             /** @var $pageSelect PageRepository */
         $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-        $rootLine = $pageSelect->getRootLine($pageId);
+        $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $pageId)->get();
 
         $initializedTsfe = false;
         $initializedPageSelect = false;


### PR DESCRIPTION
use RootlineUtility directly as proposed by the deprecation message

# What this pr does

migrate deprecated calls to PageRepository->getRootLine

# How to test

Please add a testing instruction here

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
