### PR TITLE
[FIX] Only clean buffer if used

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequestHandler.php
+++ b/Classes/IndexQueue/PageIndexerRequestHandler.php
@@ -119,7 +119,7 @@ class PageIndexerRequestHandler implements SingletonInterface
         $this->dispatcher->shutdown();
 
         // make sure that no other output messes up the data
-        ob_end_clean();
+        if (ob_get_contents()) ob_end_clean();
 
         $this->response->sendHeaders();
         echo $this->response->getContent();


### PR DESCRIPTION
# What this pr does

ob_end_clean should not be called if buffer wasn't used
