### PR TITLE
[BUGFIX] Fix language handling during indexing

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -26,6 +26,7 @@ namespace ApacheSolrForTypo3\Solr\ContentObject;
 
 use ApacheSolrForTypo3\Solr\System\Language\FrontendOverlayService;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Driver\Statement;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -198,7 +199,7 @@ class Relation
 
                 return $this->getRelatedItems($contentObject);
             } else {
-                if ($GLOBALS['TSFE']->sys_language_uid > 0) {
+                if (Util::getLanguageUid() > 0) {
                     $record = $this->frontendOverlayService->getOverlay($foreignTableName, $record);
                 }
                 $relatedItems[] = $record[$foreignTableLabelField];
@@ -302,7 +303,7 @@ class Relation
         ContentObjectRenderer $parentContentObject,
         $foreignTableName = ''
     ) {
-        if ($GLOBALS['TSFE']->sys_language_uid > 0 && !empty($foreignTableName)) {
+        if (Util::getLanguageUid() > 0 && !empty($foreignTableName)) {
             $relatedRecord = $this->frontendOverlayService->getOverlay($foreignTableName, $relatedRecord);
         }
 

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -299,7 +299,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
             $this->responseData['originalPageDocument'] = (array)$indexer->getPageSolrDocument();
             $this->responseData['solrConnection'] = [
                 'rootPage' => $indexQueueItem->getRootPageUid(),
-                'sys_language_uid' => $GLOBALS['TSFE']->sys_language_uid,
+                'sys_language_uid' => Util::getLanguageUid(),
                 'solr' => (string)$solrConnection->getNode('write')
             ];
 
@@ -345,7 +345,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
 
         $solrConnection = $connectionManager->getConnectionByRootPageId(
             $indexQueueItem->getRootPageUid(),
-            $GLOBALS['TSFE']->sys_language_uid
+            Util::getLanguageUid()
         );
 
         return $solrConnection;

--- a/Classes/System/Language/FrontendOverlayService.php
+++ b/Classes/System/Language/FrontendOverlayService.php
@@ -69,10 +69,10 @@ class FrontendOverlayService {
     public function getOverlay($tableName, $record)
     {
         if ($tableName === 'pages') {
-            return $this->tsfe->sys_page->getPageOverlay($record, $this->tsfe->sys_language_uid);
+            return $this->tsfe->sys_page->getPageOverlay($record, Util::getLanguageUid());
         }
 
-        return $this->tsfe->sys_page->getRecordOverlay($tableName, $record, $this->tsfe->sys_language_uid);
+        return $this->tsfe->sys_page->getRecordOverlay($tableName, $record, Util::getLanguageUid());
     }
 
     /**
@@ -87,11 +87,11 @@ class FrontendOverlayService {
     public function getUidOfOverlay($table, $field, $uid)
     {
         // when no language is set at all we do not need to overlay
-        if (!isset($this->tsfe->sys_language_uid)) {
+        if (Util::getLanguageUid() === null) {
             return $uid;
         }
         // when no language is set we can return the passed recordUid
-        if (!$this->tsfe->sys_language_uid > 0) {
+        if (!(Util::getLanguageUid() > 0)) {
             return $uid;
         }
 


### PR DESCRIPTION
# What this pr does
Fixes indexing of translated records that make use of `SOLR_RELATION`

* Set language id in language context during indexing
* Set language id in TypoScriptFrontendController during indexing
* replace calls to $GLOBALS['TSFE']->sys_language_uid with calls to the language context
* However setting `$GLOBALS['TSFE']->__set('sys_language_uid', $language);` was still necassery. Otherwise when TSFE is taken from the Cache the language for `SOLR_RELATION` was always the default language.

### I had two issues that are related to #2295.

#### Translated pages are not indexed
_Can already be fixed with a updated TypoScript configuration (check below)_
When Typo3 9 is used with a site config the non speaking URLs with L=1 (which EXT:solr is currently using for indexing) had no effect
The content was always delivered from the default language. This is more a configuration issue than a bug of EXT:solr.

#### SOLR_RELATION for translated records return wrong value
_My changes should solve this_
In my TypoScript indexing config for tx_news_domain_model_news i use `SOLR_RELATION`. There always language uid 0 was used.
Like dmitryd described in #2295  the wrong language id is used here. So language overlay is not performed correctly.
Disabling cache works, but slows down the indexing process significantly.

I reproduced this behaviour with
TYPO3 Version: 9.5.7
EXT:solr Version: 9.0.2

# How to test
Add the following to your TypoScript Config to fix indexing of pages. This also works before my changes.
```
[request.getQueryParams()['L'] == 0]
    config.sys_language_uid = 0
    config.language = de
[end]

[request.getQueryParams()['L'] == 1]
    config.sys_language_uid = 1
    config.language = en
[end]
```

- In Typo3 9 with site configuration and e.g. language 0 = de and language 1 = en create a translation of a page and try to index the site in both languages. This should now work.
- Use the example configuration for `tx_news_domain_model_news` (provided by EXT:solr)
 - Create translations for at least two news records
 - Assign categories and translate them as well
 - Index the records
 - The indexed news records should contain the title of the translated categories

Fixes: #2295