### PR TITLE
[BUGFIX] Respect TableMapping parameter

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
 use Doctrine\DBAL\DBALException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -255,7 +256,7 @@ class QueueItemRepository extends AbstractRepository
      */
     public function getPageItemChangedTimeByPageUid(int $pageUid)
     {
-        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         $pageContentLastChangedTime = $queryBuilder
             ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
@@ -288,7 +289,7 @@ class QueueItemRepository extends AbstractRepository
             // table is localizable
             $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];
 
-            $queryBuilder = $this->getQueryBuilder();
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($itemType);
             $queryBuilder->getRestrictions()->removeAll();
             $localizedChangedTime = $queryBuilder
                 ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
@@ -677,7 +678,7 @@ class QueueItemRepository extends AbstractRepository
         foreach ($tableUids as $table => $uids) {
             $uidList = implode(',', $uids);
 
-            $queryBuilderForRecordTable = $this->getQueryBuilder();
+            $queryBuilderForRecordTable = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
             $queryBuilderForRecordTable->getRestrictions()->removeAll();
             $resultsFromRecordTable = $queryBuilderForRecordTable
                 ->select('*')


### PR DESCRIPTION
# What this pr does

Adds support for indexing items stored in a distinct database (as defined in [`$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']`](https://docs.typo3.org/typo3cms/CoreApiReference/8.7/ApiOverview/Database/Configuration/#configuration))

# How to test

> 1. Add a new `Extern` connection in `$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']`
> 2. Set the `Extern` connection to be used for a custom record type (you can also use `tx_news_domain_model_news` or any pre-existing if you want) in `TableMapping`:
>     ```php
>     $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'] = [
>         'my_custom_record` => `Extern`
>     ]
>     ```
> 3. Add a queue configuration for your record type:
>     ```typoscript
>     plugin.tx_solr.queue {
>       custom_records = 1
>       custom_records {
>         table = my_custom_record
>         fields {
>           title = title
>         }
>       }
>     }
>     ```
> 4. Add a couple of records in your database, then go to the "Index Queue" view, select "custom_records" in the " Index Queue Initialization " section and hit "Queue selected content for indexing"


Fixes: #2311 

### Sidenote

The code also works with `tx_solr_indexqueue_item` being on the distant database **only if** `tx_solr_indexqueue_indexing_property` is there as well, because of the JOIN in [`QueueItemRepository::buildQueryForPropertyDeletion`](https://github.com/TYPO3-Solr/ext-solr/blob/151fd12/Classes/Domain/Index/Queue/QueueItemRepository.php#L486).