### PR TITLE
Fix spelling of adjective “faceted” in documentation

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1027,7 +1027,7 @@ faceting.facets.[facetName].metrics
 :Since: 8.0
 :Default: empty
 
-Metrics can be use to collect and enhance facet options with statistical data of the facetted documents. They can
+Metrics can be use to collect and enhance facet options with statistical data of the faceted documents. They can
 be used to render useful information in the context of an facet option.
 
 Example:

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -5,7 +5,7 @@ What does it do?
 ----------------
 
 Apache Solr for TYPO3 is the search engine you were looking for with special
-features such as **Facetted Search** or **Synonym Support** and an incredibly fast
+features such as **Faceted Search** or **Synonym Support** and an incredibly fast
 response times of results within milliseconds.
 
 When development started, the primary goal was to create a replacement for
@@ -19,7 +19,7 @@ The results can be rendered with flexible fluid templates, to render the results
 Feature List
 ------------
 
-* Facetted Search
+* Faceted Search
 * Spellchecking / **Did you mean**
 * **Multi Language Support**
 * Search word highlighting


### PR DESCRIPTION
# What this pr does

This pull-request fixes the spelling of the english adjective “faceted” in the documentation.

# How to test

Look into the British Oxford-Dictionary and the American New-Oxford-Dictionary for the spelling of the adjective “faceted”. It does not contain a second “t”. 
<img width="1073" alt="ext-solr-spelling-faceted" src="https://user-images.githubusercontent.com/38257959/58370604-c8fcfe00-7f08-11e9-9ed0-54751a135428.png">

Fixes: #2321
