### PR TITLE
Check rootline before index

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -38,6 +38,7 @@ use ApacheSolrForTypo3\Solr\Util;
 use Solarium\Exception\HttpException;
 use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -341,9 +342,14 @@ class Indexer extends AbstractIndexer
     protected function isRootPageIdPartOfRootLine(Item $item)
     {
         $rootPageId = $item->getRootPageUid();
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-        $rootLine = $pageRepository->getRootLine($item->getRecordPageId());
-        $pageInRootline = array_filter($rootLine, function($page) use ($rootPageId) {
+        $buildRootlineWithPid = $item->getRecordPageId();
+        if ($item->getType() === 'pages') {
+            $buildRootlineWithPid = $item->getRecordUid();
+        }
+        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $buildRootlineWithPid);
+        $rootline = $rootlineUtility->get();
+
+        $pageInRootline = array_filter($rootline, function($page) use ($rootPageId) {
             return (int)$page['uid'] === $rootPageId;
         });
         return !empty($pageInRootline);

--- a/Tests/Integration/Fixtures/fake_extension_table.sql
+++ b/Tests/Integration/Fixtures/fake_extension_table.sql
@@ -12,7 +12,7 @@ CREATE TABLE tx_fakeextension_domain_model_foo (
 	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
 	t3ver_count int(11) DEFAULT '0' NOT NULL,
 	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
-  t3ver_move_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
 	t3_origuid int(11) DEFAULT '0' NOT NULL,
 	editlock tinyint(4) DEFAULT '0' NOT NULL,
 	sys_language_uid int(11) DEFAULT '0' NOT NULL,

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
@@ -124,7 +124,6 @@
                             foo = 1
                             foo {
                                 table = tx_fakeextension_domain_model_bar
-                                additionalPageIds = 112
 
                                 fields {
                                     title = title
@@ -146,25 +145,36 @@
 
     <pages>
         <uid>1</uid>
+        <pid>0</pid>
         <title>Siteroot with correct Solr configuration</title>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
-        <pid>0</pid>
     </pages>
     <pages>
-        <title>Another siteroot with Solr configuration which should not be used</title>
         <uid>111</uid>
+        <pid>0</pid>
+        <title>Another siteroot with Solr configuration which should not be used</title>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
-        <pid>0</pid>
     </pages>
     <pages>
-        <title>Storage folder outside siteroot</title>
         <uid>112</uid>
+        <pid>111</pid>
+        <title>Storage folder outside siteroot</title>
         <is_siteroot>0</is_siteroot>
         <doktype>254</doktype>
-        <pid>111</pid>
     </pages>
+
+    <sys_domain>
+        <uid>1</uid>
+        <pid>1</pid>
+        <domainName>www.correct-domain.local</domainName>
+    </sys_domain>
+    <sys_domain>
+        <uid>2</uid>
+        <pid>111</pid>
+        <domainName>www.wrong-domain.local</domainName>
+    </sys_domain>
 
     <tx_fakeextension_domain_model_bar>
         <uid>1</uid>
@@ -172,5 +182,4 @@
         <title>external testnews</title>
         <category>4711</category>
     </tx_fakeextension_domain_model_bar>
-
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_registry>
+        <uid>4711</uid>
+        <entry_namespace>tx_solr</entry_namespace>
+        <entry_key>servers</entry_key>
+        <entry_value>a:1:{s:3:"1|0";a:7:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}}</entry_value>
+    </sys_registry>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                additionalPageIds = 111
+
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <pages>
+        <title>storage folder outside siteroot</title>
+        <uid>111</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>254</doktype>
+        <pid>0</pid>
+    </pages>
+
+    <tx_fakeextension_domain_model_bar>
+        <uid>111</uid>
+        <pid>111</pid>
+        <title>external testnews</title>
+        <category>4711</category>
+    </tx_fakeextension_domain_model_bar>
+
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
@@ -5,7 +5,7 @@
         <uid>4711</uid>
         <entry_namespace>tx_solr</entry_namespace>
         <entry_key>servers</entry_key>
-        <entry_value>a:1:{s:3:"1|0";a:7:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}}</entry_value>
+        <entry_value>a:2:{s:3:"1|0";a:7:{s:13:"connectionKey";s:3:"1|0";s:13:"rootPageTitle";s:15:"Congratulations";s:11:"rootPageUid";s:1:"1";s:8:"language";i:0;s:5:"label";s:74:"Congratulations (pid: 1, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}s:5:"111|0";a:7:{s:13:"connectionKey";s:5:"111|0";s:13:"rootPageTitle";s:15:"Second siteroot";s:11:"rootPageUid";s:3:"111";s:8:"language";i:0;s:5:"label";s:76:"Second siteroot (pid: 111, language: default) - localhost:8999/solr/core_en/";s:4:"read";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}s:5:"write";a:4:{s:6:"scheme";s:4:"http";s:4:"host";s:9:"localhost";s:4:"port";s:4:"8999";s:4:"path";s:14:"/solr/core_en/";}}}</entry_value>
     </sys_registry>
 
     <sys_template>
@@ -56,10 +56,16 @@
                             foo = 1
                             foo {
                                 table = tx_fakeextension_domain_model_bar
-                                additionalPageIds = 111
+                                additionalPageIds = 112
 
                                 fields {
                                     title = title
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 1
+                                        typolink.useCacheHash = 1
+                                        typolink.returnLast = url
+                                    }
                                 }
                             }
                         }
@@ -70,23 +76,99 @@
         <sorting>100</sorting>
     </sys_template>
 
+    <sys_template>
+        <uid>2</uid>
+        <pid>111</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+                    solr {
+                        scheme = http
+                        host   = localhost
+                        port   = 8081
+                        path   = /solr/core_en/
+                    }
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+
+                        queue {
+                            foo = 1
+                            foo {
+                                table = tx_fakeextension_domain_model_bar
+                                additionalPageIds = 112
+
+                                fields {
+                                    title = title
+                                    url = TEXT
+                                    url {
+                                        typolink.parameter = 111
+                                        typolink.useCacheHash = 1
+                                        typolink.returnLast = url
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>101</sorting>
+    </sys_template>
 
     <pages>
         <uid>1</uid>
+        <title>Siteroot with correct Solr configuration</title>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
+        <pid>0</pid>
     </pages>
     <pages>
-        <title>storage folder outside siteroot</title>
+        <title>Another siteroot with Solr configuration which should not be used</title>
         <uid>111</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+    </pages>
+    <pages>
+        <title>Storage folder outside siteroot</title>
+        <uid>112</uid>
         <is_siteroot>0</is_siteroot>
         <doktype>254</doktype>
-        <pid>0</pid>
+        <pid>111</pid>
     </pages>
 
     <tx_fakeextension_domain_model_bar>
-        <uid>111</uid>
-        <pid>111</pid>
+        <uid>1</uid>
+        <pid>112</pid>
         <title>external testnews</title>
         <category>4711</category>
     </tx_fakeextension_domain_model_bar>

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -32,7 +32,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Charset\CharsetConverter;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
@@ -558,7 +557,9 @@ class IndexerTest extends IntegrationTest
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+        $this->assertContains('"numFound":2', $solrContent, 'Could not index document into solr');
 
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*&fq=site:www.correct-domain.local');
         $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
         $this->assertContains('"url":"index.php?id=1"', $solrContent, 'Item was indexed with false site UID');
         $this->cleanUpSolrServerAndAssertEmpty();

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -512,7 +512,6 @@ class IndexerTest extends IntegrationTest
         $this->assertSame([], $result);
     }
 
-
     /**
      * @test
      */
@@ -536,6 +535,32 @@ class IndexerTest extends IntegrationTest
 
         $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
         $this->assertContains('"title":"external testnews"', $solrContent, 'Could not index document into solr');
+        $this->cleanUpSolrServerAndAssertEmpty();
+    }
+
+    /**
+     * @test
+     */
+    public function testCanIndexCustomRecordOutsideOfSiteRootWithTemplate()
+    {
+        $this->cleanUpSolrServerAndAssertEmpty();
+
+        // create fake extension database table and TCA
+        $this->importExtTablesDefinition('fake_extension2_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_mmrelated'] = include($this->getFixturePathByName('fake_extension2_mmrelated_tca.php'));
+        $this->importDataSetFromFixture('can_index_custom_record_outside_site_root_with_template.xml');
+
+        $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 1);
+
+        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+
+        // do we have the record in the index with the value from the mm relation?
+        $this->waitToBeVisibleInSolr();
+        $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
+
+        $this->assertContains('"numFound":1', $solrContent, 'Could not index document into solr');
+        $this->assertContains('"url":"index.php?id=1"', $solrContent, 'Item was indexed with false site UID');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 


### PR DESCRIPTION
# What this pr does

This PR checks, if page configured with additionalStoragePid is part of current rootline. If not, the foreign TSFE can't be used for indexer configuration.

# How to test

See Functional Test. I have created a new fixture xml file

Fixes: #2303
