### PR TITLE
[BUGFIX] Fill firstLevelCache with secondLevelCache result

### DIFF
--- a/Classes/System/Cache/TwoLevelCache.php
+++ b/Classes/System/Cache/TwoLevelCache.php
@@ -109,7 +109,10 @@ class TwoLevelCache
             return $firstLevelResult;
         }
 
-        return $this->secondLevelCache->get($cacheId);
+        $secondLevelResult = $this->secondLevelCache->get($cacheId);
+        $this->setToFirstLevelCache($cacheId, $secondLevelResult);
+
+        return $secondLevelResult;
     }
 
     /**


### PR DESCRIPTION
If the function \ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache::get is used, currently every time the secondLevelCache is fetched again as the result is never stored in the firstLevelCache. This is very expensive as it means fetching the result from database (default backend cache) and unserialize the information (as it is stored serialized by default).