### PR TITLE
[BUGFIX] Initialize TSFE on 2nd level cache hit

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -161,6 +161,9 @@ class Util
 
         if (!empty($configurationArray)) {
             // we have a cache hit and can return it.
+            if ($initializeTsfe) {
+                self::initializeTsfe($pageId, $language);
+            }
             return $configurationObjectCache[$cacheId] = self::buildTypoScriptConfigurationFromArray($configurationArray, $pageId, $language, $path);
         }
 


### PR DESCRIPTION
In addition to #2323 TSFE needs to get a proper initialization also
on a TwoLevelCache hit. Otherwise you get different TSFE objects when
indexing records via additionalPageIds outside the normal page tree for
the first indexing (without TwoLevelCache hit) and second indexing
(with TwoLevelCache hit).

Resolves: #2328
