### PR TITLE
[FEATURE] Add tx_solr_statistics to table garbage collection

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -120,6 +120,13 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['ApacheSolrForTy
     'additionalFields' => \ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTaskAdditionalFieldProvider::class
 ];
 
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_solr_statistics'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_solr_statistics'] = [
+        'dateField' => 'tstamp',
+        'expirePeriod' => 180
+    ];
+}
+
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 // registering the eID scripts


### PR DESCRIPTION
# What this pr does

Adds tx_solr_statistics table to "Table garbage collection" scheduler task.

# How to test

Check if the scheduler task mentioned above shows the table tx_solr_statistics with a default of 180 days.

Fixes: #2305 
