### PR TITLE
Allow stdWrap on sorting label

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking\Suggestion;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * This processor is used to transform the solr response into a
@@ -124,7 +125,14 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             $label = $sortingOptions['label'];
 
             $isResetOption = $field === 'relevance';
-            // @todo allow stdWrap on label
+
+            // Allow stdWrap on label:
+            $labelHasSubConfiguration = is_array($sortingOptions['label.']);
+            if ($labelHasSubConfiguration) {
+                $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+                $label = $cObj->stdWrap($label, $sortingOptions['label.']);
+            }
+
             $sorting = $this->getObjectManager()->get(Sorting::class, $resultSet, $sortingName, $field, $direction, $label, $selected, $isResetOption);
             $resultSet->addSorting($sorting);
         }


### PR DESCRIPTION
This will allow the usage of stdWrap for sorting labels.

Example: 

```
plugin.tx_solr.search {
    sorting {
        options {
            relevance {
                field = relevance
                label = Relevance
                label.data = LLL:EXT:your_sitepackage/Resources/Private/Language/locallang.xlf:search.results.sorting.relevance
              }
           }
    }
}
```

Resolves #2339