### PR TITLE
[BUGFIX] Add facet name to facet filters

### DIFF
--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -154,7 +154,7 @@ class Faceting implements Modifier, SearchRequestAware
             $tag = $this->getFilterTag($facetConfiguration, $keepAllFacetsOnSelection);
             $filterParts = $this->getFilterParts($facetConfiguration, $facetName, $filterValues);
             $operator = ($facetConfiguration['operator'] === 'OR') ? ' OR ' : ' AND ';
-            $facetFilters[] = $tag . '(' . implode($operator, $filterParts) . ')';
+            $facetFilters[$facetName] = $tag . '(' . implode($operator, $filterParts) . ')';
         }
 
         return $facetFilters;


### PR DESCRIPTION
To be able to combine facets from _GET and from flexforms, the key of the facets must be set to a proper name. Otherwise the index would be overriden.

Resolves: #2301