### PR TITLE
[BUGFIX] Send a consistent type for SOLR_RELATION multivalue

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -93,9 +93,7 @@ abstract class AbstractIndexer
 
             if (is_array($fieldValue)) {
                 // multi value
-                foreach ($fieldValue as $multiValue) {
-                    $document->addField($solrFieldName, $multiValue);
-                }
+                $document->setField($solrFieldName, $fieldValue);
             } else {
                 if ($fieldValue !== '' && $fieldValue !== null) {
                     $document->setField($solrFieldName, $fieldValue);


### PR DESCRIPTION
# What this pr does

This change set a multivalue field in one call instead of one call per value.

So, the field type is always an array, even if the multivalue field contains
only one value.

This fix one major issue where only the first value of a rootline field get indexed.

# How to test

1. Index a document with a SOLR_RELATION and multiValue=1 (like a relation to sys_category).
With a relation with only one element: the field's value in the json payload sent to solr must be an array of one element.

Before the fix, for a relation with one element, the field's value in the json payload was an int an not an array.

2. Index a document with a field with a categoryUidToHierarchy as fieldProcessingInstructions.
The hierarchy must be correctly stored as a multivalue field in solr.

Before the fix, only the first level of the hierarchy get indexed.

Fixes: #2346
