### PR TITLE
don't remove content that is visible to the user

### DIFF
--- a/Classes/HtmlContentExtractor.php
+++ b/Classes/HtmlContentExtractor.php
@@ -128,8 +128,6 @@ class HtmlContentExtractor
     public function getIndexableContent()
     {
         $content = self::cleanContent($this->content);
-        $content = strip_tags($content);
-        $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
         $content = trim($content);
 
         return $content;
@@ -153,8 +151,10 @@ class HtmlContentExtractor
 
         // prevents concatenated words when stripping tags afterwards
         $content = str_replace(['<', '>'], [' <', '> '], $content);
-
         $content = str_replace(["\t", "\n", "\r", '&nbsp;'], ' ', $content);
+        $content = strip_tags($content);
+        $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
+
         $content = self::stripUnicodeRanges($content);
         $content = trim($content);
 

--- a/Classes/HtmlContentExtractor.php
+++ b/Classes/HtmlContentExtractor.php
@@ -128,9 +128,8 @@ class HtmlContentExtractor
     public function getIndexableContent()
     {
         $content = self::cleanContent($this->content);
-        $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
-        // after entity decoding we might have tags again
         $content = strip_tags($content);
+        $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
         $content = trim($content);
 
         return $content;
@@ -154,27 +153,12 @@ class HtmlContentExtractor
 
         // prevents concatenated words when stripping tags afterwards
         $content = str_replace(['<', '>'], [' <', '> '], $content);
-        $content = static::stripTags($content);
 
         $content = str_replace(["\t", "\n", "\r", '&nbsp;'], ' ', $content);
         $content = self::stripUnicodeRanges($content);
         $content = trim($content);
 
         return $content;
-    }
-
-    /**
-     * Strips html tags, but keeps single < and > characters.
-     *
-     * @param string $content
-     * @return mixed
-     */
-    protected static function stripTags($content)
-    {
-        $content = preg_replace('@<([^>]+(<|\z))@msi', '##lt##$1', $content);
-        $content = strip_tags($content);
-        // unescape < that are not used to open a tag
-        return str_replace('##lt##', '<', $content);
     }
 
     /**

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -131,9 +131,6 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
 
         // clean content
         $content = self::cleanContent($content);
-        $content = strip_tags($content);
-        $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
-
         $content = trim($content);
         $content = preg_replace('!\s+!', ' ', $content); // reduce multiple spaces to one space
 

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -82,17 +82,17 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
     public function excludeContentByClass($indexableContent)
     {
         if (empty(trim($indexableContent))) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $excludeClasses = $this->getConfiguration()->getIndexQueuePagesExcludeContentByClassArray();
         if (count($excludeClasses) === 0) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $isInContent = Util::containsOneOfTheStrings($indexableContent, $excludeClasses);
         if (!$isInContent) {
-            return html_entity_decode($indexableContent);
+            return $indexableContent;
         }
 
         $doc = new \DOMDocument('1.0', 'UTF-8');
@@ -131,8 +131,8 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
 
         // clean content
         $content = self::cleanContent($content);
+        $content = strip_tags($content);
         $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
-        $content = static::stripTags($content); // after entity decoding we might have tags again
 
         $content = trim($content);
         $content = preg_replace('!\s+!', ' ', $content); // reduce multiple spaces to one space

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -55,7 +55,7 @@ class Typo3PageContentExtractorTest extends UnitTest
     public function changesNbspToSpace()
     {
         $content = '<!-- TYPO3SEARCH_begin -->In Olten&nbsp;ist<!-- TYPO3SEARCH_end -->';
-        $expectedResult = 'In Olten ist';
+        $expectedResult = 'In Olten ist';
 
         $contentExtractor = GeneralUtility::makeInstance(Typo3PageContentExtractor::class, $content);
         $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
@@ -135,6 +135,10 @@ class Typo3PageContentExtractorTest extends UnitTest
             'keep less then character' => [
                 'content' => '<p>If <b>the value</b> is &lt;50 please contact me</p>',
                 'expectedResult' => 'If the value is <50 please contact me'
+            ],
+            'keep escaped html' => [
+                'content' => '<em>this</em> is how to make &lt;b&gt;fat&lt;/b&gt;',
+                'expectedResult' => 'this is how to make <b>fat</b>'
             ]
         ];
     }


### PR DESCRIPTION
# What this pr does

It is related to #1541.
I changed the decoding of html so that all literals are preserved, not just `<`.

# How to test

I extended the test created by #1767. Otherwise just add xml-like content to a page and index it, it will be removed from the content.

Fixes: #2348
