### PR TITLE
[BUGFIX] Set value of grouping.numberOfGroups

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Grouping.php
@@ -247,6 +247,8 @@ class Grouping extends AbstractDeactivatable implements ParameterBuilder
         $query->getGrouping()->setFormat('grouped');
         $query->getGrouping()->setNumberOfGroups(true);
 
+        $query->setRows($this->getNumberOfGroups());
+
         $sorting = implode(' ', $this->getSortings());
         $query->getGrouping()->setSort($sorting);
         return $parentBuilder;


### PR DESCRIPTION
Fixes a regression from switching to Solarium. Set query option "rows" with
value from grouping.numberOfGroups, when grouping is enabled.

Resolves: #2350
