### PR TITLE
[FEATURE] Re-implement 'keepExistingParametersForNewSearches' (#1626)

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -142,10 +142,9 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     {
         $searchParameters = [];
         if ($this->getTypoScriptConfiguration()->getSearchKeepExistingParametersForNewSearches()) {
-            $arguments = $this->controllerContext->getRequest()->getArguments();
+            $arguments = GeneralUtility::_GPmerged('tx_solr');
+            unset($arguments['q'], $arguments['id'], $arguments['L']);
             $searchParameters = $this->translateSearchParametersToInputTagAttributes($arguments);
-            unset($searchParameters['[page]']);
-            unset($searchParameters['[q]']);
         }
         return $searchParameters;
     }

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -11,6 +11,9 @@
 					<input type="hidden" name="L" value="{languageUid}" />
 					<input type="hidden" name="id" value="{pageUid}" />
 				</f:if>
+                <f:for each="{existingParameters}" key="name" as="value">
+                    <f:form.hidden name="{pluginNamespace}{name}" value="{value}" />
+                </f:for>
 
 				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
 				<span class="input-group-btn">

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -7,13 +7,14 @@
 	<div class="tx-solr-search-form">
 		<s:searchForm id="tx-solr-search-form-pi-results" additionalFilters="{additionalFilters}" suggestHeader="{s:translate(key:'suggest_header',default:'Top Results')}">
 			<div class="input-group">
+                <f:for each="{existingParameters}" key="name" as="value">
+                    <f:form.hidden name="{pluginNamespace}{name}" value="{value}" />
+                </f:for>
+
 				<f:if condition="{addPageAndLanguageId}">
 					<input type="hidden" name="L" value="{languageUid}" />
 					<input type="hidden" name="id" value="{pageUid}" />
 				</f:if>
-                <f:for each="{existingParameters}" key="name" as="value">
-                    <f:form.hidden name="{pluginNamespace}{name}" value="{value}" />
-                </f:for>
 
 				<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
 				<span class="input-group-btn">


### PR DESCRIPTION
# What this pr does

Re-implement the feature 'keepExistingParametersForNewSearches': When doing a new search, existing parameters like filters will be carried over to the new search.
The TypoScript setting and documentation already exist from an earlier version (feature got lost in a rewrite)

# How to test

Select one or more facets, type new search words and search. With this patch, the selected facets remain active for the new search.

Fixes: #1626
