### PR TITLE
[BUGFIX] Fix getAllRequirementsMet returns true too soon

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
@@ -43,13 +43,13 @@ class RequirementsService
             $requirementMet = $this->getRequirementMet($facet, $requirement);
             $requirementMet = $this->getNegationWhenConfigured($requirementMet, $requirement);
 
-            if ($requirementMet) {
-                // early return
-                return true;
+            if (!$requirementMet) {
+                // early return as soon as one requirement is not met
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
RequirementsService->getAllRequirementsMet() returns true as soon as one requirement is met (#2374)

# What this pr does

With this PR true is only returned when ALL given requirements are fullfilled, not just one

Fixes: #2374
