### PR TITLE
Bugfix/2363 language fallback

### DIFF
--- a/Classes/Domain/Site/LegacySite.php
+++ b/Classes/Domain/Site/LegacySite.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\Util;
+use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -40,12 +41,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class LegacySite extends Site
 {
+
     /**
-     * The site's sys_language_mode
-     *
-     * @var string
+     * @var array
      */
-    protected $sysLanguageMode = null;
+    protected $typoScriptConfig = null;
 
     /**
      * Constructor.
@@ -67,31 +67,29 @@ class LegacySite extends Site
         $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
         $this->defaultLanguageId = $defaultLanguageId;
         $this->availableLanguageIds = $availableLanguageIds;
+
     }
 
     /**
-     * Gets the site's config.sys_language_mode setting
-     *
      * @param int $languageUid
-     *
-     * @return string The site's config.sys_language_mode
+     * @return array
      */
-    public function getSysLanguageMode($languageUid = 0)
+    public function getFallbackOrder(int $languageUid): array
     {
-        if ($this->sysLanguageMode !== null) {
-            return $this->sysLanguageMode;
-        }
+        if ($this->typoScriptConfig === null) {
+            try {
+                Util::initializeTsfe($this->getRootPageId(), $languageUid);
+                $this->typoScriptConfig = $GLOBALS['TSFE']->config['config'] ?? [];
 
-        try {
-            Util::initializeTsfe($this->getRootPageId(), $languageUid);
-            $this->sysLanguageMode = $GLOBALS['TSFE']->sys_language_mode;
-            return $this->sysLanguageMode;
-
-        } catch (\TYPO3\CMS\Core\Error\Http\ServiceUnavailableException $e) {
-            // when there is an error during initialization we return the default sysLanguageMode
-            return $this->sysLanguageMode;
+            } catch (\TYPO3\CMS\Core\Error\Http\ServiceUnavailableException $e) {
+                // when there is an error during initialization we return the default sysLanguageMode
+                $this->typoScriptConfig = [];
+            }
         }
+        $languageAspect = LanguageAspectFactory::createFromTypoScript($this->typoScriptConfig);
+        return $languageAspect->getFallbackChain();
     }
+
 
     /**
      * @param int $language

--- a/Classes/Domain/Site/SiteInterface.php
+++ b/Classes/Domain/Site/SiteInterface.php
@@ -111,13 +111,10 @@ interface SiteInterface
     public function getTitle();
 
     /**
-     * Gets the site's config.sys_language_mode setting
-     *
      * @param int $languageUid
-     *
-     * @return string The site's config.sys_language_mode
+     * @return array
      */
-    public function getSysLanguageMode($languageUid = 0);
+    public function getFallbackOrder(int $languageUid): array;
 
     /**
      * @param int $language

--- a/Classes/Domain/Site/Typo3ManagedSite.php
+++ b/Classes/Domain/Site/Typo3ManagedSite.php
@@ -28,8 +28,10 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Site\Entity\Site as Typo3Site;
+
 
 /**
  * Class Typo3ManagedSite
@@ -66,11 +68,12 @@ class Typo3ManagedSite extends Site
 
     /**
      * @param int $languageUid
-     * @return string
+     * @return array
      */
-    public function getSysLanguageMode($languageUid = 0)
+    public function getFallbackOrder(int $languageUid): array
     {
-        return $this->typo3SiteObject->getLanguageById($languageUid)->getFallbackType();
+        $languageAspect = LanguageAspectFactory::createFromSiteLanguage($this->typo3SiteObject->getLanguageById($languageUid));
+        return $languageAspect->getFallbackChain();
     }
 
     /**


### PR DESCRIPTION
# What this pr does

This pr fixes the language fallbacks for with site configuration

# How to test

create SiteConfiguration with multiple languages and different language-fallbacks
minimal: default language and one translation with fallback to default

have a page with is not translated, default page is show in Frontend on translation page
this page should be indexed by solr

Fixes: #2363