### PR TITLE
[TASK] Add deprecation logs

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -122,6 +122,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function getConfigurationByPageId($pageId, $language = 0, $mount = '')
     {
+        trigger_error('Method getConfigurationByPageId is deprecated since EXT:solr 10 and will be removed in v11, use Site object/SiteRepository directly.', E_USER_DEPRECATED);
+
         try {
             $site = $this->siteRepository->getSiteByPageId($pageId, $mount);
             return $site->getSolrConnectionConfiguration($language);
@@ -175,6 +177,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function getConfigurationByRootPageId($pageId, $language = 0)
     {
+        trigger_error('Method getConfigurationByRootPageId is deprecated since EXT:solr 10 and will be removed in v11, use Site object/SiteRepository directly.', E_USER_DEPRECATED);
+
         try {
             $site = $this->siteRepository->getSiteByRootPageId($pageId);
             return $site->getSolrConnectionConfiguration($language);
@@ -223,6 +227,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function getAllConfigurations()
     {
+        trigger_error('Method getAllConfigurations is deprecated since EXT:solr 10 and will be removed in v11, use Site object/SiteRepository directly.', E_USER_DEPRECATED);
+
         $solrConfigurations = [];
         foreach ($this->siteRepository->getAvailableSites() as $site) {
             foreach ($site->getAllSolrConnectionConfigurations() as $solrConfiguration) {
@@ -241,6 +247,8 @@ class ConnectionManager implements SingletonInterface
      */
     protected function setAllConfigurations(array $solrConfigurations)
     {
+        trigger_error('Method setAllConfigurations is deprecated since EXT:solr 10 and will be removed in v11, use Site object/SiteRepository directly.', E_USER_DEPRECATED);
+
         /** @var $registry Registry */
         $registry = GeneralUtility::makeInstance(Registry::class);
         $registry->set('tx_solr', 'servers', $solrConfigurations);
@@ -272,6 +280,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function getConfigurationsBySite(Site $site)
     {
+        trigger_error('Method getConfigurationsBySite is deprecated since EXT:solr 10 and will be removed in v11, use $site->getAllSolrConnectionConfigurations()', E_USER_DEPRECATED);
+
         return $site->getAllSolrConnectionConfigurations();
     }
 
@@ -301,6 +311,7 @@ class ConnectionManager implements SingletonInterface
      */
     public function updateConnections()
     {
+        trigger_error('Method updateConnections is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
 
         $solrConnections = $this->getConfiguredSolrConnections();
         $solrConnections = $this->filterDuplicateConnections($solrConnections);
@@ -318,6 +329,8 @@ class ConnectionManager implements SingletonInterface
      */
     public function updateConnectionByRootPageId($rootPageId)
     {
+        trigger_error('Method updateConnectionByRootPageId is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
+
         $systemLanguages = $this->systemLanguageRepository->findSystemLanguages();
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByRootPageId($rootPageId);
@@ -347,6 +360,8 @@ class ConnectionManager implements SingletonInterface
      */
     protected function getConfiguredSolrConnections()
     {
+        trigger_error('Method getConfiguredSolrConnections is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
+
         $configuredSolrConnections = [];
         // find website roots and languages for this installation
         $rootPages = $this->pagesRepositoryAtExtSolr->findAllRootPages();
@@ -376,6 +391,8 @@ class ConnectionManager implements SingletonInterface
      */
     protected function getConfiguredSolrConnectionByRootPage(array $rootPage, $languageId)
     {
+        trigger_error('Method getConfiguredSolrConnectionByRootPage is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
+
         $connection = [];
 
         $languageId = (int)$languageId;
@@ -471,6 +488,8 @@ class ConnectionManager implements SingletonInterface
      */
     protected function filterDuplicateConnections(array $connections)
     {
+        trigger_error('Method filterDuplicateConnections is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
+
         $hashedConnections = [];
         $filteredConnections = [];
 

--- a/Classes/Domain/Site/LegacySite.php
+++ b/Classes/Domain/Site/LegacySite.php
@@ -60,6 +60,8 @@ class LegacySite extends Site
      */
     public function __construct(TypoScriptConfiguration $configuration, array $page, $domain, $siteHash, PagesRepository $pagesRepository = null, $defaultLanguageId = 0, $availableLanguageIds = [])
     {
+        trigger_error('Using legacy sites is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
+
         $this->configuration = $configuration;
         $this->rootPage = $page;
         $this->domain = $domain;

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -119,6 +119,8 @@ abstract class Site implements SiteInterface
      */
     public function getRootPageLanguageIds() : array
     {
+        trigger_error('Method getRootPageLanguageIds is deprecated since EXT:solr 10 and will be removed in v11, use getAvailableLanguageIds instead', E_USER_DEPRECATED);
+
         $rootPageLanguageIds = [];
         $rootPageId = $this->getRootPageId();
 
@@ -268,9 +270,15 @@ abstract class Site implements SiteInterface
         $configs = [];
         foreach ($this->getAvailableLanguageIds() as $languageId) {
             try {
-                $configs[] = $this->getSolrConnectionConfiguration($languageId);
+                $configs[$languageId] = $this->getSolrConnectionConfiguration($languageId);
             } catch (NoSolrConnectionFoundException $e) {}
         }
         return $configs;
     }
+
+    /**
+     * @param int $languageId
+     * @return array
+     */
+    abstract function getSolrConnectionConfiguration(int $language = 0): array;
 }

--- a/Classes/System/Records/SystemDomain/SystemDomainRepository.php
+++ b/Classes/System/Records/SystemDomain/SystemDomainRepository.php
@@ -38,11 +38,14 @@ class SystemDomainRepository extends AbstractRepository
     /**
      * Retrieves sys_domain records for a set of root page ids.
      *
+     * @deprecated This class is deprecated since EXT:solr 10 and will be removed in EXT:solr 11 since then only the site handling configuration will be supported
      * @param array $rootPageIds
      * @return mixed
      */
     public function findDomainRecordsByRootPagesIds(array $rootPageIds = [])
     {
+        trigger_error('You are using EXT:solr without sitehandling. This setup is deprecated and will be removed in EXT:solr 11', E_USER_DEPRECATED);
+
         $resultTmp = $this->getDomainRecordsByRootPageIds($rootPageIds);
 
         $result = [];


### PR DESCRIPTION
# What this pr does

* Add's the deprecation log message for methods that have been marked as deprecated with the introduction of the site handling
* Migrate the unit tests to use the site handling logic
* Fixed getAvailableSites to respect legacy sites and TYPO3 managed sites

# How to test

* Check if getAvailableSites returns all configured sites

Fixes: #2368
