### PR TITLE
[BUGFIX] do not index hidden Frontend Languages (#2391)

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -429,7 +429,7 @@ class SiteRepository
         $pageRepository = GeneralUtility::makeInstance(PagesRepository::class);
         $availableLanguageIds = array_map(function($language) {
             return $language->getLanguageId();
-        }, $typo3Site->getAllLanguages());
+        }, $typo3Site->getLanguages());
 
         $solrConnectionConfigurations = [];
         foreach ($availableLanguageIds as $languageUid) {


### PR DESCRIPTION
# What this pr does

Languages set to "disabeld in Frontend" in Site Handling Configuration should not be tried to indexed.

# How to test

- create a Frontend-Page in the Site Module and disable "Visible in Frontend "
- Try to index that Page results in an Error


Fixes: #2391
