### PR TITLE
[TASK] add a Flag in Site Configuration to disable Solr  (#2398)

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -114,7 +114,7 @@ class IndexQueueModuleController extends AbstractModuleController
      */
     protected function canQueueSelectedSite()
     {
-        if ($this->selectedSite === null) {
+        if ($this->selectedSite === null || empty($this->solrConnectionManager->getConnectionsBySite($this->selectedSite))) {
             return false;
         }
         $enabledIndexQueueConfigurationNames = $this->selectedSite->getSolrConfiguration()->getEnabledIndexQueueConfigurationNames();

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -439,38 +439,42 @@ class SiteRepository
         }, $typo3Site->getLanguages());
 
         $solrConnectionConfigurations = [];
-        foreach ($availableLanguageIds as $languageUid) {
-            $solrConnectionConfigurations[$languageUid] = [
-                'connectionKey' =>  $rootPageRecord['uid'] . '|' . $languageUid,
-                'rootPageTitle' => $rootPageRecord['title'],
-                'rootPageUid' => $rootPageRecord['uid'],
-                'read' => [
-                    'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'read', 'http'),
-                    'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'read', 'localhost'),
-                    'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'read', 8983),
-                    // @todo: transform core to path
-                    'path' =>
-                        SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
-                        SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read', 'core_en') . '/' ,
-                    'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'read', ''),
-                    'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'read', ''),
-                    'timeout' => SiteUtility::getConnectionProperty($typo3Site, 'timeout', $languageUid, 'read', 0)
-                ],
-                'write' => [
-                    'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'write', 'http'),
-                    'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'write', 'localhost'),
-                    'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'write', 8983),
-                    // @todo: transform core to path
-                    'path' =>
-                        SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
-                        SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read', 'core_en') . '/' ,
-                    'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'write', ''),
-                    'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'write', ''),
-                    'timeout' => SiteUtility::getConnectionProperty($typo3Site, 'timeout', $languageUid, 'write', 0)
-                ],
 
-                'language' => $languageUid
-            ];
+        foreach ($availableLanguageIds as $languageUid) {
+            $solrEnabled = SiteUtility::getConnectionProperty($typo3Site, 'enabled', $languageUid, 'read', true);
+            if ($solrEnabled) {
+                $solrConnectionConfigurations[$languageUid] = [
+                    'connectionKey' =>  $rootPageRecord['uid'] . '|' . $languageUid,
+                    'rootPageTitle' => $rootPageRecord['title'],
+                    'rootPageUid' => $rootPageRecord['uid'],
+                    'read' => [
+                        'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'read', 'http'),
+                        'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'read', 'localhost'),
+                        'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'read', 8983),
+                        // @todo: transform core to path
+                        'path' =>
+                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
+                            SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read', 'core_en') . '/' ,
+                        'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'read', ''),
+                        'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'read', ''),
+                        'timeout' => SiteUtility::getConnectionProperty($typo3Site, 'timeout', $languageUid, 'read', 0)
+                    ],
+                    'write' => [
+                        'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'write', 'http'),
+                        'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'write', 'localhost'),
+                        'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'write', 8983),
+                        // @todo: transform core to path
+                        'path' =>
+                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
+                            SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read', 'core_en') . '/' ,
+                        'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'write', ''),
+                        'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'write', ''),
+                        'timeout' => SiteUtility::getConnectionProperty($typo3Site, 'timeout', $languageUid, 'write', 0)
+                    ],
+
+                    'language' => $languageUid
+                ];
+            }
         }
 
         return GeneralUtility::makeInstance(

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -25,7 +25,7 @@ namespace ApacheSolrForTypo3\Solr\System\Util;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Util;
+
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -90,21 +90,27 @@ class SiteUtility
         $languageSpecificConfiguration = $typo3Site->getLanguageById($languageId)->toArray();
         $value = self::getValueOrFallback($languageSpecificConfiguration, $keyToCheck, $fallbackKey);
 
-        if (!empty($value)) {
+        if ($value !== null) {
             return $value;
         }
 
         // if not found check global configuration
         $siteBaseConfiguration = $typo3Site->getConfiguration();
 
-        return self::getValueOrFallback($siteBaseConfiguration, $keyToCheck, $fallbackKey) ?: $defaultValue;
+        $value = self::getValueOrFallback($siteBaseConfiguration, $keyToCheck, $fallbackKey);
+        if ($value === null) {
+            return $defaultValue;
+        }
+        return $value;
+
+
     }
 
     /**
      * @param array $data
      * @param string $keyToCheck
      * @param string $fallbackKey
-     * @return string|null
+     * @return string|bool|null
      */
     protected static function getValueOrFallback(array $data, string $keyToCheck, string $fallbackKey)
     {

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -4,6 +4,22 @@
  * Global Solr Connection Settings
  */
 
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_enabled_read'] = [
+    'label' => 'Enable Solr for this site',
+    'onChange' => 'reload',
+    'config' => [
+        'type' => 'check',
+        'renderType' => 'checkboxToggle',
+        'default' => 1,
+        'items' => [
+            [
+                0 => '',
+                1 => ''
+            ]
+        ]
+    ],
+];
+
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'] = [
     'label' => 'Scheme',
     'config' => [
@@ -17,6 +33,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'] = [
         'minitems' => 0,
         'maxitems' => 1
     ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1'
 ];
 
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_host_read'] = [
@@ -27,6 +44,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_host_read'] = [
         'placeholder' => 'localhost',
         'size' => 10
     ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1'
 ];
 
 
@@ -38,6 +56,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
         'size' => 5,
         'default' => 8983
     ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1'
 ];
 
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'] = [
@@ -47,6 +66,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'] = [
         'eval' => 'required',
         'default' => '/solr/'
     ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1'
 ];
 
 
@@ -64,6 +84,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = 
             ]
         ]
     ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1'
 ];
 
 
@@ -87,7 +108,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_write']['displayCond
 $GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read, solr_host_read, solr_port_read, solr_path_read';
 $GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write, solr_host_write, solr_port_write, solr_path_write';
 
-$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;Solr,--palette--;;solr_read, solr_use_write_connection,--palette--;;solr_write';
+$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;Solr,solr_enabled_read,--palette--;;solr_read, solr_use_write_connection,--palette--;;solr_write';
 
 
 /**
@@ -141,7 +162,7 @@ $GLOBALS['SiteConfiguration']['site_language']['columns']['solr_core_read'] = [
             ],
         ],
         'placeholder' => 'core_*',
-    ],
+    ]
 ];
 
 $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -70,6 +70,7 @@ class SiteRepositoryTest extends UnitTest
 
     public function setUp()
     {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
         $this->rootPageResolverMock = $this->getDumbMock(RootPageResolver::class);
         $this->registryMock = $this->getDumbMock(Registry::class);


### PR DESCRIPTION

# What this pr does

* add a Flag in Site Configuration to disable Solr for one whole Site
* by editing the YML Site Configuration File you can also disable Solr per Site-Language
* initialize EXTENSION Configuration array for Unit-Test

# How to test

disable Solr in one Site, all Solr-BE-Modules should show the "solr is not configured" message

Fixes: #2398 
