### PR TITLE
[BUGFIX] Fix skipped tests in search controller test

### DIFF
--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -56,6 +56,8 @@ class SiteHashService
         } elseif ($allowedSitesConfiguration === '*') {
             return '*';
         } else {
+            // we thread empty allowed site configurations as __solr_current_site since this is the default behaviour
+            $allowedSitesConfiguration = empty($allowedSitesConfiguration) ? '__solr_current_site' : $allowedSitesConfiguration;
             return $this->getDomainByPageIdAndReplaceMarkers($pageId, $allowedSitesConfiguration);
         }
     }

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -624,15 +624,12 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canFacetOnHierarchicalTextCategory()
     {
-        $this->markTestSkipped('Need to be checked');
         $this->importDataSetFromFixture('can_render_path_facet_with_search_controller.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
 
         $this->indexPages([1, 2, 3]);
-
         // we should have 3 documents in solr
         $solrContent = file_get_contents('http://localhost:8999/solr/core_en/select?q=*:*');
-        echo $solrContent;
         $this->assertContains('"numFound":3', $solrContent, 'Could not index document into solr');
 
         // but when we facet on the categoryPaths:/Men/Shoes \/ Socks/ we should only have one result since the others
@@ -1011,14 +1008,14 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canRenderDetailAction()
     {
-        $this->markTestSkipped('Fixme');
         $request = $this->getPreparedRequest('Search', 'detail');
-        $request->setArgument('documentId', '23c51a0d5cf548afecc043a7068902e8f82a22a0/pages/1/0/0/0');
+        $request->setArgument('documentId', '002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0');
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
 
         $this->indexPages([1, 2]);
+
         $this->searchController->processRequest($request, $this->searchResponse);
         $this->assertContains("Products", $this->searchResponse->getContent());
     }

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -45,7 +45,9 @@ class SiteHashServiceTest extends UnitTest
         return [
             'siteHashDisabled' => ['*', '*'],
             'allSitesInSystem' => ['__all', 'solrtesta.local,solrtestb.local'],
-            'currentSiteOnly' => ['__current_site', 'solrtesta.local']
+            'currentSiteOnly' => ['__current_site', 'solrtesta.local'],
+            'emptyIsFallingBackToCurrentSiteOnly' => ['', 'solrtesta.local'],
+            'nullIsFallingBackToCurrentSiteOnly' => [null, 'solrtesta.local']
         ];
     }
 


### PR DESCRIPTION
# What this pr does

* Fixes canRenderDetailAction by adapting the hash in the test to a valid hash
* Fixes canFacetOnHierarchicalTextCategory by fixing a bug in the SiteHashService. When the setting "query.allowedSites" is not defined at all, it should use ```__solr_current_site```
as defined in the documentation. Previously the hash was calculated over an empty string, what accidentally matched on an undefined domain

# How to test

* All tests are green
* query.allowedSites can be used as documented

Related: #2397

