### PR TITLE
[TASK] Label template "Use connections settings from TYPO3_CONF_VARS" as deprecated

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -38,7 +38,7 @@
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/ConnectionFromConfVars/',
-    'Search - (Example) Use connection settings from TYPO3_CONF_VARS');
+    'Deprecated: Search - (Example) Use connection settings from TYPO3_CONF_VARS');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('solr',
     'Configuration/TypoScript/Examples/Suggest/',
     'Search - (Example) Suggest/autocomplete with jquery');


### PR DESCRIPTION
# What this pr does

* Labels the TypoScript example template to use TYPO3_CONV_VARS as deprecated

# How to test

* Label is prefixed with "Deprecated:" in the TypoScript object browser

Fixes: #2405

