### PR TITLE
[TASK] Only register updateConnections command with active legacy mode

### DIFF
--- a/Classes/Command/SolrCommandController.php
+++ b/Classes/Command/SolrCommandController.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
 
 /**
  * Controller to run solr specific tasks via CLI
+ * @todo @deprecated This class can be dropped when legacy support will be dropped
  * @extensionScannerIgnoreFile
  */
 class SolrCommandController extends CommandController

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -184,8 +184,16 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 }
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
-// @extensionScannerIgnoreLine
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \ApacheSolrForTypo3\Solr\Command\SolrCommandController::class;
+/* @var \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration $extensionConfiguration */
+$extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+    \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration::class
+);
+
+if ($extensionConfiguration->getIsAllowLegacySiteModeEnabled()) {
+    // @todo @deprecated this can be removed when legacyMode is dropped
+    // @extensionScannerIgnoreLine
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \ApacheSolrForTypo3\Solr\Command\SolrCommandController::class;
+}
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 


### PR DESCRIPTION
# What this pr does

* Only register the updateConnections command when the legacy mode is active

# How to test

* The updateConnections command is only available when legacy mode is active

Fixes: #2406
