### PR TITLE
[TASK] evaluate Integr./Con.ManagerTest skipped tests and reenable them

### DIFF
--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -27,7 +27,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use Nimut\TestingFramework\Exception\Exception;
+use ReflectionException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use function vsprintf;
 
 /**
  * This testcase can be used to check if the ConnectionManager can be used
@@ -38,9 +41,195 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class ConnectionManagerTest extends IntegrationTest
 {
 
+    public function setUp()
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+    }
+
+    /**
+     * @return array
+     */
+    public function  canFindSolrConnectionsByRootPageIdDataProvider()
+    {
+        return [
+            ['rootPageId' => 1, 'siteName' => 'integration_tree_one', 'expectedSolrHost' => 'solr.testone.endpoint'],
+            ['rootPageId' => 111, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint']
+        ];
+    }
+
+    /**
+     * ConnectionManager can find connection by root page ID (1 and then 111).
+     * There is following scenario:
+     *
+     * [0]
+     *  |
+     *  ——[ 1] First site
+     *  |
+     *  ——[111] Second site
+     *
+     * @test
+     * @dataProvider canFindSolrConnectionsByRootPageIdDataProvider
+     *
+     * @param int $rootPageId
+     * @param string $siteName
+     * @param string $expectedSolrHost
+     * @throws NoSolrConnectionFoundException
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function canFindSolrConnectionsByRootPageId(int $rootPageId, string $siteName, string $expectedSolrHost)
+    {
+        $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
+        $this->importDataSetFromFixture('ConnectionManagerTest_basic_connections.xml');
+
+        /** @var $connectionManager ConnectionManager */
+        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+
+        foreach ([0,1,2] as $languageID) {
+            $solrService = $connectionManager->getConnectionByRootPageId($rootPageId, $languageID);
+            $this->assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for root page "%s" and language "%s"', [$rootPageId, $languageID]));
+            $this->assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
+                ' Wrong connection is used. I expected "%s" as Host for "%s" Site with Root-Page ID "%".', [$expectedSolrHost, $siteName, $rootPageId]));
+        }
+    }
+
+
+    /**
+     * @return array
+     */
+    public function  canFindSolrConnectionsByPageIdDataProvider()
+    {
+        return [
+            ['pageId' => 11, 'siteName' => 'integration_tree_one', 'expectedSolrHost' => 'solr.testone.endpoint'],
+            ['ageId' => 21, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint']
+        ];
+    }
+
+    /**
+     * The connection manager must find the connections for Root Pages 1 and 111,
+     * by some of page IDs in desired tree(connection for 1 by 11, for 111 by 21).
+     * There is following scenario:
+     *
+     * [0]
+     *  |
+     *  ——[ 1] First site
+     *  |   |
+     *  |   ——[11] Subpage of first site
+     *  |
+     *  ——[111] Second site
+     *  |  |
+     *  |  ——[21] Subpage of second site
+     *  |
+     *  ——[ 3] Detached and non Root Page-Tree
+     *      |
+     *      —— [31] Subpage 1 of Detached
+     *      |
+     *      —— [32] Subpage 2 of Detached
+     *
+     * @test
+     * @dataProvider canFindSolrConnectionsByPageIdDataProvider
+     *
+     * @param int $rootPageId
+     * @param string $siteName
+     * @param string $expectedSolrHost
+     * @throws NoSolrConnectionFoundException
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function canFindSolrConnectionsByPageId(int $pageId, string $siteName, string $expectedSolrHost)
+    {
+        $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
+        $this->importDataSetFromFixture('ConnectionManagerTest_basic_connections.xml');
+
+        /** @var $connectionManager ConnectionManager */
+        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+
+        foreach ([0,1,2] as $languageID) {
+            $solrService = $connectionManager->getConnectionByPageId($pageId, $languageID);
+            $this->assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for page id "%s" and language "%s"', [$pageId, $languageID]));
+            $this->assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
+                ' Wrong connection is used. I expected "%s" as Host for "%s" Site with Root-Page ID "%".', [$expectedSolrHost, $siteName, $pageId]));
+        }
+    }
+
+    /**
+     * There is following scenario for setup, the remaining stuff happens in test methods.:
+     *
+     * [0]
+     *  |
+     *  ——[ 3] Detached and non Root Page-Tree
+     *      |
+     *      —— [31] Subpage 1 of Detached
+     *      |
+     *      —— [32] Subpage 2 of Detached
+     */
+    protected function setupNotFullyConfiguredSite()
+    {
+        $defaultLanguage = $this->buildDefaultLanguageConfiguration('EN', '/en/');
+        $german = $this->buildLanguageConfiguration('DE', '/de/');
+        $danish = $this->buildLanguageConfiguration('DA', '/da/');
+        $this->writeSiteConfiguration(
+            'integration_tree_three',
+            $this->buildSiteConfiguration(3, 'http://testthree.site/'),
+            [
+                $defaultLanguage, $german, $danish
+            ],
+            [
+                $this->buildErrorHandlingConfiguration('Fluid', [404])
+            ]
+        );
+    }
+
+    /**
+     * The connection manager must throw an exception on configured site without solr connection information by trying to get connection by root page id.
+     * There is following scenario:
+     *
+     * [0]
+     *  |
+     *  ——[ 3] Detached and non Root Page-Tree
+     *
+     * @test
+     */
+    public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByRootPageId()
+    {
+        $this->setupNotFullyConfiguredSite();
+
+        $this->expectException(NoSolrConnectionFoundException::class);
+        /** @var $connectionManager ConnectionManager */
+        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+        $connectionManager->getConnectionByRootPageId(3);
+
+        $this->expectException(NoSolrConnectionFoundException::class);
+        $connectionManager->getConnectionByPageId(31);
+    }
+
+    /**
+     * The connection manager must throw an exception on configured site without solr connection information by trying to get connection by page id.
+     * There is following scenario:
+     *
+     * [0]
+     *  |
+     *   ——[ 3] Detached and non Root Page-Tree
+     *       |
+     *       —— [31] Subpage 1 of Detached
+     *       |
+     *       —— [32] Subpage 2 of Detached
+     *
+     * @test
+     */
+    public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByPageId()
+    {
+        $this->setupNotFullyConfiguredSite();
+
+        $this->expectException(NoSolrConnectionFoundException::class);
+        /** @var $connectionManager ConnectionManager */
+        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+        $connectionManager->getConnectionByPageId(31);
+    }
+
     /**
      * ConnectionManager must use the connection for site(tree), where mount Point is defined.
-     *
      * There is following scenario:
      *
      *     [0]
@@ -61,8 +250,6 @@ class ConnectionManagerTest extends IntegrationTest
      */
     public function canFindSolrConnectionForMountedPageIfMountPointIsGiven()
     {
-        $this->markTestSkipped('Fixme');
-
         $this->importDataSetFromFixture('can_find_connection_for_mouted_page.xml');
 
         /** @var $connectionManager ConnectionManager */
@@ -73,31 +260,5 @@ class ConnectionManagerTest extends IntegrationTest
 
         $solrService1 = $connectionManager->getConnectionByPageId(25, 0, '24-14');
         $this->assertInstanceOf(SolrConnection::class, $solrService1, 'Should find solr connection for level 1 of mounted page.');
-    }
-
-    /**
-     * @test
-     */
-    public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConfigurationByRootPageId()
-    {
-        $this->markTestSkipped('Fixme');
-
-        $this->expectException(NoSolrConnectionFoundException::class);
-
-        /** @var $connectionManager ConnectionManager */
-        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
-        $connectionManager->getConfigurationByRootPageId(4711);
-    }
-
-    /**
-     * @test
-     */
-    public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByPageId()
-    {
-        $this->expectException(NoSolrConnectionFoundException::class);
-
-        /** @var $connectionManager ConnectionManager */
-        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
-        $connectionManager->getConnectionByPageId(888);
     }
 }

--- a/Tests/Integration/Fixtures/ConnectionManagerTest_basic_connections.xml
+++ b/Tests/Integration/Fixtures/ConnectionManagerTest_basic_connections.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+<!--
+There is following scenario:
+
+ [0]
+  |
+  ——[ 1] First site
+  |   |
+  |   ——[11] Subpage of first site
+  |
+  ——[111] Second site
+  |   |
+  |   ——[21] Subpage of second site
+  |
+  ——[ 3] Detached and non Root Page-Tree
+      |
+      —— [31] Subpage 1 of Detached
+      |
+      —— [32] Subpage 2 of Detached
+-->
+
+    <!-- Site tree for first site -->
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+                    enabled = 1
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>First site</title>
+    </pages>
+        <pages>
+            <uid>11</uid>
+            <pid>1</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Subpage of first site</title>
+            <TSconfig/>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+
+    <!-- Site tree for secod site -->
+    <sys_template>
+        <uid>111</uid>
+        <pid>111</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+                    enabled = 1
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>111</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Second site</title>
+    </pages>
+        <pages>
+            <uid>21</uid>
+            <pid>111</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Subpage of second site</title>
+            <TSconfig/>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+
+
+    <!-- detached and non Root Page-Tree -->
+    <pages>
+        <uid>3</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>0</pid>
+        <title>Detached and non Root Page-Tree</title>
+    </pages>
+        <pages>
+            <uid>31</uid>
+            <pid>3</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Subpage 1 of Detached</title>
+            <TSconfig/>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+        <pages>
+            <uid>32</uid>
+            <pid>3</pid>
+            <is_siteroot>0</is_siteroot>
+            <doktype>7</doktype>
+            <mount_pid>24</mount_pid>
+            <mount_pid_ol>1</mount_pid_ol>
+            <title>Subpage 2 of Detached</title>
+            <TSconfig/>
+            <content_from_pid>0</content_from_pid>
+            <tsconfig_includes/>
+        </pages>
+</dataset>


### PR DESCRIPTION
* use default test site configuration for integration tests
* implement tests for `getConnectionBy*`
* replace `exceptionIsThrownForUnAvailableSolrConnectionOnGetConfigurationByRootPageId` with:
  * `exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByRootPageId`
  * `exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByPageId`

Fixes: #2401 
