### PR TITLE
[BUGFIX] keep rootPageId as array_key, fix tests (#2414)

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -152,18 +152,20 @@ class SiteRepository
     {
         $cacheId = 'SiteRepository' . '_' . 'getAvailableSites';
 
-        $methodResult = $this->runtimeCache->get($cacheId);
-        if (!empty($methodResult)) {
-            return $methodResult;
+        $sites = $this->runtimeCache->get($cacheId);
+        if (!empty($sites)) {
+            return $sites;
         }
 
-        $legacySites = $this->extensionConfiguration->getIsAllowLegacySiteModeEnabled() ? $this->getAvailableLegacySites($stopOnInvalidSite) : [];
-        $typo3ManagedSolrSites = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        if ($this->extensionConfiguration->getIsAllowLegacySiteModeEnabled()) {
+            $sites = $this->getAvailableLegacySites($stopOnInvalidSite);
+        } else {
+            $sites = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        }
 
-        $methodResult = array_merge($legacySites, $typo3ManagedSolrSites);
-        $this->runtimeCache->set($cacheId, $methodResult);
+        $this->runtimeCache->set($cacheId, $sites);
 
-        return $methodResult;
+        return $sites;
     }
 
     /**

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -49,6 +49,7 @@ class SolrConfigurationStatusTest extends UnitTest
     protected $systemDomainRepository;
 
     public function setUp() {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         // we mock the methods to external dependencies.
         $this->systemDomainRepository = $this->getMockBuilder(SystemDomainRepository::class)->setMethods(
             ['findDomainRecordsByRootPagesIds']


### PR DESCRIPTION
# What this pr does

keeps the rootPageId as array_keys in when fetching available Sites
Fix Creation of Scheduler Task
Fix Unit-Tests for SolrConfigurationStatus

# How to test

create a new Scheduler Task, Reindex Site and/or Index Queue Worker

Fixes: #2414
