### PR TITLE
[BUGFIX] Use requested page uid in info module

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -259,7 +259,7 @@ class InfoModuleController extends AbstractModuleController
         $documentsByCoreAndType = [];
         foreach ($solrCoreConnections as $languageId => $solrCoreConnection) {
             $coreAdmin = $solrCoreConnection->getAdminService();
-            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->selectedPageUID, $languageId);
+            $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->requestedPageUID, $languageId);
 
             $documentsByType = [];
             foreach ($documents as $document) {


### PR DESCRIPTION
# What this pr does

Make sure always to use the page uid from selected pagein pagetree when fetching indexed documents in the backend info module.

# How to test

1. Setup TYPO3 9.5 instance iwth one site configuration
2. Using current master, create 2 pages with content
3. Index both pages
4. Switch to Solr info module and go for the tab "Index Documents"
5. Before this patch, you will always get the documents from the root page, now you will get the documents for current page

Fixes: #2425 