### PR TITLE
[TASK] Queue initialization with mountpoints

### DIFF
--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
@@ -123,7 +123,7 @@ There is following scenario:
 
     <!-- Second Site tree -->
     <pages>
-        <uid>2</uid>
+        <uid>111</uid>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
         <pid>0</pid>
@@ -131,7 +131,7 @@ There is following scenario:
     </pages>
     <pages>
         <uid>34</uid>
-        <pid>2</pid>
+        <pid>111</pid>
         <is_siteroot>0</is_siteroot>
         <doktype>7</doktype>
         <mount_pid>24</mount_pid>

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -117,7 +117,6 @@ class PageTest extends IntegrationTest
      */
     public function initializerIsFillingQueueWithMountPages()
     {
-        $this->markTestSkipped('Fixme');
         $this->importDataSetFromFixture('can_add_mount_pages.xml');
 
         $this->assertEmptyQueue();
@@ -152,8 +151,6 @@ class PageTest extends IntegrationTest
      */
     public function initializerIsFillingQueueWithMountedNonRootPages()
     {
-        $this->markTestSkipped('Fixme');
-
         $this->importDataSetFromFixture('mouted_shared_non_root_page_from_different_tree_can_be_indexed.xml');
         $this->assertEmptyQueue();
         $this->initializeAllPageIndexQueues();
@@ -188,8 +185,6 @@ class PageTest extends IntegrationTest
      */
     public function initializerIsFillingQueueWithMountedRootPages()
     {
-        $this->markTestSkipped('Fixme');
-
         $this->importDataSetFromFixture('mouted_shared_root_page_from_different_tree_can_be_indexed.xml');
         $this->assertEmptyQueue();
         $this->initializeAllPageIndexQueues();
@@ -228,8 +223,6 @@ class PageTest extends IntegrationTest
      */
     public function initializerIsFillingQueuesWithMultipleSitesMounted()
     {
-        $this->markTestSkipped('Fixme');
-
         $this->importDataSetFromFixture('mouted_shared_page_from_multiple_trees_can_be_queued.xml');
         $this->assertEmptyQueue();
         $this->initializeAllPageIndexQueues();
@@ -240,7 +233,7 @@ class PageTest extends IntegrationTest
         $this->assertTrue($this->indexQueue->containsItem('pages', 14));
         $this->assertTrue($this->indexQueue->containsItem('pages', 24));
 
-        $this->assertTrue($this->indexQueue->containsItem('pages', 2));
+        $this->assertTrue($this->indexQueue->containsItem('pages', 111));
         $this->assertTrue($this->indexQueue->containsItem('pages', 34));
 
         $items = $this->indexQueue->getItems('pages', 24);
@@ -260,8 +253,6 @@ class PageTest extends IntegrationTest
      */
     public function initializerAddsInfoMessagesAboutInvalidMountPages()
     {
-        $this->markTestSkipped('Fixme');
-
         $this->importDataSetFromFixture('can_add_mount_pages.xml');
 
         $this->assertEmptyQueue();


### PR DESCRIPTION
This merge request:

* Fixes the broken tests when mounted pages get initialized with the index queue

Note:

* There are still related issues in the TYPO3 core for cross domain mount points with TYPO3 9.5 (https://review.typo3.org/c/Packages/TYPO3.CMS/+/59915)

Fixes: #2396