### PR TITLE
[TASK] Fix failing PageIndexerTest

### DIFF
--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -234,7 +234,6 @@ class PageIndexerTest extends IntegrationTest
      */
     public function canExecuteAdditionalPageIndexer()
     {
-        $this->markTestSkipped('Need to be checked');
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageAddDocuments']['TestAdditionalPageIndexer'] = TestAdditionalPageIndexer::class;
 
         $this->importDataSetFromFixture('can_index_into_solr.xml');

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
@@ -18,12 +18,11 @@ class TestAdditionalPageIndexer implements AdditionalPageIndexer {
     {
         $secondDocument = clone $pageDocument;
 
-        $id = $pageDocument->getField('id');
+        $id = $pageDocument['id'];
         $copyId = $id['value'] . '-copy';
 
         $secondDocument->setField('id', $copyId);
         $secondDocument->setField('custom_stringS', 'additional text');
-
         return [$secondDocument];
     }
 }


### PR DESCRIPTION
# What this pr does

* Fixed the failing test by replacing the usage of the deprecated method getField with the usage of ['fieldName']

# How to test

Check if this test is executed in the travis-ci pipeline and green

Fixes:  #2437
