### PR TITLE
[BUGFIX] Fix no search available tests

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -133,12 +133,7 @@ class ConnectionManager implements SingletonInterface
             return $site->getSolrConnectionConfiguration($language);
         } catch(InvalidArgumentException $e) {
             /* @var NoSolrConnectionFoundException $noSolrConnectionException */
-            $noSolrConnectionException = GeneralUtility::makeInstance(
-                NoSolrConnectionFoundException::class,
-                /** @scrutinizer ignore-type */  'Could not find a Solr connection for page [' . $pageId. '] and language [' . $language . '].',
-                /** @scrutinizer ignore-type */ 1575396474
-            );
-            $noSolrConnectionException->setLanguageId($language);
+            $noSolrConnectionException = $this->buildNoConnectionException($pageId, $language);
             throw $noSolrConnectionException;
         }
     }
@@ -161,13 +156,7 @@ class ConnectionManager implements SingletonInterface
 
             return $solrConnection;
         } catch(InvalidArgumentException $e) {
-            /* @var NoSolrConnectionFoundException $noSolrConnectionException */
-            $noSolrConnectionException = GeneralUtility::makeInstance(
-                NoSolrConnectionFoundException::class,
-                /** @scrutinizer ignore-type */  'Could not find a Solr connection for page [' . $pageId. '] and language [' . $language . '].',
-                /** @scrutinizer ignore-type */ 1575396474
-            );
-            $noSolrConnectionException->setLanguageId($language);
+            $noSolrConnectionException = $this->buildNoConnectionException($pageId, $language);
             throw $noSolrConnectionException;
         }
     }
@@ -190,12 +179,7 @@ class ConnectionManager implements SingletonInterface
             return $site->getSolrConnectionConfiguration($language);
         } catch(InvalidArgumentException $e) {
             /* @var NoSolrConnectionFoundException $noSolrConnectionException */
-            $noSolrConnectionException = GeneralUtility::makeInstance(
-                NoSolrConnectionFoundException::class,
-                /** @scrutinizer ignore-type */  'Could not find a Solr connection for page [' . $pageId. '] and language [' . $language . '].',
-                /** @scrutinizer ignore-type */ 1575396474
-            );
-            $noSolrConnectionException->setLanguageId($language);
+            $noSolrConnectionException = $this->buildNoConnectionException($pageId, $language);
             throw $noSolrConnectionException;
         }
     }
@@ -528,5 +512,24 @@ class ConnectionManager implements SingletonInterface
         }
 
         return $filteredConnections;
+    }
+
+    /**
+     * @param $pageId
+     * @param $language
+     * @return NoSolrConnectionFoundException
+     */
+    protected function buildNoConnectionException($pageId, $language): NoSolrConnectionFoundException
+    {
+        /* @var NoSolrConnectionFoundException $noSolrConnectionException */
+        $noSolrConnectionException = GeneralUtility::makeInstance(
+            NoSolrConnectionFoundException::class,
+            /** @scrutinizer ignore-type */
+            'Could not find a Solr connection for page [' . $pageId . '] and language [' . $language . '].',
+            /** @scrutinizer ignore-type */
+            1575396474
+        );
+        $noSolrConnectionException->setLanguageId($language);
+        return $noSolrConnectionException;
     }
 }

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -34,6 +34,7 @@ use ApacheSolrForTypo3\Solr\System\Service\SiteService;
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -436,7 +437,11 @@ class SiteRepository
     {
         $solrConfiguration = Util::getSolrConfigurationFromPageId($rootPageRecord['uid']);
         /** @var \TYPO3\CMS\Core\Site\Entity\Site $typo3Site */
-        $typo3Site = $this->siteFinder->getSiteByPageId($rootPageRecord['uid']);
+        try {
+            $typo3Site = $this->siteFinder->getSiteByPageId($rootPageRecord['uid']);
+        } catch (SiteNotFoundException $e) {
+            throw new \InvalidArgumentException("No site found with uid ". intval($rootPageRecord['uid']));
+        }
         $domain = $typo3Site->getBase()->getHost();
 
         $siteHash = $this->getSiteHashForDomain($domain);

--- a/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
+++ b/Tests/Integration/Controller/Fixtures/can_render_error_message_when_solr_unavailable.xml
@@ -3,7 +3,7 @@
 
     <sys_template>
         <uid>1</uid>
-        <pid>333</pid>
+        <pid>1</pid>
         <root>1</root>
         <clear>3</clear>
         <config>
@@ -300,7 +300,7 @@
         <static_file_mode>0</static_file_mode>
     </sys_template>
     <pages>
-        <uid>333</uid>
+        <uid>1</uid>
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
         <title>Products</title>

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -713,9 +713,12 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function frontendWillRenderErrorMessageForSolrNotAvailableAction()
     {
-        $this->markTestSkipped('Fixme');
+        $this->applyUsingErrorControllerForCMS9andAbove();
+
+        // set a wrong port where no solr is running
+        $this->writeDefaultSolrTestSiteConfigurationForHostAndPort('http','localhost', 4711);
         $this->importDataSetFromFixture('can_render_error_message_when_solr_unavailable.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 333);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
 
         $this->searchRequest->setControllerActionName('solrNotAvailable');
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
@@ -732,7 +735,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         return [
             ['action' => 'results', 'getArguments' =>['q' => '*']],
-            ['action' => 'detail', 'getArguments' =>['id' => 333]],
+            ['action' => 'detail', 'getArguments' =>['id' => 1]],
         ];
     }
 
@@ -744,13 +747,15 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function frontendWillForwardsToErrorActionWhenSolrEndpointIsNotAvailable($action, $getArguments)
     {
-        $this->markTestSkipped('Fixme');
+        $this->applyUsingErrorControllerForCMS9andAbove();
+        // set a wrong port where no solr is running
+        $this->writeDefaultSolrTestSiteConfigurationForHostAndPort('http','localhost', 4711);
         $this->expectException(StopActionException::class);
         $this->expectExceptionMessage('forward');
         $this->expectExceptionCode(1476045801);
 
         $this->importDataSetFromFixture('can_render_error_message_when_solr_unavailable.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 333);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
 
         $_GET = $getArguments;
         $this->searchRequest->setControllerActionName($action);


### PR DESCRIPTION
# What this pr does

* Fixes the SearchController tests that test the unavailability of solr
* Refactors the ConnectionManager by extracting the logic for the NoSolrConnection found exception

# How to test

All SearchController tests are now executed again
