### PR TITLE
[BUGFIX] Connection errors are not properly catched

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Controller;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestBuilder;
+use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Mvc\Controller\SolrControllerContext;
@@ -191,7 +192,10 @@ abstract class AbstractBaseController extends ActionController
         parent::initializeAction();
         $this->typoScriptFrontendController = $GLOBALS['TSFE'];
         $this->initializeSettings();
-        $this->initializeSearch();
+
+        if ($this->actionMethodName !== 'solrNotAvailableAction') {
+            $this->initializeSearch();
+        }
     }
 
     /**
@@ -217,14 +221,18 @@ abstract class AbstractBaseController extends ActionController
     protected function initializeSearch()
     {
         /** @var \ApacheSolrForTypo3\Solr\ConnectionManager $solrConnection */
-        $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($this->typoScriptFrontendController->id, Util::getLanguageUid(), $this->typoScriptFrontendController->MP);
-        $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
+        try {
+            $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($this->typoScriptFrontendController->id, Util::getLanguageUid(), $this->typoScriptFrontendController->MP);
+            $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
 
-        $this->searchService = GeneralUtility::makeInstance(
-            SearchResultSetService::class,
-            /** @scrutinizer ignore-type */ $this->typoScriptConfiguration,
-            /** @scrutinizer ignore-type */ $search
-        );
+            $this->searchService = GeneralUtility::makeInstance(
+                SearchResultSetService::class,
+                /** @scrutinizer ignore-type */ $this->typoScriptConfiguration,
+                /** @scrutinizer ignore-type */ $search
+            );
+        } catch (NoSolrConnectionFoundException $e) {
+            $this->handleSolrUnavailable();
+        }
     }
 
     /**

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -433,14 +433,14 @@ class SiteRepository
      * @param array $rootPageRecord
      * @return Typo3ManagedSite
      */
-    protected function buildTypo3ManagedSite(array $rootPageRecord): Typo3ManagedSite
+    protected function buildTypo3ManagedSite(array $rootPageRecord): ?Typo3ManagedSite
     {
         $solrConfiguration = Util::getSolrConfigurationFromPageId($rootPageRecord['uid']);
         /** @var \TYPO3\CMS\Core\Site\Entity\Site $typo3Site */
         try {
             $typo3Site = $this->siteFinder->getSiteByPageId($rootPageRecord['uid']);
         } catch (SiteNotFoundException $e) {
-            throw new \InvalidArgumentException("No site found with uid ". intval($rootPageRecord['uid']));
+            return null;
         }
         $domain = $typo3Site->getBase()->getHost();
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -403,7 +403,9 @@ class Util
         /** @var $siteRepository SiteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByPageId($pageId);
-        $GLOBALS['TSFE']->getPageAndRootlineWithDomain($site->getRootPageId());
+        if (!is_null($site)) {
+            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($site->getRootPageId());
+        }
     }
 
     /**


### PR DESCRIPTION
# What this pr does

* Fixes the broken reports when no site is configured
* Shows the solrNotAvailableAction in the frontend when the solr site is not configured

# How to test

No error is shown in the TYPO3 system when solr is installed but not configured

Fixes: #2442
