### PR TITLE
[BUGFIX] Fix getAllRequirementsMet returns true as soon as one requirement is met

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
@@ -43,13 +43,13 @@ class RequirementsService
             $requirementMet = $this->getRequirementMet($facet, $requirement);
             $requirementMet = $this->getNegationWhenConfigured($requirementMet, $requirement);
 
-            if ($requirementMet) {
-                // early return
-                return true;
+            if (!$requirementMet) {
+                // early return as soon as one requirement is not met
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -68,6 +68,7 @@ class RequirementsServiceTest extends UnitTest
         $colorConfig = [];
         $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', $colorConfig);
         $redOption = new Option($colorFacet, 'Red', 'red', 42, true);
+
         $colorFacet->addOption($redOption);
         $colorFacet->setIsUsed(true);
 
@@ -85,6 +86,77 @@ class RequirementsServiceTest extends UnitTest
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
         $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color option is present, but is indicated to not be met');
+    }
+
+    /**
+     * @test
+     */
+    public function getAllRequirementsMetIsReturnsTrueWhenRequirementIsMetForMultipleFacets()
+    {
+        $resultSet = new SearchResultSet();
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', []);
+        $redOption = new Option($colorFacet, 'Red', 'red', 42, true);
+        $colorFacet->addOption($redOption);
+        $colorFacet->setIsUsed(true);
+        $resultSet->addFacet($colorFacet);
+
+        $siteFacet = new OptionsFacet($resultSet, 'mysize', 'sizes_stringM', 'Sizes', []);
+        $xlOption = new Option($colorFacet, 'XL', 'xl', 12, true);
+        $siteFacet->addOption($xlOption);
+        $siteFacet->setIsUsed(true);
+        $resultSet->addFacet($siteFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'red,green'
+                ],
+                'matchesSize' => [
+                    'facet' => 'mysize',
+                    'values' => 'xl'
+                ],
+
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color and size option is present, but is indicated to not be met');
+    }
+
+    /**
+     * @test
+     */
+    public function getAllRequirementsMetIsReturnsFalseWhenOnlyOneConfiguredRequirementIsMet()
+    {
+        $resultSet = new SearchResultSet();
+        $colorFacet = new OptionsFacet($resultSet, 'mycolor', 'colors_stringM', 'Colors', []);
+        $redOption = new Option($colorFacet, 'Red', 'red', 42, true);
+        $colorFacet->addOption($redOption);
+        $colorFacet->setIsUsed(true);
+        $resultSet->addFacet($colorFacet);
+
+        $sizeFacet = new OptionsFacet($resultSet, 'mysize', 'size_stringM', 'Size', []);
+        $resultSet->addFacet($sizeFacet);
+
+        $categoryConfig = [
+            'requirements.' => [
+                'matchesColor' => [
+                    'facet' => 'mycolor',
+                    'values' => 'red,green'
+                ],
+                'matchesSize' => [
+                    'facet' => 'mysize',
+                    'values' => 'xl'
+                ],
+
+            ]
+        ];
+        $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
+        $resultSet->addFacet($categoryFacet);
+        $service = new RequirementsService();
+        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met since the matchesSize requirement is not met.');
     }
 
     /**


### PR DESCRIPTION
# What this pr does

Fixes the bug and add's unit tests for that case.

# How to test

A facet is only rendered when all requirements are met. Note: A single requirement is met when only one *value* matches (as mentioned in the documentation), so really multiple requirements need to be configured.

Fixes: #2375
