### PR TITLE
[TASK] Pass empty string if addQueryStringMethod is not set #2449

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -239,7 +239,19 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     protected function buildUriFromPageUidAndArguments($pageUid): string
     {
         $uriBuilder = $this->getControllerContext()->getUriBuilder();
-        $uri = $uriBuilder->reset()->setTargetPageUid($pageUid)->setTargetPageType($this->arguments['pageType'])->setNoCache($this->arguments['noCache'])->setUseCacheHash(!$this->arguments['noCacheHash'])->setArguments($this->arguments['additionalParams'])->setCreateAbsoluteUri($this->arguments['absolute'])->setAddQueryString($this->arguments['addQueryString'])->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString'])->setAddQueryStringMethod($this->arguments['addQueryStringMethod'])->setSection($this->arguments['section'])->build();
+        $uri = $uriBuilder
+            ->reset()
+            ->setTargetPageUid($pageUid)
+            ->setTargetPageType($this->arguments['pageType'])
+            ->setNoCache($this->arguments['noCache'])
+            ->setUseCacheHash(!$this->arguments['noCacheHash'])
+            ->setArguments($this->arguments['additionalParams'])
+            ->setCreateAbsoluteUri($this->arguments['absolute'])
+            ->setAddQueryString($this->arguments['addQueryString'])
+            ->setArgumentsToBeExcludedFromQueryString($this->arguments['argumentsToBeExcludedFromQueryString'])
+            ->setAddQueryStringMethod($this->arguments['addQueryStringMethod'] ?? '')
+            ->setSection($this->arguments['section'])
+            ->build();
         return $uri;
     }
 }


### PR DESCRIPTION
# What this pr does

Pass empty string to UriBuilder if addQueryStringMethod parameter is not set in SearchFormViewhelper

# How to test


Fixes: #2449 
