### PR TITLE
[TASK] Allow to install on TYPO3 v10 #2447

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
   },
   "require": {
     "php": ">=7.2.0",
-    "typo3/cms-core": "^9.5.0",
-    "typo3/cms-backend": "^9.5.0",
-    "typo3/cms-extbase": "^9.5.0",
-    "typo3/cms-frontend": "^9.5.0",
-    "typo3/cms-fluid": "^9.5.0",
-    "typo3/cms-reports": "^9.5.0",
-    "typo3/cms-scheduler": "^9.5.0",
-    "typo3/cms-tstemplate": "^9.5.0",
+    "typo3/cms-core": "^9.5.0 || ^10.0",
+    "typo3/cms-backend": "^9.5.0 || ^10.0",
+    "typo3/cms-extbase": "^9.5.0 || ^10.0",
+    "typo3/cms-frontend": "^9.5.0 || ^10.0",
+    "typo3/cms-fluid": "^9.5.0 || ^10.0",
+    "typo3/cms-reports": "^9.5.0 || ^10.0",
+    "typo3/cms-scheduler": "^9.5.0 || ^10.0",
+    "typo3/cms-tstemplate": "^9.5.0 || ^10.0",
     "solarium/solarium": "~4.2.0"
   },
   "require-dev": {


### PR DESCRIPTION
# What this pr does

Allow to install EXT:solr via composer on v10

# How to test

Install EXT:solr via composer

Fixes: #2447 
