### PR TITLE
[BUGFIX:BACKPORT] Add facet name to facet filters (#2343)

### DIFF
--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -154,7 +154,7 @@ class Faceting implements Modifier, SearchRequestAware
             $tag = $this->getFilterTag($facetConfiguration, $keepAllFacetsOnSelection);
             $filterParts = $this->getFilterParts($facetConfiguration, $facetName, $filterValues);
             $operator = ($facetConfiguration['operator'] === 'OR') ? ' OR ' : ' AND ';
-            $facetFilters[] = $tag . '(' . implode($operator, $filterParts) . ')';
+            $facetFilters[$facetName] = $tag . '(' . implode($operator, $filterParts) . ')';
         }
 
         return $facetFilters;


### PR DESCRIPTION
# What this pr does

To be able to combine facets from _GET and from flexforms, the key of the facets must be set to a proper name. Otherwise the index would be overriden.

Fixes: #2301
