### PR TITLE
[!!!][TASK] Add field for image and price

### DIFF
--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -240,7 +240,7 @@ class SuggestService {
             'title' => $document->getTitle(),
             'content' => $document->getContent(),
             'group' => $document->getHasGroupItem() ? $document->getGroupItem()->getGroupValue() : '',
-            'previewImage' => $document['previewImage_stringS'] ? $document['previewImage_stringS'] : '',
+            'previewImage' => $document['image'] ? $document['image'] : '',
         ];
         foreach ($additionalTopResultsFields as $additionalTopResultsField) {
             $fields[$additionalTopResultsField] = $document[$additionalTopResultsField] ? $document[$additionalTopResultsField] : '';

--- a/Documentation/Releases/solr-release-10-0.rst
+++ b/Documentation/Releases/solr-release-10-0.rst
@@ -47,6 +47,12 @@ Drop TYPO3 8 compatibility
 To simplify the development we've dropped the compatibility for TYPO3 8 LTS. If you need to use TYPO3 8 please use the 9.0.x branch.
 
 
+Add default field for image and price
+-------------------------------------
+
+To allow external applications to index common information for product's we've added a field for price and image. Along with that we've changed the suggest to render the content of the "image" field instead of "previewImage_stringS", this might require changes in  your index configuration.
+
+
 Migration from EXT:solr 9 to EXT:solr 10
 ========================================
 

--- a/Resources/Private/Solr/configsets/ext_solr_10_0_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_10_0_0/conf/general_schema_fields.xml
@@ -110,6 +110,10 @@
 
 	<field name="url"         type="string" indexed="true" stored="true" />
 
+	<!-- optional fields that could be filled but should have a defined name in the schema -->
+	<field name="image"       type="string" indexed="true" stored="true" />
+	<field name="price"       type="double" indexed="true" stored="true" />
+
 	<!--
 		A set of fields to contain text extracted from tag contents which
 		we can boost at query time.


### PR DESCRIPTION
# What this pr does

* Add's a field "image" and "price" that can be filled and used by external applications
* Migrate the suggest to use the content of the "image" field instead of "previewImage_stringS"

# How to test

* Index image and price and check if they are store in solr
* Check if image is show in suggest if configured

Fixes: #2412

