### PR TITLE
[BUGFIX] Indexing properties should only be deleted when not referenced anymore

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -486,19 +486,25 @@ class QueueItemRepository extends AbstractRepository
      */
     private function buildQueryForPropertyDeletion(QueryBuilder $queryBuilderForDeletingItems, array $rootPageIds, string $indexQueueConfigurationList, string $itemTypeList, array $itemUids, array $uids): QueryBuilder
     {
-        $queryBuilderForDeletingProperties = $queryBuilderForDeletingItems->getConnection()->createQueryBuilder();
-        $queryBuilderForDeletingProperties->delete('tx_solr_indexqueue_indexing_property')->innerJoin(
+        $queryBuilderForSelectingProperties = $queryBuilderForDeletingItems->getConnection()->createQueryBuilder();
+        $queryBuilderForSelectingProperties->select('items.uid')->from('tx_solr_indexqueue_indexing_property', 'properties')->innerJoin(
             'properties',
             $this->table,
             'items',
-            (string)$queryBuilderForDeletingProperties->expr()->andX(
-                $queryBuilderForDeletingProperties->expr()->eq('items.uid', $queryBuilderForDeletingProperties->quoteIdentifier('properties.item_id')),
-                empty($rootPageIds) ? '' : $queryBuilderForDeletingProperties->expr()->in('items.root', $rootPageIds),
-                empty($indexQueueConfigurationList) ? '' : $queryBuilderForDeletingProperties->expr()->in('items.indexing_configuration', $queryBuilderForDeletingProperties->createNamedParameter($indexQueueConfigurationList)),
-                empty($itemTypeList) ? '' : $queryBuilderForDeletingProperties->expr()->in('items.item_type', $queryBuilderForDeletingProperties->createNamedParameter($itemTypeList)),
-                empty($itemUids) ? '' : $queryBuilderForDeletingProperties->expr()->in('items.item_uid', $itemUids),
-                empty($uids) ? '' : $queryBuilderForDeletingProperties->expr()->in('items.uid', $uids)
+            (string)$queryBuilderForSelectingProperties->expr()->andX(
+                $queryBuilderForSelectingProperties->expr()->eq('items.uid', $queryBuilderForSelectingProperties->quoteIdentifier('properties.item_id')),
+                empty($rootPageIds) ? '' : $queryBuilderForSelectingProperties->expr()->in('items.root', $rootPageIds),
+                empty($indexQueueConfigurationList) ? '' : $queryBuilderForSelectingProperties->expr()->in('items.indexing_configuration', $queryBuilderForSelectingProperties->createNamedParameter($indexQueueConfigurationList)),
+                empty($itemTypeList) ? '' : $queryBuilderForSelectingProperties->expr()->in('items.item_type', $queryBuilderForSelectingProperties->createNamedParameter($itemTypeList)),
+                empty($itemUids) ? '' : $queryBuilderForSelectingProperties->expr()->in('items.item_uid', $itemUids),
+                empty($uids) ? '' : $queryBuilderForSelectingProperties->expr()->in('items.uid', $uids)
             )
+        );
+        $propertyEntriesToDelete = implode(',', array_column($queryBuilderForSelectingProperties->execute()->fetchAll(), 'uid'));
+
+        $queryBuilderForDeletingProperties = $queryBuilderForDeletingItems->getConnection()->createQueryBuilder();
+        $queryBuilderForDeletingProperties->delete('tx_solr_indexqueue_indexing_property')->where(
+            $queryBuilderForDeletingProperties->expr()->in('item_id', $propertyEntriesToDelete)
         );
         return $queryBuilderForDeletingProperties;
     }

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -503,9 +503,16 @@ class QueueItemRepository extends AbstractRepository
         $propertyEntriesToDelete = implode(',', array_column($queryBuilderForSelectingProperties->execute()->fetchAll(), 'uid'));
 
         $queryBuilderForDeletingProperties = $queryBuilderForDeletingItems->getConnection()->createQueryBuilder();
+
+        // make sure executing the propety deletion query doesn't fail if there are no properties to delete
+        if (empty($propertyEntriesToDelete)) {
+            $propertyEntriesToDelete = '0';
+        }
+
         $queryBuilderForDeletingProperties->delete('tx_solr_indexqueue_indexing_property')->where(
             $queryBuilderForDeletingProperties->expr()->in('item_id', $propertyEntriesToDelete)
         );
+
         return $queryBuilderForDeletingProperties;
     }
 

--- a/Tests/Integration/Domain/Index/Queue/Fixtures/can_keep_indexing_properties.xml
+++ b/Tests/Integration/Domain/Index/Queue/Fixtures/can_keep_indexing_properties.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                plugin.tx_solr {
+
+                    enabled = 1
+
+
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                        }
+
+                        queue {
+
+                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+                            pages = 1
+                            pages {
+                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+                                // allowed page types (doktype) when indexing records from table "pages"
+                                allowedPageTypes = 1,7
+
+                                indexingPriority = 0
+
+                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+                                indexer {
+                                    // add options for the indexer here
+                                }
+
+                                // Only index standard pages and mount points that are not overlayed.
+                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+                                fields {
+                                    sortSubTitle_stringS = subtitle
+                                    custom_stringS = TEXT
+                                    custom_stringS.value = my text
+                                }
+                            }
+
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello solr</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+
+    <pages>
+        <uid>4711</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>hello subpage</title>
+        <subtitle>the subtitle</subtitle>
+        <crdate>1449151778</crdate>
+        <tstamp>1449151778</tstamp>
+    </pages>
+
+</dataset>


### PR DESCRIPTION
# What this pr does

* Add's a fix that only deletes indexing properties for records that are not referenced in any index queue item. Previously they get deleted and are therefore also lost for other indexing configuration
* Add's a functional test for that bug

# How to test

* Create a record with indexing properties that is referenced with to indexing configurations
* Delete one item from index indexing queue, e.g. by re initializing them
* The indexing properties should remain for the other index queue item with the same record information but other index queue name

Fixes: #2335
