### PR TITLE
[FEATURE] automatically send big solr queries via POST

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -242,6 +242,7 @@ class SolrConnection
         }
 
         $client = new Client(['adapter' => 'Solarium\Core\Client\Adapter\Guzzle']);
+        $client->getPlugin('postbigrequest');
         $client->clearEndpoints();
 
         $newEndpointOptions = $this->getNode($endpointKey)->getSolariumClientOptions();


### PR DESCRIPTION
# What this pr does
Enable the Plugin 'postbigrequest'

# How to test

configure around 20 facets, so the query going to solr is really big.
previously to this change we would get: ``resulted in a `414 URI Too Long` response``

related: #1675 
