### PR TITLE
[BUGFIX] Docker container does not start when no volum is configured

### DIFF
--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -3,14 +3,8 @@ MAINTAINER Timo Hund <timo.hund@dkd.de>
 ENV TERM linux
 
 USER root
-
 RUN rm -fR /opt/solr/server/solr/*
-
-COPY Resources/Private/Solr/ /var/solr/data
-
-RUN mkdir -p /var/solr/data/data && \
-    chown -R solr:solr /var/solr/data
-
 USER solr
 
-VOLUME ["/var/solr/data/data"]
+COPY Resources/Private/Solr/ /var/solr/data
+RUN mkdir -p /var/solr/data/data


### PR DESCRIPTION
# What this pr does


* Removes the volume declaration (since for 8.2  it is allready defined in the base Dockerfile)
* Simplifies the Dockerfile since switching user is only needed to remove the default configuration

# How to test

* Check if the container can be used with and without a volume definition for "/var/solr/data/data"

Fixes: #2477
