### PR TITLE
[BUGFIX] Remove pages_language_overlay leftovers

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/StrategyFactory.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/StrategyFactory.php
@@ -37,7 +37,7 @@ class StrategyFactory {
      */
     public static function getByTable($table)
     {
-        $isPageRelated = in_array($table, ['tt_content','pages','pages_language_overlay']);
+        $isPageRelated = in_array($table, ['tt_content','pages']);
         return $isPageRelated ? new PageStrategy() : new RecordStrategy();
     }
 }

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -281,10 +281,6 @@ class QueueItemRepository extends AbstractRepository
     {
         $localizedChangedTime = 0;
 
-        if ($itemType === 'pages') {
-            $itemType = 'pages_language_overlay';
-        }
-
         if (isset($GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'])) {
             // table is localizable
             $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -111,10 +111,6 @@ class ConfigurationAwareRecordService
 
         $recordWhereClause = $solrConfiguration->getIndexQueueAdditionalWhereClauseByConfigurationName($indexingConfigurationName);
 
-        if ($recordTable === 'pages_language_overlay') {
-            return $this->getPageOverlayRecordIfParentIsAccessible($recordUid, $recordWhereClause);
-        }
-
         $row = $this->getRecordForIndexConfigurationIsValid($recordTable, $recordUid, $recordWhereClause);
 
         return $row;
@@ -168,7 +164,7 @@ class ConfigurationAwareRecordService
     }
 
     /**
-     * This method retrieves the pages_language_overlay record when the parent record is accessible
+     * This method retrieves the parent pages record when the parent record is accessible
      * through the recordWhereClause
      *
      * @param int $recordUid

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -268,7 +268,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
     /**
      * Checks if the related index queue item is indexed.
      *
-     * * For tt_content and pages_language_overlay the page from the pid is checked
+     * * For tt_content the page from the pid is checked
      * * For all other records the table it's self is checked
      *
      * @param string $table The table name.

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -444,10 +444,6 @@ class TypoScriptConfiguration
         foreach ($indexingConfigurations as $indexingConfigurationName) {
             $monitoredTable = $this->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
             $monitoredTables[] = $monitoredTable;
-            if ($monitoredTable === 'pages') {
-                // when monitoring pages, also monitor creation of translations
-                $monitoredTables[] = 'pages_language_overlay';
-            }
         }
 
         return array_values(array_unique($monitoredTables));

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
@@ -13,7 +13,7 @@ return [
                 'MM' => 'tx_fakeextension3_pages_mm',
                 'MM_opposite_field' => 'relations',
                 'MM_match_fields' => [
-                    'tablenames' => 'pages_language_overlay',
+                    'tablenames' => 'pages',
                     'fieldname' => 'page_relations'
                 ],
                 'size' => 10,

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_table.sql
@@ -13,8 +13,3 @@ CREATE TABLE pages (
    page_relations int(11) unsigned DEFAULT '0' NOT NULL,
    relations varchar(90) DEFAULT '' NOT NULL
 );
-
-CREATE TABLE pages_language_overlay (
-   page_relations int(11) unsigned DEFAULT '0' NOT NULL,
-   relations varchar(90) DEFAULT '' NOT NULL
-);

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -341,7 +341,7 @@ class TypoScriptConfigurationTest extends UnitTest
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $monitoredTables =  $configuration->getIndexQueueMonitoredTables();
-        $this->assertEquals(['tx_model_news', 'tx_model_bar', 'pages', 'pages_language_overlay'], $monitoredTables);
+        $this->assertEquals(['tx_model_news', 'tx_model_bar', 'pages'], $monitoredTables);
     }
 
     /**
@@ -375,7 +375,6 @@ class TypoScriptConfigurationTest extends UnitTest
         $this->assertFalse($configuration->getIndexQueueIsMonitoredTable('tx_mycustom_table2'), 'tx_mycustom_table2 was not expected to be monitored');
 
         $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('pages'), 'pages was expected to be monitored');
-        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('pages_language_overlay'), 'pages_language_overlay was expected to be monitored');
         $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_bar'), 'tx_model_bar was expected to be monitored');
         $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_news'), 'tx_model_news was expected to be monitored');
     }


### PR DESCRIPTION
# What this pr does

* Remove the leftovers where the pages_language_overlay logic is still present.

# How to test

* The table pages_language_overlay is not used anymore in the extension

Fixes: #2482
