### PR TITLE
[TASK] Site configuration status check - incl. languages config fallback

### DIFF
--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
@@ -30,6 +30,8 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder;
 
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -63,6 +65,8 @@ class TYPO3SiteStrategy extends AbstractUriStrategy
      * @param int $language
      * @param string $mountPointParameter
      * @return string
+     * @throws SiteNotFoundException
+     * @throws InvalidRouteArgumentsException
      */
     protected function buildPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0,  string $mountPointParameter = '')
     {

--- a/Classes/Report/SiteHandlingStatus.php
+++ b/Classes/Report/SiteHandlingStatus.php
@@ -24,11 +24,15 @@ namespace ApacheSolrForTypo3\Solr\Report;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Typo3ManagedSite;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use Exception;
+use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Core\Site\Entity\Site as Typo3Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Reports\Status;
 
@@ -42,6 +46,13 @@ use TYPO3\CMS\Reports\Status;
 class SiteHandlingStatus extends AbstractSolrStatus
 {
     const TITLE_SITE_HANDLING_CONFIGURATION = 'Site handling configuration';
+
+    const
+        CSS_STATUS_NOTICE = 'notice',
+        CSS_STATUS_INFO = 'info',
+        CSS_STATUS_OK = 'success',
+        CSS_STATUS_WARNING = 'warning',
+        CSS_STATUS_ERROR = 'danger';
 
     /**
      * Site Repository
@@ -78,13 +89,14 @@ class SiteHandlingStatus extends AbstractSolrStatus
             $reports[] = GeneralUtility::makeInstance(
                 Status::class,
                 /** @scrutinizer ignore-type */ self::TITLE_SITE_HANDLING_CONFIGURATION,
-                /** @scrutinizer ignore-type */ 'The lagacy site mode is enabled.',
+                /** @scrutinizer ignore-type */ 'The lagacy site mode is enabled. This setting is global and can not be applied per site.',
                 /** @scrutinizer ignore-type */ 'The legacy site mode is not recommended and will be removed in EXT:Solr 11. Please switch to site handling as soon as possible.',
                 /** @scrutinizer ignore-type */ Status::WARNING
             );
             return $reports;
         }
 
+        /* @var Site $site */
         foreach ($this->siteRepository->getAvailableSites() as $site) {
             if (!($site instanceof Typo3ManagedSite)) {
                 $reports[] = GeneralUtility::makeInstance(
@@ -94,10 +106,9 @@ class SiteHandlingStatus extends AbstractSolrStatus
                     /** @scrutinizer ignore-type */ vsprintf('The configured Site "%s" is not TYPO3 managed site. Please refer to TYPO3 site management docs and configure the site properly.', [$site->getLabel()]),
                     /** @scrutinizer ignore-type */ Status::ERROR
                 );
-                return $reports;
+                continue;
             }
-
-            $reports[] = $this->generateValidationReportForSiteHandlingConfiguration($site->getTypo3SiteObject());
+            $reports[] = $this->generateValidationReportForSingleSite($site->getTypo3SiteObject());
         }
 
         return $reports;
@@ -109,40 +120,89 @@ class SiteHandlingStatus extends AbstractSolrStatus
      * @param Typo3Site $ypo3Site
      * @return Status
      */
-    protected function generateValidationReportForSiteHandlingConfiguration(Typo3Site $ypo3Site): Status
+    protected function generateValidationReportForSingleSite(Typo3Site $ypo3Site): Status
     {
         $variables = [
             'identifier' => $ypo3Site->getIdentifier()
         ];
         $globalPassedStateForThisSite = true;
 
-        // check scheme of base URI
-        $schemeValidationStatus = !empty($ypo3Site->getBase()->getScheme()) && (strpos('http', $ypo3Site->getBase()->getScheme()) !== false);
-        $variables['validationResults']['scheme'] = [
-            'label' => 'Requirement: Valid scheme in Entry Point[base].',
-            'message' => 'Entry Point[base] must contain valid HTTP scheme as http[s]:// to be able to index records.',
-            'passed' => $schemeValidationStatus
-        ];
-        $globalPassedStateForThisSite = $globalPassedStateForThisSite && $schemeValidationStatus;
-
-        // check authority of base URI
-        $authorityValidationStatus = !empty($ypo3Site->getBase()->getAuthority());
-        $variables['validationResults']['authority'] = [
-            'label' => 'Requirement: Valid Authority in Entry Point[base].',
-            'message' => 'Entry Point[base] must define the authority as [user-info@]host[:port] to be able to index records.',
-            'passed' => $authorityValidationStatus
-        ];
-        $globalPassedStateForThisSite = $globalPassedStateForThisSite && $authorityValidationStatus;
+        foreach ($ypo3Site->getAllLanguages() as $siteLanguage) {
+            if (!$siteLanguage->isEnabled()) {
+                $variables['validationResults'][$siteLanguage->getTitle()] = [
+                    'label' => 'Language: ' . $siteLanguage->getTitle(),
+                    'message' => 'No checks: The language is disabled in site configuration.',
+                    'CSSClassesFor' => [
+                        'tr' => self::CSS_STATUS_NOTICE
+                    ],
+                    'passed' => true
+                ];
+                continue;
+            }
+            $variables['validationResults'][$siteLanguage->getTitle()] = $this->generateValidationResultsForSingleSiteLanguage($siteLanguage);
+            $globalPassedStateForThisSite = $globalPassedStateForThisSite && $variables['validationResults'][$siteLanguage->getTitle()]['passed'];
+        }
 
         $renderedReport = $this->getRenderedReport('SiteHandlingStatus.html', $variables);
         /* @var Status $status */
         $status = GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */ 'Site Identifier: ' . $ypo3Site->getIdentifier(),
+            /** @scrutinizer ignore-type */ sprintf('Site Identifier: "%s"', $ypo3Site->getIdentifier()),
             /** @scrutinizer ignore-type */ '',
             /** @scrutinizer ignore-type */ $renderedReport,
             /** @scrutinizer ignore-type */ $globalPassedStateForThisSite == true ? Status::OK : Status::ERROR
         );
         return $status;
+    }
+
+    /**
+     * Generates the validation result array for using them in standalone view as an table row.
+     *
+     * @param SiteLanguage $siteLanguage
+     * @return array
+     */
+    protected function generateValidationResultsForSingleSiteLanguage(SiteLanguage $siteLanguage): array
+    {
+        $validationResult = [
+            'label' => 'Language: ' . $siteLanguage->getTitle(),
+            'passed' => true,
+            'CSSClassesFor' => [
+                'tr' => self::CSS_STATUS_OK
+            ]
+        ];
+
+        if (!GeneralUtility::isValidUrl((string)$siteLanguage->getBase())) {
+            $validationResult['message'] = sprintf('Entry Point[base]="%s" is not valid URL. Following parts of defined URL are empty or invalid: "%s"', (string)$siteLanguage->getBase(), $this->fetchInvalidPartsOfUri($siteLanguage->getBase()));
+            $validationResult['passed'] = false;
+            $validationResult['CSSClassesFor']['tr'] = self::CSS_STATUS_ERROR;
+        } else {
+            $validationResult['message'] = sprintf('Entry Point[base]="%s" is valid URL.', (string)$siteLanguage->getBase());
+        }
+
+        return $validationResult;
+    }
+
+    /**
+     * @param UriInterface $uri
+     * @return string
+     */
+    protected function fetchInvalidPartsOfUri(UriInterface $uri): string
+    {
+        $invalidParts = '';
+        /* @var UrlHelper $solrUriHelper */
+        $solrUriHelper = GeneralUtility::makeInstance(UrlHelper::class, $uri);
+        try {
+            $solrUriHelper->getScheme();
+        } catch (\TypeError $error) {
+            $invalidParts .= 'scheme';
+        }
+
+        try {
+            $solrUriHelper->getHost();
+        } catch (\TypeError $error) {
+            $invalidParts .= ', host';
+        }
+
+        return $invalidParts;
     }
 }

--- a/Resources/Private/Templates/Backend/Reports/SiteHandlingStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/SiteHandlingStatus.html
@@ -1,7 +1,7 @@
 <table class="table table-condensed table-hover table-striped">
-    <thead><tr><td colspan="3">Site Identifier: {identifier}</td></tr></thead>
-
     <f:for each="{validationResults}" as="validationResult">
-        <tr><th>{validationResult.label}</th><td>{validationResult.message}</td><td>{f:if(condition: '{validationResult.passed}', then: 'OK', else: 'FAILED')}</td></tr>
+        <tr {f:render(section: 'CSSClassesFor', arguments:{validationResult: validationResult, forTag: 'tr'})}><th {f:render(section: 'CSSClassesFor', arguments:{validationResult: validationResult, forTag: 'th'})} >{validationResult.label}</th><td {f:render(section: 'CSSClassesFor', arguments:{validationResult: validationResult, forTag: 'td'})}>{validationResult.message}</td></tr>
     </f:for>
 </table>
+
+<f:section name="CSSClassesFor"><f:if condition="{validationResult.CSSClassesFor.{forTag}}">class="{validationResult.CSSClassesFor.{forTag}}"</f:if></f:section>


### PR DESCRIPTION
# What this pr does

Show status check for "Entry Point[base]" settings of site:



# How to test

Try Following:

1. Valide URL in global base 
  \+ languages:
  base = /da/
  base = /de/
  ![Bildschirmfoto 2019-10-18 um 14 27 39](https://user-images.githubusercontent.com/25453927/67094168-812a8c00-f1b3-11e9-86aa-e0edb189eb90.jpg)


2. Invalide URL in global base(no scheme) 
  \+ languages:
  base = /
  base = Valide URL 
  base = /da/
  ![Bildschirmfoto 2019-10-18 um 14 23 24](https://user-images.githubusercontent.com/25453927/67093915-f0ec4700-f1b2-11e9-8fe5-5d4ea40fedd2.jpg)

3. Disable some language
  ![Bildschirmfoto 2019-10-18 um 14 41 28](https://user-images.githubusercontent.com/25453927/67095098-6a853480-f1b5-11e9-962e-d8db3cd4b31a.jpg)

Fixes: #2480
