### PR TITLE
[Bugfix] add typecasting (#2486)

### DIFF
--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategy.php
@@ -70,7 +70,7 @@ class TYPO3SiteStrategy extends AbstractUriStrategy
      */
     protected function buildPageIndexingUriFromPageItemAndLanguageId(Item $item, int $language = 0,  string $mountPointParameter = '')
     {
-        $site = $this->siteFinder->getSiteByPageId($item->getRecordUid());
+        $site = $this->siteFinder->getSiteByPageId((int)$item->getRecordUid());
         $parameters = [];
 
         if ($language > 0) {


### PR DESCRIPTION
getRecordUid() returns database result as string and requires typecasting.