### PR TITLE
[BUGFIX] Indexing user protected pages does not work as expected

### DIFF
--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -142,6 +142,7 @@ class Rootline
     ) {
         $accessRootline = GeneralUtility::makeInstance(Rootline::class);
 
+        /** @var  $pageSelector PageRepository */
         $pageSelector = GeneralUtility::makeInstance(PageRepository::class);
         $pageSelector->init(false);
         $rootline = $pageSelector->getRootLine($pageId, $mountPointParameter);
@@ -160,7 +161,7 @@ class Rootline
         }
 
         // current page
-        $currentPageRecord = $pageSelector->getPage($pageId);
+        $currentPageRecord = $pageSelector->getPage($pageId, true);
         if ($currentPageRecord['fe_group']) {
             $accessRootline->push(GeneralUtility::makeInstance(
                 RootlineElement::class,

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -35,8 +35,7 @@ use TYPO3\CMS\Frontend\Page\PageRepositoryGetPageHookInterface;
 use TYPO3\CMS\Frontend\Page\PageRepositoryGetPageOverlayHookInterface;
 
 /**
- * Index Queue Page Indexer frontend helper to track which user groups are used
- * on a page.
+ * The UserGroupDetector is responsible to identify the fe_group references on records that are visible on the page (not the page itself).
  *
  * @author Ingo Renner <ingo@typo3.org>
  */

--- a/Tests/Integration/Access/Fixtures/user_protected_page.xml
+++ b/Tests/Integration/Access/Fixtures/user_protected_page.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <hidden>0</hidden>
+        <extendToSubpages>1</extendToSubpages>
+    </pages>
+    <pages>
+        <uid>10</uid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <pid>1</pid>
+        <fe_group>4711</fe_group>
+    </pages>
+</dataset>

--- a/Tests/Integration/Access/RootlineTest.php
+++ b/Tests/Integration/Access/RootlineTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Access;
+use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+/**
+ * Class RootlineTest
+ */
+class RootlineTest extends IntegrationTest {
+    /**
+     * @test
+     */
+    public function canGetAccessRootlineByPageId()
+    {
+        $this->importDataSetFromFixture('user_protected_page.xml');
+        $accessRootline = Rootline::getAccessRootlineByPageId(10);
+        $this->assertSame('10:4711', (string)$accessRootline, 'Did not determine expected access rootline for fe_group protected page');
+        $accessRootline = Rootline::getAccessRootlineByPageId(1);
+        $this->assertSame('', (string)$accessRootline, 'Access rootline for non protected page should be empty');
+    }
+}


### PR DESCRIPTION
# What this pr does

Disables the user permission check when building the access rootline since this is required to build an access rootline for user restricted pages

# How to test

Test to index pages with and without user restrictions

Fixes: #2417
