### PR TITLE
[BUGFIX] Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 language: php
 
 services:
+  - mysql
   - docker
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
-
-jdk:
-  - oraclejdk8
 
 addons:
   apt:
     packages:
       - parallel
-      - oracle-java8-installer
 env:
   global:
-    - JAVA_HOME=/usr/lib/jvm/java-8-oracle
+    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
     - TYPO3_DATABASE_NAME="typo3_ci"
     - TYPO3_DATABASE_HOST="127.0.0.1"
     - TYPO3_DATABASE_USERNAME="root"
@@ -34,12 +30,8 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - php: 5.5
-      env: TYPO3_VERSION="^8.7"
     - php: 5.6
       env: TYPO3_VERSION="^8.7"
-    - php: 5.5
-      env: TYPO3_VERSION="8.x-dev"
     - php: 5.6
       env: TYPO3_VERSION="8.x-dev"
     - php: 7.1
@@ -48,10 +40,9 @@ matrix:
       env: TYPO3_VERSION="~7.6.16"
 
 before_install:
+  - sudo apt-get install openjdk-8-jre
   - composer self-update
   - composer --version
-  # resources for solr
-  - sudo update-java-alternatives -s java-8-oracle
 
 install:
   - Build/Test/bootstrap.sh

--- a/Resources/Private/Install/install-solr.sh
+++ b/Resources/Private/Install/install-solr.sh
@@ -161,13 +161,20 @@ then
 fi
 
 JAVA_VERSION_INSTALLED=$(java -version 2>&1 | grep -Eom1 "[._0-9]{5,}")
-# extract the main Java version from 1.7.0_11 => 7
-JAVA_VERSION_INSTALLED=${JAVA_VERSION_INSTALLED:2:1}
+JAVA_MAJOR_VERSION_INSTALLED=${JAVA_VERSION_INSTALLED%%\.*}
+
+# check if java uses the old version number like 1.7.0_11
+if [ $JAVA_MAJOR_VERSION_INSTALLED -eq 1 ]
+then
+	# extract the main Java version from 1.7.0_11 => 7
+	JAVA_MAJOR_VERSION_INSTALLED=${JAVA_VERSION_INSTALLED:2:1}
+fi
+
 
 # check if java version is equal or higher then required
-if [ $JAVA_VERSION_INSTALLED -lt $JAVA_VERSION ]
+if [ $JAVA_MAJOR_VERSION_INSTALLED -lt $JAVA_VERSION ]
 then
-	cecho "You have installed Java version $JAVA_VERSION_INSTALLED. Please install Java $JAVA_VERSION or newer." $red
+	cecho "You have installed Java version $JAVA_MAJOR_VERSION_INSTALLED. Please install Java $JAVA_VERSION or newer." $red
 	PASSALLCHECKS=0
 fi
 


### PR DESCRIPTION
# What this pr does

* Uses openjdk for that branch for now since oracle jdk in that age is no longer available
