### PR TITLE
If we have root page in the root page, we always have only last page …

### DIFF
--- a/Classes/System/Page/Rootline.php
+++ b/Classes/System/Page/Rootline.php
@@ -93,6 +93,7 @@ class Rootline
         foreach ($this->rootLineArray as $page) {
             if (Site::isRootPage($page)) {
                 $rootPageId = $page['uid'];
+                break;
             }
         }
 


### PR DESCRIPTION
If we have root page in the root page, we always have only last page in rootLineArray!

# What this pr does

If we have root page in the root page

# How to test
Add new site configuration for some page with different solr paths and move this page into the root page, after that you need a switch to tab "info" in SOLR administration panel and compare root page path and children root page path

