### PR TITLE
Closes #2511: database exception in RecordMonitor

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -440,8 +440,7 @@ class RecordMonitor extends AbstractDataHandlerListener
      */
     protected function getIsTranslationParentRecordEnabled($recordTable, $recordUid)
     {
-        $tableEnableFields = implode(', ', $GLOBALS['TCA'][$recordTable]['ctrl']['enablecolumns']);
-        $l10nParentRecord = (array)BackendUtility::getRecord($recordTable, $recordUid, $tableEnableFields, '', false);
+        $l10nParentRecord = (array)BackendUtility::getRecord($recordTable, $recordUid, '*', '', false);
         return $this->tcaService->isEnabledRecord($recordTable, $l10nParentRecord);
     }
 


### PR DESCRIPTION
# What this pr does

This PR fixes a #2511 

# How to test

To test you would need to index a table with translations enabled but without enable fields.

Fixes: #2511 
