### PR TITLE
[FEATURE] Allow composite label and concatenate values by glue (#2525)

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -573,7 +573,18 @@ The current record's field name to use to resolve the relation to the foreign ta
 :TS Path: plugin.tx_solr.index.queue.[indexConfig].fields.[fieldName].foreignLabelField
 :Since: 2.0
 
-Usually the label field to retrieve from the related records is determined automatically using TCA, using this option the desired field can be specified explicitly. To specify the label field for recursive relations, the field names can be separated by a dot, e.g. for a category hierarchy to get the name of the parent category one could use "parent.name" (since version:2.9).
+Usually the label field to retrieve from the related records is determined automatically using TCA, using this option the desired field can be specified explicitly.
+To specify the label field for recursive relations, the field names can be separated by a dot, e.g. for a category hierarchy to get the name of the parent category one could use "parent.name" (since version:2.9).
+If your label consists of multiple fields, separete them with a comma (since version:10.1).
+
+**foreignLabelFieldGlue**
+
+:Type: String
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].fields.[fieldName].foreignLabelFieldGlue
+:Since: 10.1
+:Default: (space)
+
+If `foreignLabelField` is a comma separated list, this value will be used for concatenating the parts. Defaults to a blank space.
 
 **multiValue**
 


### PR DESCRIPTION
# What this pr does

Allows creating a composite label by defining multiple label fields which are concatenated by a configurable glue. If no glue was configured it will use a blank space.

# How to test

Add some categories to a page and this to your TypoScript:
```
plugin.tx_solr.index.queue.pages.fields {
  categoryTest_stringM = SOLR_RELATION
  categoryTest_stringM {
    localField = category
    foreignLabelField = uid, title
    foreignLabelFieldGlue = -
    multiValue = 1
  }
}
```

Index the page. Look into the Solr document.
It should have a "categoryTest_stringM" field with values being the UID and title of the category separated by -.

Fixes: #2525