### PR TITLE
[BUGFIX] Update test dependencies and fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,13 @@ addons:
   apt:
     packages:
       - parallel
-
 env:
   global:
     - TYPO3_DATABASE_NAME="typo3_ci"
     - TYPO3_DATABASE_HOST="127.0.0.1"
     - TYPO3_DATABASE_USERNAME="root"
     - TYPO3_DATABASE_PASSWORD=""
-    - PHP_CS_FIXER_VERSION="^2.11"
+    - PHP_CS_FIXER_VERSION="^2.16.1"
   matrix:
     - TYPO3_VERSION="^9.5"
     - TYPO3_VERSION="9.5.x-dev"
@@ -34,6 +33,7 @@ matrix:
     - env: TYPO3_VERSION="9.5.x-dev"
 
 before_install:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS typo3_ci;'
   - composer self-update
   - composer --version
   - composer validate --no-check-lock

--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -63,7 +63,6 @@ fi
 
 # Install build tools
 composer global require friendsofphp/php-cs-fixer:"$PHP_CS_FIXER_VERSION"
-composer global require scrutinizer/ocular:"1.5.2"
 composer global require namelesscoder/typo3-repository-client
 
 # Setup TYPO3 environment variables

--- a/Build/Test/publish_coverage.sh
+++ b/Build/Test/publish_coverage.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export TYPO3_BIN_DIR="$(pwd)/.Build/bin/"
-export COMPOSER_BIN_DIR="$HOME/.composer/vendor/bin"
-
-# Add TYPO3_BIN_DIR and COMPOSER_BIN_DIR to $PATH
-export PATH="$TYPO3_BIN_DIR:$COMPOSER_BIN_DIR:$PATH"
-
-ls -la
-ocular code-coverage:upload --format=php-clover coverage.unit.clover
-ocular code-coverage:upload --format=php-clover coverage.integration.clover
+wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
+php ocular.phar code-coverage:upload --format=php-clover coverage.unit.clover
+php ocular.phar code-coverage:upload --format=php-clover coverage.integration.clover
+rm ocular.phar

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -1,16 +1,17 @@
 <?php
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
-class UtilTest extends UnitTest
+class UtilTest extends IntegrationTest
 {
     public function setUp()
     {
+        parent::setUp();
         /** @var \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend|\Prophecy\Prophecy\ObjectProphecy $frontendCache */
         $frontendCache = $this->prophesize(\TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class);
         /** @var \TYPO3\CMS\Core\Cache\CacheManager|\Prophecy\Prophecy\ObjectProphecy $cacheManager */
@@ -22,10 +23,17 @@ class UtilTest extends UnitTest
             ->getCache('cache_runtime')
             ->willReturn($frontendCache->reveal());
         $cacheManager
+            ->getCache('cache_hash')
+            ->willReturn($frontendCache->reveal());
+        $cacheManager
+            ->getCache('cache_core')
+            ->willReturn($frontendCache->reveal());
+        $cacheManager
             ->getCache('tx_solr_configuration')
             ->willReturn($frontendCache->reveal());
         GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager->reveal());
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'] = [];
     }
 
     public function tearDown()

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     "solarium/solarium": "~4.2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0",
-    "nimut/testing-framework": "^4.0.0"
+    "phpunit/phpunit": "^7.0",
+    "nimut/testing-framework": "^5.0.0"
   },
   "replace": {
     "typo3-ter/solr": "self.version",


### PR DESCRIPTION
# What this pr does

* Moves a unit test to the functional tests, since a cache was added in the core
* Updates the nimut testing framework and phpunit to the latest possible version
* Use occular as phar since a conflict with different symfony console dependecy versions could not be resolved.

# How to test

Travis build is green now and all tests get executed

