### PR TITLE
Feature/use object manager

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
@@ -75,6 +75,11 @@ abstract class AbstractFacet
     protected $allRequirementsMet = true;
 
     /**
+     * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
      * AbstractFacet constructor.
      *
      * @param SearchResultSet $resultSet
@@ -90,6 +95,16 @@ abstract class AbstractFacet
         $this->field = $field;
         $this->label = $label;
         $this->configuration = $configuration;
+    }
+
+    /**
+     * Injects the object manager
+     *
+     * @param \TYPO3\CMS\Extbase\Object\ObjectManagerInterface $objectManager
+     */
+    public function injectObjectManager(\TYPO3\CMS\Extbase\Object\ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
@@ -96,7 +96,8 @@ class HierarchyFacet extends AbstractFacet
     {
         /** @var $parentNode Node|null */
         $parentNode = isset($this->nodesByKey[$parentKey]) ? $this->nodesByKey[$parentKey] : null;
-        $node = new Node($this, $parentNode, $key, $label, $value, $count, $selected);
+        /** @var Node $node */
+        $node = $this->objectManager->get(Node::class, $this, $parentNode, $key, $label, $value, $count, $selected);
         $this->nodesByKey[$key] = $node;
 
         if ($parentNode === null) {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -70,7 +70,7 @@ class OptionsFacetParser extends AbstractFacetParser
 
             $isOptionsActive = in_array($optionsValue, $optionsFromRequest);
             $label = $this->getLabelFromRenderingInstructions($optionsValue, $count, $facetName, $facetConfiguration);
-            $facet->addOption(new Option($facet, $label, $optionsValue, $count, $isOptionsActive, $metricsFromSolrResponse[$optionsValue]));
+            $facet->addOption($this->objectManager->get(Option::class, $facet, $label, $optionsValue, $count, $isOptionsActive, $metricsFromSolrResponse[$optionsValue]));
         }
 
         // after all options have been created we apply a manualSortOrder if configured

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
@@ -81,7 +81,7 @@ class QueryGroupFacetParser extends AbstractFacetParser
                     $facetName,
                     $facetConfiguration
                 );
-                $facet->addOption(new Option($facet, $label, $value, $count, $isOptionsActive));
+                $facet->addOption($this->objectManager->get(Option::class, $facet, $label, $value, $count, $isOptionsActive));
             }
         }
 

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -65,7 +65,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
 
             foreach ($countsFromResponse as $rangeCountValue => $count) {
                 $rangeCountValue = $this->parseResponseValue($rangeCountValue);
-                $rangeCount = new $facetRangeCountClass($rangeCountValue, $count);
+                $rangeCount = $this->objectManager->get($facetRangeCountClass, $rangeCountValue, $count);
                 $rangeCounts[] = $rangeCount;
                 $allCount += $count;
             }
@@ -87,7 +87,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
             $type = isset($facetConfiguration['type']) ? $facetConfiguration['type'] : 'numericRange';
             $gap = isset($facetConfiguration[$type . '.']['gap']) ? $facetConfiguration[$type . '.']['gap'] : 1;
 
-            $range = new $facetItemClass($facet, $from, $to, $fromInResponse, $toInResponse, $gap, $allCount, $rangeCounts, true);
+            $range = $this->objectManager->get($facetItemClass, $facet, $from, $to, $fromInResponse, $toInResponse, $gap, $allCount, $rangeCounts, true);
             $facet->setRange($range);
         }
 

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -126,7 +126,7 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
 
             $isResetOption = $field === 'relevance';
             // @todo allow stdWrap on label
-            $sorting = new Sorting($resultSet, $sortingName, $field, $direction, $label, $selected, $isResetOption);
+            $sorting = $this->getObjectManager()->get(Sorting::class, $resultSet, $sortingName, $field, $direction, $label, $selected, $isResetOption);
             $resultSet->addSorting($sorting);
         }
 


### PR DESCRIPTION
# What this pr does
Use ObjectManager to create new objects.

For some projects we need to overwrite the objects to implement custom behavior. This is not possible when they are constructed with new.