### PR TITLE
[TASK] Update the URI of the main Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To try out Apache Solr for TYPO3 visit [www.typo3-solr.com](http://www.typo3-sol
 
 -   **Main Documentation:**
 
-    https://docs.typo3.org/typo3cms/extensions/solr/
+    https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/
 
 
 -   **Slack Channel:**


### PR DESCRIPTION
# What this pr does
As the old URI is only giving documentation up to solr 9.0.2 I updated
the URI to the new location of the documentation. Also I used `master`
as documentation branch. When backported to the old branches this part
of the path could/should be adjusted.

# How to test
Visit the old URI and the new one

Fixes: #2505
