### PR TITLE
Allow Wildcards in Filter Queries

### DIFF
--- a/Classes/System/Service/ConfigurationService.php
+++ b/Classes/System/Service/ConfigurationService.php
@@ -131,7 +131,7 @@ class ConfigurationService
             $fieldName = $filter['field'];
             $fieldValue = $filter['value'];
 
-            if (!is_numeric($fieldValue)) {
+            if (!is_numeric($fieldValue) && strpos($fieldValue, '?') === false && strpos($fieldValue, '*') === false) {
                 $fieldValue = '"' . str_replace('"', '\"', $fieldValue) . '"';
             }
 


### PR DESCRIPTION
# What this pr does

Filter Queries are escaped by " if they are not numeric. Therefore wildcards are not possible. This commit extends the check, if the fieldValue should be escaped by double quotes.

# How to test

Add a filter in the FlexForm "url"
/private -> only page with Slug /private is found
/private* -> no page is found

# Test after fix

\/private* -> page /private and subpages are found