### PR TITLE
[FEATURE] Enable SuggestAction to Provide pure JSON

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -47,9 +47,8 @@ class SuggestController extends AbstractBaseController
      * @param array $additionalFilters
      * @return string
      */
-    public function suggestAction($queryString, $callback, $additionalFilters = [])
+    public function suggestAction($queryString, $callback = null, $additionalFilters = [])
     {
-        $jsonPCallback = htmlspecialchars($callback);
         // Get suggestions
         $rawQuery = htmlspecialchars(mb_strtolower(trim($queryString)));
 
@@ -72,8 +71,12 @@ class SuggestController extends AbstractBaseController
             $this->handleSolrUnavailable();
             $result = ['status' => false];
         }
-
-        return htmlspecialchars($jsonPCallback) . '(' . json_encode($result) . ')';
+        if ($callback) {
+            return htmlspecialchars($callback) . '(' . json_encode($result) . ')';
+        }
+        else {
+            return json_encode($result);
+        }
     }
 
 }


### PR DESCRIPTION
# What this pr does

With this, the SuggestAction Controller can handle Requests with no `tx_solr[callback]` given and willthen return pure JSON with no callback-prefix.

# How to test

Call the Controller with no callback-parameter. It is still not crashing and returns a pure JSON.
