### PR TITLE
One category must have many ancestor categories

### DIFF
--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -91,11 +91,17 @@ class Service
                         /** @var $processor PageUidToHierarchy */
                         $processor = GeneralUtility::makeInstance(PageUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
+                        if ($isSingleValueField && count($fieldValue) > 1){
+                                $isSingleValueField = false;
+                        }
                         break;
                     case 'categoryUidToHierarchy':
                         /** @var $processor CategoryUidToHierarchy */
                         $processor = GeneralUtility::makeInstance(CategoryUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
+                        if ($isSingleValueField && count($fieldValue) > 1){
+                                $isSingleValueField = false;
+                        }
                         break;
                     case 'uppercase':
                         $fieldValue = array_map('mb_strtoupper', $fieldValue);


### PR DESCRIPTION
One category must have many ancestor categories so returning only the first category, will result on not valid results when filtering by facets.

# What this pr does

Fix the multicategories problem on categoryUidToHierarchy

# How to test
Add one children category to a Document. It will only index the root category. 
