### PR TITLE
IndexInspector is showing wrong language to document relation

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -290,8 +290,8 @@ class ConnectionManager implements SingletonInterface
     {
         $connections = [];
 
-        foreach ($site->getAllSolrConnectionConfigurations() as $solrConnectionConfiguration) {
-            $connections[] = $this->getConnectionFromConfiguration($solrConnectionConfiguration);
+        foreach ($site->getAllSolrConnectionConfigurations() as $languageId => $solrConnectionConfiguration) {
+            $connections[$languageId] = $this->getConnectionFromConfiguration($solrConnectionConfiguration);
         }
 
         return $connections;


### PR DESCRIPTION
# What this pr does

* Is adding the language uid as array key again in order to have the correct core to language
relation in the IndexInspector

# How to test

Check in the backend if the correct core is used when the documents are shown with the index inspector.

Fixes: #2553