### PR TITLE
[TASK] Replace current URL with new filter URL

### DIFF
--- a/Resources/Public/JavaScript/search_controller.js
+++ b/Resources/Public/JavaScript/search_controller.js
@@ -27,6 +27,7 @@ function SearchController() {
                 _this.scrollToTopOfElement(solrParent, 50);
                 jQuery("body").trigger("tx_solr_updated");
                 loader.fadeOut().remove();
+                history.replaceState({}, null, uri.removeQuery("type").href());
             }
         );
         return false;


### PR DESCRIPTION
# What this pr does

When a user clicks on a facet filter option the result is loaded using AJAX (if you choose to use the AJAXIFY static typoscript template). If you then request another page (e.g. from the search results) and return back to the search results using the browser back button your set filter options are gone.
This PR adds JS code to replace the current browsers URL on the search results page after the AJAX call is returned.
Therefore the status of the chosen filter options is reflected in the URL and you can use the back button to return to search page with the previously chosen options already set.

# How to test

- Create a page with the solr search plugin
- Configure facet options to filter the search result
- Use the solr static typoscript template "AJAXIFY search results"
- Click a filter option and see that the current url is changed.

# What was changed

I added only a single line of JS code to the file "search_controller", which replaces the current URL with the AJAX filter URL, without the type parameter though.
