### PR TITLE
Records are not properly overlayed when language context exists

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -27,7 +27,9 @@ class Tsfe implements SingletonInterface
     {
         $context = GeneralUtility::makeInstance(Context::class);
         if ($context->hasAspect('language')) {
-            if ($context->getPropertyFromAspect('language', 'id') === $language) {
+            $hasRightLanguageId = $context->getPropertyFromAspect('language', 'id') === $language;
+            $hasRightContentLanguageId = $context->getPropertyFromAspect('language', 'contentId')  === $language;
+            if ($hasRightLanguageId && $hasRightContentLanguageId) {
                 return;
             }
         }


### PR DESCRIPTION
# What this pr does

* Checks in addition if contentId is set as expected in order to force a re-initialization of the language context if required

Fixes: #2559
