### PR TITLE
Add PHP 7.4 to travis.yml and require TYPO3 10 build to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 jdk:
   - oraclejdk8
@@ -30,7 +31,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: TYPO3_VERSION="^10.0"
     - env: TYPO3_VERSION="dev-master"
 
 before_install:

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -307,6 +307,7 @@ class UtilTest extends IntegrationTest
             $context->hasAspect('language')->shouldBeCalled()->willReturn(true);
             $context->getPropertyFromAspect('language', 'id')->shouldBeCalled()->willReturn(0);
             $context->getPropertyFromAspect('language', 'id', 0)->shouldBeCalled()->willReturn(0);
+            $context->getPropertyFromAspect('language', 'contentId')->shouldBeCalled()->willReturn(0);
             $context->getAspect('frontend.user')->shouldBeCalled()->willReturn($frontendUserAspect->reveal());
             $context->getAspect('workspace')->shouldBeCalled()->willReturn($workspaceAspect->reveal());
             $context->getPropertyFromAspect('visibility', 'includeHiddenContent', false)->shouldBeCalled();


### PR DESCRIPTION
# What this pr does

* Add's php 7.4 to the travis setup
* Makes build passing against TYPO3 10 required

# How to test

* Build should be executed with PHP 7.4 as well
* Builds against TYPO3 10 should be green and required to be green

Fixes: #2561
