### PR TITLE
[BUGFIX] Place loading animation in accurate center position

### DIFF
--- a/Resources/Public/StyleSheets/Frontend/loader.css
+++ b/Resources/Public/StyleSheets/Frontend/loader.css
@@ -1,7 +1,7 @@
 
 .tx-solr-loader {
     position: fixed;
-    left: 50%;
+    left: calc(50% - 50px);
     top: 35%;
     width: 100px;
     height: 100px;


### PR DESCRIPTION
The loading animation used for the Ajaxify TS template, when loading facetted search results is now placed accurately in the center. This error showed especially on mobile devices, where you could see that the animation was not placed in the center correctly.

# What this pr does

It places the loading animation accurately in the center.

# How to test

- Make a facetted search
- Use the Ajaxify static Typoscript template
- Choose a filter option and see the loading animation being placed in the center