### PR TITLE
[FEATURE] Add check for .tx-solr-autocomplete to add autocomplete div

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -3,7 +3,13 @@ function SuggestController() {
     this.init = function () {
 
         jQuery('form[data-suggest]').each(function () {
-            var $form = $(this), $searchBox = $form.find('.tx-solr-suggest');
+            var $form = $(this), $searchBox = $form.find('.tx-solr-suggest'), $formAutoComplete;
+
+            if ($form.find('.tx-solr-autocomplete').length > 0){
+                $formAutoComplete = $form.find('.tx-solr-autocomplete');
+            } else {
+                $formAutoComplete = $('body');
+            }
 
             $form.find('.tx-solr-suggest-focus').focus();
 
@@ -29,6 +35,7 @@ function SuggestController() {
                 paramName: 'tx_solr[queryString]',
                 groupBy: 'category',
                 maxHeight: 1000,
+                appendTo: $formAutoComplete,
                 autoSelectFirst: false,
                 triggerSelectOnValidInput: false,
                 width: $searchBox.outerWidth() * 0.66,


### PR DESCRIPTION

# What this pr does
Before this change the autocomplete div `.autocomplete-suggestions` was always added to the body (see `jquery.autocomplete.min.js`). But when you want to overwrite styling relative to the form this was impossible. So by adding a check for `.tx-solr-autocomplete` you can now add a div with class `.tx-solr-autocomplete` inside the form to have your autocomplete on that position.

# How to test
Add `<div class="tx-solr-autocomplete"></div>` somewhere inside the `<s:searchForm id="tx-solr-search-form-pi-results">` element and see the autocomplete divs are now added on that position. By removing the div, the autocomplete is appended to the body.

Fixes: #2569 
