### PR TITLE
[BUGFIX] Remove breaking semicolon from SearchResultSetService

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -87,7 +87,7 @@ class SearchResultSetService
     protected $typoScriptConfiguration;
 
     /**
-     * @var SolrLogManager;
+     * @var SolrLogManager
      */
     protected $logger = null;
 


### PR DESCRIPTION
The trailing semicolon in line 90 was breaking the functionality of
phpdocumentor, which was updated by TYPO3 core recently. Removing it
makes the frontend work again.

Solves: #2573
