### PR TITLE
Remove wrong semicolon in variable type doc comment

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -87,7 +87,7 @@ class SearchResultSetService
     protected $typoScriptConfiguration;
 
     /**
-     * @var SolrLogManager;
+     * @var SolrLogManager
      */
     protected $logger = null;
 


### PR DESCRIPTION
With the semicolon the symfony/property-info/Extractor/PhpDocExtractor.php throws an exception due to an invalid tag.

# What this pr does

Removes a semicolon to have a valid @var tag.

# How to test

1. Use TYPO3 v10
2. Use current master of Solr
3. Create a plugin with search form
4. Visit the page
5. See the exception

Fixes: #2580
