### PR TITLE
[BUGFIX] Docker image managed resources are not writable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: bionic
+
 language: php
 
 services:
   - mysql
-  - docker
 
 php:
   - 7.2
@@ -36,6 +37,10 @@ matrix:
       env: TYPO3_VERSION="^10.0"
 
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - mysql -e 'CREATE DATABASE IF NOT EXISTS typo3_ci;'
   - composer self-update
   - composer --version
@@ -45,8 +50,8 @@ install:
   - Build/Test/bootstrap.sh
 
 script:
-  - Build/Test/cibuild.sh
   - Build/Test/cibuild_docker.sh
+  - Build/Test/cibuild.sh
 
 after_script:
   - Build/Test/publish_coverage.sh

--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -10,8 +10,8 @@ EXTENSION_ROOTPATH="$SCRIPTPATH/../../"
 SOLR_INSTALL_PATH="/opt/solr-tomcat/"
 
 if [[ $* == *--use-defaults* ]]; then
-    export TYPO3_VERSION="^8.7"
-    export PHP_CS_FIXER_VERSION="v2.3.2"
+    export TYPO3_VERSION="^10.4"
+    export PHP_CS_FIXER_VERSION="^2.16.1"
     export TYPO3_DATABASE_HOST="localhost"
     export TYPO3_DATABASE_NAME="test"
     export TYPO3_DATABASE_USERNAME="root"
@@ -19,11 +19,11 @@ if [[ $* == *--use-defaults* ]]; then
 fi
 
 if [[ $* == *--local* ]]; then
-    echo -n "Choose a TYPO3 Version (e.g. dev-master,^8.7): "
+    echo -n "Choose a TYPO3 Version (e.g. dev-master,^10.4): "
     read typo3Version
     export TYPO3_VERSION=$typo3Version
 
-    echo -n "Choose a php-cs-fixer version (v2.3.2): "
+    echo -n "Choose a php-cs-fixer version (v2.16.1): "
     read phpCSFixerVersion
     export PHP_CS_FIXER_VERSION=$phpCSFixerVersion
 

--- a/Build/Test/cibuild_docker.sh
+++ b/Build/Test/cibuild_docker.sh
@@ -1,5 +1,69 @@
 #!/bin/bash
 
+
+## BASH COLORS
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+## DEFAULT VOLUME EXPORT from original Solr Dockerfile:
+# see Dockerfile in desired version https://github.com/docker-solr/docker-solr/blob/abb53a7/8.5/Dockerfile
+DEFAULT_IMAGE_VOLUME_EXPORT_PATH="/var/solr"
+
+## Local docker things.
+LOCAL_VOLUME_PATH=${HOME}"/solrcivolume"
+LOCAL_VOLUME_NAME="solrci-volume"
+LOCAL_IMAGE_NAME="solrci-image"
+LOCAL_CONTAINER_NAME="solrci-container"
+
+## In Schema configuration available solr cores
+AVAILABLE_CORES=(
+  "core_de"
+  "core_en"
+  "core_ar"
+  "core_hy"
+  "core_eu"
+  "core_ptbr"
+  "core_my"
+  "core_ca"
+  "core_zh"
+  "core_cs"
+  "core_da"
+  "core_nl"
+  "core_fi"
+  "core_fr"
+  "core_gl"
+  "core_el"
+  "core_hi"
+  "core_hu"
+  "core_id"
+  "core_it"
+  "core_ja"
+  "core_km"
+  "core_ko"
+  "core_lo"
+  "core_no"
+  "core_fa"
+  "core_pl"
+  "core_pt"
+  "core_ro"
+  "core_ru"
+  "core_es"
+  "core_sv"
+  "core_th"
+  "core_tr"
+  "core_uk"
+  "core_rs"
+  "core_ie"
+  "core_lv"
+)
+
+prettyPrintOrExitOnError ()
+{
+  local output=${2}
+  [ ${1} -eq 0 ] && echo -en ${GREEN}' ✔\n'${NC} || { echo -en ${RED}' ✘\n'${NC} "${output[@]}"; cleanUp; exit 1; }
+}
+
 isHTTP200 ()
 {
   response=$(curl --write-out %{http_code} --silent --output /dev/null "${1}")
@@ -10,82 +74,152 @@ isHTTP200 ()
   return 1
 }
 
-assertCoreIsAvailable ()
+isPathOwnedBySolr ()
 {
-    echo "checking ${1}"
-    isHTTP200 "http://localhost:8998/solr/${1}/select" || { echo "${1} failed" ; exit 1; }
-    isHTTP200 "http://localhost:8998/solr/${1}/mlt?q=*" || { echo "${1} failed" ; exit 1; }
+  local status=0
+  for path in "$@"
+  do
+    [ `sudo stat -c '%u' $path` == 8983 ] && echo -e '  '${GREEN}'✔'${NC} $path || { echo -e '  '${RED}'✘'${NC} $path; status=1; }
+  done
+
+  return $status;
 }
 
-echo "Building docker image"
-docker build -t solrci -f Docker/SolrServer/Dockerfile .
+build_image ()
+{
+  echo -n "Building docker image"
+  prettyPrintOrExitOnError $? "$(docker build -t $LOCAL_IMAGE_NAME -f Docker/SolrServer/Dockerfile . 2>&1)"
+}
 
-echo "Creating testvolume"
-mkdir -p ~/solrcivolume
+run_container ()
+{
+  echo -n "Creating testvolume"
+  prettyPrintOrExitOnError $? "$(mkdir -p $LOCAL_VOLUME_PATH 2>&1)"
 
-echo "Add permissions to solr group"
-sudo chmod g+w ~/solrcivolume
+  echo -n "Add permissions to solr group"
+  prettyPrintOrExitOnError $? "$(sudo chmod g+w LOCAL_VOLUME_PATH 2>&1)"
 
-echo "Changing group of volume to solr user"
-sudo chown :8983 ~/solrcivolume
+  echo -n "Changing group of volume to solr user"
+  prettyPrintOrExitOnError $? "$(sudo chown 8983:8983 LOCAL_VOLUME_PATH 2>&1)"
 
-echo "Starting container"
-docker run -d -p 127.0.0.1:8998:8983 -v ~/solrcivolume:/var/solr/data/data solrci
+  echo -n "Create named volume inside of ~/solrcivolume"
+  prettyPrintOrExitOnError $? "$(docker volume create --name $LOCAL_VOLUME_NAME --opt type=none --opt device=$LOCAL_VOLUME_PATH --opt o=bind 2>&1)"
 
-echo "Waiting for container to boot"
-while true; do
-    isHTTP200 "http://localhost:8998/solr/"
-    if [ $? = 0 ]; then
-        echo "solr is up"
-        break
-    else
-        echo "#"
+  echo -n "Starting container"
+  prettyPrintOrExitOnError $? "$(docker run --name=$LOCAL_CONTAINER_NAME -d -p 127.0.0.1:8998:8983 -v $LOCAL_VOLUME_NAME:$DEFAULT_IMAGE_VOLUME_EXPORT_PATH $LOCAL_IMAGE_NAME 2>&1)"
+}
+
+cleanUp ()
+{
+  echo "Clean up the artifacts"
+
+  echo -n "  stop container $LOCAL_CONTAINER_NAME"
+  prettyPrintOrExitOnError $? "$(docker stop $LOCAL_CONTAINER_NAME 2>&1)"
+
+  echo -n "  remove container $LOCAL_CONTAINER_NAME"
+  prettyPrintOrExitOnError $? "$(docker container rm $LOCAL_CONTAINER_NAME 2>&1)"
+
+  echo -n "  remove volume $LOCAL_VOLUME_NAME"
+  prettyPrintOrExitOnError $? "$(docker volume rm $LOCAL_VOLUME_NAME 2>&1)"
+
+  echo -n "  remove image LOCAL_IMAGE_NAME"
+  prettyPrintOrExitOnError $? "$(docker image rm $LOCAL_IMAGE_NAME 2>&1)"
+
+  echo -n "  remove \"$LOCAL_VOLUME_PATH\" directory"
+  prettyPrintOrExitOnError $? "$(sudo rm -Rf $LOCAL_VOLUME_PATH 2>&1)"
+}
+
+isCoreAvailable ()
+{
+  isHTTP200 "http://localhost:8998/solr/${1}/select" || { return 1; }
+  isHTTP200 "http://localhost:8998/solr/${1}/mlt?q=*" || { return 1; }
+  return 0;
+}
+
+pingCore ()
+{
+  isHTTP200 "http://localhost:8998/solr/${1}/admin/ping" && { return 0; } || { return 1; }
+}
+
+assertVolumeExportHasNotBeenChanged ()
+{
+  echo -n "Check Dockerfile's VOLUME defintion has not been changed"
+  local EXPORTED_VULUME=$(docker image inspect --format='{{ range $a, $b := .Config.Volumes }}{{ printf "%s " $a }}{{end}}' $LOCAL_IMAGE_NAME)
+  if [[ "$EXPORTED_VULUME" == "$DEFAULT_IMAGE_VOLUME_EXPORT_PATH " ]]; then
+    prettyPrintOrExitOnError 0;
+  else
+    prettyPrintOrExitOnError 1 ${RED}'\n  The VOLUME defintion of image has been changed to "'"$EXPORTED_VULUME"'".\n\n"'"${NC}"
+  fi
+}
+
+assertAllCoresAreUp ()
+{
+  echo "Waiting for cores:"
+
+  local cores=("${AVAILABLE_CORES[@]}")
+  local iteration=0
+  while true ; do
+    ((iteration++))
+    if [ $iteration -gt 30 ] ; then
+      echo -ne ${RED}'\nTimeout by pinging the cores.\n\n'${NC}
+      cleanUp
+      exit 1;
     fi
+
+    for key in "${!cores[@]}" ; do
+      pingCore "${cores[$key]}"
+      if [[ $? == 0 ]]; then
+        echo -en "  ""${cores[$key]}"
+        unset 'cores[key]'
+        prettyPrintOrExitOnError 0
+      fi
+    done
+
+    if [ "${#cores[@]}" -eq 0 ] ; then
+      return 0
+    fi
+
     sleep 1
-done
+  done
+}
 
-echo "Give container some time to initialize cores"
-sleep 20
+assertAllCoresAreQueriable ()
+{
+  echo -e "\nCheck all cores are queriable:"
+  for core in "${AVAILABLE_CORES[@]}"
+  do
+    echo -n "  $core"
+    prettyPrintOrExitOnError $? "$(isCoreAvailable $core 2>&1)"
+  done
+}
 
-assertCoreIsAvailable "core_de"
-assertCoreIsAvailable "core_en"
-assertCoreIsAvailable "core_ar"
-assertCoreIsAvailable "core_hy"
-assertCoreIsAvailable "core_eu"
-assertCoreIsAvailable "core_ptbr"
-assertCoreIsAvailable "core_my"
-assertCoreIsAvailable "core_ca"
-assertCoreIsAvailable "core_zh"
-assertCoreIsAvailable "core_cs"
-assertCoreIsAvailable "core_da"
-assertCoreIsAvailable "core_nl"
-assertCoreIsAvailable "core_fi"
-assertCoreIsAvailable "core_fr"
-assertCoreIsAvailable "core_gl"
-assertCoreIsAvailable "core_el"
-assertCoreIsAvailable "core_hi"
-assertCoreIsAvailable "core_hu"
-assertCoreIsAvailable "core_id"
-assertCoreIsAvailable "core_it"
-assertCoreIsAvailable "core_ja"
-assertCoreIsAvailable "core_km"
-assertCoreIsAvailable "core_ko"
-assertCoreIsAvailable "core_lo"
-assertCoreIsAvailable "core_no"
-assertCoreIsAvailable "core_fa"
-assertCoreIsAvailable "core_pl"
-assertCoreIsAvailable "core_pt"
-assertCoreIsAvailable "core_ro"
-assertCoreIsAvailable "core_ru"
-assertCoreIsAvailable "core_es"
-assertCoreIsAvailable "core_sv"
-assertCoreIsAvailable "core_th"
-assertCoreIsAvailable "core_tr"
-assertCoreIsAvailable "core_uk"
-assertCoreIsAvailable "core_rs"
-assertCoreIsAvailable "core_ie"
-assertCoreIsAvailable "core_lv"
+assertNeccesseryPathsAreOwnedBySolr ()
+{
+  echo -e "\nCheck paths are owned by solr(8983)":
+  local paths=(
+    $LOCAL_VOLUME_PATH/data
+    $LOCAL_VOLUME_PATH/data/data
+    $LOCAL_VOLUME_PATH/data/configsets/ext_solr_*/conf/
+    $LOCAL_VOLUME_PATH/data/configsets/*/conf/_schema_analysis*.json
+  )
 
-echo "all checks passed"
+  isPathOwnedBySolr "${paths[@]}" || { echo -e ${RED}'\nThe image has files, which are not owned by solr(8983) user.\n'${NC}; exit 1; }
+}
+
+### run the tests
+
+build_image
+assertVolumeExportHasNotBeenChanged
+
+run_container
+assertAllCoresAreUp
+
+assertNeccesseryPathsAreOwnedBySolr
+
+assertAllCoresAreQueriable
+
+echo -e "${GREEN}"'\nAll checks passed successfully!\n'"${NC}"
+
+cleanUp
+
 exit 0
-

--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -6,5 +6,5 @@ USER root
 RUN rm -fR /opt/solr/server/solr/*
 USER solr
 
-COPY Resources/Private/Solr/ /var/solr/data
+COPY --chown=$SOLR_USER:$SOLR_GROUP Resources/Private/Solr/ /var/solr/data
 RUN mkdir -p /var/solr/data/data

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_arabic.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_arabic.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_armenian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_armenian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_basque.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_basque.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_brazilian_portuguese.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_brazilian_portuguese.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_bulgarian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_bulgarian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_burmese.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_burmese.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_catalan.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_catalan.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_chinese.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_chinese.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_czech.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_czech.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_danish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_danish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_dutch.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_dutch.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_english.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_english.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_finnish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_finnish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_french.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_french.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_galician.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_galician.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_generic.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_generic.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_german.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_german.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_greek.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_greek.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_hindi.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_hindi.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_hungarian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_hungarian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_indonesian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_indonesian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_irish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_irish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_italian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_italian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_japanese.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_japanese.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_khmer.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_khmer.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_korean.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_korean.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_lao.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_lao.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_latvia.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_latvia.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_norwegian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_norwegian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_persian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_persian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_polish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_polish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_portuguese.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_portuguese.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_romanian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_romanian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_russian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_russian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_serbian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_serbian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_spanish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_spanish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_swedish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_swedish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_thai.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_thai.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_turkish.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_turkish.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_ukrainian.json
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/_schema_analysis_synonyms_ukrainian.json
@@ -1,0 +1,1 @@
+{"initArgs":{"ignoreCase":false},"initializedOn":"2020-04-22T13:10:36.456Z","managedMap":{}}

--- a/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_0_0/conf/brazilian_portuguese/schema.xml
@@ -170,7 +170,7 @@
 
 			<filter class="solr.LowerCaseFilterFactory"/>
 
-			<filter class="solr.ManagedStopFilterFactory" managed="brazilian-portuguese"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -180,7 +180,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="brazilian_portuguese" />
-			<filter class="solr.ManagedStopFilterFactory" managed="brazilian-portuguese"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="brazilian_portuguese"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -130,12 +130,14 @@ abstract class IntegrationTest extends FunctionalTestCase
      * Loads a Fixture from the Fixtures folder beside the current test case.
      *
      * @param $fixtureName
-     * @throws ReflectionException
-     * @throws Exception
      */
     protected function importDataSetFromFixture($fixtureName)
     {
-        $this->importDataSet($this->getFixturePathByName($fixtureName));
+        try {
+            $this->importDataSet($this->getFixturePathByName($fixtureName));
+            return;
+        } catch (\Exception $e) {}
+        $this->fail(sprintf('Can not import "%s" fixture.', $fixtureName));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,15 @@
   },
   "require": {
     "php": ">=7.2.0",
-    "typo3/cms-core": "^9.5.0 || ^10.0",
-    "typo3/cms-backend": "^9.5.0 || ^10.0",
-    "typo3/cms-extbase": "^9.5.0 || ^10.0",
-    "typo3/cms-frontend": "^9.5.0 || ^10.0",
-    "typo3/cms-fluid": "^9.5.0 || ^10.0",
-    "typo3/cms-reports": "^9.5.0 || ^10.0",
-    "typo3/cms-scheduler": "^9.5.0 || ^10.0",
-    "typo3/cms-tstemplate": "^9.5.0 || ^10.0",
+    "ext-json": "*",
+    "typo3/cms-core": "^9.5.0 || ^10.4.0",
+    "typo3/cms-backend": "^9.5.0 || ^10.4.0",
+    "typo3/cms-extbase": "^9.5.0 || ^10.4.0",
+    "typo3/cms-frontend": "^9.5.0 || ^10.4.0",
+    "typo3/cms-fluid": "^9.5.0 || ^10.4.0",
+    "typo3/cms-reports": "^9.5.0 || ^10.4.0",
+    "typo3/cms-scheduler": "^9.5.0 || ^10.4.0",
+    "typo3/cms-tstemplate": "^9.5.0 || ^10.4.0",
     "solarium/solarium": "~4.2.0"
   },
   "require-dev": {


### PR DESCRIPTION
# What this pr does

* Fixes file permissions inside docker image.
* Adds test cases for CI docker build
* Improves documentation about docker usage

# How to test

Build the image and try to change stop words and sysnonyms via EXT:Solr "Core Optimization" module. Managing them must be possible.
Alternatively in Solr Admin UI Logs module the warning messages like
`Cannot write to config directory /var/solr/data/configsets/ext_solr_11_0_0/conf; switching to use InMemory storage instead.` must not be present.

Following commands can be used to build and run the image:

```
docker build -t solrci-image -f Docker/SolrServer/Dockerfile
docker run --name=solrci-container -d -p 8983:8983
```


Fixes: #2555 by docs improvement
