### PR TITLE
[TASK] Fix Util integration tests for TYPO3 10 LTS

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -70,11 +70,13 @@ class Tsfe implements SingletonInterface
             $site = $siteFinder->getSiteByPageId($pageId);
             $siteLanguage = $site->getLanguageById($language);
 
+                /** @var ServerRequest $request */
             $request = GeneralUtility::makeInstance(ServerRequest::class);
             $request = $request->withAttribute('site', $site);
             $this->requestCache[$cacheId] = $request->withAttribute('language', $siteLanguage);
         }
         $GLOBALS['TYPO3_REQUEST'] = $this->requestCache[$cacheId];
+
 
         if (!isset($this->tsfeCache[$cacheId])) {
 


### PR DESCRIPTION
# What this pr does

* Fixes the integration tests for the Util class by adjusting the assertions

# How to test

* Check if the test is now exected for TYPO3 9 and 10 and is green on travis

