### PR TITLE
[TASK] Fix integration tests for ResultSetReconstitutionProcessor

### DIFF
--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/simple_site.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/simple_site.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                page = PAGE
+                page.typeNum = 0
+                page.bodyTag = <body>
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+        <static_file_mode>0</static_file_mode>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -71,11 +71,9 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
      */
     public function canApplyRenderingInstructionsOnOptions()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-
-        $this->fakeTSFEToUseCObject();
+        $this->importDataSetFromFixture('simple_site.xml');
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->fakeTSFE(1);
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -124,10 +122,9 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
      */
     public function labelCanBeUsedAsCObject()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-        $this->fakeTSFEToUseCObject();
+        $this->importDataSetFromFixture('simple_site.xml');
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->fakeTSFE(1);
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
         // before the reconstitution of the domain object from the response we expect that no facets
@@ -182,19 +179,5 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
         $fakeObjectManager = $this->getFakeObjectManager();
         $processor->setObjectManager($fakeObjectManager);
         return $processor;
-    }
-
-    /**
-     *
-     */
-    protected function fakeTSFEToUseCObject()
-    {
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'] = array_merge($GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'], ['TEXT' => TextContentObject::class, 'CASE' => CaseContentObject::class, ]);
-
-        $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class, [], 1, 0);
-        $TSFE->cObjectDepthCounter = 5;
-        $TSFE->fe_user = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
-        $GLOBALS['TSFE'] = $TSFE;
-        $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
     }
 }


### PR DESCRIPTION
# What this pr does

* Changes the ResultSetReconsitutionProcessorTest to use the initialization logic for Sites
to be able to use the cObject from TSFE in ResultSetReconsitutionProcessor

# How to test

Tests of ResultSetReconsitutionProcessor are executed and green for TYPO3 9 & 10

