### PR TITLE
[TASK] Fix absRefPrefix test

### DIFF
--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -106,9 +106,6 @@ class IndexServiceTest extends IntegrationTest
      */
     public function canResolveBaseAsPrefix($absRefPrefix, $expectedUrl)
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
         $this->cleanUpSolrServerAndAssertEmpty();
 
         // create fake extension database table and TCA


### PR DESCRIPTION
# What this pr does

* Removes the conditional skip for TYPO3 10 since this seems to be fixed in the core

# How to test

Test is executed with TYPO3 9 & 10 and green
