### PR TITLE
[BUGFIX] Fix indexing when default language is disabled in site config

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -528,7 +528,7 @@ class Indexer extends AbstractIndexer
         $defaultLanguageUid = $this->getDefaultLanguageUid($item, $site->getRootPage(), $siteLanguages);
         $translationOverlays = $this->getTranslationOverlaysWithConfiguredSite((int)$pageId, $site, (array)$siteLanguages);
 
-        $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId, 0, $item->getMountPointIdentifier());
+        $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId, $defaultLanguageUid, $item->getMountPointIdentifier());
         $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays);
 
         if ($defaultLanguageUid == 0) {
@@ -611,10 +611,12 @@ class Indexer extends AbstractIndexer
      * @return int
      * @throws \RuntimeException
      */
-    private function getDefaultLanguageUid(Item $item, array $rootPage, array $siteLanguages)
+    protected function getDefaultLanguageUid(Item $item, array $rootPage, array $siteLanguages)
     {
         $defaultLanguageUid = 0;
-        if (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) > 1) {
+        if (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) == 1 && $siteLanguages[min(array_keys($siteLanguages))] > 0) {
+            $defaultLanguageUid = $siteLanguages[min(array_keys($siteLanguages))];
+        } elseif (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) > 1) {
             unset($siteLanguages[array_search('0', $siteLanguages)]);
             $defaultLanguageUid = $siteLanguages[min(array_keys($siteLanguages))];
         } elseif (($rootPage['l18n_cfg'] & 1) == 1 && count($siteLanguages) == 1) {

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -616,4 +616,29 @@ class IndexerTest extends IntegrationTest
         $this->assertCount(1, $result, "Expect only one SOLR connection.");
         $this->assertArrayNotHasKey(0, $result, "Expect, that there is no solr connection returned for default language,");
     }
+
+    /**
+     * @test
+     */
+    public function getSolrConnectionsByItemReturnsNoDefaultConnectionDefaultLanguageIsHiddenInSiteConfig()
+    {
+        $this->writeDefaultSolrTestSiteConfigurationForHostAndPort('http', 'localhost', 8999, true);
+        $this->importDataSetFromFixture('can_index_with_rootPage_set_to_hide_default_language.xml');
+        $itemMetaData = [
+            'uid' => 1,
+            'root' => 1,
+            'item_type' => 'pages',
+            'item_uid' => 1,
+            'indexing_configuration' => '',
+            'has_indexing_properties' => false
+        ];
+        $item = new Item($itemMetaData);
+
+        $result = $this->callInaccessibleMethod($this->indexer,'getSolrConnectionsByItem', $item);
+
+        $this->assertEmpty($result[0], 'Connection for default language was expected to be empty');
+        $this->assertInstanceOf(SolrConnection::class, $result[1], "Expect SolrConnection object in connection array item with key 1.");
+        $this->assertCount(1, $result, "Expect only one SOLR connection.");
+        $this->assertArrayNotHasKey(0, $result, "Expect, that there is no solr connection returned for default language,");
+    }
 }

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -481,15 +481,19 @@ abstract class IntegrationTest extends FunctionalTestCase
      * @param int $port
      * @return void
      */
-    protected function writeDefaultSolrTestSiteConfigurationForHostAndPort($scheme = 'http', $host = 'localhost', $port = 8999)
+    protected function writeDefaultSolrTestSiteConfigurationForHostAndPort($scheme = 'http', $host = 'localhost', $port = 8999, $disableDefaultLanguage = false)
     {
-        $siteCreatedHash = md5($scheme . $host . $port);
+        $siteCreatedHash = md5($scheme . $host . $port . $disableDefaultLanguage);
         if (self::$lastSiteCreated === $siteCreatedHash) {
             return;
         }
 
         $defaultLanguage = $this->buildDefaultLanguageConfiguration('EN', '/en/');
         $defaultLanguage['solr_core_read'] = 'core_en';
+
+        if ($disableDefaultLanguage === true) {
+            $defaultLanguage['enabled'] = 0;
+        }
 
         $german = $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback');
         $german['solr_core_read'] = 'core_de';


### PR DESCRIPTION
# What this pr does

* Fixes the indexing if the default language was disabled in the site config
* Add's an integration test for that case

# How to test

Check the indexing of a site when the default language was disabled in the site configuration.

Fixes: #2451
