### PR TITLE
[BUGFIX] Remove eval int from port in site configuration

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -52,7 +52,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
     'label' => 'Port',
     'config' => [
         'type' => 'input',
-        'eval' => 'int,required',
+        'eval' => 'required',
         'size' => 5,
         'default' => 8983
     ],


### PR DESCRIPTION
If using dot env, the eval int option leads to an error in the site config.

Resolves: #2533