### PR TITLE
Replace usage of TYPO3_branch

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -313,10 +313,7 @@ class Util
      */
     public static function getIsTYPO3VersionBelow10()
     {
-        if (!defined('TYPO3_branch')) {
-            $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-        }
-        return (bool)version_compare(TYPO3_branch, '10.0', '<');
+        return GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 10;
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
   "require": {
     "php": ">=7.2.0",
     "ext-json": "*",
-    "typo3/cms-core": "^9.5.0 || ^10.4.0",
-    "typo3/cms-backend": "^9.5.0 || ^10.4.0",
-    "typo3/cms-extbase": "^9.5.0 || ^10.4.0",
-    "typo3/cms-frontend": "^9.5.0 || ^10.4.0",
-    "typo3/cms-fluid": "^9.5.0 || ^10.4.0",
-    "typo3/cms-reports": "^9.5.0 || ^10.4.0",
-    "typo3/cms-scheduler": "^9.5.0 || ^10.4.0",
-    "typo3/cms-tstemplate": "^9.5.0 || ^10.4.0",
+    "typo3/cms-core": "^9.5.16 || ^10.4.0",
+    "typo3/cms-backend": "^9.5.16 || ^10.4.0",
+    "typo3/cms-extbase": "^9.5.16 || ^10.4.0",
+    "typo3/cms-frontend": "^9.5.16 || ^10.4.0",
+    "typo3/cms-fluid": "^9.5.16 || ^10.4.0",
+    "typo3/cms-reports": "^9.5.16 || ^10.4.0",
+    "typo3/cms-scheduler": "^9.5.16 || ^10.4.0",
+    "typo3/cms-tstemplate": "^9.5.16 || ^10.4.0",
     "solarium/solarium": "~4.2.0"
   },
   "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '9.5.0-'
+            'typo3' => '9.5.16-10.5.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
In favor of the deprecated constant TYPO3_branch the class Typo3Version should be used.
This is available since 9.5.16