### PR TITLE
[TASK] Remove langdisable=1 in FlexForms

### DIFF
--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/FlexForms/Results.xml
+++ b/Configuration/FlexForms/Results.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>


### PR DESCRIPTION
The langDisable setting has been removed with TYPO3 7 and can be
removed.