### PR TITLE
[BUGFIX] set max TYPO3 Version to 10.4.99 in ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '9.5.16-10.5.99'
+            'typo3' => '9.5.16-10.4.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
set to max supported TYPO3 Version 10.4.99 in ext_emconf.php