### PR TITLE
[TASK] Use fixed groups instead of env variables

### DIFF
--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -6,5 +6,5 @@ USER root
 RUN rm -fR /opt/solr/server/solr/*
 USER solr
 
-COPY --chown=$SOLR_USER:$SOLR_GROUP Resources/Private/Solr/ /var/solr/data
+COPY --chown=solr:solr Resources/Private/Solr/ /var/solr/data
 RUN mkdir -p /var/solr/data/data


### PR DESCRIPTION
# What this pr does

* Changes the user and group to the real groups of the container since this fails on docker hub and is same on each environment. 

# How to test

* Check if the docker container is build on docker hub and synonyms and stopwords can be written

Fixes: #2612
