### PR TITLE
[BUGFIX] Add option to override 'port' in frontend indexing URL

### DIFF
--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
@@ -72,6 +72,11 @@ abstract class AbstractUriStrategy
             $urlHelper->setHost($overrideConfiguration['host']);
         }
 
+        // overwriting the port
+        if (!empty($overrideConfiguration['port'])) {
+            $urlHelper->setPort($overrideConfiguration['port']);
+        }
+
         // setting a path if TYPO3 is installed in a sub directory
         if (!empty($overrideConfiguration['path'])) {
             $urlHelper->setPath($overrideConfiguration['path']);

--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -107,6 +107,24 @@ class UrlHelper {
     }
 
     /**
+     * @param string $port
+     * @return UrlHelper
+     */
+    public function setPort(string $port)
+    {
+        $this->setUrlPart('port', $port);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPort(): string
+    {
+        return $this->getUrlPart('port');
+    }
+
+    /**
      * @param string $scheme
      * @return UrlHelper
      */


### PR DESCRIPTION
# What this pr does

This adds the missing port option to the override configuration:

```
plugin.tx_solr.index.queue.pages.indexer.frontendDataHelper.port = 80
```

# How to test

Obvious ;-)

Fixes: #2327
