### PR TITLE
[FEATURE] Change FileWriter configuration to use logFileInfix

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -192,7 +192,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['LOG']['ApacheSolrForTypo3']['Solr']['wri
     $GLOBALS['TYPO3_CONF_VARS']['LOG']['ApacheSolrForTypo3']['Solr']['writerConfiguration'] = [
         $logLevel => [
             'TYPO3\\CMS\\Core\\Log\\Writer\\FileWriter' => [
-                'logFile' => 'typo3temp/var/logs/solr.log'
+                'logFileInfix' => 'solr'
             ]
         ],
     ];


### PR DESCRIPTION
# What this pr does

Currently Solr logs into a hardcoded logfile "typo3temp/var/logs/solr.log", which is in a different directory than the other logfiles. Since v9, TYPO3 by default logs into "typo3temp/var/log" (note the missing S). This is unexpected, and could lead to user not finding the log file at all. See also: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Feature-85236-InfixOptionToDefaultLogFileNamesForFileWriter.html

# How to test

Activate logging in TypoScript an do something to create log output (e.g. logging.indexing = 1). There will be a new log file created in typo3temp/var/log named "typo3_solr_f5841fa7f9.log".

Fixes: #2626
