### PR TITLE
[BUGFIX:BACKPORT] Re-enable Integration Tests for TYPO3 v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,13 @@ env:
     - PHP_CS_FIXER_VERSION="^2.16.1"
   matrix:
     - TYPO3_VERSION="^9.5"
-    - TYPO3_VERSION="^10.0"
+    - TYPO3_VERSION="^10.4"
     - TYPO3_VERSION="dev-master"
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: TYPO3_VERSION="dev-master"
-    - php: 7.2
-      env: TYPO3_VERSION="^10.0"
 
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/Build/Test/IntegrationFrontendTests.xml
+++ b/Build/Test/IntegrationFrontendTests.xml
@@ -1,0 +1,29 @@
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="true"
+    stopOnError="true"
+    stopOnFailure="true"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false">
+
+    <testsuites>
+        <testsuite name="ext-solr-integration-tests">
+            <directory>../../Tests/Integration/Controller</directory>
+            <exclude>../../Tests/Integration/Controller/Backend/</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">../../Classes/</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <const name="TYPO3_MODE" value="FE" />
+    </php>
+</phpunit>

--- a/Build/Test/IntegrationFrontendTests.xml
+++ b/Build/Test/IntegrationFrontendTests.xml
@@ -14,10 +14,14 @@
 
     <testsuites>
         <testsuite name="ext-solr-integration-tests">
-            <directory>../../Tests/Integration/Controller</directory>
-            <exclude>../../Tests/Integration/Controller/Backend/</exclude>
+            <directory>../../Tests/Integration/</directory>
         </testsuite>
     </testsuites>
+    <groups>
+        <include>
+            <group>frontend</group>
+        </include>
+    </groups>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">../../Classes/</directory>

--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -15,10 +15,13 @@
 	<testsuites>
 		<testsuite name="ext-solr-integration-tests">
 			<directory>../../Tests/Integration/</directory>
-			<directory>../../Tests/Integration/Controller/Backend/</directory>
-			<exclude>../../Tests/Integration/Controller/</exclude>
 		</testsuite>
 	</testsuites>
+	<groups>
+		<exclude>
+			<group>frontend</group>
+		</exclude>
+	</groups>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">../../Classes/</directory>

--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -15,6 +15,8 @@
 	<testsuites>
 		<testsuite name="ext-solr-integration-tests">
 			<directory>../../Tests/Integration/</directory>
+			<directory>../../Tests/Integration/Controller/Backend/</directory>
+			<exclude>../../Tests/Integration/Controller/</exclude>
 		</testsuite>
 	</testsuites>
 	<filter>
@@ -22,4 +24,7 @@
 			<directory suffix=".php">../../Classes/</directory>
 		</whitelist>
 	</filter>
+	<php>
+		<const name="TYPO3_MODE" value="BE" />
+	</php>
 </phpunit>

--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -27,7 +27,4 @@
 			<directory suffix=".php">../../Classes/</directory>
 		</whitelist>
 	</filter>
-	<php>
-		<const name="TYPO3_MODE" value="BE" />
-	</php>
 </phpunit>

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -71,4 +71,10 @@ fi
 echo "Run integration tests"
 INTEGRATION_BOOTSTRAP=".Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTestsBootstrap.php"
 .Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.clover
-.Build/bin/phpunit --colors -c Build/Test/IntegrationFrontendTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.clover
+if [ $? -ne "0" ]; then
+    echo "Error during running the integration tests please check and fix them"
+    exit 1
+fi
+
+echo "Run frontend-related integration tests"
+.Build/bin/phpunit --colors -c Build/Test/IntegrationFrontendTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.frontend.clover

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -71,3 +71,4 @@ fi
 echo "Run integration tests"
 INTEGRATION_BOOTSTRAP=".Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTestsBootstrap.php"
 .Build/bin/phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.clover
+.Build/bin/phpunit --colors -c Build/Test/IntegrationFrontendTests.xml --bootstrap=$INTEGRATION_BOOTSTRAP --coverage-clover=coverage.integration.clover

--- a/Build/Test/publish_coverage.sh
+++ b/Build/Test/publish_coverage.sh
@@ -4,4 +4,5 @@ set -e
 wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
 php ocular.phar code-coverage:upload --format=php-clover coverage.unit.clover
 php ocular.phar code-coverage:upload --format=php-clover coverage.integration.clover
+php ocular.phar code-coverage:upload --format=php-clover coverage.integration.frontend.clover
 rm ocular.phar

--- a/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
@@ -16,6 +16,7 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
+use ApacheSolrForTypo3\Solr\Mvc\Controller\SolrControllerContext;
 use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -46,13 +47,18 @@ abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
     }
 
     /**
+     * @param RenderingContextInterface|null $renderingContext
      * @return SearchUriBuilder|object
      */
-    protected static function getSearchUriBuilder()
+    protected static function getSearchUriBuilder(RenderingContextInterface $renderingContext = null)
     {
         if (!isset(self::$searchUriBuilder)) {
             $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
             self::$searchUriBuilder = $objectManager->get(SearchUriBuilder::class);
+        }
+
+        if ($renderingContext && method_exists($renderingContext, 'getControllerContext')) {
+            self::$searchUriBuilder->injectUriBuilder($renderingContext->getControllerContext()->getUriBuilder());
         }
 
         return self::$searchUriBuilder;

--- a/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
@@ -39,7 +39,7 @@ class AddFacetItemViewHelper extends AbstractValueViewHelper
         $itemValue = self::getValueFromArguments($arguments);
         $resultSet = self::getResultSetFromArguments($arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getAddFacetValueUri($previousRequest, $name, $itemValue);
+        $uri = self::getSearchUriBuilder($renderingContext)->getAddFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelper.php
@@ -35,7 +35,7 @@ class RemoveAllFacetsViewHelper extends AbstractUriViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getRemoveAllFacetsUri($previousRequest);
+        $uri = self::getSearchUriBuilder($renderingContext)->getRemoveAllFacetsUri($previousRequest);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
@@ -40,7 +40,7 @@ class RemoveFacetItemViewHelper extends AbstractValueViewHelper
         $itemValue = self::getValueFromArguments($arguments);
         $resultSet = self::getResultSetFromArguments($arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getRemoveFacetValueUri($previousRequest, $name, $itemValue);
+        $uri = self::getSearchUriBuilder($renderingContext)->getRemoveFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
@@ -47,7 +47,7 @@ class RemoveFacetViewHelper extends AbstractUriViewHelper
         /** @var  $facet AbstractFacet */
         $facet = $arguments['facet'];
         $previousRequest = $facet->getResultSet()->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getRemoveFacetUri($previousRequest, $facet->getName());
+        $uri = self::getSearchUriBuilder($renderingContext)->getRemoveFacetUri($previousRequest, $facet->getName());
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
@@ -40,7 +40,7 @@ class SetFacetItemViewHelper extends AbstractValueViewHelper
         $itemValue = self::getValueFromArguments($arguments);
         $resultSet = self::getResultSetFromArguments($arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
-        $uri = self::getSearchUriBuilder()->getSetFacetValueUri($previousRequest, $name, $itemValue);
+        $uri = self::getSearchUriBuilder($renderingContext)->getSetFacetValueUri($previousRequest, $name, $itemValue);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Paginate/GroupItemPageViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Paginate/GroupItemPageViewHelper.php
@@ -49,7 +49,7 @@ class GroupItemPageViewHelper extends AbstractUriViewHelper
         $page = $arguments['page'];
         $groupItem = $arguments['groupItem'];
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getResultGroupItemPageUri($previousRequest, $groupItem, (int)$page);
+        $uri = self::getSearchUriBuilder($renderingContext)->getResultGroupItemPageUri($previousRequest, $groupItem, (int)$page);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Paginate/ResultPageViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Paginate/ResultPageViewHelper.php
@@ -46,7 +46,7 @@ class ResultPageViewHelper extends AbstractUriViewHelper
     {
         $page = $arguments['page'];
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getResultPageUri($previousRequest, $page);
+        $uri = self::getSearchUriBuilder($renderingContext)->getResultPageUri($previousRequest, $page);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
@@ -35,7 +35,7 @@ class CurrentSearchViewHelper extends AbstractUriViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getCurrentSearchUri($previousRequest);
+        $uri = self::getSearchUriBuilder($renderingContext)->getCurrentSearchUri($previousRequest);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
@@ -45,7 +45,7 @@ class StartNewSearchViewHelper extends AbstractUriViewHelper
     {
         $queryString = $arguments['queryString'];
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getNewSearchUri($previousRequest, $queryString);
+        $uri = self::getSearchUriBuilder($renderingContext)->getNewSearchUri($previousRequest, $queryString);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
@@ -35,7 +35,7 @@ class RemoveSortingViewHelper extends AbstractUriViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getRemoveSortingUri($previousRequest);
+        $uri = self::getSearchUriBuilder($renderingContext)->getRemoveSortingUri($previousRequest);
         return $uri;
     }
 }

--- a/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
@@ -47,7 +47,7 @@ class SetSortingViewHelper extends AbstractUriViewHelper
         $sortingName = $arguments['sortingName'];
         $sortingDirection = $arguments['sortingDirection'];
         $previousRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext);
-        $uri = self::getSearchUriBuilder()->getSetSortingUri($previousRequest, $sortingName, $sortingDirection);
+        $uri = self::getSearchUriBuilder($renderingContext)->getSetSortingUri($previousRequest, $sortingName, $sortingDirection);
         return $uri;
     }
 }

--- a/Tests/Integration/Controller/AbstractFrontendControllerTest.php
+++ b/Tests/Integration/Controller/AbstractFrontendControllerTest.php
@@ -39,6 +39,7 @@ abstract class AbstractFrontendControllerTest  extends IntegrationTest {
      */
     protected function indexPages($importPageIds)
     {
+        $existingAttributes = $GLOBALS['TYPO3_REQUEST'] ? $GLOBALS['TYPO3_REQUEST']->getAttributes() : [];
         foreach ($importPageIds as $importPageId) {
             $fakeTSFE = $this->getConfiguredTSFE($importPageId);
             $GLOBALS['TSFE'] = $fakeTSFE;
@@ -65,6 +66,11 @@ abstract class AbstractFrontendControllerTest  extends IntegrationTest {
         /** @var $beUser  \TYPO3\CMS\Core\Authentication\BackendUserAuthentication */
         $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
         $GLOBALS['BE_USER'] = $beUser;
+        if (!empty($existingAttributes)) {
+            foreach ($existingAttributes as $attributeName => $attribute) {
+                $GLOBALS['TYPO3_REQUEST'] = $GLOBALS['TYPO3_REQUEST']->withAttribute($attributeName, $attribute);
+            }
+        }
         $this->waitToBeVisibleInSolr();
     }
 

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -576,10 +576,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canRenderHierarchicalFacet()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-
         $this->importDataSetFromFixture('can_render_search_controller.xml');
 
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
@@ -607,10 +603,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canFacetOnHierarchicalFacetItem()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-
         $this->importDataSetFromFixture('can_render_search_controller.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
@@ -637,10 +629,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canFacetOnHierarchicalTextCategory()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-
         $this->importDataSetFromFixture('can_render_path_facet_with_search_controller.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
@@ -968,10 +956,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canSortByMetric()
     {
-        if(!Util::getIsTYPO3VersionBelow10()) {
-            $this->markTestSkipped('Needs to be checked with TYPO3 10');
-        }
-
         $this->importDataSetFromFixture('can_sort_by_metric.xml');
         $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -98,6 +98,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canShowSearchForm()
     {
@@ -113,6 +114,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canSearchForPrices()
     {
@@ -131,6 +133,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoAPaginatedSearch()
     {
@@ -150,6 +153,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canOpenSecondPageOfPaginatedSearch()
     {
@@ -170,6 +174,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canGetADidYouMeanProposalForATypo()
     {
@@ -189,6 +194,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canAutoCorrectATypo()
     {
@@ -218,6 +224,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderAFacetWithFluid()
     {
@@ -240,6 +247,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoAnInitialEmptySearchWithoutResults()
     {
@@ -268,6 +276,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoAnInitialEmptySearchWithResults()
     {
@@ -296,6 +305,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoAnInitialSearchWithoutResults()
     {
@@ -325,6 +335,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoAnInitialSearchWithResults()
     {
@@ -352,6 +363,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function removeOptionLinkWillBeShownWhenFacetWasSelected()
     {
@@ -374,6 +386,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function removeOptionLinkWillIsAlsoShownWhenAFacetIsNotInTheResponse()
     {
@@ -396,6 +409,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canFilterOnPageSections()
     {
@@ -425,6 +439,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function exceptionWillBeThrownWhenAWrongTemplateIsConfiguredForTheFacet()
     {
@@ -456,6 +471,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderAScoreAnalysisWhenBackendUserIsLoggedIn()
     {
@@ -477,6 +493,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canSortFacetsByLex()
     {
@@ -518,6 +535,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canSortFacetsByOptionCountWhenNothingIsConfigured()
     {
@@ -550,6 +568,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderQueryGroupFacet()
     {
@@ -573,6 +592,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderHierarchicalFacet()
     {
@@ -600,6 +620,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canFacetOnHierarchicalFacetItem()
     {
@@ -626,6 +647,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canFacetOnHierarchicalTextCategory()
     {
@@ -652,6 +674,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDefineAManualSortOrder()
     {
@@ -694,6 +717,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canSeeTheParsedQueryWhenABackendUserIsLoggedIn()
     {
@@ -715,6 +739,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function frontendWillRenderErrorMessageForSolrNotAvailableAction()
     {
@@ -749,6 +774,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      * @param array $getArguments
      * @dataProvider frontendWillForwardsToErrorActionWhenSolrEndpointIsNotAvailableDataProvider
      * @test
+     * @group frontend
      */
     public function frontendWillForwardsToErrorActionWhenSolrEndpointIsNotAvailable($action, $getArguments)
     {
@@ -769,6 +795,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canShowLastSearchesFromSessionInResponse()
     {
@@ -792,6 +819,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canChangeResultsPerPage()
     {
@@ -814,6 +842,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canShowLastSearchesFromDatabaseInResponse()
     {
@@ -844,6 +873,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canNotStoreQueyStringInLastSearchesWhenQueryDoesNotReturnAResult()
     {
@@ -874,6 +904,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canOverwriteAFilterWithTheFlexformSettings()
     {
@@ -896,6 +927,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderDateRangeFacet()
     {
@@ -924,6 +956,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderASecondFacetOnTheTypeField()
     {
@@ -953,6 +986,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canSortByMetric()
     {
@@ -980,6 +1014,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function formActionIsRenderingTheForm()
     {
@@ -996,6 +1031,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function searchingAndRenderingFrequentSearchesIsShowingTheTermAsFrequentSearch()
     {
@@ -1015,6 +1051,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderDetailAction()
     {
@@ -1032,6 +1069,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canRenderSearchFormOnly()
     {
@@ -1048,6 +1086,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      * The template root path is configured in the typoscript template to point to another folder-
      *
      * @test
+     * @group frontend
      */
     public function canRenderAsUserObjectWithCustomTemplatePath()
     {
@@ -1066,6 +1105,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canPassCustomSettingsToView()
     {
@@ -1095,6 +1135,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      * Only the entry template points to a different file.
      *
      * @test
+     * @group frontend
      */
     public function canRenderAsUserObjectWithCustomTemplateInTypoScript()
     {

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -87,6 +87,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @test
+     * @group frontend
      */
     public function canDoABasicSuggest()
     {

--- a/Tests/Integration/TSFETestBootstrapper.php
+++ b/Tests/Integration/TSFETestBootstrapper.php
@@ -112,6 +112,7 @@ class TSFETestBootstrapper
                 $siteLanguage = $site->getLanguageById($language);
                 $request = $request->withAttribute('site', $site);
                 $request = $request->withAttribute('language', $siteLanguage);
+                $request = $request->withAttribute('routing', $pageArguments);
             } catch (SiteNotFoundException $e) {
                 throw $e;
             }
@@ -121,7 +122,7 @@ class TSFETestBootstrapper
 
         /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
         $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $siteLanguage, $pageArguments);
-        $TSFE->set_no_cache();
+        $TSFE->set_no_cache('', true);
         $GLOBALS['TSFE'] = $TSFE;
 
         $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -23,10 +23,10 @@ class UtilTest extends IntegrationTest
     {
         parent::setUp();
 
-        /** @var \TYPO3\CMS\Core\Cache\CacheManager|\Prophecy\Prophecy\ObjectProphecy $cacheManager */
-        $cacheManager = $this->prophesize(\TYPO3\CMS\Core\Cache\CacheManager::class);
-
         if (Util::getIsTYPO3VersionBelow10()) {
+
+            /** @var \TYPO3\CMS\Core\Cache\CacheManager|\Prophecy\Prophecy\ObjectProphecy $cacheManager */
+            $cacheManager = $this->prophesize(\TYPO3\CMS\Core\Cache\CacheManager::class);
             /** @var \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend|\Prophecy\Prophecy\ObjectProphecy $frontendCache */
             $frontendCache = $this->prophesize(\TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class);
             $cacheManager
@@ -44,32 +44,11 @@ class UtilTest extends IntegrationTest
             $cacheManager
                 ->getCache('cache_rootline')
                 ->willReturn($frontendCache->reveal());
-        } else {
-            /** @var \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend|\Prophecy\Prophecy\ObjectProphecy $frontendCache */
-            $frontendCache = $this->prophesize(\TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class);
-            $frontendCache->require(Argument::any())->willReturn([]);
-            $frontendCache->get(Argument::any())->willReturn([]);
-            $frontendCache->set(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn();
             $cacheManager
-                ->getCache('pages')
+                ->getCache('tx_solr_configuration')
                 ->willReturn($frontendCache->reveal());
-            $cacheManager
-                ->getCache('runtime')
-                ->willReturn($frontendCache->reveal());
-            $cacheManager
-                ->getCache('hash')
-                ->willReturn($frontendCache->reveal());
-            $cacheManager
-                ->getCache('core')
-                ->willReturn($frontendCache->reveal());
-            $cacheManager
-                ->getCache('hash')
-                ->willReturn($frontendCache->reveal());
+            GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager->reveal());
         }
-        $cacheManager
-            ->getCache('tx_solr_configuration')
-            ->willReturn($frontendCache->reveal());
-        GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager->reveal());
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'] = [];
     }

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -321,7 +321,8 @@ class UtilTest extends IntegrationTest
             $context->getPropertyFromAspect('backend.user', 'isLoggedIn', false)->shouldBeCalled();
             $context->setAspect('frontend.user', Argument::any())->shouldBeCalled();
             $context->getPropertyFromAspect('workspace', 'id')->shouldBeCalled()->willReturn(0);
-            $context->getPropertyFromAspect('date', 'accessTime', 0)->shouldBeCalled()->willReturn(0);
+            $context->getPropertyFromAspect('date', 'accessTime', 0)->willReturn(0);
+            $context->getPropertyFromAspect('typoscript', 'forcedTemplateParsing')->willReturn(false);
             $context->getPropertyFromAspect('visibility', 'includeHiddenPages')->shouldBeCalled()->willReturn(false);
             $context->setAspect('typoscript', Argument::any())->shouldBeCalled();
             GeneralUtility::setSingletonInstance(Context::class, $context->reveal());

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -28,6 +28,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveAllFacetsViewHelper;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -46,10 +48,15 @@ class RemoveAllFacetsViewHelperTest extends AbstractFacetItemViewHelperTest
         $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
         $searchResultSetMock->expects($this->once())->method('getUsedSearchRequest')->will($this->returnValue($mockedPreviousFakedRequest));
 
+        $uriBuilderMock = $this->getDumbMock(UriBuilder::class);
+        $controllerContextMock = $this->getDumbMock(ControllerContext::class);
+        $controllerContextMock->expects($this->any())->method('getUriBuilder')->will($this->returnValue($uriBuilderMock));
+
         $variableProvideMock = $this->getDumbMock(StandardVariableProvider::class);
         $variableProvideMock->expects($this->once())->method('get')->with('resultSet')->will($this->returnValue($searchResultSetMock));
         $renderContextMock = $this->getDumbMock(RenderingContext::class);
         $renderContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableProvideMock));
+        $renderContextMock->expects($this->any())->method('getControllerContext')->will($this->returnValue($controllerContextMock));
 
         $viewHelper = new RemoveAllFacetsViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);


### PR DESCRIPTION
Some tests within SearchControllerTests were skipped for TYPO3 v10,
which are re-enabled now.

The main reason why this happened was/is the changed behaviour
of DependencyInjection in TYPO3 v10. This way, a Singleton (in this case
EnvironmentService of Extbase) cannot be replaced during a Functional
Call anymore - which should not be done in any case.

Some frontend-related tests failed for this reason, because it was not possible
to mock the behaviour of TYPO3_MODE=FE in Tests.

Enabling these tests showed that the tests failed as the ViewHelpers did not
receive the current request by the ControllerContext, which is now
optionally injected into all ViewHelpers that generated links.

To run these Integration Tests, a new PHPunit configuration
called "IntegrationFrontendTests.xml" is added which is executed with
the TYPO3_MODE=FE constant activated in the configuration.

All other tests continue to work as before.

In addition, some cleanups to avoid deprecation logs in TSFETestBootstrapper
and to execute frontend calls within another frontend calls have been
made including the handling of TYPO3_REQUEST.

Fixes: #2630, #2587