### PR TITLE
[BUGFIX] Ensure to hand in PSR-7 Request to TSFE->getPageAndRootlineWithDomain

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -102,7 +102,7 @@ class Tsfe implements SingletonInterface
 
             // @extensionScannerIgnoreLine
             $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($pageId);
+            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($pageId, $GLOBALS['TYPO3_REQUEST']);
 
             $template = GeneralUtility::makeInstance(TemplateService::class, $context);
             $GLOBALS['TSFE']->tmpl = $template;


### PR DESCRIPTION
Since EXT:solr is using an internal TYPO3 Core method in TSFE (getPageAndRootlineWithDomain) the change adapts the internal method call to use the adaption for TYPO3 v10.4.4 and adds compatibility with that branch.