### PR TITLE
[BUGFIX] Ensure to hand in PSR-7 Request to TSFE->getPageAndRootlineWithDomain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,18 @@ env:
     - PHP_CS_FIXER_VERSION="^2.16.1"
   matrix:
     - TYPO3_VERSION="^9.5"
+    - TYPO3_VERSION="9.5.x-dev"
+    - TYPO3_VERSION="10.4.3"
     - TYPO3_VERSION="^10.4"
+    - TYPO3_VERSION="10.4.x-dev"
     - TYPO3_VERSION="dev-master"
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: TYPO3_VERSION="dev-master"
+    - env: TYPO3_VERSION="10.4.x-dev"
+    - env: TYPO3_VERSION="9.5.x-dev"
 
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -102,7 +102,7 @@ class Tsfe implements SingletonInterface
 
             // @extensionScannerIgnoreLine
             $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($pageId);
+            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($pageId, $GLOBALS['TYPO3_REQUEST']);
 
             $template = GeneralUtility::makeInstance(TemplateService::class, $context);
             $GLOBALS['TSFE']->tmpl = $template;

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -308,7 +308,7 @@ class UtilTest extends IntegrationTest
             $GLOBALS['TYPO3_REQUEST'] = GeneralUtility::makeInstance(ServerRequest::class);
             $tsfeProphecy->willBeConstructedWith([$context->reveal(), $site->reveal(), $siteLanguage->reveal()]);
             $tsfeProphecy->getSite()->shouldBeCalled()->willReturn($site);
-            $tsfeProphecy->getPageAndRootlineWithDomain($pageId)->shouldBeCalled();
+            $tsfeProphecy->getPageAndRootlineWithDomain($pageId, Argument::type(ServerRequest::class))->shouldBeCalled();
             $tsfeProphecy->getConfigArray()->shouldBeCalled();
             $tsfeProphecy->settingLanguage()->shouldBeCalled();
             $tsfeProphecy->newCObj()->shouldBeCalled();


### PR DESCRIPTION
# What this pr does

Since EXT:solr is using an internal TYPO3 Core method in TSFE (getPageAndRootlineWithDomain) the change adapts the internal method call to use the adaption for TYPO3 v10.4.4 and adds compatibility with that branch.

# How to test

Check if indexing is working and all tests are green

Thx to: @bmack & @dkd-kaehm 

Fixes: #2640
