### PR TITLE
[BUGFIX:Backport] Fix multiple rootpages in nested sites

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -515,7 +515,12 @@ class Indexer extends AbstractIndexer
     {
         $solrConnections = [];
 
-        $pageId = $item->getRootPageUid();
+        $rootPageId = $item->getRootPageUid();
+        if ($item->getType() === 'pages') {
+            $pageId = $item->getRecordUid();
+        } else {
+            $pageId = $item->getRecordPageId();
+        }
 
         // Solr configurations possible for this item
         $site = $item->getSite();
@@ -528,7 +533,7 @@ class Indexer extends AbstractIndexer
         $defaultLanguageUid = $this->getDefaultLanguageUid($item, $site->getRootPage(), $siteLanguages);
         $translationOverlays = $this->getTranslationOverlaysWithConfiguredSite((int)$pageId, $site, (array)$siteLanguages);
 
-        $defaultConnection = $this->connectionManager->getConnectionByPageId($pageId, $defaultLanguageUid, $item->getMountPointIdentifier());
+        $defaultConnection = $this->connectionManager->getConnectionByPageId($rootPageId, $defaultLanguageUid, $item->getMountPointIdentifier());
         $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays);
 
         if ($defaultLanguageUid == 0) {

--- a/Classes/System/Page/Rootline.php
+++ b/Classes/System/Page/Rootline.php
@@ -93,6 +93,7 @@ class Rootline
         foreach ($this->rootLineArray as $page) {
             if (Site::isRootPage($page)) {
                 $rootPageId = $page['uid'];
+                break;
             }
         }
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_with_multiple_sites.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_with_multiple_sites.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+                page = PAGE
+                page.typeNum = 0
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+
+                plugin.tx_solr {
+                    enabled = 1
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+                        queue {
+				pages = 1
+				pages {
+					allowedPageTypes = 1
+								fields {
+									sitetitle_stringS = TEXT
+									sitetitle_stringS.value = Outer Site
+								}
+				}
+                        }
+                    }
+                }
+            ]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+	<sys_template>
+		<uid>2</uid>
+		<pid>111</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+                page = PAGE
+
+                # very simple rendering
+                page.10 = CONTENT
+                page.10 {
+                    table = tt_content
+                    select.orderBy = sorting
+                    select.where = colPos=0
+                    renderObj = COA
+                    renderObj {
+                        10 = TEXT
+                        10.field = bodytext
+                    }
+                }
+                plugin.tx_solr {
+                    enabled = 1
+                    index {
+                        fieldProcessingInstructions {
+                            changed = timestampToIsoDate
+                            created = timestampToIsoDate
+                            endtime = timestampToUtcIsoDate
+                            rootline = pageUidToHierarchy
+                            pageHierarchy_stringM = pathToHierarchy
+                        }
+                        queue {
+				pages = 1
+				pages {
+					allowedPageTypes = 1
+								fields {
+									sitetitle_stringS = TEXT
+									sitetitle_stringS.value = Inner Site
+								}
+				}
+                        }
+                    }
+
+                }
+            ]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+
+	<pages>
+		<uid>1</uid>
+		<title>Outer Site</title>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+	</pages>
+
+	<pages>
+		<uid>111</uid>
+		<pid>1</pid>
+		<title>Inner Site</title>
+		<doktype>1</doktype>
+		<is_siteroot>1</is_siteroot>
+		<hidden>0</hidden>
+	</pages>
+
+	<pages>
+		<uid>120</uid>
+		<pid>111</pid>
+		<title>Subpage of Inner Site</title>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+	</pages>
+</dataset>


### PR DESCRIPTION
SolR currently traverses all pages in the root line to the
most outer page with is_siteroot in a setup with nested sites.

The Indexer thus always indexed from the most outer page
in previous revisions, however the root page should always
be based on the first site within a single tree
