### PR TITLE
[BUGFIX:Backport] Always return array on non-mounted sites

### DIFF
--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -337,6 +337,6 @@ class Page extends AbstractInitializer
         /* @var $siteRepository SiteRepository */
         $mountedSite = $siteRepository->getSiteByPageId($mountPageSourceId, $mountPageIdentifier);
 
-        return $mountedSite->getPages($mountPageSourceId);
+        return $mountedSite ? $mountedSite->getPages($mountPageSourceId) : [];
     }
 }


### PR DESCRIPTION
# What this pr does

Ensures that Page::resolveMountPageTree allways returns an array
