### PR TITLE
[BUGFIX:Backport] Remove unneeded is_siteroot flag in nested storage folder

### DIFF
--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_configuration_in_rootline.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_with_configuration_in_rootline.xml
@@ -101,7 +101,6 @@
     <pages>
         <title>storage folder</title>
         <uid>3</uid>
-        <is_siteroot>1</is_siteroot>
         <doktype>254</doktype>
         <pid>2</pid>
     </pages>


### PR DESCRIPTION
# What this pr does

Removes the wrong is_siteroot flag of a sys_folder in the fixtures
