### PR TITLE
[BUGFIX:BACKPORT:10] Fix missing renderType attribute in flexform for search plugin

### DIFF
--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -37,6 +37,7 @@
                             <config>
                                 <section>1</section>
                                 <type>select</type>
+                                <renderType>selectSingle</renderType>
                                 <itemsProcFunc>ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions->getAvailableTemplates</itemsProcFunc>
                             </config>
                         </TCEforms>


### PR DESCRIPTION
In the search plugin selection "form only" the renderType attribute is missing
in the flexform configuration which prevents rendering the custom template
select in the backend. This fixes it by adding the renderType attribute.

Fixes: #2661 