### PR TITLE
[BUGFIX:BACKPORT:11] use num_found in static db table #2667

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -90,7 +90,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
             'tstamp' => $this->getTime(),
             'language' => Util::getLanguageUid(),
             // @extensionScannerIgnoreLine
-            'num_found' => isset($response->response->numFound) ? (int)$response->response->numFound : 0,
+            'num_found' => (int)$resultSet->getAllResultCount(),
             'suggestions_shown' => is_object($response->spellcheck->suggestions) ? (int)get_object_vars($response->spellcheck->suggestions) : 0,
             // @extensionScannerIgnoreLine
             'time_total' => isset($response->debug->timing->time) ? $response->debug->timing->time : 0,


### PR DESCRIPTION
**Describe the bug**
using EXT:solrfluidgrouping always inserts num_found=0 in statisticRecord

**To Reproduce**
Steps to reproduce the behavior:
1. EXT:solrfluidgrouping
2. Enable statistics = 1 in TS
3. Go to your search page
4. Search for phrase with results
4. See error in in tx_solr_statistics table num_found is 0

**Expected behavior**
num_found should reflect number of Results


**Used versions (please complete the following information):**
 - TYPO3 Version: [e.g. 10.4]
 - EXT:solr Version: [e.g. 11.0.1]

**Fix**
use `$resultSet->getAllResultCount()` instead of `$response->response->numFound` for tx_solr_statistics num_found DB column

Fixes: #2667

