### PR TITLE
[BUGFIX] Build core base path right, when path is slash only

### DIFF
--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -187,7 +187,7 @@ class Node {
     {
         $pathWithoutLeadingAndTrailingSlashes = trim(trim($this->path), "/");
         $pathWithoutLastSegment = substr($pathWithoutLeadingAndTrailingSlashes, 0, strrpos($pathWithoutLeadingAndTrailingSlashes, "/"));
-        return '/' . $pathWithoutLastSegment . '/';
+        return ($pathWithoutLastSegment === '') ? '/' : '/' . $pathWithoutLastSegment . '/';
     }
 
     /**


### PR DESCRIPTION
Fixes: #2680