### PR TITLE
[DOCS] Improvements for contributing to the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,6 +282,31 @@ make test
 
 ## Documentation
 
+The documentation for typo3-solr exists in the *Documentation* subdirectory.
+ 
+It is rendered on docs.typo3.org:
+
+* https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/
+
+It can be modified by changing the reStructuredText files (.rst).
+
+The documentation for this extension has the same structure as the 
+official TYPO3 documentation and is generated using the same workflow,
+tools and infrastructure as the official TYPO3 documentation. 
+
+Please look at the general information about TYPO3 documentation for 
+more information:
+
+* [Directory and file structure](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/DirectoryFilenames.html)
+* [How to contribute]()
+* [reStructuredText & sphinx](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingReST/Index.html)
+* [Render documentation with Docker](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Index.html)
+
+For issues and pull requests, please use the tag [DOCS] in your commit 
+messages / PR title / issue title, e.g.: 
+
+    [DOCS] Fix typos
+
 
 ## Translations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,8 +282,6 @@ make test
 
 ## Documentation
 
-The documentation currently is still mainly on [TYPO3 forge](https://forge.typo3.org/projects/extension-solr/wiki),
-but we are in the process of migrating it to TYPO3's documentation server using [Restructured Text](https://github.com/TYPO3-Solr/ext-solr/issues/20).
 
 ## Translations
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -15,4 +15,16 @@ t3api       = https://docs.typo3.org/typo3cms/CoreApiReference/
 
 [html_theme_options]
 
+# ........................................................
+# ...  (recommended) to get the "Edit me on GitHub Button"
+# ........................................................
+
+github_branch        = master
+github_repository    = TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument
+
+# .................................................................
+# ...  (recommended) Fill in values to get links via the docs theme
+# .................................................................
+
 project_issues       = https://github.com/TYPO3-Solr/ext-solr/issues
+project_repository   = https://github.com/TYPO3-Solr/ext-solr


### PR DESCRIPTION
# What this pr does

see commits:

* Remove outdated information in CONTRIBUTING.md
* Changes to get an "Edit on GitHub" button on top right of rendered docs
* Add information about contributing to docs in CONTRIBUTING.md

# How to test

You can render documentation locally using Docker:

* [Render documentation with Docker](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Index.html)

For this change, I don't think it is necessary (as only Settings.cfg was changed).


Fixes: #2689
