### PR TITLE
[BUGFIX:BACKPORT:10] Fix assignment for page uid variable

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -231,7 +231,7 @@ class PageIndexerRequest
         $headers = $this->header;
         $headers[] = 'User-Agent: ' . $this->getUserAgent();
         $itemId = $this->indexQueueItem->getIndexQueueUid();
-        $pageId = $this->indexQueueItem->getRecordPageId();
+        $pageId = $this->indexQueueItem->getRecordUid();
 
         $indexerRequestData = [
             'requestId' => $this->requestId,


### PR DESCRIPTION
The variable is currently assigned to the page parent uid, but for page records the index queue item record uid represents the page uid already.

Fixes: #2663