### PR TITLE
[DOCS] Fix links

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -20,7 +20,7 @@ t3api       = https://docs.typo3.org/typo3cms/CoreApiReference/
 # ........................................................
 
 github_branch        = master
-github_repository    = TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument
+github_repository    = TYPO3-Solr/ext-solr
 
 # .................................................................
 # ...  (recommended) Fill in values to get links via the docs theme


### PR DESCRIPTION
This change fixes links for the "Edit on GitHub" button and in CONTRIBUTING.md due to an error in the previously merged PR #2690 

I am very sorry about this blunder. This time I double checked by rendering locally. 

btw. the "Edit on GitHub" is now already visible in the rendered documentation for "master". 