### PR TITLE
[BUGFIX] removing backticks in addSelectLiteral

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -156,8 +156,8 @@ class StatisticsRepository extends AbstractRepository
         $queryBuilder = $this->getQueryBuilder();
         $result = $queryBuilder
             ->addSelectLiteral(
-                'FLOOR(`tstamp`/' . $bucketSeconds . ') AS `bucket`',
-                '(`tstamp` - (`tstamp` % 86400)) AS `timestamp`',
+                'FLOOR(tstamp/' . $bucketSeconds . ') AS bucket',
+                '(tstamp - (tstamp % 86400)) AS timestamp',
                 $queryBuilder->expr()->count('*', 'numQueries')
             )
             ->from($this->table)


### PR DESCRIPTION
Using backticks to specify columns in addSelectLiteral will result in an Doctrine\DBAL\Exception\SyntaxErrorException.

# What this pr does

Remove the backticks in addSelectLiteral used in \ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository::getQueriesOverTime

# How to test

Using TYPO3 V10 with a postgresql DB and apache-solr-for-typo3/solr V11.0.2.
Selecting the Solr Info Module in TYPO3 Backend will throw an Doctrine\DBAL\Exception\SyntaxErrorException.
Plain Installation. Nothing indexed yet.

Fixes: #2700
