### PR TITLE
[BUGFIX] using named parameter for empty string comparison

### DIFF
--- a/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
@@ -57,7 +57,7 @@ class QueueStatisticsRepository extends AbstractRepository
                 $queryBuilder->quoteIdentifier('pending')
             ]), true)
             ->add('select', vsprintf('(%s) AS %s', [
-                $queryBuilder->expr()->notLike('errors', '""'),
+                $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter('')),
                 $queryBuilder->quoteIdentifier('failed')
             ]), true)
             ->add('select', $queryBuilder->expr()->count('*', 'count'), true)


### PR DESCRIPTION
# What this pr does

After loading the indexing configuration and selecting The Index Queue Modul an Doctrine\DBAL\Exception\SyntaxErrorException occurs.

# How to test

Create an indexing configuration and load it in TYPO3 Backend Module.
Click on Index Queue.


Fixes: #2702 
