### PR TITLE
Prevent duplicate urls for page 0

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -421,7 +421,11 @@ class SearchRequest
     {
         $this->stateChanged = true;
         $path = $this->prefixWithNamespace('page');
-        $this->argumentsAccessor->set($path, $page);
+        if ($page === 0) {
+            $this->argumentsAccessor->reset($path);
+        } else {
+            $this->argumentsAccessor->set($path, $page);
+        }
         return $this;
     }
 

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -421,10 +421,10 @@ class SearchRequest
     {
         $this->stateChanged = true;
         $path = $this->prefixWithNamespace('page');
+        $this->argumentsAccessor->set($path, $page);
+        // use initial url by switching back to page 0
         if ($page === 0) {
             $this->argumentsAccessor->reset($path);
-        } else {
-            $this->argumentsAccessor->set($path, $page);
         }
         return $this;
     }

--- a/Tests/Unit/Domain/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/SearchRequestBuilderTest.php
@@ -63,7 +63,7 @@ class SearchRequestBuilderTest extends UnitTest
     /**
      * @test
      */
-    public function testPageIsSetToZeroWhenValidResultsPerPageValueWasPassed()
+    public function testPageIsResettedWhenValidResultsPerPageValueWasPassed()
     {
         $this->configurationMock->expects($this->once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
             ->will($this->returnValue([10, 25]));
@@ -71,7 +71,7 @@ class SearchRequestBuilderTest extends UnitTest
 
         $requestArguments = ['q' => 'test', 'page' => 5, 'resultsPerPage' => 25];
         $request = $this->searchRequestBuilder->buildForSearch($requestArguments, 0, 0);
-        $this->assertSame($request->getPage(), 0, 'Page was not resetted to 0');
+        $this->assertSame($request->getPage(), null, 'Page was not resetted.');
     }
 
     /**


### PR DESCRIPTION
Reset page argument if set to 0.
As 0 is the default, there is no need to have two different states to represent this.
By resetting, the array will not return the info and links to page 0 will not include the page argument.
This prevents two separate urls to the same source.

# What this pr does

Reset page internally when being set to zero.

# How to test

Create a search result with pagination. Open another page then the first.
Check the generated url for the first page, it should no longer contain the page argument.
Before this change it would contain the argument with value 0.

Fixes: #2719
