### PR TITLE
[BUGFIX:BACKPORT:11] Restricted pages are not being indexed in Typo3 10

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
@@ -59,7 +59,7 @@ abstract class AbstractFrontendHelper implements FrontendHelper
     protected $action = null;
 
     /**
-     * @var \ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager
+     * @var SolrLogManager
      */
     protected $logger = null;
 

--- a/Classes/IndexQueue/FrontendHelper/Dispatcher.php
+++ b/Classes/IndexQueue/FrontendHelper/Dispatcher.php
@@ -24,7 +24,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Manager;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/IndexQueue/FrontendHelper/Manager.php
+++ b/Classes/IndexQueue/FrontendHelper/Manager.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use RuntimeException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -67,7 +68,7 @@ class Manager
      *
      * @param string $action The action to get a frontend helper for.
      * @return FrontendHelper Index Queue page indexer frontend helper
-     * @throws \RuntimeException if the class registered for an action is not an implementation of ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\FrontendHelper
+     * @throws RuntimeException if the class registered for an action is not an implementation of ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\FrontendHelper
      */
     public function resolveAction($action)
     {
@@ -78,7 +79,7 @@ class Manager
         $frontendHelper = GeneralUtility::makeInstance(self::$frontendHelperRegistry[$action]);
         if (!$frontendHelper instanceof FrontendHelper) {
             $message = self::$frontendHelperRegistry[$action] . ' is not an implementation of ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\FrontendHelper';
-            throw new \RuntimeException($message, 1292497896);
+            throw new RuntimeException($message, 1292497896);
         }
 
         $this->activatedFrontendHelpers[$action] = $frontendHelper;

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -88,21 +88,15 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
     {
         $pageIndexingHookRegistration = PageIndexer::class;
 
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][__CLASS__] = $pageIndexingHookRegistration . '->authorizeFrontendUser';
-        // disable TSFE cache for TYPO3 v9
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = $pageIndexingHookRegistration . '->disableCaching';
+        if (Util::getIsTYPO3VersionBelow10()) { // @todo: remove by dropping TYPO3 9.5 support, See: https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][__CLASS__] = $pageIndexingHookRegistration . '->authorizeFrontendUser';
+            // disable TSFE cache for TYPO3 v9
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['tslib_fe-PostProc'][__CLASS__] = $pageIndexingHookRegistration . '->disableCaching';
+        }
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['pageIndexing'][__CLASS__] = $pageIndexingHookRegistration;
 
         // indexes fields defined in plugin.tx_solr.index.queue.pages.fields
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\PageFieldMappingIndexer'] = PageFieldMappingIndexer::class;
-
-        // making sure this instance is reused when called by the hooks registered before
-        // \TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction() and \TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj() use
-        // these storages while the object was instantiated by
-        // ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Manager before.
-        // \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance() also uses a dedicated cache
-        $GLOBALS['T3_VAR']['callUserFunction_classPool'][__CLASS__] = $this;
-        //$GLOBALS['T3_VAR']['getUserObj'][$pageIndexingHookRegistration] = $this;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class] = PageFieldMappingIndexer::class;
 
         $this->registerAuthorizationService();
     }

--- a/Classes/IndexQueue/PageIndexerRequestHandler.php
+++ b/Classes/IndexQueue/PageIndexerRequestHandler.php
@@ -25,7 +25,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Dispatcher;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -63,6 +62,7 @@ class PageIndexerRequestHandler implements SingletonInterface
      * Constructor.
      *
      * Initializes request, response, and dispatcher.
+     * @param string|null $jsonEncodedParameters
      */
     public function __construct(string $jsonEncodedParameters = null)
     {

--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+namespace ApacheSolrForTypo3\Solr\Middleware;
+
+/***************************************************************
+ * Copyright notice
+ *
+ * (c) 2020 dkd Internet Services GmbH <solr-eb-support@dkd.de>
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ * A copy is found in the text file GPL.txt and important notices to the license
+ * from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\AuthorizationService;
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequestHandler;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Util;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
+
+/**
+ * Class FrontendUserAuthenticator is responsible to fake a frontend user and fe_groups.
+ * It makes possible to Index access restricted pages and content elements.
+ */
+class FrontendUserAuthenticator implements MiddlewareInterface
+{
+
+    /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * FrontendUserAuthorizator constructor.
+     *
+     * @param Context|null $context
+     * @noinspection PhpUnused
+     */
+    public function __construct(?Context $context = null)
+    {
+        $this->context = $context ?? GeneralUtility::makeInstance(Context::class);
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     * @noinspection PhpUnused
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (Util::getIsTYPO3VersionBelow10()
+            || !$request->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)
+        ) {
+            return $handler->handle($request);
+        }
+
+        // disable TSFE cache for TYPO3 v10
+        $request = $request->withAttribute('noCache', true);
+        $jsonEncodedParameters = $request->getHeader(PageIndexerRequest::SOLR_INDEX_HEADER)[0];
+
+        /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
+        $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class, $jsonEncodedParameters);
+        if (!$pageIndexerRequestHandler->getRequest()->isAuthenticated()) {
+            /* @var SolrLogManager $logger */
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, self::class);
+            $logger->log(
+                SolrLogManager::ERROR,
+                'Invalid Index Queue Frontend Request detected!',
+                [
+                    'page indexer request' => (array)$pageIndexerRequestHandler->getRequest(),
+                    'index queue header' => $jsonEncodedParameters
+                ]
+            );
+
+            return new JsonResponse(['error' => ['code' => 403, 'message' => 'Invalid Index Queue Request.']], 403);
+
+        }
+        $request = $this->tryToAuthenticateFrontendUser($pageIndexerRequestHandler, $request);
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * Fakes a logged in user to retrieve access restricted content.
+     *
+     * @param PageIndexerRequestHandler $handler
+     * @param ServerRequestInterface $request
+     * @return ServerRequestInterface
+     * @noinspection PhpUnused
+     */
+    protected function tryToAuthenticateFrontendUser(PageIndexerRequestHandler $handler, ServerRequestInterface $request): ServerRequestInterface
+    {
+        $accessRootline = $this->getAccessRootline($handler);
+        $stringAccessRootline = (string)$accessRootline;
+
+        if (empty($stringAccessRootline)) {
+            return $request;
+        }
+
+        $groups = $accessRootline->getGroups();
+
+        /* @var FrontendUserAuthentication $feUser */
+        $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
+        $feUser->user[$feUser->username_column] = AuthorizationService::SOLR_INDEXER_USERNAME;
+        /* @noinspection PhpParamsInspection */
+        $this->context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $groups));
+        $request = $request->withAttribute('frontend.user', $feUser);
+
+        return $request;
+    }
+
+    /**
+     * Gets the access rootline as defined by the request.
+     *
+     * @param PageIndexerRequestHandler $handler
+     * @return Rootline The access rootline to use for indexing.
+     */
+    protected function getAccessRootline(PageIndexerRequestHandler $handler): Rootline
+    {
+        $stringAccessRootline = '';
+
+        if ($handler->getRequest()->getParameter('accessRootline')) {
+            $stringAccessRootline = $handler->getRequest()->getParameter('accessRootline');
+        }
+
+        /* @noinspection PhpIncompatibleReturnTypeInspection */
+        return GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $stringAccessRootline);
+    }
+
+}

--- a/Classes/Middleware/PageIndexerFinisher.php
+++ b/Classes/Middleware/PageIndexerFinisher.php
@@ -53,6 +53,7 @@ class PageIndexerFinisher implements MiddlewareInterface
     {
         $response = $handler->handle($request);
         if ($request->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
+            /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
             $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class);
             $pageIndexerRequestHandler->shutdown();
             $pageIndexResponse = $pageIndexerRequestHandler->getResponse();

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,5 +1,6 @@
 <?php
 
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
 return [
     'frontend' => [
         'apache-solr-for-typo3/page-indexer-initialization' => [

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -3,6 +3,10 @@
 /** @noinspection PhpFullyQualifiedNameUsageInspection */
 return [
     'frontend' => [
+        'apache-solr-for-typo3/page-indexer-fe-user-authenticator' => [
+            'target' => \ApacheSolrForTypo3\Solr\Middleware\FrontendUserAuthenticator::class,
+            'before' => ['apache-solr-for-typo3/page-indexer-initialization']
+        ],
         'apache-solr-for-typo3/page-indexer-initialization' => [
             'target' => \ApacheSolrForTypo3\Solr\Middleware\PageIndexerInitialization::class,
             'before' => ['typo3/cms-frontend/tsfe'],

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -84,7 +84,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->searchController = $this->objectManager->get(SearchController::class);
         $this->searchRequest = $this->getPreparedRequest();
         $this->searchResponse = $this->getPreparedResponse();
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\PageFieldMappingIndexer'] = PageFieldMappingIndexer::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class] = PageFieldMappingIndexer::class;
     }
 
     /**

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -81,7 +81,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
         $this->suggestRequest = $this->getPreparedRequest('Suggest', 'suggest');
         $this->suggestResponse = $this->getPreparedResponse();
 
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\PageFieldMappingIndexer'] = PageFieldMappingIndexer::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class] = PageFieldMappingIndexer::class;
 
     }
 


### PR DESCRIPTION
* implements FrontendUserAuthenticator middleware for indexing requests,
   which fakes FE users with FE groups needed to access restricted pages and content elements

Fixes: #2634