### PR TITLE
[BUGFIX] Hard codes plugin namespace #2691

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -151,7 +151,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     {
         $searchParameters = [];
         if ($this->getTypoScriptConfiguration()->getSearchKeepExistingParametersForNewSearches()) {
-            $arguments = GeneralUtility::_GPmerged('tx_solr');
+            $arguments = GeneralUtility::_GPmerged($this->getTypoScriptConfiguration()->getSearchPluginNamespace());
             unset($arguments['q'], $arguments['id'], $arguments['L']);
             $searchParameters = $this->translateSearchParametersToInputTagAttributes($arguments);
         }


### PR DESCRIPTION
ViewHelper SearchFormViewHelper contains a hard coded plugin namespace 'tx_solr'.

# What this pr does

This Pull-Request is replaced the hard coded plugin namespace the configuration value

# How to test

TBD

Fixes: #2691
