### PR TITLE
[DOCS] Note that config.index_enable is still needed - master

### DIFF
--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -90,6 +90,12 @@ Please check the :ref:`appendix-version-matrix`, the you can find the proposed v
 
 |
 
+**Pages are not indexed. I did everything by the book.**
+
+You forgot to set `config.index_enable = 1` in your TypoScript setup: :ref:`started-enable-indexing`
+
+|
+
 **My indexed documents are empty, i can not find the content of a page?**
 
 Did you configure the search markers ( "<!-- TYPO3SEARCH_begin -->" and "<!-- TYPO3SEARCH_end -->") on your page? Check the paragraph :ref:`started-search-markers` and make sure your page renders them.

--- a/Documentation/GettingStarted/ConfigureExtension.rst
+++ b/Documentation/GettingStarted/ConfigureExtension.rst
@@ -34,6 +34,20 @@ The most simple configuration for my page was:
         stdWrap.dataWrap = <!--TYPO3SEARCH_begin-->|<!--TYPO3SEARCH_end-->
     }
 
+.. _started-enable-indexing:
+
+Enable indexing
+---------------
+
+Indexing wil only work if you allow content to be indexed by stating so in your TypoScript setup configuration:
+
+
+.. code-block:: typoscript
+
+    config {
+        index_enable = 1
+    }
+
 Site Handling or Legacy site mode
 ---------------------------------
 


### PR DESCRIPTION
# What this pr does

Makes it clear that `config.index_enable = 1` is still required to index anything.

# How to test

Setup a clean install and try to index any content without `config.index_enable = 1`

Fixes: #2523
