### PR TITLE
[BUGFIX:BACKPORT:10] Removes secondary parameter #2746

### DIFF
--- a/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
@@ -61,18 +61,32 @@ class IfHasAccessToModuleViewHelper extends AbstractConditionViewHelper
         $this->registerArgument('signature', 'string', 'The full signature of module. Simply mainmodulename_submodulename in most cases.');
     }
 
-
+    /**
+     * Evaluate condition
+     *
+     * @param null $arguments
+     * @return bool
+     */
     protected static function evaluateCondition($arguments = null)
     {
         /* @var BackendUserAuthentication $beUser */
         $beUser = $GLOBALS['BE_USER'];
-        $hasAccessToModule = $beUser->modAccess(
-            self::getModuleConfiguration(self::getModuleSignatureFromArguments($arguments)),
-            false
-        );
+        try {
+            $hasAccessToModule = $beUser->modAccess(
+                self::getModuleConfiguration(self::getModuleSignatureFromArguments($arguments))
+            );
+        } catch (\RuntimeException $exception) {
+            return false;
+        }
         return $hasAccessToModule;
     }
 
+    /**
+     * Returns the backend module configuration
+     *
+     * @param string $moduleSignature
+     * @return mixed
+     */
     protected static function getModuleConfiguration(string $moduleSignature)
     {
         return $GLOBALS['TBE_MODULES']['_configuration'][$moduleSignature];


### PR DESCRIPTION
Calls of method BackendUserAuthentication::modAccess with two arguments deprecated since TYPO3 9.5, only one parameter is available in TYPO3 10.4

# What this pr does

This pull request removes the second parameter in call of method BackendUserAuthentication::modAccess.
This parameter is deprecated since TYPO3 9.5 and dropped in version 10.4.

https://github.com/TYPO3/TYPO3.CMS/blob/bf49d5eab37c660fce310905e18f8880ac378cae/typo3/sysext/core/Classes/Authentication/BackendUserAuthentication.php#L447

# How to test

Steps to reproduce the behavior:
1. Be on at least TYPO3 9.5
2. Enable reporting of deprecation errors (trigger_error + E_USER_DEPRECATED)
3. Visit the Solr "Info" backend module
4. An error is triggered

_Expected behavior_
No error should be triggered; the return value from modAccess() can be cast to boolean which results in identical behavior.

Fixes: #2746
