### PR TITLE
[BUGFIX] Fix type error in UrlHelper

### DIFF
--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -103,7 +103,7 @@ class UrlHelper {
      */
     public function getHost(): string
     {
-        return $this->getUrlPart('host');
+        return $this->getUrlPart('host') ?? '';
     }
 
     /**
@@ -121,7 +121,7 @@ class UrlHelper {
      */
     public function getPort(): string
     {
-        return $this->getUrlPart('port');
+        return $this->getUrlPart('port') ?? '';
     }
 
     /**
@@ -139,7 +139,7 @@ class UrlHelper {
      */
     public function getScheme(): string
     {
-        return $this->getUrlPart('scheme');
+        return $this->getUrlPart('scheme') ?? '';
     }
 
     /**
@@ -157,7 +157,7 @@ class UrlHelper {
      */
     public function getPath(): string
     {
-        return $this->getUrlPart('path');
+        return $this->getUrlPart('path') ?? '';
     }
 
     /**

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -161,4 +161,40 @@ class UrlHelperTest extends UnitTest
         $urlHelper = new UrlHelper($uri);
         $this->assertSame($uri, $urlHelper->getUrl(), 'Could not get unmodified url');
     }
+
+    /**
+     * @test
+     */
+    public function ifNoSchemeIsGivenGetSchemeReturnsAnEmptyString(): void
+    {
+        $urlHelper = new UrlHelper('www.google.de');
+        $this->assertSame('', $urlHelper->getScheme());
+    }
+
+    /**
+     * @test
+     */
+    public function ifNoPathIsGivenGetPathReturnsAnEmptyString(): void
+    {
+        $urlHelper = new UrlHelper('https://www.google.de');
+        $this->assertSame('', $urlHelper->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function ifNoPortIsGivenGetPortReturnsAnEmptyString(): void
+    {
+        $urlHelper = new UrlHelper('https://www.google.de');
+        $this->assertSame('', $urlHelper->getPort());
+    }
+
+    /**
+     * @test
+     */
+    public function ifNoHostIsGivenGetHostReturnsAnEmptyString(): void
+    {
+        $urlHelper = new UrlHelper('/my/path/to/a/site');
+        $this->assertSame('', $urlHelper->getHost());
+    }
 }


### PR DESCRIPTION
If some url part is not set the getters have to return
an emtpy string.

Fixes: #2756 
