### PR TITLE
[BUGFIX] Pass `FrontendUserAuthentication` to `TypoScriptFrontendController`

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -81,11 +81,12 @@ class Tsfe implements SingletonInterface
 
 
         if (!isset($this->tsfeCache[$cacheId])) {
-
+            $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
+            
             if (Util::getIsTYPO3VersionBelow10()) {
                 $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, [], $pageId, 0);
             } else {
-                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $siteLanguage);
+                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $siteLanguage, null, $feUser);
                 $GLOBALS['TSFE']->id = $pageId;
                 $GLOBALS['TSFE']->type = 0;
             }
@@ -95,7 +96,6 @@ class Tsfe implements SingletonInterface
             // see http://forge.typo3.org/issues/42122
             $pageRecord = BackendUtility::getRecord('pages', $pageId, 'fe_group');
 
-            $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
             $userGroups = [0, -1];
             if (!empty($pageRecord['fe_group'])) {
                 $userGroups = array_unique(array_merge($userGroups, explode(',', $pageRecord['fe_group'])));


### PR DESCRIPTION
# What this pr does

The indexing fails when the `TypoScriptFrontendController` is constructed w/o a frontend user in `TypoScriptFrontendController::initUserGroups()` on line 930 when the visibility `includeHiddenContent` assigned to `$this->fe_user->showHiddenRecords;` This PR passes the `$fe_user` to the `TypoScriptFrontendController::_construct()`.

Fixes: #2761 
