### PR TITLE
[TASK] Move to travis stages to save build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
   - mysql
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
+  - 7.3
+  - 7.2
 
 jdk:
   - oraclejdk11
@@ -18,53 +18,17 @@ addons:
     packages:
       - parallel
       - haveged
+
 env:
-  global:
-    - TYPO3_DATABASE_NAME="typo3_ci"
-    - TYPO3_DATABASE_HOST="127.0.0.1"
-    - TYPO3_DATABASE_USERNAME="root"
-    - TYPO3_DATABASE_PASSWORD=""
-    - PHP_CS_FIXER_VERSION="^2.16.1"
-  matrix:
-    - TYPO3_VERSION="^10.4"
-    - TYPO3_VERSION="10.4.x-dev"
-    - TYPO3_VERSION="dev-master"
+  - TYPO3_VERSION="^10.4"
+  - TYPO3_VERSION="10.4.x-dev"
+  - TYPO3_VERSION="11.0.x-dev"
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: TYPO3_VERSION="10.4.x-dev"
-    - env: TYPO3_VERSION="dev-master"
+script: echo "scipt outside jobs.include.*.stage TYPO3_VERSION=$TYPO3_VERSION"
 
-before_install:
-  # Move MySQL data to ram file system
-  - sudo mount -o remount,size=3584m /var/ramfs
-  - sudo systemctl stop mysql && sudo mv /var/lib/mysql /var/ramfs/. && sudo ln -s /var/ramfs/mysql /var/lib/mysql
-  - sudo systemctl start mysql
-  - mysql -e 'CREATE DATABASE IF NOT EXISTS typo3_ci;'
-  # Install newer docker version
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  # Update composer
-  - composer self-update
-  - composer --version
-  - composer validate --no-check-lock
-
-install:
-  - Build/Test/bootstrap.sh
-
-script:
-  - Build/Test/cibuild_docker.sh
-  - Build/Test/cibuild.sh
-
-after_script:
-  - Build/Test/publish_coverage.sh
-  - Build/Test/cleanup.sh
-  - Build/Release/ter_tag_uploader.sh
-
-cache:
-  directories:
-    - $HOME/.composer/cache
-    - $HOME/solr/downloads
+jobs:
+  include:
+    - stage: release
+      env:
+        - TYPO3_VERSION="^10.4"
+      script: echo 'Release Stage' && echo "TYPO3_VERSION=$TYPO3_VERSION"


### PR DESCRIPTION
# What this Pull-Request does:

An experiment for introduction of [Travis build stages](https://docs.travis-ci.com/user/build-stages/). 
This should reduce the build and fail time.
The building and testing of Docker Image functionality takes about 4 minutes and can be checked once, because they are the same. Also the build&test of Docker image can be omitted by PHP/TYPO3 Version combinations.
As Idea the Travis build stages and workspaces should be used to save 3-4 minutes for each PHP/TYPO3 Version combination.
Moreover the Apache-Solr Server bootstraping by reusing the build image, can save additional 3-4 minutes.

This is currently as draft to define all the needed stages and workspaces as first step.

In second step we will push the artefacts in workspaces to be able to share them between the stages.