### PR TITLE
Don't break chinese unicode characters

### DIFF
--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -134,7 +134,7 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
         // clean content
         $content = self::cleanContent($content);
         $content = trim($content);
-        $content = preg_replace('!\s+!', ' ', $content); // reduce multiple spaces to one space
+        $content = preg_replace('!\s+!u', ' ', $content); // reduce multiple spaces to one space
 
         return $content;
     }


### PR DESCRIPTION
# What this pr does

Our site supports (traditional and simplified) chinese. While indexing some pages errored in the Solr index queue module but there was no error in the logs. Here is what happened. 

Solr fetches the page and extracts the content from it. The method `preg_replace()` breaks some unicode chars and I can see the famous � sign in the content _after_ the content was processed. Later, when the content is converted to JSON, it breaks silently by returning an empty string because. Guzzle returns an empty response and Solr marks the page as an error. 

To fix this I added the `u` modifier to switch the Unicode support on for `preg_replace()`. From the [PHP manual](https://www.php.net/manual/de/reference.pcre.pattern.modifiers.php):

> u (PCRE_UTF8)
> This modifier turns on additional functionality of PCRE that is incompatible with Perl. Pattern and subject strings are treated as UTF-8. An invalid subject will cause the 
> preg_* function to match nothing; an invalid pattern will trigger an error of level E_WARNING. Five and six octet UTF-8 sequences are regarded as invalid since PHP 
> 5.3.4 (resp. PCRE 7.3 2007-08-28); formerly those have been regarded as valid UTF-8.

Fixes: #2810
