### PR TITLE
[BUGFIX] Enable unicode when fetching pages

### DIFF
--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -134,7 +134,7 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
         // clean content
         $content = self::cleanContent($content);
         $content = trim($content);
-        $content = preg_replace('!\s+!', ' ', $content); // reduce multiple spaces to one space
+        $content = preg_replace('!\s+!u', ' ', $content); // reduce multiple spaces to one space
 
         return $content;
     }

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -139,7 +139,11 @@ class Typo3PageContentExtractorTest extends UnitTest
             'keep escaped html' => [
                 'content' => '<em>this</em> is how to make &lt;b&gt;fat&lt;/b&gt;',
                 'expectedResult' => 'this is how to make <b>fat</b>'
-            ]
+            ],
+            'support chinese characters' => [
+                'content' => '媒体和投资者 新闻 财务报告 公司股票信息 概览',
+                'expectedResult' => '媒体和投资者 新闻 财务报告 公司股票信息 概览'
+            ],
         ];
     }
 


### PR DESCRIPTION
# What this pr does

Our site supports (traditional and simplified) chinese. While indexing some pages errored in the Solr index queue module but there was no error in the logs. Here is what happened. 

Solr fetches the page and extracts the content from it. The method `preg_replace()` breaks some unicode chars and I can see the famous � sign in the content _after_ the content was processed. Later, when the content is converted to JSON. The empty content is than sent back to Guzzle. Solr considers a response with empty content as error and therefore marks the page as an error. 

To fix this I added the `u` modifier to switch the Unicode support on for `preg_replace()`. From the [PHP manual](https://www.php.net/manual/de/reference.pcre.pattern.modifiers.php):

> u (PCRE_UTF8)
> This modifier turns on additional functionality of PCRE that is incompatible with Perl. Pattern and subject strings are treated as UTF-8. An invalid subject will cause the 
> preg_* function to match nothing; an invalid pattern will trigger an error of level E_WARNING. Five and six octet UTF-8 sequences are regarded as invalid since PHP 
> 5.3.4 (resp. PCRE 7.3 2007-08-28); formerly those have been regarded as valid UTF-8.

Fixes: #2810