### PR TITLE
[BUGFIX:BACKPORT:10] disabled Solr Sites #2795

### DIFF
--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -299,6 +299,11 @@ abstract class Site implements SiteInterface
         return $configs;
     }
 
+    public function isEnabled(): bool
+    {
+        return !empty($this->getAllSolrConnectionConfigurations());
+    }
+
     /**
      * @param int $languageId
      * @return array

--- a/Classes/Domain/Site/SiteInterface.php
+++ b/Classes/Domain/Site/SiteInterface.php
@@ -128,4 +128,6 @@ interface SiteInterface
      * @throws NoSolrConnectionFoundException
      */
     public function getAllSolrConnectionConfigurations(): array;
+
+    public function isEnabled(): bool;
 }

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -217,8 +217,10 @@ class SiteRepository
                     //get each site only once
                     continue;
                 }
-
-                $typo3ManagedSolrSites[$rootPageId] = $this->buildSite($rootPageId);
+                $typo3ManagedSolrSite = $this->buildSite($rootPageId);
+                if ($typo3ManagedSolrSite->isEnabled()) {
+                    $typo3ManagedSolrSites[$rootPageId] = $typo3ManagedSolrSite;
+                }
 
             } catch (\Exception $e) {
                 if ($stopOnInvalidSite) {

--- a/Tests/Integration/Domain/Site/Fixtures/get_available_sites_do_not_return_sites_not_enabled.xml
+++ b/Tests/Integration/Domain/Site/Fixtures/get_available_sites_do_not_return_sites_not_enabled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+    <pages>
+        <uid>111</uid>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+    <pages>
+        <uid>211</uid>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+</dataset>

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -66,6 +66,16 @@ class SiteRepositoryTest extends IntegrationTest
     /**
      * @test
      */
+    public function getAvailableSitesDoNotReturnSitesNotEnabled(): void
+    {
+        $this->importDataSetFromFixture('get_available_sites_do_not_return_sites_not_enabled.xml');
+        $sites = $this->siteRepository->getAvailableSites();
+        $this->assertSame(2, count($sites), 'Expected to retrieve two sites');
+    }
+
+    /**
+     * @test
+     */
     public function canGetAllPagesFromSite()
     {
         $this->importDataSetFromFixture('can_get_all_pages_from_sites.xml');

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -498,6 +498,12 @@ abstract class IntegrationTest extends FunctionalTestCase
             ]
         );
 
+        $this->writeSiteConfiguration(
+            'integration_tree_three',
+            $this->buildSiteConfiguration(211, 'http://testthree.site/'),
+            [$defaultLanguage]
+        );
+
         $globalSolrSettings = [
             'solr_scheme_read' => $scheme,
             'solr_host_read' => $host,
@@ -508,6 +514,8 @@ abstract class IntegrationTest extends FunctionalTestCase
         ];
         $this->mergeSiteConfiguration('integration_tree_one', $globalSolrSettings);
         $this->mergeSiteConfiguration('integration_tree_two', $globalSolrSettings);
+        // disable solr for site three
+        $this->mergeSiteConfiguration('integration_tree_three', ['solr_enabled_read' => false]);
 
         clearstatcache();
         usleep(500);

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -122,7 +122,9 @@ class SiteRepositoryTest extends UnitTest
         $siteMock = $this->getSiteMock(333, [0,1,2]);
         $this->fakeSitesInTYPO3Systems([$siteMock]);
 
-        $this->assertThatSitesAreCreatedWithPageIds([333]);
+        $this->assertThatSitesAreCreatedWithPageIds([333], [
+            0 => ['language' => 0]
+        ]);
         $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getFirstAvailableSite();
@@ -139,7 +141,7 @@ class SiteRepositoryTest extends UnitTest
         $siteMockB = $this->getSiteMock(234, [0,2]);
         $this->fakeSitesInTYPO3Systems([$siteMockA, $siteMockB]);
 
-        $this->assertThatSitesAreCreatedWithPageIds([123,234]);
+        $this->assertThatSitesAreCreatedWithPageIds([123,234],[0 => ['language' => 0], 1 => ['language' => 1]]);
         $this->assertCacheIsWritten();
 
         $sites = $this->siteRepository->getAvailableSites();
@@ -199,7 +201,7 @@ class SiteRepositoryTest extends UnitTest
                     $site->expects($this->any())->method('getRootPageId')->will(
                         $this->returnValue($idToUse)
                     );
-
+                    $site->expects($this->any())->method('isEnabled')->willReturn(count($fakedConnectionConfiguration) > 0);
                     $site->expects($this->any())
                         ->method('getAllSolrConnectionConfigurations')
                         ->willReturn($fakedConnectionConfiguration);


### PR DESCRIPTION
SiteRepository should not return sites with disabled solr
when calling "getAvailableSites"

Resolves: #2795