### PR TITLE
[BUGFIX:BACKPORT:11] Quote field within score calculation

### DIFF
--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -51,7 +51,7 @@ class ScoreCalculationService
     /**
      * Renders an array of score objects into an score output.
      *
-     * @param $highScores
+     * @param array $highScores
      * @return string
      */
     public function render(array $highScores)
@@ -121,7 +121,7 @@ class ScoreCalculationService
 
             // keep track of highest score per search term
             if (!$scoreWasSetForFieldBefore || $scoreIsHigher) {
-                $pattern = '/' . $field . '\^([\d.]*)/';
+                $pattern = '/' . preg_quote($field, '/') . '\^([\d.]*)/';
                 $boostMatches = [];
                 preg_match_all($pattern, $queryFields, $boostMatches);
                 $boost = $boostMatches[1][0];


### PR DESCRIPTION
# What this pr does

Quote the value of variable $field for regular expressions.
The quote avoid exceptions in case the value contains one single slash.

# How to test

To reproduce use the project https://github.com/TYPO3-Solr/solr-ddev-site

1. Open the backend
2. Select page `EXT:Solr test cases`
3. Add a text element with content `/Users/user1/Pictures/picture1.png`
4. Save page and index
5. Open frontend and search for `Users/`

**Expected behavior**
Page `EXT:Solr test cases` should be listed within the search results

Fixes: #2824 
