### PR TITLE
[BUGFIX] Check if $recordUid is non-numeric before substitution

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -39,6 +39,7 @@ use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * A class that monitors changes to records so that the changed record gets
@@ -303,7 +304,7 @@ class RecordMonitor extends AbstractDataHandlerListener
             return;
         }
 
-        if ($status === 'new') {
+        if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];
         }
         if ($this->isDraftRecord($table, $recordUid)) {


### PR DESCRIPTION
It is assumed here that if the $status is 'new', then the $recordUid must be a 'NEW...' string, which is normally the case.
However the $id is passed by reference and might be changed by other extensions. gridelements for example changes the $id.
https://gitlab.com/coderscare/gridelements/-/issues/156
So the check must be made more robust here.
