### PR TITLE
[BUGFIX:BACKPORT:10]  IndexInspector wrong language to document relation

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -290,8 +290,8 @@ class ConnectionManager implements SingletonInterface
     {
         $connections = [];
 
-        foreach ($site->getAllSolrConnectionConfigurations() as $solrConnectionConfiguration) {
-            $connections[] = $this->getConnectionFromConfiguration($solrConnectionConfiguration);
+        foreach ($site->getAllSolrConnectionConfigurations() as $languageId => $solrConnectionConfiguration) {
+            $connections[$languageId] = $this->getConnectionFromConfiguration($solrConnectionConfiguration);
         }
 
         return $connections;


### PR DESCRIPTION
* Is adding the language uid as array key again 
   in order to have the correct core to language 
   relation in the IndexInspector

Fixes: #2553
Fixes: #2731

Authored-by: Timo Hund