### PR TITLE
[BUGFIX] Fix wrong hierarchy for only one relation

### DIFF
--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -83,16 +83,19 @@ class Service
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'pathToHierarchy':
+                        $isSingleValueField = false;
                         /** @var $processor PathToHierarchy */
                         $processor = GeneralUtility::makeInstance(PathToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'pageUidToHierarchy':
+                        $isSingleValueField = false;
                         /** @var $processor PageUidToHierarchy */
                         $processor = GeneralUtility::makeInstance(PageUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'categoryUidToHierarchy':
+                        $isSingleValueField = false;
                         /** @var $processor CategoryUidToHierarchy */
                         $processor = GeneralUtility::makeInstance(CategoryUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);


### PR DESCRIPTION
If a field has just one related record the field processor service
detects this as a single value field. In case of hierarchy this might
be wrong, because a hierarchy can always have multiple values caused
by a depth > 1.

# What this pr does

Fix the bug, that e.g. just one sys_category is selected the indexed value in a field, which is called e.g. taxonomy_strangM, holds just the first level of the hierarchy. The configuration of the field looks like:

```
  taxonomy_stringM = SOLR_RELATION
  taxonomy_stringM {
    localField = categories
    foreignLabelField = uid
    multiValue = 1
  }
```
# How to test

Add the field as configured above to the solr fields and select only one category in categories, which is in a deeper level (> 1). This should cause a solr document field value like: ["0-9/","1-9/36/"], but the value is just ["0-9/"] instead.

Fixes: #2501
Replaces: #2502