### PR TITLE
[TASK:BACKPORT:11] Disable cache time information for ajax request

### DIFF
--- a/Configuration/TypoScript/Examples/Suggest/setup.typoscript
+++ b/Configuration/TypoScript/Examples/Suggest/setup.typoscript
@@ -9,6 +9,7 @@ tx_solr_suggest {
         admPanel = 0
         additionalHeaders.10.header = Content-type: application/javascript
         no_cache = 0
+        debug = 0
     }
 
     10 = USER


### PR DESCRIPTION
If `$GLOBALS['TYPO3_CONF_VARS']['FE']['debug']` is enabled (e.g. on Staging or local environments), the TypoScriptFrontendController will add some information to the response 
```html
<!-- Cached page generated 14-01-21 08:19. Expires 15-01-21 08:19 -->
```

to avoid this, the setting `config.debug=0` can be used which turns this of, no matter which global debug config is set

Fixes: #2834