### PR TITLE
[BUGFIX] Change filter for workspace

### DIFF
--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -301,7 +301,8 @@ abstract class AbstractInitializer implements IndexQueueInitializer
 
         if (!empty($GLOBALS['TCA'][$this->type]['ctrl']['versioningWS'])) {
             // versioning is enabled for this table: exclude draft workspace records
-            $conditions['versioningWS'] = 'pid != -1';
+            /* @see \TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction::buildExpression */
+            $conditions['versioningWS'] = 't3ver_wsid = 0';
         }
 
         if (count($conditions)) {


### PR DESCRIPTION
# What this pr does

Since TYPO3 10.4 the workspace now is not identify by pid value -1,
instead field 't3ver_wsid' is in use to filter workspace records.

This bugfix changes the filter to this new field and takes care about TYPO3 9.5 compatibility.

# How to test

This test uses project https://github.com/TYPO3-Solr/solr-ddev-site

1. Install extension workspaces: `ddev composer require typo3/cms-workspaces:^10.4`
2. Activate extension: `ddev exec vendor/bin/typo3cms extension:activate workspaces`
3. Create a new workspace `Solr test` within the backend
  - Note: When save an error occured, but the workspace is created
4. Switch to workspace `Solr test`
5. Add a new site `Workspace-site`
6. Activate the page
  - Note: When save an error occured, but the page is activated
7. Go to the Solr Index Queue and initialise the Queue

You should not find the page within the index queue.

Fixes: #2847 