### PR TITLE
[BUGFIX:BP:11] Change filter for workspace

### DIFF
--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -30,6 +30,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Initializer;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -301,7 +302,12 @@ abstract class AbstractInitializer implements IndexQueueInitializer
 
         if (!empty($GLOBALS['TCA'][$this->type]['ctrl']['versioningWS'])) {
             // versioning is enabled for this table: exclude draft workspace records
-            $conditions['versioningWS'] = 'pid != -1';
+            if (Util::getIsTYPO3VersionBelow10()) {
+                $conditions['versioningWS'] = 'pid != -1';
+            } else {
+                /* @see \TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction::buildExpression */
+                $conditions['versioningWS'] = 't3ver_wsid = 0';
+            }
         }
 
         if (count($conditions)) {


### PR DESCRIPTION
# What this pr does

Since TYPO3 10.4 the workspace now is not identify by pid value -1,
instead field 't3ver_wsid' is in use to filter workspace records.

This bugfix changes the filter to this new field and takes care about TYPO3 9.5 compatibility.

# How to test

1. Install extension workspaces: `ddev composer require typo3/cms-workspaces:^10.4`
2. Activate extension: `ddev exec vendor/bin/typo3cms extension:activate workspaces`
3. Create a new workspace `Solr test` within the backend
  - Note: When save an error occured, but the workspace is created
4. Switch to workspace `Solr test`
5. Add a new site `Workspace-site`
6. Activate the page
  - Note: When save an error occured, but the page is activated
7. Go to the Solr Index Queue and initialise the Queue

You should not find the page within the index queue.

Fixes: #2847 