### PR TITLE
[BUGFIX:BACKPORT:10] Fix handling of case sensitive variant ids

### DIFF
--- a/Classes/Domain/Variants/VariantsProcessor.php
+++ b/Classes/Domain/Variants/VariantsProcessor.php
@@ -82,7 +82,7 @@ class VariantsProcessor implements SearchResultSetProcessor {
         }
 
         $variantsField = $this->typoScriptConfiguration->getSearchVariantsField();
-        foreach ($resultSet->getSearchResults() as $key => $resultDocument) {
+        foreach ($resultSet->getSearchResults() as $resultDocument) {
             /** @var $resultDocument SearchResult */
             $variantId = $resultDocument[$variantsField] ?? null;
 
@@ -91,12 +91,11 @@ class VariantsProcessor implements SearchResultSetProcessor {
                 continue;
             }
 
-            $variantAccessKey = mb_strtolower($variantId);
-            if (!isset($response->{'expanded'}) || !isset($response->{'expanded'}->{$variantAccessKey})) {
+            if (!isset($response->{'expanded'}) || !isset($response->{'expanded'}->{$variantId})) {
                 continue;
             }
 
-            $this->buildVariantDocumentAndAssignToParentResult($response, $variantAccessKey, $resultDocument);
+            $this->buildVariantDocumentAndAssignToParentResult($response, $variantId, $resultDocument);
         }
 
         return $resultSet;

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
@@ -182,6 +182,7 @@
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
         <title>Products</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>2</uid>
@@ -189,6 +190,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Woman Products</title>
+        <author>Jane Doe</author>
     </pages>
     <pages>
         <uid>3</uid>
@@ -196,6 +198,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Men Products</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>4</uid>
@@ -203,6 +206,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Men Socks</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>5</uid>
@@ -210,6 +214,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Men Jeans</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>6</uid>
@@ -217,6 +222,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Woman Shoes</title>
+        <author>Jane Doe</author>
     </pages>
     <pages>
         <uid>7</uid>
@@ -224,6 +230,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Woman T-Shirts</title>
+        <author>Jane Doe</author>
     </pages>
     <pages>
         <uid>8</uid>
@@ -231,6 +238,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Men T-Shirts</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>9</uid>
@@ -238,6 +246,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Men Sweatshirts</title>
+        <author>John Doe</author>
     </pages>
     <pages>
         <uid>10</uid>
@@ -245,6 +254,7 @@
         <is_siteroot>0</is_siteroot>
         <doktype>1</doktype>
         <title>Woman Sweatshirts</title>
+        <author>John Doe</author>
     </pages>
 
     <tt_content>

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -120,6 +120,53 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
+    public function canGetCaseSensitiveVariants()
+    {
+        $this->indexPageIdsFromFixture('can_get_searchResultSet.xml', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->waitToBeVisibleInSolr();
+        $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1, 0, 0);
+
+        $typoScriptConfiguration = Util::getSolrConfiguration();
+        $typoScriptConfiguration->mergeSolrConfiguration([
+            'search.' =>[
+                'variants' => 1,
+                'variants.' => [
+                    'variantField' => 'author',
+                    'expand' => 1,
+                    'limit' => 11
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
+        $this->assertEquals('author', $typoScriptConfiguration->getSearchVariantsField());
+        $this->assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
+
+        $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
+        $this->assertSame(2, count($searchResults), 'There should be two results at all');
+
+        // We assume that the first result has one variants.
+        $firstResult = $searchResults[0];
+        $this->assertSame(6, count($firstResult->getVariants()));
+        $this->assertSame('John Doe', $firstResult->getAuthor());
+
+        $secondResult = $searchResults[1];
+        $this->assertSame(2, count($secondResult->getVariants()));
+        $this->assertSame('Jane Doe', $secondResult->getAuthor());
+
+        // And every variant is indicated to be a variant.
+        foreach ($firstResult->getVariants() as $variant) {
+            $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
+        }
+        foreach ($secondResult->getVariants() as $variant) {
+            $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
+        }
+    }
+
+    /**
+     * @test
+     */
     public function canGetZeroResultsWithVariantsOnEmptyIndex()
     {
         $this->importDataSetFromFixture('can_get_searchResultSet.xml');


### PR DESCRIPTION
# What this pr does

This PR backports the fix of the handling of case sensitive variant ids for
EXT:solr 10.x

The VariantsProcessor expects the content of the variant field to be
in lowercase and explicitly applies an mb_strtolower. Since Solr returns
the contents in the expanded field unchanged and the contents might be
case sensitive, the variants may not be recognized correctly and cannot
be accessed.

This issue is fixed by removing the unnecessary mb_strtolower.

# How to test

Configure a custom variant field with case sensitive contents and check if the 
variants are detected correctly and are accessible.

Fixes: #2865

