### PR TITLE
[FEATURE:BACKPORT:10] Store number of existing variants

### DIFF
--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -35,6 +35,25 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
  */
 class SearchResult extends Document
 {
+    /**
+     * The variant field value
+     *
+     * Value of Solr collapse field, which is defined via
+     * TypoScript variable "variants.variantField"
+     *
+     * @var string
+     */
+    protected $variantFieldValue = '';
+
+    /**
+     * Number of variants found
+     *
+     * May differ from documents in variants as
+     * returned variants are limited by expand.rows
+     *
+     * @var int
+     */
+    protected $variantsNumFound = 0;
 
     /**
      * @var SearchResult[]
@@ -83,6 +102,38 @@ class SearchResult extends Document
     public function setGroupItem(GroupItem $group)
     {
         $this->groupItem = $group;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVariantFieldValue(): string
+    {
+        return $this->variantFieldValue;
+    }
+
+    /**
+     * @param string $variantFieldValue
+     */
+    public function setVariantFieldValue(string $variantFieldValue)
+    {
+        $this->variantFieldValue = $variantFieldValue;
+    }
+
+    /**
+     * @return int
+     */
+    public function getVariantsNumFound(): int
+    {
+        return $this->variantsNumFound;
+    }
+
+    /**
+     * @param int $numFound
+     */
+    public function setVariantsNumFound(int $numFound)
+    {
+        $this->variantsNumFound = $numFound;
     }
 
     /**

--- a/Classes/Domain/Variants/VariantsProcessor.php
+++ b/Classes/Domain/Variants/VariantsProcessor.php
@@ -39,8 +39,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @package ApacheSolrForTypo3\Solr\Domain\Variants
  */
-class VariantsProcessor implements SearchResultSetProcessor {
-
+class VariantsProcessor implements SearchResultSetProcessor
+{
     /**
      * @var TypoScriptConfiguration
      */
@@ -96,6 +96,8 @@ class VariantsProcessor implements SearchResultSetProcessor {
             }
 
             $this->buildVariantDocumentAndAssignToParentResult($response, $variantId, $resultDocument);
+            $resultDocument->setVariantsNumFound($response->{'expanded'}->{$variantId}->{'numFound'});
+            $resultDocument->setVariantFieldValue($variantId);
         }
 
         return $resultSet;

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -7,7 +7,7 @@
 
 
 tx_solr.search
-===============
+==============
 
 The search section, you probably already guessed it, provides configuration options for the all things related to actually searching the index, setting query parameters, formatting and processing result documents and the result listing.
 
@@ -1424,6 +1424,8 @@ variants.limit
 ~~~~~~~~~~~~~~
 
 Limit of expanded documents.
+
+Though this setting limits the returned variants, you still can get the number of existing variants, it's set in "document.variantsNumFound" (since EXT:solr 10)
 
 :Type: Integer
 :TS Path: plugin.tx_solr.search.variants.limit

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -32,6 +32,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 
 class SearchResultSetServiceTest extends IntegrationTest
 {
@@ -147,20 +148,30 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->assertSame(2, count($searchResults), 'There should be two results at all');
 
         // We assume that the first result has one variants.
+        /* @var SearchResult $firstResult */
         $firstResult = $searchResults[0];
         $this->assertSame(6, count($firstResult->getVariants()));
         $this->assertSame('John Doe', $firstResult->getAuthor());
+        $this->assertSame(6, $firstResult->getVariantsNumFound());
+        $this->assertSame('John Doe', $firstResult->getVariantFieldValue());
 
+        /* @var SearchResult $secondResult */
         $secondResult = $searchResults[1];
         $this->assertSame(2, count($secondResult->getVariants()));
         $this->assertSame('Jane Doe', $secondResult->getAuthor());
+        $this->assertSame(2, $secondResult->getVariantsNumFound());
+        $this->assertSame('Jane Doe', $secondResult->getVariantFieldValue());
 
         // And every variant is indicated to be a variant.
         foreach ($firstResult->getVariants() as $variant) {
             $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
+            $this->assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
+            $this->assertSame($firstResult, $variant->getVariantParent(), 'Variant parent should be set');
         }
         foreach ($secondResult->getVariants() as $variant) {
             $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
+            $this->assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
+            $this->assertSame($secondResult, $variant->getVariantParent(), 'Variant parent should be set');
         }
     }
 


### PR DESCRIPTION
# What this pr does

To allow to access the number of existing variants, the SearchResult
is extended. Without this modification the number of existing variants
can is unknown, as the number of returned variants may be limited by
variants.limit.

This is a backport of #2871 for EXT:solr 10.x

# How to test

Configure variants and check the set `variantsNumFound` in SearchResult

Resolves: #2870
