### PR TITLE
[BUGFIX] Fix missing variant field value

### DIFF
--- a/Classes/Domain/Variants/VariantsProcessor.php
+++ b/Classes/Domain/Variants/VariantsProcessor.php
@@ -89,13 +89,13 @@ class VariantsProcessor implements SearchResultSetProcessor
                 continue;
             }
 
+            $resultDocument->setVariantFieldValue($variantId);
             if (!isset($response->{'expanded'}) || !isset($response->{'expanded'}->{$variantId})) {
                 continue;
             }
 
             $this->buildVariantDocumentAndAssignToParentResult($response, $variantId, $resultDocument);
             $resultDocument->setVariantsNumFound($response->{'expanded'}->{$variantId}->{'numFound'});
-            $resultDocument->setVariantFieldValue($variantId);
         }
 
         return $resultSet;

--- a/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
+++ b/Tests/Integration/Domain/Search/ResultSet/Fixtures/can_get_searchResultSet.xml
@@ -256,6 +256,14 @@
         <title>Woman Sweatshirts</title>
         <author>John Doe</author>
     </pages>
+    <pages>
+        <uid>11</uid>
+        <pid>1</pid>
+        <is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+        <title>Children Sweatshirts</title>
+        <author>Baby Doe</author>
+    </pages>
 
     <tt_content>
         <uid>1</uid>

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -122,7 +122,7 @@ class SearchResultSetServiceTest extends IntegrationTest
      */
     public function canGetCaseSensitiveVariants()
     {
-        $this->indexPageIdsFromFixture('can_get_searchResultSet.xml', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $this->indexPageIdsFromFixture('can_get_searchResultSet.xml', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
         $this->waitToBeVisibleInSolr();
         $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1, 0, 0);
@@ -144,7 +144,8 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
 
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
-        $this->assertSame(2, count($searchResults), 'There should be two results at all');
+        $this->assertSame(3, count($searchResults), 'There should be three results at all');
+
 
         // We assume that the first result has one variants.
         /* @var SearchResult $firstResult */
@@ -161,6 +162,13 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->assertSame(2, $secondResult->getVariantsNumFound());
         $this->assertSame('Jane Doe', $secondResult->getVariantFieldValue());
 
+        /* @var SearchResult $secondResult */
+        $thirdResult = $searchResults[2];
+        $this->assertSame(0, count($thirdResult->getVariants()));
+        $this->assertSame('Baby Doe', $thirdResult->getAuthor());
+        $this->assertSame(0, $thirdResult->getVariantsNumFound());
+        $this->assertSame('Baby Doe', $thirdResult->getVariantFieldValue());
+
         // And every variant is indicated to be a variant.
         foreach ($firstResult->getVariants() as $variant) {
             $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
@@ -172,6 +180,7 @@ class SearchResultSetServiceTest extends IntegrationTest
             $this->assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
             $this->assertSame($secondResult, $variant->getVariantParent(), 'Variant parent should be set');
         }
+
     }
 
     /**


### PR DESCRIPTION
If variants are enabled and a returned Solr document has no variants, the variant field value is not set. Currently variantFieldValue is only set if variantId is set in expanded, but if there is only one variant in the Solr index there will be no data in the expanded array.

This comit fixes this issue by ensuring that the variant field value is set even if there is no data in the expanded array.

# How to test

1. Activate variants
2. Set the variant field to simulate
2.1. one document with at least one variant
2.2. one document without further variants
3. Check the variant field value of the document without variants, it's now set

Fixes: #2878
