### PR TITLE
[TASK:BP:10] Remove TYPO3 long time ago deprecated cache class

### DIFF
--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1,31 +1,18 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\System\Configuration;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *  A copy is found in the textfile GPL.txt and important notices to the license
- *  from the author is found in LICENSE.txt distributed with these scripts.
- *
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Record;
@@ -59,6 +46,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Marc Bastian Heinrichs <mbh@mbh-software.de>
  * @author Timo Schmidt <timo.schmidt@dkd.de>
+ * @copyright (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
  */
 class TypoScriptConfiguration
 {
@@ -1242,7 +1230,7 @@ class TypoScriptConfiguration
      * @param int $defaultIfEmpty
      * @return int
      */
-    public function getSearchFrequentSearchesMinSize($defaultIfEmpty = 14)
+    public function getSearchFrequentSearchesMinSize($defaultIfEmpty = 14): int
     {
         $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.frequentSearches.minSize', $defaultIfEmpty);
         return (int)$result;
@@ -1256,7 +1244,7 @@ class TypoScriptConfiguration
      * @param int $defaultIfEmpty
      * @return int
      */
-    public function getSearchFrequentSearchesMaxSize($defaultIfEmpty = 32)
+    public function getSearchFrequentSearchesMaxSize($defaultIfEmpty = 32): int
     {
         $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.frequentSearches.maxSize', $defaultIfEmpty);
         return (int)$result;

--- a/Classes/ViewHelpers/Widget/Controller/FrequentlySearchedController.php
+++ b/Classes/ViewHelpers/Widget/Controller/FrequentlySearchedController.php
@@ -42,11 +42,12 @@ class FrequentlySearchedController extends AbstractWidgetController implements L
     protected function getInitializedCache(): ?FrontendInterface
     {
         $cacheIdentifier = 'tx_solr';
+        /* @var FrontendInterface $cacheInstance */
         try {
             $cacheInstance = GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheIdentifier);
         } catch (NoSuchCacheException $exception) {
-            $this->logger->error($exception->getMessage());
-           return null;
+            $this->logger->error('Getting cache failed: ' . $exception->getMessage());
+            return null;
         }
 
         return $cacheInstance;
@@ -61,6 +62,7 @@ class FrequentlySearchedController extends AbstractWidgetController implements L
         $cache = $this->getInitializedCache();
         $configuration = $this->controllerContext->getTypoScriptConfiguration();
 
+        /* @var FrequentSearchesService $frequentSearchesService */
         $frequentSearchesService = GeneralUtility::makeInstance(
             FrequentSearchesService::class,
             /** @scrutinizer ignore-type */ $configuration,
@@ -72,18 +74,23 @@ class FrequentlySearchedController extends AbstractWidgetController implements L
         $minimumSize = $configuration->getSearchFrequentSearchesMinSize();
         $maximumSize = $configuration->getSearchFrequentSearchesMaxSize();
 
-        $this->view->assign('contentArguments', ['frequentSearches' => $this->enrichFrequentSearchesInfo($frequentSearches, $minimumSize, $maximumSize)]);
+        $this->view->assign(
+            'contentArguments',
+            [
+                'frequentSearches' => $this->enrichFrequentSearchesInfo($frequentSearches, $minimumSize, $maximumSize)
+            ]
+        );
     }
 
     /**
      * Enrich the frequentSearches
      *
      * @param array Frequent search terms as array with terms as keys and hits as the value
-     * @param integer $minimumSize
-     * @param integer $maximumSize
+     * @param int $minimumSize
+     * @param int $maximumSize
      * @return array An array with content for the frequent terms markers
      */
-    protected function enrichFrequentSearchesInfo(array $frequentSearchTerms, $minimumSize, $maximumSize)
+    protected function enrichFrequentSearchesInfo(array $frequentSearchTerms, int $minimumSize, int $maximumSize): array
     {
         $frequentSearches = [];
         if (count($frequentSearchTerms)) {
@@ -94,7 +101,12 @@ class FrequentlySearchedController extends AbstractWidgetController implements L
 
             foreach ($frequentSearchTerms as $term => $hits) {
                 $size = round($minimumSize + (($hits - $minimumHits) * $step));
-                $frequentSearches[] = ['q' => htmlspecialchars_decode($term), 'hits' => $hits, 'style' => 'font-size: ' . $size . 'px', 'class' => 'tx-solr-frequent-term-' . $size, 'size' => $size];
+                $frequentSearches[] = [
+                    'q' => htmlspecialchars_decode($term),
+                    'hits' => $hits,
+                    'style' => 'font-size: ' . $size . 'px', 'class' => 'tx-solr-frequent-term-' . $size,
+                    'size' => $size
+                ];
             }
         }
 

--- a/Classes/ViewHelpers/Widget/Controller/FrequentlySearchedController.php
+++ b/Classes/ViewHelpers/Widget/Controller/FrequentlySearchedController.php
@@ -16,8 +16,11 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\FrequentSearches\FrequentSearchesService;
 use ApacheSolrForTypo3\Solr\Widget\AbstractWidgetController;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -27,22 +30,23 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Timo Hund <timo.hund@dkd.de>
  * @package ApacheSolrForTypo3\Solr\ViewHelpers\Widget\Controller
  */
-class FrequentlySearchedController extends AbstractWidgetController
+class FrequentlySearchedController extends AbstractWidgetController implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * Initializes the cache for this command.
      *
-     * @return \TYPO3\CMS\Core\Cache\AbstractFrontend
+     * @return FrontendInterface|null
      */
-    protected function getInitializedCache()
+    protected function getInitializedCache(): ?FrontendInterface
     {
         $cacheIdentifier = 'tx_solr';
         try {
             $cacheInstance = GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheIdentifier);
-        } catch (NoSuchCacheException $e) {
-            /** @var t3lib_cache_Factory $typo3CacheFactory */
-            $typo3CacheFactory = $GLOBALS['typo3CacheFactory'];
-            $cacheInstance = $typo3CacheFactory->create($cacheIdentifier, $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$cacheIdentifier]['frontend'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$cacheIdentifier]['backend'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$cacheIdentifier]['options']);
+        } catch (NoSuchCacheException $exception) {
+            $this->logger->error($exception->getMessage());
+           return null;
         }
 
         return $cacheInstance;


### PR DESCRIPTION
# What this pr does

Drop creating cache fallback within class FrequentlySearchedController.
The fallback based on old TYPO3 vor code and is not functional since at least TYPO3 7.

# How to test

Please add a testing instruction here

Fixes: #2782
