### PR TITLE
Remove initial focus() for accessibility

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -11,8 +11,6 @@ function SuggestController() {
                 $formAutoComplete = $('body');
             }
 
-            $form.find('.tx-solr-suggest-focus').focus();
-
             jQuery.ajaxSetup({jsonp: "tx_solr[callback]"});
 
             // when no specific container found, use the form as container


### PR DESCRIPTION
The Inital focus() should be removed since the user should always start at the beginning of the page.
In the current state the user just gets pulled in the search field with no idea where he is.

# What this pr does

Remove inital focus() of search input field

# How to test

On Page load the focus should not jump into the search input field.
