### PR TITLE
[BUGFIX] writing errorHandling of site configuration

### DIFF
--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -496,9 +496,7 @@ abstract class IntegrationTest extends FunctionalTestCase
             [
                 $defaultLanguage, $german, $danish
             ],
-            [
-                $this->buildErrorHandlingConfiguration('Fluid', [404])
-            ]
+            $this->buildErrorHandlingConfiguration('Fluid', [404])
         );
 
         $this->writeSiteConfiguration(
@@ -507,9 +505,7 @@ abstract class IntegrationTest extends FunctionalTestCase
             [
                 $defaultLanguage, $german, $danish
             ],
-            [
-                $this->buildErrorHandlingConfiguration('Fluid', [404])
-            ]
+            $this->buildErrorHandlingConfiguration('Fluid', [404])
         );
 
         $this->writeSiteConfiguration(


### PR DESCRIPTION
# What this pr does

currently the errorHandling for site configuration is written

```
errorHandling:
  -
    -
      errorFluidTemplate: typo3/sysext/core/Tests/Functional/Fixtures/Frontend/FluidError.html
...
```
which will never be grabed because of array depth 2 

but shoult be array depth 1
```
errorHandling:
  -
    errorFluidTemplate: typo3/sysext/core/Tests/Functional/Fixtures/Frontend/FluidError.html
...
```

# How to test

s. your written site-configuration in
`cat .Build/Web/typo3temp/var/tests/functional-<*>/typo3conf/sites/integration_tree_one/config.yaml`
