### PR TITLE
[BUGFIX] remove escaping on suggestion prefix

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -2,28 +2,18 @@
 
 namespace ApacheSolrForTypo3\Solr\Controller;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2017 Timo Hund <timo.hund@dkd.de>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
@@ -35,6 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
+ * @copyright (c) 2017 Timo Hund <timo.hund@dkd.de>
  */
 class SuggestController extends AbstractBaseController
 {
@@ -71,10 +62,10 @@ class SuggestController extends AbstractBaseController
             $result = ['status' => false];
         }
         if ($callback) {
-            return htmlspecialchars($callback) . '(' . json_encode($result) . ')';
+            return htmlspecialchars($callback) . '(' . json_encode($result, JSON_UNESCAPED_SLASHES) . ')';
         }
         else {
-            return json_encode($result);
+            return json_encode($result, JSON_UNESCAPED_SLASHES);
         }
     }
 

--- a/Classes/Domain/Search/Query/SuggestQuery.php
+++ b/Classes/Domain/Search/Query/SuggestQuery.php
@@ -1,31 +1,20 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2009-2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\ReturnFields;
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Util;
 
@@ -33,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Util;
  * A query specialized to get search suggestions
  *
  * @author Ingo Renner <ingo@typo3.org>
+ * @copyright (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class SuggestQuery extends Query
 {
@@ -63,7 +53,7 @@ class SuggestQuery extends Query
         $this->configuration = $solrConfiguration->getObjectByPathOrDefault('plugin.tx_solr.suggest.', []);
 
         if (!empty($this->configuration['treatMultipleTermsAsSingleTerm'])) {
-            $this->prefix = EscapeService::escape($keywords);
+            $this->prefix = $keywords;
         } else {
             $matches = [];
             preg_match('/^(:?(.* |))([^ ]+)$/', $keywords, $matches);
@@ -71,7 +61,7 @@ class SuggestQuery extends Query
             $partialKeyword = trim($matches[3]);
 
             $this->setQuery($fullKeywords);
-            $this->prefix = EscapeService::escape($partialKeyword);
+            $this->prefix = $partialKeyword;
         }
 
         $this->getEDisMax()->setQueryAlternative('*:*');

--- a/Tests/Integration/Controller/Fixtures/can_suggest_with_uri_special_chars.xml
+++ b/Tests/Integration/Controller/Fixtures/can_suggest_with_uri_special_chars.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+		<![CDATA[
+		config.disableAllHeaderCode = 1
+		config.tx_extbase {
+			mvc {
+
+			}
+
+			features {
+				requireCHashArgumentForActionArguments = 0
+				useRawDocuments = 1
+			}
+		}
+
+		page = PAGE
+		page.typeNum = 0
+		page.bodyTag = <body>
+
+		# very simple rendering
+		page.10 = CONTENT
+		page.10 {
+			table = tt_content
+			select.orderBy = sorting
+			select.where = colPos=0
+			renderObj = COA
+			renderObj {
+				10 = TEXT
+				10.field = bodytext
+			}
+		}
+
+		@import 'EXT:solr/Configuration/TypoScript/Solr/setup.typoscript'
+
+		plugin.tx_solr {
+			enabled = 1
+			index.queue.pages.fields {
+				title_textPath = title
+			}
+			suggest.suggestField = title
+		}
+
+		]]>
+		</config>
+		<sorting>100</sorting>
+		<static_file_mode>0</static_file_mode>
+	</sys_template>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<title>Uri Special Chars</title>
+	</pages>
+
+	<pages>
+		<uid>2</uid>
+		<pid>1</pid>
+		<title>Some/</title>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<pid>1</pid>
+		<title>Some/Large</title>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+	</pages>
+
+	<pages>
+		<uid>4</uid>
+		<pid>1</pid>
+		<title>Some/Large/Path</title>
+		<is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+	</pages>
+</dataset>


### PR DESCRIPTION
Since solarium escapes the special uri characters with RFC1738,
there are no needs to do the same within the EXT:Solr.

see:
https://github.com/solariumphp/solarium/blob/97a9df0c2d9ba35db3c747b30c0809702296f18b/src/Component/RequestBuilder/RequestParamsTrait.php#L153


This is the first step of removing the escaping/encoding from EXT:Solr API.
Other components of EXT:solr will be fixed as well in different pull requests.
