### PR TITLE
[BUGFIX:BP:10] remove escaping on suggestion prefix

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -2,28 +2,18 @@
 
 namespace ApacheSolrForTypo3\Solr\Controller;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2017 Timo Hund <timo.hund@dkd.de>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
@@ -35,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
- * @package ApacheSolrForTypo3\Solr\Controller
  */
 class SuggestController extends AbstractBaseController
 {
@@ -49,7 +38,6 @@ class SuggestController extends AbstractBaseController
      */
     public function suggestAction($queryString, $callback, $additionalFilters = [])
     {
-        $jsonPCallback = htmlspecialchars($callback);
         // Get suggestions
         $rawQuery = htmlspecialchars(mb_strtolower(trim($queryString)));
 
@@ -72,8 +60,12 @@ class SuggestController extends AbstractBaseController
             $this->handleSolrUnavailable();
             $result = ['status' => false];
         }
-
-        return htmlspecialchars($jsonPCallback) . '(' . json_encode($result) . ')';
+        if ($callback) {
+            return htmlspecialchars($callback) . '(' . json_encode($result, JSON_UNESCAPED_SLASHES) . ')';
+        }
+        else {
+            return json_encode($result, JSON_UNESCAPED_SLASHES);
+        }
     }
 
 }

--- a/Classes/Domain/Search/Query/SuggestQuery.php
+++ b/Classes/Domain/Search/Query/SuggestQuery.php
@@ -1,31 +1,20 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2009-2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\ReturnFields;
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Util;
 
@@ -33,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Util;
  * A query specialized to get search suggestions
  *
  * @author Ingo Renner <ingo@typo3.org>
+ * @copyright (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class SuggestQuery extends Query
 {
@@ -63,7 +53,7 @@ class SuggestQuery extends Query
         $this->configuration = $solrConfiguration->getObjectByPathOrDefault('plugin.tx_solr.suggest.', []);
 
         if (!empty($this->configuration['treatMultipleTermsAsSingleTerm'])) {
-            $this->prefix = EscapeService::escape($keywords);
+            $this->prefix = $keywords;
         } else {
             $matches = [];
             preg_match('/^(:?(.* |))([^ ]+)$/', $keywords, $matches);
@@ -71,7 +61,7 @@ class SuggestQuery extends Query
             $partialKeyword = trim($matches[3]);
 
             $this->setQuery($fullKeywords);
-            $this->prefix = EscapeService::escape($partialKeyword);
+            $this->prefix = $partialKeyword;
         }
 
         $this->getEDisMax()->setQueryAlternative('*:*');

--- a/Tests/Integration/Controller/Fixtures/can_suggest_with_uri_special_chars.xml
+++ b/Tests/Integration/Controller/Fixtures/can_suggest_with_uri_special_chars.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+		<![CDATA[
+		config.disableAllHeaderCode = 1
+		config.tx_extbase {
+			mvc {
+
+			}
+
+			features {
+				requireCHashArgumentForActionArguments = 0
+				useRawDocuments = 1
+			}
+		}
+
+		page = PAGE
+		page.typeNum = 0
+		page.bodyTag = <body>
+
+		# very simple rendering
+		page.10 = CONTENT
+		page.10 {
+			table = tt_content
+			select.orderBy = sorting
+			select.where = colPos=0
+			renderObj = COA
+			renderObj {
+				10 = TEXT
+				10.field = bodytext
+			}
+		}
+
+		@import 'EXT:solr/Configuration/TypoScript/Solr/setup.typoscript'
+
+		plugin.tx_solr {
+			enabled = 1
+			index.queue.pages.fields {
+				title_textPath = title
+			}
+			suggest.suggestField = title
+		}
+
+		]]>
+		</config>
+		<sorting>100</sorting>
+		<static_file_mode>0</static_file_mode>
+	</sys_template>
+
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<title>Uri Special Chars</title>
+	</pages>
+
+	<pages>
+		<uid>2</uid>
+		<pid>1</pid>
+		<title>Some/</title>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<pid>1</pid>
+		<title>Some/Large</title>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+	</pages>
+
+	<pages>
+		<uid>4</uid>
+		<pid>1</pid>
+		<title>Some/Large/Path</title>
+		<is_siteroot>0</is_siteroot>
+        <doktype>1</doktype>
+	</pages>
+</dataset>

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -1,50 +1,34 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2018 Timo Hund <timo.hund@dkd.de>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
-use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
-use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
-use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Controller\SuggestController;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 use TYPO3\CMS\Extbase\Mvc\Request;
-use TYPO3\CMS\Extbase\Mvc\Web\Response;
+use TYPO3\CMS\Extbase\Mvc\Response;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
-use TYPO3\CMS\Fluid\View\Exception\InvalidTemplateResourceException;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Page\PageGenerator;
 
 /**
  * Integration testcase to test for the SuggestController
  *
  * @author Timo Hund
+ * @copyright (c) 2018 Timo Hund <timo.hund@dkd.de>
+ * @group frontend
  */
 class SuggestControllerTest extends AbstractFrontendControllerTest
 {
@@ -76,13 +60,11 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
 
         $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
 
-        /** @var  $searchController SearchController */
         $this->suggestController = $this->objectManager->get(SuggestController::class);
         $this->suggestRequest = $this->getPreparedRequest('Suggest', 'suggest');
         $this->suggestResponse = $this->getPreparedResponse();
 
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\\Solr\\IndexQueue\\FrontendHelper\\PageFieldMappingIndexer'] = PageFieldMappingIndexer::class;
-
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class] = PageFieldMappingIndexer::class;
     }
 
     /**
@@ -102,5 +84,43 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
 
         //we assume to get suggestions like Sweatshirt
         $this->assertContains('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
+    }
+
+    /**
+     * @test
+     */
+    public function canSuggestWithUriSpecialChars()
+    {
+        $this->importDataSetFromFixture('can_suggest_with_uri_special_chars.xml');
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
+        $this->indexPages([1, 2, 3, 4]);
+
+        // @todo: add more variants
+        // @TODO: Check why does solr return some/larg instead of some/large
+        $testCases = [
+            [
+                'prefix' => 'Some/',
+                'expected' => 'suggestions":{"some/":1,"some/larg":1,"some/large/path":1}'
+            ],
+            [
+                'prefix' => 'Some/Large',
+                'expected' => 'suggestions":{"some/large/path":1}'
+            ],
+        ];
+        foreach ($testCases as $testCase) {
+            $this->expectSuggested($testCase['prefix'], $testCase['expected']);
+        }
+    }
+
+    protected function expectSuggested(string $prefix, string $expected)
+    {
+        $this->suggestRequest->setArgument('queryString', $prefix);
+        $this->suggestRequest->setArgument('callback', 'rand');
+
+        $this->suggestController->processRequest($this->suggestRequest, $this->suggestResponse);
+        $result = $this->suggestResponse->getContent();
+
+        //we assume to get suggestions like Sweatshirt
+        $this->assertContains($expected, $result, 'Response did not contain expected suggestions: ' . $expected);
     }
 }


### PR DESCRIPTION
Since solarium escapes the special uri characters with RFC1738,
there are no needs to do the same within the EXT:Solr.

see:
https://github.com/solariumphp/solarium/blob/97a9df0c2d9ba35db3c747b30c0809702296f18b/src/Component/RequestBuilder/RequestParamsTrait.php#L153

This is the first step of removing the escaping/encoding from EXT:Solr API.
Other components of EXT:solr will be fixed as well in different pull requests.

Fixes: #2917