### PR TITLE
[BUGFIX:BP:10] Make relevance sorting option markable as active

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -134,6 +134,10 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
                 $label = $cObj->stdWrap($label, $sortingOptions['label.']);
             }
 
+            if ($isResetOption && !$hasSorting) {
+                $selected = true;
+            }
+            
             $sorting = $this->getObjectManager()->get(Sorting::class, $resultSet, $sortingName, $field, $direction, $label, $selected, $isResetOption);
             $resultSet->addSorting($sorting);
         }

--- a/Resources/Private/Partials/Result/Sorting.html
+++ b/Resources/Private/Partials/Result/Sorting.html
@@ -14,7 +14,7 @@
 
 				<f:if condition="{sorting.isResetOption}">
 					<f:then>
-						<li>
+						<li class="{f:if(condition: '{sorting.selected}', then: 'active')}" >
 							<a href="{s:uri.sorting.removeSorting()}" class="solr-ajaxified">{sorting.label}</a>
 						</li>
 					</f:then>

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -1059,7 +1059,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $this->assertEquals(1, $searchResultSet->getSortings()->getCount(), 'No sorting was created');
-        $this->assertFalse($searchResultSet->getSortings()->getHasSelected(), 'Expected that no selected sorting was present');
+        $this->assertEquals('relevance', $searchResultSet->getSortings()->getSelected()->getName());
+        $this->assertTrue($searchResultSet->getSortings()->getHasSelected(), 'The sorting by "relevance/score" is active but not marked as selected.');
     }
 
     /**


### PR DESCRIPTION
* Makes it possible to mark relevance sorting option as active.

Fixes: #2541