### PR TITLE
[BUGFIX] Add missing applicationType to faked request

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -5,6 +5,7 @@ use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Context\TypoScriptAspect;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Error\Http\InternalServerErrorException;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
@@ -87,8 +88,10 @@ class Tsfe implements SingletonInterface
         if (!isset($this->requestCache[$cacheId])) {
             /* @var ServerRequest $request */
             $request = GeneralUtility::makeInstance(ServerRequest::class);
-            $request = $request->withAttribute('site', $site);
-            $this->requestCache[$cacheId] = $request->withAttribute('language', $siteLanguage);
+            $this->requestCache[$cacheId] = $request
+                ->withAttribute('site', $site)
+                ->withAttribute('language', $siteLanguage)
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
         }
         $GLOBALS['TYPO3_REQUEST'] = $this->requestCache[$cacheId];
 


### PR DESCRIPTION
# What this pr does

When initializing the TSFE a TYPO3_REQUEST is also initialized.
A request must always have a applicationType attribute.
If no applicationType is given `ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])`
can't bee used and throws an exception.

# How to test

Call `ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])` on the 
`$GLOBALS['TYPO3_REQUEST']` that is initialized in
`Classes/FrontendEnvironment/Tsfe.php`

Fixes: #2932 