### PR TITLE
[BUGFIX] Delete documents for valid connections only

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -122,7 +122,7 @@ abstract class AbstractStrategy
             $siteHash = $site->getSiteHash();
             // a site can have multiple connections (cores / languages)
             $solrConnections = $this->connectionManager->getConnectionsBySite($site);
-            if ($language > 0) {
+            if ($language > 0 && isset($solrConnections[$language])) {
                 $solrConnections = [$language => $solrConnections[$language]];
             }
             $this->deleteRecordInAllSolrConnections($table, $uid, $solrConnections, $siteHash, $enableCommitsSetting);


### PR DESCRIPTION
This prevents the Exception `Call to a member function getWriteService() on null` when solr is disabled (solr_enabled_read: false)

# What this pr does

It prevents an exception when solr is disabled (solr_enabled_read: false)

# How to test

Set `solr_enabled_read: false` and save a translated page

Fixes: #2940