### PR TITLE
[TEMPORARY][For Build only] Add option for assoc keys for tx_solr[filter] facet parameters

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/UrlFacetDataBag.php
+++ b/Classes/Domain/Search/ResultSet/Facets/UrlFacetDataBag.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
+
+/**
+ * Copyright notice
+ *
+ * (c) 2020 Lars Tode <lars.tode@dkd.de>
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
+use ApacheSolrForTypo3\Solr\Utility\ParameterSortingUtility;
+
+/**
+ * Data bag for facets inside of an url
+ *
+ * @author Lars Tode <lars.tode@dkd.de>
+ * @api
+ */
+class UrlFacetDataBag implements \Countable
+{
+    /**
+     * Parameters array has a numeric index
+     */
+    const PARAMETER_STYLE_INDEX = 'index';
+
+    /**
+     * Parameters array uses combination of key and value as index
+     */
+    const PARAMETER_STYLE_ASSOC = 'assoc';
+
+    /**
+     * Used parameter style
+     *
+     * @var string
+     */
+    protected $parameterStyle = self::PARAMETER_STYLE_INDEX;
+
+    /**
+     * Argument namespace as configures in TypoScript
+     *
+     * @var string
+     */
+    protected $argumentNameSpace = 'tx_solr';
+
+    /**
+     * @var ArrayAccessor
+     */
+    protected $argumentsAccessor;
+
+    /**
+     * Mark the data bag as changed
+     *
+     * @var bool
+     */
+    protected $changed = false;
+
+    /**
+     * Parameters should be sorted
+     *
+     * @var bool
+     */
+    protected $sort = false;
+
+    /**
+     * UrlFacetDataBag constructor.
+     * 
+     * @param ArrayAccessor $argumentsAccessor
+     * @param string $argumentNameSpace
+     * @param string $parameterStyle
+     */
+    public function __construct(
+        ArrayAccessor $argumentsAccessor,
+        string $argumentNameSpace = 'tx_solr',
+        string $parameterStyle = self::PARAMETER_STYLE_INDEX
+    ) {
+        // Take care that the url style matches in case and is one of the allowed values
+        $parameterStyle = strtolower(trim($parameterStyle));
+        if (empty($parameterStyle) ||
+            (!in_array($parameterStyle, [self::PARAMETER_STYLE_INDEX, self::PARAMETER_STYLE_ASSOC]))) {
+            $parameterStyle = self::PARAMETER_STYLE_INDEX;
+        }
+        $this->argumentsAccessor = $argumentsAccessor;
+        $this->argumentNameSpace = $argumentNameSpace;
+        $this->parameterStyle = $parameterStyle;
+
+        if ($this->parameterStyle === self::PARAMETER_STYLE_ASSOC) {
+            $this->sort = true;
+        }
+    }
+
+    /**
+     * Enable the sort of URL parameters
+     *
+     * @return $this
+     */
+    public function enableSort(): self
+    {
+        $this->sort = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable the sort of URL parameters
+     *
+     * @return $this
+     */
+    public function disableSort(): self
+    {
+        // If the parameter style is assoc, all parameters have to be sorted!
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            $this->sort = false;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns the information if the parameters are sorted
+     *
+     * @return bool
+     */
+    public function isSorted(): bool
+    {
+        return $this->sort;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParameterStyle(): string
+    {
+        return $this->parameterStyle;
+    }
+
+    /**
+     * Helper method to prefix an accessor with the arguments namespace.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function prefixWithNamespace(string $path = 'filter'): string
+    {
+        return $this->argumentNameSpace . ':' . $path;
+    }
+
+    /**
+     * Returns the list of activate facet names
+     *
+     * @return array
+     */
+    public function getActiveFacetNames(): array
+    {
+        $activeFacets = $this->getActiveFacets();
+        $facetNames = [];
+
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            array_map(function($activeFacet) use (&$facetNames) {
+                $facetNames[] = substr($activeFacet, 0, strpos($activeFacet, ':'));
+            }, $activeFacets);
+        } else {
+            array_map(function($activeFacet) use (&$facetNames) {
+                $facetNames[] = substr($activeFacet, 0, strpos($activeFacet, ':'));
+            }, array_keys($activeFacets));
+        }
+
+        return $facetNames;
+    }
+
+    /**
+     * Returns all facet values for a certain facetName
+     * @param string $facetName
+     * @return array
+     */
+    public function getActiveFacetValuesByName(string $facetName): array
+    {
+        $values = [];
+        $activeFacets = $this->getActiveFacets();
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            array_map(function($activeFacet) use (&$values, $facetName) {
+                $parts = explode(':', $activeFacet, 2);
+                if ($parts[0] === $facetName) {
+                    $values[] = $parts[1];
+                }
+            }, $activeFacets);
+        } else {
+            array_map(function($activeFacet) use (&$values, $facetName) {
+                $parts = explode(':', $activeFacet, 2);
+                if ($parts[0] === $facetName) {
+                    $values[] = $parts[1];
+                }
+            }, array_keys($activeFacets));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Returns the active facets
+     *
+     * @return array
+     */
+    public function getActiveFacets(): array
+    {
+        $path = $this->prefixWithNamespace('filter');
+        $pathValue = $this->argumentsAccessor->get($path, []);
+
+        if (!is_array($pathValue)) {
+            $pathValue = [];
+        }
+
+        // Sort url parameter
+        if ($this->sort) {
+            ParameterSortingUtility::sortByType(
+                $pathValue,
+                $this->parameterStyle
+            );
+        }
+
+        return $pathValue;
+    }
+
+    /**
+     * Returns the active count of facets
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->getActiveFacets());
+    }
+
+    /**
+     * Sets and overwrite the active facets
+     *
+     * @param array $activeFacets
+     *
+     * @return UrlFacetDataBag
+     */
+    public function setActiveFacets(array $activeFacets = []): UrlFacetDataBag
+    {
+        $path = $this->prefixWithNamespace('filter');
+        $this->argumentsAccessor->set($path, $activeFacets);
+
+        return $this;
+    }
+
+    /**
+     * Adds a facet value to the request.
+     *
+     * @param string $facetName
+     * @param mixed $facetValue
+     *
+     * @return UrlFacetDataBag
+     */
+    public function addFacetValue(string $facetName, $facetValue): UrlFacetDataBag
+    {
+        if ($this->hasFacetValue($facetName, $facetValue)) {
+            return $this;
+        }
+
+        $facetValues = $this->getActiveFacets();
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            $facetValues[] = $facetName . ':' . $facetValue;
+        } else {
+            $facetValues[$facetName . ':' . $facetValue] = 1;
+        }
+
+        $this->changed = true;
+        $this->setActiveFacets($facetValues);
+
+        return $this;
+    }
+
+    /**
+     * Removes a facet value from the request.
+     *
+     * @param string $facetName
+     * @param mixed $facetValue
+     *
+     * @return UrlFacetDataBag
+     */
+    public function removeFacetValue(string $facetName, $facetValue): UrlFacetDataBag
+    {
+        if (!$this->hasFacetValue($facetName, $facetValue)) {
+            return $this;
+        }
+        $facetValues = $this->getActiveFacets();
+        $facetValueToLookFor = $facetName . ':' . $facetValue;
+
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            foreach ($facetValues as $index => $facetValue) {
+                if ($facetValue === $facetValueToLookFor) {
+                    unset($facetValues[$index]);
+                    break;
+                }
+            }
+        } else {
+            if (isset($facetValues[$facetValueToLookFor])) {
+                unset($facetValues[$facetValueToLookFor]);
+            }
+        }
+        $this->changed = true;
+        $this->setActiveFacets($facetValues);
+
+        return $this;
+    }
+
+    /**
+     * Removes all facet values from the request by a certain facet name
+     *
+     * @param string $facetName
+     *
+     * @return UrlFacetDataBag
+     */
+    public function removeAllFacetValuesByName(string $facetName): UrlFacetDataBag
+    {
+        $facetValues = $this->getActiveFacets();
+        $filterOptions = 0;
+        if ($this->parameterStyle === self::PARAMETER_STYLE_ASSOC) {
+            $filterOptions = ARRAY_FILTER_USE_KEY;
+        }
+
+        $facetValues = array_filter($facetValues, function($facetNameValue) use ($facetName) {
+            $parts = explode(':', $facetNameValue, 2);
+            return $parts[0] !== $facetName;
+        }, $filterOptions);
+
+        $this->changed = true;
+        $this->setActiveFacets($facetValues);
+
+        return $this;
+    }
+
+    /**
+     * Removes all active facets from the request.
+     *
+     * @return UrlFacetDataBag
+     */
+    public function removeAllFacets(): UrlFacetDataBag
+    {
+        $path = $this->prefixWithNamespace('filter');
+        $this->argumentsAccessor->reset($path);
+        $this->changed = true;
+        return $this;
+    }
+
+    /**
+     * Test if there is a active facet with a given value
+     *
+     * @param string $facetName
+     * @param mixed $facetValue
+     * @return bool
+     */
+    public function hasFacetValue(string $facetName, $facetValue): bool
+    {
+        $facetNameAndValueToCheck = $facetName . ':' . $facetValue;
+        $facetValues = $this->getActiveFacets();
+
+        if ($this->parameterStyle === self::PARAMETER_STYLE_INDEX) {
+            return in_array($facetNameAndValueToCheck, $this->getActiveFacets());
+        } else {
+            return isset($facetValues[$facetNameAndValueToCheck]) && (int)$facetValues[$facetNameAndValueToCheck] === 1;
+        }
+    }
+
+    /**
+     * Returns the information if the data bag has changes
+     *
+     * @return bool
+     */
+    public function hasChanged(): bool
+    {
+        return $this->changed;
+    }
+
+    /**
+     * Resets the internal change status by explicit acknowledge the change
+     *
+     * @return $this
+     */
+    public function acknowledgeChange(): UrlFacetDataBag
+    {
+        $this->changed = false;
+
+        return $this;
+    }
+}

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Uri;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
+use ApacheSolrForTypo3\Solr\Utility\ParameterSortingUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 
@@ -85,6 +86,14 @@ class SearchUriBuilder
 
         $arguments = $persistentAndFacetArguments + $additionalArguments;
 
+        // Sort filter arguments
+        if (is_array($arguments['tx_solr']['filter']) && $previousSearchRequest->isActiveFacetsSorted()) {
+            ParameterSortingUtility::sortByType(
+                $arguments['tx_solr']['filter'],
+                $previousSearchRequest->getActiveFacetsUrlParameterStyle()
+            );
+        }
+
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $arguments);
     }
@@ -123,6 +132,14 @@ class SearchUriBuilder
         }
         $arguments = $persistentAndFacetArguments + $additionalArguments;
 
+        // Sort filter arguments
+        if (is_array($arguments['tx_solr']['filter']) && $previousSearchRequest->isActiveFacetsSorted()) {
+            ParameterSortingUtility::sortByType(
+                $arguments['tx_solr']['filter'],
+                $previousSearchRequest->getActiveFacetsUrlParameterStyle()
+            );
+        }
+
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $arguments);
     }
@@ -145,6 +162,14 @@ class SearchUriBuilder
 
         $arguments = $persistentAndFacetArguments + $additionalArguments;
 
+        // Sort filter arguments
+        if (is_array($arguments['tx_solr']['filter']) && $previousSearchRequest->isActiveFacetsSorted()) {
+            ParameterSortingUtility::sortByType(
+                $arguments['tx_solr']['filter'],
+                $previousSearchRequest->getActiveFacetsUrlParameterStyle()
+            );
+        }
+
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $arguments);
     }
@@ -165,6 +190,14 @@ class SearchUriBuilder
         }
 
         $arguments = $persistentAndFacetArguments + $additionalArguments;
+
+        // Sort filter arguments
+        if (is_array($arguments['tx_solr']['filter']) && $previousSearchRequest->isActiveFacetsSorted()) {
+            ParameterSortingUtility::sortByType(
+                $arguments['tx_solr']['filter'],
+                $previousSearchRequest->getActiveFacetsUrlParameterStyle()
+            );
+        }
 
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $arguments);
@@ -217,6 +250,14 @@ class SearchUriBuilder
             /** @scrutinizer ignore-type */ $contextSystemLanguage,
             /** @scrutinizer ignore-type */ $contextConfiguration);
         $arguments = $request->setRawQueryString($queryString)->getAsArray();
+
+        // Sort filter arguments
+        if (is_array($arguments['tx_solr']['filter']) && $previousSearchRequest->isActiveFacetsSorted()) {
+            ParameterSortingUtility::sortByType(
+                $arguments['tx_solr']['filter'],
+                $previousSearchRequest->getActiveFacetsUrlParameterStyle()
+            );
+        }
 
         $pageUid = $this->getTargetPageUidFromRequestConfiguration($previousSearchRequest);
         return $this->buildLinkWithInMemoryCache($pageUid, $arguments);

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use function Webmozart\Assert\Tests\StaticAnalysis\boolean;
 
 /**
  * TypoScript configuration object, used to read all TypoScript configuration.
@@ -1785,6 +1786,38 @@ class TypoScriptConfiguration
     public function getSearchFacetingFacetLimit($defaultIfEmpty = 100)
     {
         return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.faceting.facetLimit', $defaultIfEmpty);
+    }
+
+    /**
+     * Return the configured url parameter style value for facets, used for building faceting parameters.
+     *
+     * plugin.tx_solr.search.faceting.urlParameterStyle
+     *
+     * @param string $defaultUrlParameterStyle
+     * @return string
+     */
+    public function getSearchFacetingUrlParameterStyle(string $defaultUrlParameterStyle = 'index'): string
+    {
+        return (string)$this->getValueByPathOrDefaultValue(
+            'plugin.tx_solr.search.faceting.urlParameterStyle',
+            $defaultUrlParameterStyle
+        );
+    }
+
+    /**
+     * Return the configuration if the URL parameters should be sorted.
+     *
+     * plugin.tx_solr.search.faceting.urlParameterSort
+     *
+     * @param bool $defaultUrlParameterSort
+     * @return bool
+     */
+    public function getSearchFacetingUrlParameterSort(bool $defaultUrlParameterSort = false): bool
+    {
+        return (bool)$this->getValueByPathOrDefaultValue(
+            'plugin.tx_solr.search.faceting.urlParameterSort',
+            $defaultUrlParameterSort
+        );
     }
 
     /**

--- a/Classes/Utility/ParameterSortingUtility.php
+++ b/Classes/Utility/ParameterSortingUtility.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Utility;
+
+/**
+ * Copyright notice
+ *
+ * (c) 2020 Lars Tode <lars.tode@dkd.de>
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+/**
+ * Utility class to sort parameters
+ *
+ * This class is used in places building URI for links, facets etc.
+ *
+ * @see \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetDataBag::getActiveFacets
+ * @see \ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder::getAddFacetValueUri
+ */
+class ParameterSortingUtility
+{
+    /**
+     * Sort a list of parameters either by their key or value
+     *
+     * @param array $parameters
+     * @param string $type
+     * @return array
+     */
+    public static function sortByType(array &$parameters, string $type = 'index'): array
+    {
+        switch ($type) {
+            case 'assoc':
+                return self::sortByIndex($parameters);
+            case 'index':
+            default:
+                return self::sortByValue($parameters);
+        }
+    }
+
+    /**
+     * Sort a list of parameters by their values
+     *
+     * @param array $parameters
+     * @return array
+     */
+    public static function sortByValue(array &$parameters)
+    {
+        usort(
+            $parameters,
+            [self::class, 'sort']
+        );
+        return $parameters;
+    }
+
+    /**
+     * Sort a list of parameters by their keys
+     *
+     * @param array $parameters
+     * @return array
+     */
+    public static function sortByIndex(array &$parameters)
+    {
+        uksort(
+            $parameters,
+            [self::class, 'sort']
+        );
+
+        return $parameters;
+    }
+
+    /**
+     * Since the sort operation did not differs between keys and values it is placed inside an own method
+     *
+     * @param string $a
+     * @param string $b
+     * @return bool
+     */
+    public static function sort(string $a, string $b): bool
+    {
+        return strcmp($a, $b) > 0;
+    }
+}

--- a/Configuration/TypoScript/Solr/constants.typoscript
+++ b/Configuration/TypoScript/Solr/constants.typoscript
@@ -23,5 +23,11 @@ plugin.tx_solr {
 		results {
 			resultsPerPage = 10
 		}
+		faceting {
+			# cat=advanced ; type=options[index,assoc] ; label=Choose the style of the URL parameters
+			urlParameterStyle = index
+			# cat=advanced ; type=boolean ; label=Enable sorting or URL parameters
+			urlParameterSort = 0
+		}
 	}
 }

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -137,7 +137,7 @@ plugin.tx_solr {
 				// @ slop = 1 will math "Hello World" and/or "Hello wonderful World"
 				// Note: this value is for implicit phrase searching(without double quotes)
 				slop = 0
-				
+
 				// The concept of query slop is similar to phrase.slop but it applies to the explicit phrase queries from the user and to match documents instead of boosting.
 				// Also if the user uses double quotes in the search term, then
 				// the query slop value is used and
@@ -273,6 +273,8 @@ plugin.tx_solr {
 			limit = 10
 			showEmptyFacets = 0
 			keepAllFacetsOnSelection = 0
+			urlParameterStyle = {$plugin.tx_solr.search.faceting.urlParameterStyle}
+			urlParameterSort = {$plugin.tx_solr.search.faceting.urlParameterSort}
 
 			facetLinkUrlParameters =
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -882,6 +882,29 @@ faceting.facetLinkUrlParameters.useForFacetResetLinkUrl
 
 Allows to prevent adding the URL parameters to the facets reset link by setting the option to 0.
 
+faceting.urlParameterStyle
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Option/String (index or assoc)
+:TS Path: plugin.tx_solr.search.faceting.urlParameterStyle
+:Since: 11.1
+:Default: index
+
+Allows to change the url style of facets. This can be legacy index or more modern associative style.
+
+Index style: tx_solr[filter][0]=type:pages
+Associative style: tx_solr[filter][type:pages]=1
+
+faceting.urlParameterSort
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.faceting.urlParameterSort
+:Since: 11.1
+:Default: 0
+
+Allows to enable sorting of url parameters, so the single state of facets is associated with same url, no matter in which order the facets were selected.
+
 faceting.facets
 ~~~~~~~~~~~~~~~
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/AbstractFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/AbstractFacetParserTest.php
@@ -16,10 +16,12 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Faceting;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetDataBag;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
+use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
@@ -48,7 +50,9 @@ abstract class AbstractFacetParserTest extends UnitTest
         $usedQueryMock = $this->getMockBuilder(Query::class)->setMethods(['getFaceting'])->disableOriginalConstructor()->getMock();
         $usedQueryMock->expects($this->any())->method('getFaceting')->will($this->returnValue($facetingMock));
 
-        $searchRequestMock = $this->getMockBuilder(SearchRequest::class)->setMethods(['getActiveFacetNames', 'getContextTypoScriptConfiguration', 'getActiveFacets'])->getMock();
+        $searchRequestMock = $this->getMockBuilder(SearchRequest::class)
+            ->setMethods(['getActiveFacetNames', 'getContextTypoScriptConfiguration', 'getActiveFacets', 'getActiveFacetValuesByName'])
+            ->getMock();
 
         $fakeResponse = new ResponseAdapter($fakeResponseJson, 200);
 
@@ -57,21 +61,32 @@ abstract class AbstractFacetParserTest extends UnitTest
         $searchResultSet->setUsedSearchRequest($searchRequestMock);
         $searchResultSet->setResponse($fakeResponse);
 
+        $activeUrlFacets = new UrlFacetDataBag(
+            new ArrayAccessor([ 'tx_solr' => ['filter' => $activeFilters] ])
+        );
         $configuration = [];
         $configuration['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = $facetConfiguration;
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchRequestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfiguration));
+        $searchRequestMock->expects($this->any())
+            ->method('getContextTypoScriptConfiguration')
+            ->will($this->returnValue($typoScriptConfiguration));
 
-        $activeFacetNames = [];
-        $activeFacetValueMap = [];
-        foreach ($activeFilters as $filter) {
-            list($facetName, $value) = explode(':', $filter, 2);
-            $activeFacetNames[] = $facetName;
-            $activeFacetValueMap[] = $filter;
-        }
-
-        $searchRequestMock->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue($activeFacetNames));
-        $searchRequestMock->expects($this->any())->method('getActiveFacets')->will($this->returnValue($activeFacetValueMap));
+        // Replace calls with own data bag
+        $searchRequestMock->expects($this->any())
+            ->method('getActiveFacetNames')
+            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+                return $activeUrlFacets->getActiveFacetNames();
+            }));
+        $searchRequestMock->expects($this->any())
+            ->method('getActiveFacets')
+            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+                return $activeUrlFacets->getActiveFacets();
+            }));
+        $searchRequestMock->expects($this->any())
+            ->method('getActiveFacetValuesByName')
+            ->will($this->returnCallback(function(string $facetName) use ($activeUrlFacets) {
+                return $activeUrlFacets->getActiveFacetValuesByName($facetName);
+            }));
 
         return $searchResultSet;
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -215,7 +215,7 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
         $this->assertTrue($facet->getIsUsed());
 
         $valueSelectedItem = $selectedFacetByUrl->getLabel();
-        $this->assertSame('14', $valueSelectedItem, 'Unpexcted value for selected item');
+        $this->assertSame('14', $valueSelectedItem, 'Unexpected value for selected item');
 
         $subItemCountOfSelectedFacet = $selectedFacetByUrl->getChildNodes()->count();
         $this->assertSame(15, $subItemCountOfSelectedFacet, 'Expected to have 15 sub items below path /1/14/');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -14,9 +14,11 @@ namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\OptionBase
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetDataBag;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
+use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
@@ -51,18 +53,25 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
         $configuration = [];
         $configuration['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = $facetConfiguration;
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchRequestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfiguration));
+        $searchRequestMock->expects($this->any())
+            ->method('getContextTypoScriptConfiguration')
+            ->will($this->returnValue($typoScriptConfiguration));
 
-        $activeFacetNames = [];
-        $activeFacetValueMap = [];
-        foreach ($activeFilters as $filter) {
-            list($facetName, $value) = explode(':', $filter, 2);
-            $activeFacetNames[] = $facetName;
-            $activeFacetValueMap[] = [$facetName, $value, true];
-        }
+        $activeUrlFacets = new UrlFacetDataBag(
+            new ArrayAccessor([ 'tx_solr' => ['filter' => $activeFilters] ])
+        );
 
-        $searchRequestMock->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue($activeFacetNames));
-        $searchRequestMock->expects($this->any())->method('getHasFacetValue')->will($this->returnValueMap($activeFacetValueMap));
+        $searchRequestMock->expects($this->any())
+            ->method('getActiveFacetNames')
+            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+                return $activeUrlFacets->getActiveFacetNames();
+            }));
+
+        $searchRequestMock->expects($this->any())
+            ->method('getHasFacetValue')
+            ->will($this->returnCallback(function(string $facetName, $facetValue) use ($activeUrlFacets) {
+                return $activeUrlFacets->hasFacetValue($facetName, $facetValue);
+            }));
 
         return $searchResultSet;
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetDataBagTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetDataBagTest.php
@@ -1,0 +1,206 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetDataBag;
+use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+
+/**
+ * Testcases for the url data bag
+ *
+ * @author Lars Tode <lars.tode@dkd.de>
+ */
+class UrlFacetDataBagTest extends UnitTest
+{
+    /**
+     * Test data for index based url parameters
+     *
+     * @var \string[][][]
+     */
+    protected $indexParameters = [
+        'tx_solr' => [
+            'filter' => [
+                'type:pages',
+                'type:example',
+                'type:news',
+                'created:12345'
+            ]
+        ]
+    ];
+    /**
+     * Test data for assoc based url parameters
+     *
+     * @var \string[][][]
+     */
+    protected $assocParameters = [
+        'tx_solr' => [
+            'filter' => [
+                'type:pages' => 1,
+                'type:example' => 1,
+                'type:news' => 1,
+                'created:12345' => 1
+            ]
+        ]
+    ];
+
+    /**
+     * @test
+     */
+    public function canFilterIndexFacetsParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $urlFacetBack->enableSort();
+        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+    }
+
+    /**
+     * @test
+     */
+    public function canFilterAssocFacetsParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveAllIndexFacetsParameter()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $this->assertEquals(4, $urlFacetBack->count());
+        $urlFacetBack->removeAllFacets();
+        $this->assertEquals(0, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveAllAssocFacetsParameter()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $this->assertEquals(4, $urlFacetBack->count());
+        $urlFacetBack->removeAllFacets();
+        $this->assertEquals(0, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveAllFacetsParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $this->assertEquals(4, $urlFacetBack->count());
+        $urlFacetBack->removeAllFacetValuesByName('type');
+        $this->assertEquals(1, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveAllAssocFacetsParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $this->assertEquals(4, $urlFacetBack->count());
+        $urlFacetBack->removeAllFacetValuesByName('type');
+        $this->assertEquals(1, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveASingleFacetParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $this->assertEquals(4, $urlFacetBack->count());
+        $urlFacetBack->removeFacetValue('type', 'example');
+        $this->assertEquals(3, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveASingleAssocFacetParameterByName()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $urlFacetBack->removeFacetValue('type', 'example');
+        $this->assertEquals(3, $urlFacetBack->count());
+    }
+
+    /**
+     * @test
+     */
+    public function keepOrderingOfIndexParameters()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $this->assertEquals(['pages', 'example', 'news'], $urlFacetBack->getActiveFacetValuesByName('type'));
+    }
+
+    /**
+     * @test
+     */
+    public function canSortIndexParameters()
+    {
+        $urlFacetBack = new UrlFacetDataBag(new ArrayAccessor($this->indexParameters));
+        $urlFacetBack->enableSort();
+        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+    }
+
+    /**
+     * @test
+     */
+    public function didNotKeepOrderingOfAssocParameters()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $this->assertNotEquals(
+            ['pages', 'example', 'news'],
+            $urlFacetBack->getActiveFacetValuesByName('type')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function assocParametersSortedByDefault()
+    {
+        $urlFacetBack = new UrlFacetDataBag(
+            new ArrayAccessor($this->assocParameters),
+            'tx_solr',
+            'assoc'
+        );
+        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+    }
+}


### PR DESCRIPTION
Introduce new url facet data bag in order to change the internal structure of URLs. The data bag supports numeric and associative index

* Introduce new configuration options for url parameter style and sorting
   TypoScript settings:
   plugin.tx_solr.search.faceting.urlParameterStyle
   plugin.tx_solr.search.faceting.urlParameterSort
* Add two new TypoScript configuration settings 
   in order to configure the parameter style and sorting.
* Changes style configuration from numeric to string introduce sorting
* Changes the TypoScript configuration from integer to string 
   in order to make it more friendly for integrators. 
* Introduce new sorting of parameters
* Move sorting of parameters into own utility class.
   The logic how to sort facet url parameters now located inside of an own 
   utility class in order to reuse it inside of facet link generation.
* Introduce sorting of url parameters inside link ViewHelpers

Fixes: #2307