### PR TITLE
[BUGFIX] use pages configuration as default #issue-2742

### DIFF
--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -169,6 +169,9 @@ abstract class Site implements SiteInterface
         // Fetch configuration in order to be able to read initialPagesAdditionalWhereClause
         $solrConfiguration = $this->getSolrConfiguration();
         $indexQueueConfigurationName = $configurationAwareRecordService->getIndexingConfigurationName('pages', $this->rootPage['uid'], $solrConfiguration);
+        if ($indexQueueConfigurationName === null) {
+            $indexQueueConfigurationName = 'pages';
+        }
         $initialPagesAdditionalWhereClause = $solrConfiguration->getInitialPagesAdditionalWhereClause($indexQueueConfigurationName);
 
         return array_merge($pageIds, $this->pagesRepository->findAllSubPageIdsByRootPage($rootPageId, $maxDepth, $initialPagesAdditionalWhereClause));

--- a/Tests/Integration/Domain/Site/Fixtures/get_pages_returns_subpages_when_root_pages_should_not_be_indexed.xml
+++ b/Tests/Integration/Domain/Site/Fixtures/get_pages_returns_subpages_when_root_pages_should_not_be_indexed.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+				plugin.tx_solr {
+					enabled = 1
+					index {
+						queue {
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+								allowedPageTypes = 1,7,4
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+								additionalWhereClause = (doktype = 1 OR doktype=4 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+							}
+						}
+					}
+				}
+			]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+
+    <pages>
+        <uid>1</uid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+        <title>Hello Solr</title>
+		<no_search>1</no_search>
+    </pages>
+
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <doktype>1</doktype>
+        <title>1st Subpage</title>
+    </pages>
+
+</dataset>

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -119,4 +119,18 @@ class SiteTest extends IntegrationTest
 
         $this->assertEquals([0, 1, 2], $languageIds);
     }
+
+    /**
+     * @test
+     */
+    public function getPagesReturnsSubpagesWhenRootPageShouldNotBeIndexed()
+    {
+        $this->importDataSetFromFixture('get_pages_returns_subpages_when_root_pages_should_not_be_indexed.xml');
+        /** @var $siteRepository SiteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $site = $siteRepository->getSiteByRootPageId(1);
+        $pages = $site->getPages();
+        $this->assertSame(2, count($pages));
+        $this->assertTrue(in_array(2, $pages));
+    }
 }


### PR DESCRIPTION
Site->getPages() should use page indexConfigurationName if no configuration is found for rootPage

Resolves: #2742
Replaces: #2898