### PR TITLE
[BUGFIX:BP:11.0] Delete synonyms with URL special chars

### DIFF
--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -95,11 +95,12 @@ class SolrAdminService extends AbstractSolrService
     /**
      * Constructor
      *
-     * @param TypoScriptConfiguration $typoScriptConfiguration
-     * @param SynonymParser $synonymParser
-     * @param StopWordParser $stopWordParser
-     * @param SchemaParser $schemaParser
-     * @param SolrLogManager $logManager
+     * @param Client $client
+     * @param TypoScriptConfiguration|null $typoScriptConfiguration
+     * @param SolrLogManager|null $logManager
+     * @param SynonymParser|null $synonymParser
+     * @param StopWordParser|null $stopWordParser
+     * @param SchemaParser|null $schemaParser
      */
     public function __construct(
         Client $client,
@@ -279,7 +280,7 @@ class SolrAdminService extends AbstractSolrService
         $this->initializeSynonymsUrl();
         $synonymsUrl = $this->_synonymsUrl;
         if (!empty($baseWord)) {
-            $synonymsUrl .= '/' . $baseWord;
+            $synonymsUrl .= '/' . rawurlencode(rawurlencode($baseWord));
         }
 
         $response = $this->_sendRawGet($synonymsUrl);
@@ -318,7 +319,7 @@ class SolrAdminService extends AbstractSolrService
             throw new \InvalidArgumentException('Must provide base word.');
         }
 
-        $response = $this->_sendRawDelete($this->_synonymsUrl . '/' . urlencode($baseWord));
+        $response = $this->_sendRawDelete($this->_synonymsUrl . '/' . rawurlencode(rawurlencode($baseWord)));
         return $response;
     }
 
@@ -362,7 +363,7 @@ class SolrAdminService extends AbstractSolrService
             throw new \InvalidArgumentException('Must provide stop word.');
         }
 
-        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . urlencode($stopWord));
+        return $this->_sendRawDelete($this->_stopWordsUrl . '/' . rawurlencode(rawurlencode($stopWord)));
     }
 
     /**

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -66,8 +66,14 @@ class SolrAdminServiceTest extends IntegrationTest
     {
         return [
             'normal' => ['baseword' => 'homepage', 'synonyms' => ['website']],
-            'umlaut' => ['baseword' => 'früher', 'synonyms' => ['vergangenheit']]
-
+            'umlaut' => ['baseword' => 'früher', 'synonyms' => ['vergangenheit']],
+            '"' => ['baseword' => '"', 'synonyms' => ['quote mark']],
+            '%' => ['baseword' => '%', 'synonyms' => ['percent']],
+            '#' => ['baseword' => '#', 'synonyms' => ['hashtag']],
+            ':' => ['baseword' => ':', 'synonyms' => ['colon']],
+            ';' => ['baseword' => ';', 'synonyms' => ['semicolon']],
+            // '/' still persists in https://issues.apache.org/jira/browse/SOLR-6853
+            //'/' => ['baseword' => '/', 'synonyms' => ['slash']]
         ];
     }
 
@@ -77,7 +83,7 @@ class SolrAdminServiceTest extends IntegrationTest
      * @dataProvider synonymDataProvider
      * @test
      */
-    public function canAddSynonym($baseWord, $synonyms = [])
+    public function canAddAndDeleteSynonym($baseWord, $synonyms = [])
     {
         $this->solrAdminService->deleteSynonym($baseWord);
         $this->solrAdminService->reloadCore();


### PR DESCRIPTION
The fix is ported from https://github.com/solariumphp/solarium/pull/742

Note: 
The issue on base words containing "/" character in base word 
still persists in Apache Solr.
See: https://issues.apache.org/jira/browse/SOLR-6853

Fixes: #2336