### PR TITLE
[TASK] Add folding and normalization Filters

### DIFF
--- a/Documentation/Releases/solr-release-11-1.rst
+++ b/Documentation/Releases/solr-release-11-1.rst
@@ -20,6 +20,34 @@ The focus of this release has been on URL and SEO optimizations.
 New in this release
 ===================
 
+ASCII and Scandinavian Folding Filter
+-------------------------------------
+
+To improve the search behaviour we introduce folding filters, e.g. allowing to skip accents in search terms. The following languages are
+now using the ASCII folding filter:
+
+* dutch
+* english
+* finish
+* french
+* german
+* hungarian
+* irish
+* italian
+* polish
+* portuguese
+* serbian (for fields that don't include the Serbian Normalization Filter)
+* spanish
+* turkish
+
+For the Scandinavian languages, Norwegian, Swedish and Danish, a similiar approach is used, but we're using the more specialized Scandinavian Normalization
+and Scandinavian Folding Filters.
+
+Folding process usally takes place at a late stage, so your configurations shouldn't be affected. But for the Scandinavian languages the Scandinavian Normalization
+Filter processes the terms earlier, so your protected words for the Snowball Porter Filter, e.g. danish/protwords.txt, might be affected, please be sure to use the
+right spelling (see https://solr.apache.org/guide/8_8/language-analysis.html#scandinavian-normalization-filter).
+
+
 Apache Solr 8.8.2 support
 -------------------------
 

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/danish/schema.xml
@@ -57,12 +57,14 @@
 				protected="danish/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -80,11 +82,13 @@
 			/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -97,6 +101,7 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
@@ -114,12 +119,14 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
@@ -135,6 +142,7 @@
 			/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Danish" protected="danish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -147,17 +155,21 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -168,19 +180,21 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/dutch/schema.xml
@@ -65,6 +65,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -87,6 +88,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,6 +117,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -135,6 +138,7 @@
 			/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -150,6 +154,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -170,7 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -180,7 +186,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/english/schema.xml
@@ -64,6 +64,7 @@
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -84,6 +85,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -114,6 +116,7 @@
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -135,6 +138,7 @@
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -150,6 +154,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -171,7 +177,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -181,7 +187,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/finnish/schema.xml
@@ -64,6 +64,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,6 +87,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,6 +117,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -135,6 +138,7 @@
 					protected="finnish/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -150,6 +154,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -170,7 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -180,7 +186,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/french/schema.xml
@@ -64,6 +64,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,6 +87,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -116,6 +118,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -137,6 +140,7 @@
 					protected="french/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -152,6 +156,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -160,6 +165,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -172,6 +178,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -181,6 +188,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/german/schema.xml
@@ -72,6 +72,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -94,6 +95,7 @@
 
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -131,6 +133,7 @@
 
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +161,7 @@
 			/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -173,6 +177,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -181,6 +186,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -201,6 +207,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -211,6 +218,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/hungarian/schema.xml
@@ -62,6 +62,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -82,6 +83,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -111,6 +113,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -131,6 +134,7 @@
 					protected="hungarian/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -146,6 +150,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="index">
@@ -154,6 +159,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -166,7 +172,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -176,7 +182,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/irish/schema.xml
@@ -63,6 +63,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -83,6 +84,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -112,6 +114,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -132,6 +135,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -147,6 +151,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -155,6 +160,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -168,6 +174,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -178,6 +185,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/italian/schema.xml
@@ -64,6 +64,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,6 +87,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,6 +117,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -135,6 +138,7 @@
 					protected="italian/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -150,6 +154,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -170,6 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -180,6 +187,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/norwegian/schema.xml
@@ -57,12 +57,14 @@
 				protected="norwegian/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -79,11 +81,13 @@
 				protected="norwegian/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -96,6 +100,7 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
@@ -111,12 +116,14 @@
 				protected="norwegian/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
@@ -131,6 +138,7 @@
 					protected="norwegian/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Norwegian" protected="norwegian/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 
@@ -144,17 +152,21 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -165,8 +177,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -174,9 +188,11 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/polish/schema.xml
@@ -63,6 +63,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -85,6 +86,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -114,6 +116,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -134,6 +137,7 @@
 					protected="polish/protwords.txt"
 			/>
 			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -149,6 +153,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -172,6 +178,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -182,6 +189,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/portuguese/schema.xml
@@ -63,6 +63,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -84,6 +85,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -113,6 +115,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -133,6 +136,7 @@
 					protected="portuguese/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -147,6 +151,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -154,6 +159,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -166,6 +172,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -176,6 +183,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/serbian/schema.xml
@@ -149,6 +149,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -157,6 +158,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -181,7 +183,6 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/spanish/schema.xml
@@ -64,6 +64,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,6 +87,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -114,6 +116,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -134,6 +137,7 @@
 					protected="spanish/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 
@@ -150,6 +154,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -158,6 +163,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 
@@ -171,6 +177,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -181,6 +188,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/swedish/schema.xml
@@ -57,12 +57,14 @@
 				protected="swedish/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -79,11 +81,13 @@
 				protected="swedish/protwords.txt"
 			/>
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -96,6 +100,7 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
@@ -113,12 +118,14 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
@@ -133,6 +140,7 @@
 					protected="swedish/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Swedish" protected="swedish/protwords.txt"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -145,17 +153,21 @@
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 
@@ -167,8 +179,10 @@
 			<tokenizer class="solr.StandardTokenizerFactory"/>
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -176,9 +190,11 @@
 			<tokenizer class="solr.StandardTokenizerFactory" />
 
 			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ScandinavianNormalizationFilterFactory"/>
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ScandinavianFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>

--- a/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_1_0/conf/turkish/schema.xml
@@ -64,6 +64,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -85,6 +86,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -112,6 +114,7 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -130,6 +133,7 @@
 					protected="turkish/protwords.txt"
 			/>
 			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -145,6 +149,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -154,6 +159,7 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -166,6 +172,7 @@
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -176,6 +183,7 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>


### PR DESCRIPTION
# What this pr does

Adds the folding and normalization filters to improve the search
behaviour e.g. accents can be skipped.

For must languages the ASCII Folding Filter is used, but for e.g. for
Scandinavian languages language specific folding and normalization
filters are used.

Adapted schemata are:
- danish (Scandinavian Normalization, Scandinavian Folding)
- dutch
- english
- finish
- french
- german
- hungarian
- irish
- italian
- norwegian (Scandinavian Normalization, Scandinavian Folding)
- polish
- portuguese
- serbian (if no Serbian Normalization Filter)
- swedish (Scandinavian Normalization, Scandinavian Folding)
- spanish
- turkish

# How to test

Test stemming and search behaviour of the affected cores, e.g. by using the analysis module.

Please add a testing instruction here

Resolves: #2270

