### PR TITLE
Fix #2970: use correct html tags in templates

### DIFF
--- a/Resources/Private/Partials/Result/Document.html
+++ b/Resources/Private/Partials/Result/Document.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="Document">
 
@@ -46,3 +48,5 @@
 	</div>
 
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Result/Facets.html
+++ b/Resources/Private/Partials/Result/Facets.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="Facets">
 	<div id="tx-solr-faceting">
@@ -20,3 +22,5 @@
 	</div>
 
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Result/FacetsActive.html
+++ b/Resources/Private/Partials/Result/FacetsActive.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="FacetsActive">
 	<f:if condition="{resultSet.facets.used -> f:count()}">
@@ -21,3 +23,5 @@
 		</div>
 	</f:if>
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Result/PerPage.html
+++ b/Resources/Private/Partials/Result/PerPage.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="PerPage">
 	<div id="results-per-page">
@@ -17,3 +19,5 @@
 		</form>
 	</div>
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Result/RelevanceBar.html
+++ b/Resources/Private/Partials/Result/RelevanceBar.html
@@ -1,6 +1,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
 
 <f:section name="RelevanceBar">
 

--- a/Resources/Private/Partials/Result/Sorting.html
+++ b/Resources/Private/Partials/Result/Sorting.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="Sorting">
 	<div id="tx-solr-sorting" class="secondaryContentSection dropdown">
@@ -46,3 +48,5 @@
 		</ul>
 	</div>
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="Form">
 
@@ -30,3 +32,5 @@
 	</div>
 
 </f:section>
+
+</html>

--- a/Resources/Private/Partials/Search/FrequentlySearched.html
+++ b/Resources/Private/Partials/Search/FrequentlySearched.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="FrequentlySearched">
 

--- a/Resources/Private/Partials/Search/LastSearches.html
+++ b/Resources/Private/Partials/Search/LastSearches.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:section name="LastSearches">
 

--- a/Resources/Private/Templates/Search/Detail.html
+++ b/Resources/Private/Templates/Search/Detail.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:layout name="Fullwidth"/>
 
@@ -16,3 +18,5 @@
 		<f:else>No document found!</f:else>
 	</f:if>
 </f:section>
+
+</html>

--- a/Resources/Private/Templates/Search/Form.html
+++ b/Resources/Private/Templates/Search/Form.html
@@ -1,9 +1,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:layout name="Fullwidth"/>
 
 <f:section name="content">
 	<f:render partial="Search/Form" section="Form" arguments="{search:search, additionalFilters:additionalFilters, pluginNamespace:pluginNamespace}" />
 </f:section>
+
+</html>

--- a/Resources/Private/Templates/Search/FrequentlySearched.html
+++ b/Resources/Private/Templates/Search/FrequentlySearched.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
       xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-      xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+      xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:layout name="Fullwidth"/>
 
@@ -9,3 +11,5 @@
     <f:render partial="Search/FrequentlySearched" section="FrequentlySearched" />
 
 </f:section>
+
+</html>

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -1,6 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:layout name="Split"/>
 
@@ -122,3 +124,5 @@
 		</div>
 	</div>
 </f:section>
+
+</html>

--- a/Resources/Private/Templates/Search/SolrNotAvailable.html
+++ b/Resources/Private/Templates/Search/SolrNotAvailable.html
@@ -1,9 +1,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
 
 <f:layout name="Fullwidth"/>
 
 <f:section name="content">
 	Search is currently not available.
 </f:section>
+
+</html>

--- a/Resources/Private/Templates/ViewHelpers/Widget/GroupItemPaginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/GroupItemPaginate/Index.html
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 <f:if condition="{configuration.insertAbove}">
 	<f:render section="paginator" arguments="{pagination: contentArguments.pagination, configuration:configuration, resultSet:resultSet, groupItem:groupItem}" />

--- a/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers/"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 <f:if condition="{configuration.insertAbove}">
 	<f:render section="paginator" arguments="{pagination: contentArguments.pagination, configuration:configuration, resultSet:resultSet}" />


### PR DESCRIPTION
# What this pr does

This PR fixes #2970. There is only one commit (165566674c57471fa0f30426f1c336f4422af98b). All others are from Github's fork/master sync.

# How to test

By code review.

Fixes: #2970
