### PR TITLE
[TASK] Adapt cHash handling for TYPO3 10

### DIFF
--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -75,7 +75,7 @@ class SearchUriBuilder
      * @param $facetValue
      * @return string
      */
-    public function getAddFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
+    public function getAddFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->removeAllGroupItemPages()->addFacetValue($facetName, $facetValue)
@@ -100,7 +100,7 @@ class SearchUriBuilder
      * @param $facetValue
      * @return string
      */
-    public function getSetFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
+    public function getSetFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue): string
     {
         $previousSearchRequest = $previousSearchRequest
             ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacetValuesByName($facetName);
@@ -114,7 +114,7 @@ class SearchUriBuilder
      * @param $facetValue
      * @return string
      */
-    public function getRemoveFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue)
+    public function getRemoveFacetValueUri(SearchRequest $previousSearchRequest, $facetName, $facetValue): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->removeAllGroupItemPages()->removeFacetValue($facetName, $facetValue)
@@ -137,7 +137,7 @@ class SearchUriBuilder
      * @param $facetName
      * @return string
      */
-    public function getRemoveFacetUri(SearchRequest $previousSearchRequest, $facetName)
+    public function getRemoveFacetUri(SearchRequest $previousSearchRequest, $facetName): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacetValuesByName($facetName)
@@ -160,7 +160,7 @@ class SearchUriBuilder
      * @param SearchRequest $previousSearchRequest
      * @return string
      */
-    public function getRemoveAllFacetsUri(SearchRequest $previousSearchRequest)
+    public function getRemoveAllFacetsUri(SearchRequest $previousSearchRequest): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->removeAllGroupItemPages()->removeAllFacets()
@@ -184,7 +184,7 @@ class SearchUriBuilder
      * @param $page
      * @return string
      */
-    public function getResultPageUri(SearchRequest $previousSearchRequest, $page)
+    public function getResultPageUri(SearchRequest $previousSearchRequest, $page): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->setPage($page)
@@ -200,7 +200,7 @@ class SearchUriBuilder
      * @param int $page
      * @return string
      */
-    public function getResultGroupItemPageUri(SearchRequest $previousSearchRequest, GroupItem $groupItem, int $page)
+    public function getResultGroupItemPageUri(SearchRequest $previousSearchRequest, GroupItem $groupItem, int $page): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->setGroupItemPage($groupItem->getGroup()->getGroupName(), $groupItem->getGroupValue(), $page)
@@ -213,7 +213,7 @@ class SearchUriBuilder
      * @param $queryString
      * @return string
      */
-    public function getNewSearchUri(SearchRequest $previousSearchRequest, $queryString)
+    public function getNewSearchUri(SearchRequest $previousSearchRequest, $queryString): string
     {
         /** @var $request SearchRequest */
         $contextConfiguration = $previousSearchRequest->getContextTypoScriptConfiguration();
@@ -241,7 +241,7 @@ class SearchUriBuilder
      * @param $sortingDirection
      * @return string
      */
-    public function getSetSortingUri(SearchRequest $previousSearchRequest, $sortingName, $sortingDirection)
+    public function getSetSortingUri(SearchRequest $previousSearchRequest, $sortingName, $sortingDirection): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->setSorting($sortingName, $sortingDirection)
@@ -255,7 +255,7 @@ class SearchUriBuilder
      * @param SearchRequest $previousSearchRequest
      * @return string
      */
-    public function getRemoveSortingUri(SearchRequest $previousSearchRequest)
+    public function getRemoveSortingUri(SearchRequest $previousSearchRequest): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()->removeSorting()
@@ -269,7 +269,7 @@ class SearchUriBuilder
      * @param SearchRequest $previousSearchRequest
      * @return string
      */
-    public function getCurrentSearchUri(SearchRequest $previousSearchRequest)
+    public function getCurrentSearchUri(SearchRequest $previousSearchRequest): string
     {
         $persistentAndFacetArguments = $previousSearchRequest
             ->getCopyForSubRequest()
@@ -284,7 +284,7 @@ class SearchUriBuilder
      * @param SearchRequest $request
      * @return array
      */
-    protected function getAdditionalArgumentsFromRequestConfiguration(SearchRequest $request)
+    protected function getAdditionalArgumentsFromRequestConfiguration(SearchRequest $request): array
     {
         if ($request->getContextTypoScriptConfiguration() == null) {
             return [];
@@ -303,9 +303,9 @@ class SearchUriBuilder
 
     /**
      * @param SearchRequest $request
-     * @return integer|null
+     * @return int|null
      */
-    protected function getTargetPageUidFromRequestConfiguration(SearchRequest $request)
+    protected function getTargetPageUidFromRequestConfiguration(SearchRequest $request): ?int
     {
         if ($request->getContextTypoScriptConfiguration() == null) {
             return null;
@@ -317,11 +317,11 @@ class SearchUriBuilder
     /**
      * Build the link with an i memory cache that reduces the amount of required typolink calls.
      *
-     * @param integer $pageUid
+     * @param int|null $pageUid
      * @param array $arguments
      * @return string
      */
-    protected function buildLinkWithInMemoryCache($pageUid, array $arguments)
+    protected function buildLinkWithInMemoryCache(?int $pageUid, array $arguments): string
     {
         $values = [];
         $structure = $arguments;
@@ -335,13 +335,8 @@ class SearchUriBuilder
             $this->uriBuilder->reset()->setTargetPageUid($pageUid);
             $uriCacheTemplate = $this->uriBuilder->setArguments($structure)->setUseCacheHash(false)->build();
 
-            // even if we call build with disabled cHash in TYPO3 9 a cHash will be generated when site management is active
-            // to prevent wrong cHashes we remove the cHash here from the cached uri template.
-            // @todo: This can be removed when https://forge.typo3.org/issues/87120 is resolved and we can ship a proper configuration
             /* @var UrlHelper $urlHelper */
             $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $uriCacheTemplate);
-            $urlHelper->removeQueryParameter('cHash');
-
             self::$preCompiledLinks[$hash] = (string)$urlHelper;
         }
 
@@ -351,8 +346,7 @@ class SearchUriBuilder
         $values = array_map(function($value) {
             return urlencode($value);
         }, $values);
-        $uri = str_replace($keys, $values, $uriCacheTemplate);
-        return $uri;
+        return str_replace($keys, $values, $uriCacheTemplate);
     }
 
     /**

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -1,29 +1,22 @@
 <?php
 namespace ApacheSolrForTypo3\Solr\System\Configuration;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2017- Timo Schmidt <timo.schmidt@dkd.de
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as CoreExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -42,12 +35,15 @@ class ExtensionConfiguration
 
     /**
      * ExtensionConfiguration constructor.
+     *
      * @param array $configurationToUse
+     * @throws ExtensionConfigurationExtensionNotConfiguredException
+     * @throws ExtensionConfigurationPathDoesNotExistException
      */
-    public function __construct($configurationToUse = [])
+    public function __construct(array $configurationToUse = [])
     {
         if (empty($configurationToUse)) {
-            $this->configuration = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('solr');
+            $this->configuration = GeneralUtility::makeInstance(CoreExtensionConfiguration::class)->get('solr');
         } else {
             $this->configuration = $configurationToUse;
         }
@@ -86,9 +82,9 @@ class ExtensionConfiguration
     /**
      * Get configuration for useConfigurationMonitorTables
      *
-     * @return array of tableName
+     * @return array of table names
      */
-    public function getIsUseConfigurationMonitorTables()
+    public function getIsUseConfigurationMonitorTables(): array
     {
         $monitorTables = [];
         $monitorTablesList = $this->getConfigurationOrDefaultValue('useConfigurationMonitorTables', '');
@@ -101,30 +97,60 @@ class ExtensionConfiguration
     }
 
     /**
-     * Get configuration for allowLegacySiteMode
+     * Returns a list of available/whitelisted EXT:solr plugin namespaces.
+     * Builds from "pluginNamespaces" extension configuration setting.
+     *
+     * @return array
+     */
+    public function getAvailablePluginNamespaces(): array
+    {
+        $pluginNamespacesList = 'tx_solr,' . $this->getConfigurationOrDefaultValue(
+                'pluginNamespaces'
+            );
+        return array_unique(GeneralUtility::trimExplode(',', $pluginNamespacesList));
+    }
+
+    /**
+     * Returns a list of cacheHash-excludedParameters matching the EXT:solr plugin namespaces.
+     *
+     * Builds from "pluginNamespaces" and takes "includeGlobalQParameterInCacheHash"
+     * extension configuration settings into account.
+     *
+     * @return array
+     */
+    public function getCacheHashExcludedParameters(): array
+    {
+        $pluginNamespaces = array_map(
+            function ($pluginNamespace) {
+                return '^' . $pluginNamespace . '[';
+            },
+            $this->getAvailablePluginNamespaces()
+        );
+        if (false === $this->getIncludeGlobalQParameterInCacheHash()) {
+            $pluginNamespaces[] = 'q';
+        }
+        return array_combine($pluginNamespaces, $pluginNamespaces);
+    }
+
+    /**
+     * Returns the "includeGlobalQParameterInCacheHash" extension configuration setting.
      *
      * @return bool
      */
-    public function getIsAllowLegacySiteModeEnabled(): bool
+    public function getIncludeGlobalQParameterInCacheHash(): bool
     {
-        trigger_error('solr:deprecation: Method getIsAllowLegacySiteModeEnabled is deprecated since EXT:solr 11 and will be removed in 12. Since EXT:solr 10 legacy site handling is deprecated and was removed in EXT:solr 11.', E_USER_DEPRECATED);
-
-        //@todo throw exception if set to true and log deprecation
-        $legacyModeIsActive = $this->getConfigurationOrDefaultValue('allowLegacySiteMode', false);
-        if($legacyModeIsActive === true) {
-            throw new \InvalidArgumentException("Legacy mode is not supported anymore, please migrate your system to use sitehandling now!");
-        }
-
-        return false;
+        return (bool)$this->getConfigurationOrDefaultValue('includeGlobalQParameterInCacheHash', false);
     }
 
     /**
      * @param string $key
      * @param mixed $defaultValue
-     * @return mixed
+     * @return mixed|null
      */
-    protected function getConfigurationOrDefaultValue($key, $defaultValue)
+    protected function getConfigurationOrDefaultValue(string $key, $defaultValue = null)
     {
-        return isset($this->configuration[$key]) ? $this->configuration[$key] : $defaultValue;
+        return $this->configuration[$key] ?? $defaultValue;
     }
+
+
 }

--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -2,26 +2,21 @@
 namespace ApacheSolrForTypo3\Solr\System\UserFunctions;
 
 /*
- * Copyright (C) 2016  Daniel Siepmann <coding@daniel-siepmann.de>
+ * This file is part of the TYPO3 CMS project.
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA.
+ * The TYPO3 project - inspiring people to share!
  */
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\FrontendEnvironment;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -166,6 +161,20 @@ class FlexFormUserFunctions
         $newItems = $this->buildSelectItemsFromAvailableTemplate($availableTemplate);
 
         $parentInformation['items'] = $newItems;
+    }
+
+    /**
+     * @param array $parentInformation
+     */
+    public function getAvailablePluginNamespaces(array &$parentInformation)
+    {
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $namespaces = [];
+        foreach ($extensionConfiguration->getAvailablePluginNamespaces() as $namespace) {
+            $label = $namespace === 'tx_solr' ? 'Default' : '';
+            $namespaces[$namespace] = [$label, $namespace];
+        }
+        $parentInformation['items'] = $namespaces;
     }
 
     /**

--- a/Configuration/FlexForms/Form.xml
+++ b/Configuration/FlexForms/Form.xml
@@ -44,8 +44,10 @@
                             <exclude>1</exclude>
                             <label>Plugin Namespace</label>
                             <config>
-                                <type>input</type>
-                                <eval>trim</eval>
+								<section>1</section>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<itemsProcFunc>ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions->getAvailablePluginNamespaces</itemsProcFunc>
                                 <default>tx_solr</default>
                             </config>
                         </TCEforms>

--- a/Configuration/FlexForms/Results.xml
+++ b/Configuration/FlexForms/Results.xml
@@ -170,9 +170,11 @@
                             <exclude>1</exclude>
                             <label>Plugin Namespace</label>
                             <config>
-                                <type>input</type>
-                                <eval>trim</eval>
-                                <default>tx_solr</default>
+								<section>1</section>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<itemsProcFunc>ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions->getAvailablePluginNamespaces</itemsProcFunc>
+								<default>tx_solr</default>
                             </config>
                         </TCEforms>
                     </view.pluginNamespace>

--- a/Documentation/Releases/solr-release-11-1.rst
+++ b/Documentation/Releases/solr-release-11-1.rst
@@ -48,6 +48,25 @@ Filter processes the terms earlier, so your protected words for the Snowball Por
 right spelling (see https://solr.apache.org/guide/8_8/language-analysis.html#scandinavian-normalization-filter).
 
 
+cHash configuration
+-------------------
+
+EXT:solrs components like range facets can not be properly handled by cHash stack, because the amount of possible range-combinations is infinite, therefore they must be excluded from cHash calculation.
+
+This change makes it possible to exclude all EXT:solr parameters from cache hash. To prevent misconfigurations, the new extension configuration setting "pluginNamespaces" was introduced, which is used in FlexForm and in
+TYPO3_CONF_VARS/FE/cacheHash/excludedParameters. This setting makes it impossible to chose invalid/unhandled EXT:solr plugin namespace on FlexForm (Plugin -> Options -> Plugin Namespace)
+
+Please follow the following migration instructions
+
+Plugin namespaces:
+Needed only if other as default (tx_solr) plugin namespace is used in instance. Add the used namespace[s] to $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr']['pluginNamespaces'] or via backend
+"Settings" -> "Extension Configuration" -> "solr" -> "A list of white listed plugin namespaces"
+
+Global q parameter:
+Needed only if global "q" parameter without plugin namespace is used and wants to be included in cache hash calculation. Set the setting $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr']['pluginNamespaces'] = '1'
+or enable it via backend "Settings" -> "Extension Configuration" -> "solr" -> "Include/Exclude global q parameter in/from cacheHash"
+
+
 Apache Solr 8.8.2 support
 -------------------------
 
@@ -55,7 +74,6 @@ With EXT:solr 11.1 we support Apache Solr 8.8.2, the latest release of Apache So
 
 To see what has changed in Apache Solr please read the release notes of Apache Solr:
 https://solr.apache.org/docs/8_8_2/changes/Changes.html
-
 
 Update to Solarium 6
 --------------------

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -223,8 +223,15 @@ class SearchUriBuilderTest extends UnitTest
     public function addFacetUriRemovesPreviousGroupPage()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects($this->any())
+            ->method('getSearchPluginNamespace')
+            ->will($this->returnValue('tx_solr'));
+        $configurationMock->expects($this->once())
+            ->method('getSearchTargetPage')
+            ->will($this->returnValue(1));
+        $configurationMock->expects($this->any())
+            ->method('getSearchFacetingFacetLinkUrlParametersAsArray')
+            ->will($this->returnValue([]));
 
         $previousRequest =  new SearchRequest([
                 'tx_solr' => [

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,3 +1,9 @@
+# cat=basic/enable/8; type=string; label=A list of white listed plugin namespaces (Required by cacheHash/excludedParameters and plugin flex form): Note: This list only is available in Plugin -> Options -> Plugin Namespace
+pluginNamespaces = tx_solr
+
+# cat=basic/enable/9; type=boolean; label=Include/Exclude global q parameter in/from cacheHash
+includeGlobalQParameterInCacheHash = 0
+
 # cat=basic/enable/10; type=boolean; label=Use closest rootpage for configuration (Performance improvement)
 useConfigurationFromClosestTemplate = 0
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -177,6 +177,18 @@ if (!function_exists('strptime')) {
         \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration::class
     );
 
+    // cacheHash handling
+    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
+        $GLOBALS['TYPO3_CONF_VARS'],
+        [
+            'FE' => [
+                'cacheHash' => [
+                    'excludedParameters' => $extensionConfiguration->getCacheHashExcludedParameters()
+                ]
+            ]
+        ]
+    );
+
     # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['searchResultClassName '])) {


### PR DESCRIPTION
# What this pr does

cHash handling was adapted/disabled to fix generated links in TYPO3 9,
as this adaptions lead to invalid links, e.g. facet links, in TYPO3 10
and Site configuration support is available since EXT:solr 10 there is
no need for this adaptions.

This commit removes the implemented removal of the cHash parameter,
now the UriBuilder is used to build the link template.

# How to test

Index some contents and check the generated links in the frontend:
- facet
- sorting
- pagination

Resolves: #2725
