### PR TITLE
[TASK] Make TYPO3 11 LTS comaptible

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -44,6 +44,6 @@ $GLOBALS['TCA']['pages']['palettes']['slimmed_miscellaneous'] = [
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
     'pages',
     '--palette--;;slimmed_miscellaneous',
-    (string)\TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SYSFOLDER,
+    (string)\TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_SYSFOLDER,
     'after:module'
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -188,7 +188,7 @@ if (!function_exists('strptime')) {
     }
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['LOG']['ApacheSolrForTypo3']['Solr']['writerConfiguration'])) {
-        $context = \TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext();
+        $context = \TYPO3\CMS\Core\Core\Environment::getContext();
         if ($context->isProduction()) {
             $logLevel = \TYPO3\CMS\Core\Log\LogLevel::ERROR;
         } elseif ($context->isDevelopment()) {


### PR DESCRIPTION
# What this pr does

Change namespaces for 

 * PageRepository
 * ApplicationContext

To be able to install in TYPO3 11

# How to test

Install the extension without the PR to get fatal errors about unknown method and class names 

Fixes: #2976 