### PR TITLE
[TASK] Make language cache work with multi site setups

### DIFF
--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -114,10 +114,11 @@ class SiteUtility
         $fallbackKey = 'solr_' . $property . '_read';
 
         // try to find language specific setting if found return it
-        if (isset(self::$languages[$languageId]) === false) {
-            self::$languages[$languageId] = $typo3Site->getLanguageById($languageId)->toArray();
+        $rootPageUid = $typo3Site->getRootPageId();
+        if (isset(self::$languages[$rootPageUid][$languageId]) === false) {
+            self::$languages[$rootPageUid][$languageId] = $typo3Site->getLanguageById($languageId)->toArray();
         }
-        $value = self::getValueOrFallback(self::$languages[$languageId], $keyToCheck, $fallbackKey);
+        $value = self::getValueOrFallback(self::$languages[$rootPageUid][$languageId], $keyToCheck, $fallbackKey);
         if ($value !== null) {
             return $value;
         }
@@ -137,10 +138,11 @@ class SiteUtility
      */
     protected static function writeConnectionIsEnabled(Site $typo3Site, int $languageId): bool
     {
-        if (isset(self::$languages[$languageId]) === false) {
-            self::$languages[$languageId] = $typo3Site->getLanguageById($languageId)->toArray();
+        $rootPageUid = $typo3Site->getRootPageId();
+        if (isset(self::$languages[$rootPageUid][$languageId]) === false) {
+            self::$languages[$rootPageUid][$languageId] = $typo3Site->getLanguageById($languageId)->toArray();
         }
-        $value = self::getValueOrFallback(self::$languages[$languageId], 'solr_use_write_connection', 'solr_use_write_connection');
+        $value = self::getValueOrFallback(self::$languages[$rootPageUid][$languageId], 'solr_use_write_connection', 'solr_use_write_connection');
         if ($value !== null) {
             return $value;
         }


### PR DESCRIPTION
# What this pr does

This pr makes the implemented language cache in SiteUtility.php (see https://github.com/TYPO3-Solr/ext-solr/commit/c3ed93df060b3ab9e8cb052bde13dd0663f27bba) work with multi site setups.
The languages should to be stored per root page, otherwise it leads to problems when having multiple rootpages that share sys_language ids for the languages.


Fixes: #2986 
