### PR TITLE
[BUGFIX:BP:10] getRangeString(): check type before format() - call

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRange.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRange.php
@@ -80,7 +80,9 @@ class DateRange extends AbstractRangeFacetItem
      */
     protected function getRangeString()
     {
-        return $this->startRequested->format('Ymd') . '0000-' . $this->endRequested->format('Ymd') . '0000';
+        $from = null === $this->startRequested ? '' : $this->startRequested->format('Ymd') . '0000';
+        $till = null === $this->endRequested ? '' : $this->endRequested->format('Ymd') . '0000';
+        return $from . '-' . $till;
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Test\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRange;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use DateTime;
+use function Webmozart\Assert\Tests\StaticAnalysis\null;
+
+/**
+ * Class DateRangeTest
+ */
+class DateRangeTest extends UnitTest
+{
+    /**
+     * @test
+     * @noinspection PhpUndefinedVariableInspection
+     */
+    public function canHandleHalfOpenDateRanges()
+    {
+        $dateTime = new DateTime('2021-07-20 16:04:21.000000');
+        $dateRangeOpenStart = new DateRange(
+            $this->getDumbMock(DateRangeFacet::class),
+            null,
+            $dateTime,
+            null,
+            null,
+            null,
+            null,
+            [],
+            null
+        );
+        $dateRangeOpenEnd = new DateRange(
+            $this->getDumbMock(DateRangeFacet::class),
+            $dateTime,
+            null,
+            null,
+            null,
+            null,
+            null,
+            [],
+            null
+        );
+
+        try {
+            $dateRangeCollectionKeyOpenStart = $dateRangeOpenStart->getCollectionKey();
+            $dateRangeCollectionKeyOpenEnd = $dateRangeOpenEnd->getCollectionKey();
+
+        } catch (\Error $error) {
+            $this->fail(
+                'Can\'t handle half open date ranges. Please see: https://github.com/TYPO3-Solr/ext-solr/issues/2942 and error: ' . PHP_EOL .
+                $error->getMessage() . ' in ' . $error->getFile() . ':' . $error->getLine()
+            );
+        }
+        $this->assertEquals('-202107200000', $dateRangeCollectionKeyOpenStart);
+        $this->assertEquals('202107200000-', $dateRangeCollectionKeyOpenEnd);
+    }
+
+}


### PR DESCRIPTION
function can be called publicly (via parent's getUriValue()), thus an incomplete range may lead to an unexpected exception

Fixes: #2942
Backported from: #2943