### PR TITLE
Update TypoScript condition to Expression Language

### DIFF
--- a/Configuration/TypoScript/Examples/Suggest/setup.typoscript
+++ b/Configuration/TypoScript/Examples/Suggest/setup.typoscript
@@ -23,7 +23,7 @@ tx_solr_suggest {
     }
 }
 
-[globalString = GP:tx_solr|callback = ]
+[traverse(request.getQueryParams(), 'tx_solr/callback') == '']
     tx_solr_suggest.config.additionalHeaders.10.header = Content-type: application/json
 [global]
 


### PR DESCRIPTION
# What this pr does

Based on the issue in https://github.com/TYPO3-Solr/ext-solr/issues/2988
Updating typoscript condition to use the Symfony Expression Language.

# How to test

Have the extension installed, use Solr, have no "_Expression could not be parsed. - {"expression":"globalString = GP:tx_solr|callback = "}_" in your typo3 error logs.

Fixes: #2988
