### PR TITLE
[BUGFIX] Prevent fatal on suggest action with invalid filters params

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -64,9 +64,7 @@ class SuggestController extends AbstractBaseController
         if ($callback) {
             return htmlspecialchars($callback) . '(' . json_encode($result, JSON_UNESCAPED_SLASHES) . ')';
         }
-        else {
-            return json_encode($result, JSON_UNESCAPED_SLASHES);
-        }
+        return json_encode($result, JSON_UNESCAPED_SLASHES);
     }
 
 }

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -171,7 +171,7 @@ class SuggestService {
         $rawResponse = $response->getRawResponse();
         $results = json_decode($rawResponse);
         $suggestConfig = $this->typoScriptConfiguration->getObjectByPath('plugin.tx_solr.suggest.');
-        $facetSuggestions = $results->facet_counts->facet_fields->{$suggestConfig['suggestField']};
+        $facetSuggestions = $results->facet_counts->facet_fields->{$suggestConfig['suggestField']} ?? [];
         $facetSuggestions = ParsingUtil::getMapArrayFromFlatArray($facetSuggestions);
 
         return $facetSuggestions ?? [];


### PR DESCRIPTION
This change prevents fatal error on suggest if invalid syntax on Apache Solr "qf" parameters.

Related: #2318