### PR TITLE
[BUGFIX] Respect TCA setting of 'tstamp' field

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -289,7 +289,7 @@ class QueueItemRepository extends AbstractRepository
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($itemType);
             $queryBuilder->getRestrictions()->removeAll();
             $localizedChangedTime = $queryBuilder
-                ->add('select', $queryBuilder->expr()->max($tStampField, 'changed_time'))
+                ->add('select', $queryBuilder->expr()->max($timeStampField, 'changed_time'))
                 ->from($itemType)
                 ->orWhere(
                     $queryBuilder->expr()->eq('uid', $itemUid),

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -284,11 +284,12 @@ class QueueItemRepository extends AbstractRepository
         if (isset($GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'])) {
             // table is localizable
             $translationOriginalPointerField = $GLOBALS['TCA'][$itemType]['ctrl']['transOrigPointerField'];
+            $timeStampField = $GLOBALS['TCA'][$itemType]['ctrl']['tstamp'];
 
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($itemType);
             $queryBuilder->getRestrictions()->removeAll();
             $localizedChangedTime = $queryBuilder
-                ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
+                ->add('select', $queryBuilder->expr()->max($tStampField, 'changed_time'))
                 ->from($itemType)
                 ->orWhere(
                     $queryBuilder->expr()->eq('uid', $itemUid),


### PR DESCRIPTION
# What this pr does
When updating a tracked, localisable item in the Solr queue the TCA setting for the "tstamp" / last updated on field ist not evaluated.
This leads to an exception with records that use a non-default name for this database field.

This PR changes this behaviour to use the TCA settings for the `$itemType`.

# How to test
Add (or change) a custom record that is configured for Solr to use a non-default name for this field. E.g:
```php
$GLOBALS['TCA'][$table]['ctrl']['tstamp'] = 'updated_on';
```
Then you can test this exception and the fix before and after applying this small change.

Fixes: TYPO3-Solr#3037
