### PR TITLE
[BUGFIX] Set solr_path_read to be not required in site configuration #3041

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -64,7 +64,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'] = [
     'description' => 'I.e. if you use Hosted-Solr.com the path inside the admin panel. Should not contain "/solr/".',
     'config' => [
         'type' => 'input',
-        'eval' => 'required',
+        'eval' => 'trim',
         'default' => '/'
     ],
     'displayCond' => 'FIELD:solr_enabled_read:=:1'


### PR DESCRIPTION
# What this pr does

It sets solr_path_read in site configuration to be not required

# How to test

Leave solr_path_read empty and try to save the site configuration within its Sites module

Fixes: #3041
