### PR TITLE
[BUGFIX] Enforce visibility context in Tsfe

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Context\TypoScriptAspect;
 use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Error\Http\InternalServerErrorException;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
@@ -96,6 +97,20 @@ class Tsfe implements SingletonInterface
         $GLOBALS['TYPO3_REQUEST'] = $this->requestCache[$cacheId];
 
         if (!isset($this->tsfeCache[$cacheId])) {
+            // TYPO3 by default enables a preview mode if a backend user is logged in,
+            // the VisibilityAspect is configured to show hidden elements.
+            // Due to this setting hidden relations/translations might be indexed
+            // when running the Solr indexer via the TYPO3 backend.
+            // To avoid this, the VisibilityAspect is adapted for indexing.
+            $context->setAspect(
+                'visibility',
+                GeneralUtility::makeInstance(
+                    VisibilityAspect::class,
+                    false,
+                    false
+                )
+            );
+
             $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
 
             /* @var TypoScriptFrontendController $globalsTSFE */


### PR DESCRIPTION
# What this pr does

TYPO3 by default enables a preview mode if a backend user is logged in,
the VisibilityAspect is configured to show hidden elements.

Due to this setting hidden relations/translations might be indexed
when running the Solr indexer via the TYPO3 backend.

To avoid this, the VisibilityAspect is adapted for indexing.

# How to test

1. Create two sys_categories "Category 1" and "Category 2". Create a German translation for both of them ("Kategorie 1" and "Kategorie 2") and disable the translation of "Category 2"
2. Create a Ext:news record and assign both categories to it. Then create a German translation. Make sure both categories are selected there as well.
3. Add News indexer in TypoScript setup:
```typoscript
@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript'
```
3. Index the news record **via the TYPO3 backend**.
4. Look at the index entries.
In `core_en` the entry has: `"category_stringM":["Category 1", "Category 2"],`
In `core_de` the entry has: `"category_stringM":["Kategorie 1", "Category 2"],`

Fixes: #3046