### PR TITLE
[BUGFIX] Harden SearchRequest against array get parameters

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/UrlFacetContainer.php
+++ b/Classes/Domain/Search/ResultSet/Facets/UrlFacetContainer.php
@@ -189,7 +189,7 @@ class UrlFacetContainer implements \Countable
             $activeFacets = array_keys($activeFacets);
         }
         array_map(function($activeFacet) use (&$values, $facetName) {
-            $parts = explode(':', $activeFacet, 2);
+            $parts = explode(':', (string)$activeFacet, 2);
             if ($parts[0] === $facetName) {
                 $values[] = $parts[1];
             }
@@ -325,7 +325,7 @@ class UrlFacetContainer implements \Countable
         }
 
         $facetValues = array_filter($facetValues, function($facetNameValue) use ($facetName) {
-            $parts = explode(':', $facetNameValue, 2);
+            $parts = explode(':', (string)$facetNameValue, 2);
             return $parts[0] !== $facetName;
         }, $filterOptions);
 

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -554,15 +554,14 @@ class SearchRequest
 
     /**
      * Method to check if the query string is an empty string
-     * (also empty string or whitespaces only are handled as empty).
+     * (also whitespaces only are handled as empty).
      *
      * When no query string is set (null) the method returns false.
      * @return bool
      */
     public function getRawUserQueryIsEmptyString()
     {
-        $path = $this->prefixWithNamespace('q');
-        $query = $this->argumentsAccessor->get($path, null);
+        $query = $this->getRawUserQuery();
 
         if ($query === null) {
             return false;

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -225,6 +225,16 @@ class Faceting implements Modifier, SearchRequestAware
      */
     protected function getFiltersByFacetName(array $resultParameters, array $allFacets): array
     {
+        // validate $resultParameters['filter'] to be an array of string
+        if (!is_array($resultParameters['filter'])) {
+            return [];
+        }
+        foreach ($resultParameters['filter'] as $filter) {
+            if (!is_string($filter)) {
+                return [];
+            }
+        }
+
         // format for filter URL parameter:
         // tx_solr[filter]=$facetName0:$facetValue0,$facetName1:$facetValue1,$facetName2:$facetValue2
         $filters = array_map('rawurldecode', $resultParameters['filter']);


### PR DESCRIPTION
Pass filters or the q parameter as arrays like this:
https://www.example.com/search/?search[filter][0][]=type:News&search[q][]=nhsi4k1z

It will trigger a TYPO3 Exception like this:
Uncaught TYPO3 Exception: #1476107295: PHP Warning: trim() expects parameter 1 to be string, array given in /path/private/typo3conf/ext/solr/Classes/Domain/Search/SearchRequest.php line 562

This change adds a few checks to handle that case

Fixes: #3062
