### PR TITLE
[BUG][BP:11.5] Empty filter leads to an exception within the route enhancer

### DIFF
--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -332,12 +332,21 @@ class RoutingService implements LoggerAwareInterface
             return $queryParams;
         }
 
-        if (!isset($queryParams[$this->getPluginNamespace()]['filter'])) {
+        if (!isset($queryParams[$this->getPluginNamespace()]['filter']) ||
+            empty($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
                 ->/** @scrutinizer ignore-call */
                 info('Mask info: Query parameters has no filter in namespace ' . $this->getPluginNamespace());
             return $queryParams;
         }
+
+        if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
+            $this->logger
+                ->/** @scrutinizer ignore-call */
+                warning('Mask info: Filter within the Query parameters is not an array');
+            return $queryParams;
+        }
+
         $queryParameterMap = $this->getQueryParameterMap();
         $newQueryParams = $queryParams;
 
@@ -500,9 +509,17 @@ class RoutingService implements LoggerAwareInterface
             return $queryParams;
         }
 
-        if (!isset($queryParams[$this->getPluginNamespace()]['filter'])) {
+        if (!isset($queryParams[$this->getPluginNamespace()]['filter']) ||
+            empty($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
                 ->info('Mask info: Query parameters has no filter in namespace ' . $this->getPluginNamespace());
+            return $queryParams;
+        }
+
+        if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
+            $this->logger
+                ->/** @scrutinizer ignore-call */
+                warning('Mask info: Filter within the Query parameters is not an array');
             return $queryParams;
         }
 
@@ -584,7 +601,15 @@ class RoutingService implements LoggerAwareInterface
             $queryParams[$this->getPluginNamespace()] = [];
         }
 
-        if (!isset($queryParams[$this->getPluginNamespace()]['filter'])) {
+        if (!isset($queryParams[$this->getPluginNamespace()]['filter']) ||
+            is_null($queryParams[$this->getPluginNamespace()]['filter'])) {
+            $queryParams[$this->getPluginNamespace()]['filter'] = [];
+        }
+
+        if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
+            $this->logger
+                ->/** @scrutinizer ignore-call */
+                warning('Inflate query: Expected filter to be an array. Replace it with an array structure!');
             $queryParams[$this->getPluginNamespace()]['filter'] = [];
         }
 


### PR DESCRIPTION
**Describe the bug**

Empty filter leads to an exception within the route enhancer

**To Reproduce**

Steps to reproduce the behavior:
1. Use the solr ddev site package
2. Configure the example route enhancer configuration
3. Add sites and categories
4. Index all pages
5. Open the Search page
6. An PHP error occures which indicate, that the filter is not an array

**Expected behavior**
Empty filter, even within the parameter list, should not lead to an error

**Used versions (please complete the following information):**
 - TYPO3 Version: 10.4.20
 - Browser: -
 - EXT:solr Version: main
 - Used Apache Solr Version: -
 - PHP Version: -
 - MySQL Version: -

Fixes: #3054