### PR TITLE
[BUGFIX] changed from always picking the 0 array value to pick always…

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -384,7 +384,7 @@ abstract class AbstractModuleController extends ActionController
         if (empty($solrCoreConnections)) {
             return;
         }
-        $this->selectedSolrCoreConnection = $solrCoreConnections[0];
+        $this->selectedSolrCoreConnection = array_shift($solrCoreConnections);
         $moduleData->setCore($this->selectedSolrCoreConnection->getAdminService()->getCorePath());
         $this->moduleDataStorageService->persistModuleData($moduleData);
     }


### PR DESCRIPTION
Hello, 

we got the issues that we have TYPO3 pages were the default language ist disabled in the site config. With this settings we cant use the TYPO3 BE Module "Core Optimization" because there always was showing up an exception (Call to a member function getAdminService() on null). 

With this little fix we prevent the hard access on the default language solr settings (uid 0) and use instead the first in the connection array. 

In our example "$this->selectedSolrCoreConnection" got only the key [8]=> ...  (language uid) and we don´t have 0.

What is your opinion about that?

Best Regard
Fabio