### PR TITLE
[BUGFIX] Remove hidden translated record in index

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -78,7 +78,6 @@ abstract class AbstractStrategy
      *
      * @param string $table
      * @param int $uid
-     * @return mixed
      */
     abstract protected function removeGarbageOfByStrategy($table, $uid);
 

--- a/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
@@ -36,7 +36,6 @@ class PageStrategy extends AbstractStrategy {
     /**
      * @param string $table
      * @param int $uid
-     * @return mixed
      */
     protected function removeGarbageOfByStrategy($table, $uid)
     {
@@ -47,7 +46,6 @@ class PageStrategy extends AbstractStrategy {
 
         if ($table === 'pages') {
             $this->collectPageGarbageByPageChange($uid);
-            return;
         }
     }
 


### PR DESCRIPTION
# What this pr does

Takes care about removing translated record in index. It also remove the superflous `@return` since it's not used anywhere

# How to test

Hide a translation of a record. The translation is not in index anymore

Fixes: #2235 
