### PR TITLE
[BUGFIX] Don't use jQuery.ajaxSetup()

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -13,8 +13,6 @@ function SuggestController() {
 
             $form.find('.tx-solr-suggest-focus').focus();
 
-            jQuery.ajaxSetup({jsonp: "tx_solr[callback]"});
-
             // when no specific container found, use the form as container
             if ($searchBox.length === 0) {
                 $searchBox = $form;
@@ -32,6 +30,9 @@ function SuggestController() {
             $form.find('.tx-solr-suggest').devbridgeAutocomplete({
                 serviceUrl: $form.data('suggest'),
                 dataType: 'jsonp',
+                ajaxSettings: {
+                    jsonp: "tx_solr[callback]"
+                },
                 paramName: 'tx_solr[queryString]',
                 groupBy: 'category',
                 maxHeight: 1000,


### PR DESCRIPTION
Using jQuery.ajaxSetup() in suggest_controller.js overwrites all subsequent ajax requests from jQuery globally. This (potentially) breaks request from other plugins and code.

This results in the same query params being sent, without touching ajax calls from other pieces of code.

Fixes: #2503