### PR TITLE
[TASK] Use Environment::getContext() instead of GeneralUtility

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -200,7 +200,7 @@ if (!function_exists('strptime')) {
     }
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['LOG']['ApacheSolrForTypo3']['Solr']['writerConfiguration'])) {
-        $context = \TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext();
+        $context = \TYPO3\CMS\Core\Core\Environment::getContext();
         if ($context->isProduction()) {
             $logLevel = \TYPO3\CMS\Core\Log\LogLevel::ERROR;
         } elseif ($context->isDevelopment()) {


### PR DESCRIPTION
Use the proper way to get the current context instead of deprecated call
