### PR TITLE
[DOCS] add missing doc for plugin.tx_solr.logging.indexing.pageIndexed

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrLogging.rst
+++ b/Documentation/Configuration/Reference/TxSolrLogging.rst
@@ -72,6 +72,17 @@ indexing.indexQueuePageIndexerGetData
 
 If enabled, the requested data will be logged. Request data includes item, url, parameters, headers, data, decodedData and report.
 
+indexing.pageIndexed
+--------------------
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.logging.indexing.pageIndexed
+:Default: 0
+:Options: 0,1
+:Since: 2.0
+
+If enabled, it will be logged if a page was indexed successful or not. Additionally, an error is logged if indexing is disabled (via `config.index_enable`)
+
 query.filters
 -------------
 


### PR DESCRIPTION
# What this pr does

Add missing doc for plugin.tx_solr.logging.indexing.pageIndexed
