### PR TITLE
[Bugfix:BP:11-1] routeenhancer with empty filters

### DIFF
--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -609,6 +609,9 @@ class RoutingService implements LoggerAwareInterface
         foreach ($queryParams[$this->getPluginNamespace()]['filter'] as $set) {
             $separator = $this->detectFacetAndValueSeparator((string)$set);
             [$facetName, $facetValuesString] = explode($separator, $set, 2);
+            if ($facetValuesString == null) {
+                continue;
+            }
             $facetValues = explode($this->urlFacetQueryService->getMultiValueSeparator(), $facetValuesString);
 
             /**


### PR DESCRIPTION
Skips empty filters so no error gets thrown when using search & facets

# What this pr does

When using routeEnhancers and filters as inputs, there is a possibility that an filter is empty  which results in an url like
`?tx_solr[q]=&tx_solr[filter][0]=`. This would throw an error

This pr adds an check if the filter is completely empty and skips it

# How to test
Use an routeEnhancer and add an facet to the search form. Leave the fields empty and send

Fixes: #3099 
