### PR TITLE
Handle solr responses != 200

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -191,6 +191,8 @@ class Indexer extends AbstractIndexer
             $response = $this->solr->getWriteService()->addDocuments($documents);
             if ($response->getHttpStatus() == 200) {
                 $itemIndexed = true;
+            } else {
+                throw new Exception('Solr Response: ' . $response->getHttpStatusMessage(), 1637318787);
             }
         } catch (HttpException $e) {
             $response = new ResponseAdapter($e->getBody(), $httpStatus = 500, $e->getStatusMessage());


### PR DESCRIPTION
# What this pr does

This make sure that a non 200 response from solr is handled as a proper error. This patch is considered as a workaround rather than the actual solution. I leave that to the pro's ;-)

# How to test

Make solr return a status 400 and nothing should happen to the index queue item. Then apply this patch and the item should be handled as an error and subsequent runs should be processing the next items in line.

Related: #3108
