### PR TITLE
[BUGFIX] Fix autosuggest with non-ascii terms

### DIFF
--- a/Documentation/Appendix/DynamicFieldTypes.rst
+++ b/Documentation/Appendix/DynamicFieldTypes.rst
@@ -73,6 +73,8 @@ Extension               Type                                 Multivalue  Comment
 \*_textExactM           textExact                            Yes
 \*_textSpellS           textSpell                            No
 \*_textSpellM           textSpell                            Yes
+\*_textSpellExactS      textSpellExact                       No
+\*_textSpellExactM      textSpellExact                       Yes
 \*_phoneticS            Phonetic                             No
 \*_phoneticM            Phonetic                             Yes
 \*_point                point                                No

--- a/Documentation/Configuration/Reference/TxSolrSuggest.rst
+++ b/Documentation/Configuration/Reference/TxSolrSuggest.rst
@@ -34,6 +34,9 @@ suggestField
 
 Sets the Solr index field used to get suggestions from. A general advice is to use a field without stemming on it. For practical reasons this is currently the spell checker field.
 
+Note: With EXT:solr 11.1.0 ASCII folding and language depending normalization filters were introduced, but due to the special behaviour of the auto suggestions ascii-terms were not treated correctly. So with 11.1.3 the untouched tokens are also kept, as this might lead to duplicate
+suggestions, a new field for exact suggestions is introduced, if you want to avoid duplicates and use stricter suggestions, just configure `spellExact` as suggest field. 
+
 forceHttps
 ----------
 

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/arabic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/arabic/schema.xml
@@ -202,4 +202,30 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.ArabicStemFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.ArabicStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/armenian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/armenian/schema.xml
@@ -169,4 +169,23 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/basque/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/basque/schema.xml
@@ -184,4 +184,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/brazilian_portuguese/schema.xml
@@ -187,4 +187,27 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/bulgarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/bulgarian/schema.xml
@@ -189,4 +189,29 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.BulgarianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.BulgarianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/burmese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/burmese/schema.xml
@@ -105,4 +105,17 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory" />
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/catalan/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/catalan/schema.xml
@@ -182,4 +182,27 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/chinese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/chinese/schema.xml
@@ -116,4 +116,21 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 		</analyzer>
 	</fieldType>
+
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/czech/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/czech/schema.xml
@@ -184,4 +184,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.CzechStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.CzechStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/danish/schema.xml
@@ -213,4 +213,24 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/dutch/schema.xml
@@ -176,7 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -186,9 +186,29 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/english/schema.xml
@@ -177,7 +177,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -187,7 +187,29 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<!-- no synonyms here because we do not want to add them as spell suggestion -->
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/finnish/schema.xml
@@ -176,7 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -186,9 +186,29 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/french/schema.xml
@@ -178,7 +178,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -188,10 +188,31 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.ElisionFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ElisionFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.ElisionFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/galician/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/galician/schema.xml
@@ -189,4 +189,28 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.GalicianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.GalicianStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/general_schema_fields.xml
@@ -170,6 +170,11 @@
 	<copyField source="subTitle" dest="spell" />
 	<copyField source="content"  dest="spell" />
 
+	<field name="spellExact" type="textSpellExact" indexed="true" stored="false" multiValued="true" />
+	<copyField source="title"    dest="spellExact" />
+	<copyField source="subTitle" dest="spellExact" />
+	<copyField source="content"  dest="spellExact" />
+
 	<field name="sortTitle" type="string" indexed="true" stored="false" docValues="true" />
 	<copyField source="title" dest="sortTitle" />
 
@@ -243,6 +248,8 @@
 
 	<dynamicField name="*_textSpellS" type="textSpell" indexed="true" stored="true" multiValued="false" />
 	<dynamicField name="*_textSpellM" type="textSpell" indexed="true" stored="true" multiValued="true" />
+	<dynamicField name="*_textSpellExactS" type="textSpellExact" indexed="true" stored="true" multiValued="false" />
+	<dynamicField name="*_textSpellExactM" type="textSpellExact" indexed="true" stored="true" multiValued="true" />
 
 	<dynamicField name="*_stringEdgeNgramS" type="stringEdgeNgram" indexed="true" stored="true" multiValued="false" />
 	<dynamicField name="*_stringEdgeNgramM" type="stringEdgeNgram" indexed="true" stored="true" multiValued="true" />

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/generic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/generic/schema.xml
@@ -180,4 +180,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/german/schema.xml
@@ -207,7 +207,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -218,10 +218,40 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.DictionaryCompoundWordTokenFilterFactory"
+				dictionary="german/german-common-nouns.txt"
+				minWordSize="5"
+				minSubwordSize="4"
+				maxSubwordSize="15"
+				onlyLongestMatch="false"
+			/>
+
+			<!-- no synonyms here because we do not want to add them as spell suggestion -->
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/greek/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/greek/schema.xml
@@ -188,4 +188,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.GreekLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/hindi/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/hindi/schema.xml
@@ -197,4 +197,30 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.IndicNormalizationFilterFactory"/>
+			<filter class="solr.HindiNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.IndicNormalizationFilterFactory"/>
+			<filter class="solr.HindiNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/hungarian/schema.xml
@@ -172,7 +172,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -182,7 +182,28 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/indonesian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/indonesian/schema.xml
@@ -187,4 +187,28 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/irish/schema.xml
@@ -174,7 +174,7 @@
 
 			<!-- no synonyms here because we do not want to add them as spell suggestion -->
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -185,10 +185,33 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.IrishLowerCaseFilterFactory"/>
+
+			<!-- no synonyms here because we do not want to add them as spell suggestion -->
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.IrishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/italian/schema.xml
@@ -176,7 +176,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -187,10 +187,32 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/japanese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/japanese/schema.xml
@@ -117,4 +117,20 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/khmer/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/khmer/schema.xml
@@ -99,4 +99,14 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory" />
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/korean/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/korean/schema.xml
@@ -117,4 +117,20 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false"/>
+			<filter class="solr.LowerCaseFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+			<filter class="solr.CJKWidthFilterFactory"/>
+			<filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="false" />
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/lao/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/lao/schema.xml
@@ -99,4 +99,14 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.ICUTokenizerFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ICUTokenizerFactory" />
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/latvia/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/latvia/schema.xml
@@ -183,4 +183,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/norwegian/schema.xml
@@ -198,4 +198,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/persian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/persian/schema.xml
@@ -192,4 +192,30 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.PersianNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.ArabicNormalizationFilterFactory"/>
+			<filter class="solr.PersianNormalizationFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/polish/schema.xml
@@ -178,7 +178,7 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -189,11 +189,36 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.FlattenGraphFilterFactory"/>
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.StempelPolishStemFilterFactory"/>
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/portuguese/schema.xml
@@ -172,7 +172,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -183,10 +183,32 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/romanian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/romanian/schema.xml
@@ -179,4 +179,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/russian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/russian/schema.xml
@@ -184,4 +184,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/serbian/schema.xml
@@ -188,4 +188,28 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+			<filter class="solr.SerbianNormalizationFilterFactory" haircut="bald"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/spanish/schema.xml
@@ -177,7 +177,7 @@
 			<filter class="solr.LowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -188,10 +188,32 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/swedish/schema.xml
@@ -200,4 +200,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/thai/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/thai/schema.xml
@@ -149,4 +149,26 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.ThaiTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.ThaiTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/turkish/schema.xml
@@ -172,7 +172,7 @@
 			<filter class="solr.TurkishLowerCaseFilterFactory"/>
 
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
@@ -183,10 +183,32 @@
 
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
 
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.TurkishLowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
 </schema>

--- a/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/ukrainian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf/ukrainian/schema.xml
@@ -183,4 +183,27 @@
 		</analyzer>
 	</fieldType>
 
+	<!-- Setup simple analysis for more exact spell checking, considers non-ascii charaters as they are -->
+	<fieldType name="textSpellExact" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+		<analyzer type="index">
+			<tokenizer class="solr.StandardTokenizerFactory"/>
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.StandardTokenizerFactory" />
+
+			<filter class="solr.LowerCaseFilterFactory"/>
+
+			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
+			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+
+			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+		</analyzer>
+	</fieldType>
+
 </schema>


### PR DESCRIPTION
# What this pr does
The introduced ASCII folding filters or language depending normalization filters lead to issues with the auto suggest function due to the differing stemming behaviour.

To fix this issue the original token is preserved if possible, this e.g. allows suggestions for search terms with and without accents. As this extension might lead to unwanted duplicates a new field textSpellExact is introduced, which considers non-ascii characters as given.

# How to test

As soon as branch is checked out and configset is updated, you can test the  default auto suggest behaviour, e.g. with german cores and documents containing "künstler" you should get suggestions for "kunst" and "künst".

By switching the spell field via `plugin.tx_solr.suggest.suggestField = spellExact` you should get more exact suggestions, as they used to be in EXT:solr prior 11.0.

Fixes: #3096 
