### PR TITLE
[FIX] Can't index pages which require a user session

### DIFF
--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -131,6 +131,7 @@ class FrontendUserAuthenticator implements MiddlewareInterface
         /* @noinspection PhpParamsInspection */
         $this->context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $groups));
         $request = $request->withAttribute('frontend.user', $feUser);
+        $feUser->start($request);
 
         return $request;
     }


### PR DESCRIPTION
The initialization of the user was not fully completed on indexer crawl page requests, thus storing data in the user session was not possible.

# What this pr does

Initialize the fake user which is used when indexer crawles pages.

# How to test

Try to index a page which puts data into the user session store (e.g. form honeypot) - which previously resulted in an "Call to a member function set() on null" error.

Relates: #2976
Fixes: #3088
