### PR TITLE
[TASK] Add Czech translation

### DIFF
--- a/Resources/Private/Language/cs.locallang.xlf
+++ b/Resources/Private/Language/cs.locallang.xlf
@@ -1,0 +1,467 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="cs" datatype="plaintext" original="EXT:solr/Resources/Private/Language/locallang.xlf"  date="2021-12-17T10:22:00Z">
+		<header>
+			<generator>LFEditor</generator>
+		</header>
+		<body>
+
+			<trans-unit id="cache_initialize_solr_connections" xml:space="preserve">
+				<source>Initialize Solr connections</source>
+				<target>Zahájení Solr připojení</target>
+			</trans-unit>
+
+			<!-- Index Administration -->
+			<trans-unit id="solr.backend.index_administration.description" xml:space="preserve">
+				<source>The Index Administration Module is responsible for emptying the cores(deleting documents) on Solr Server and index queues in TYPO3 CMS. </source>
+				<target>Modul správy indexu je zodpovědný za vyprázdnění jader (mazání dokumentů) na Solr Server a indexové fronty v TYPO3 CMS.</target>
+			</trans-unit>
+
+			<trans-unit id="solr.backend.index_administration.index_emptied_all" xml:space="preserve">
+				<source>Index emptied for Site "%s" (%s).</source>
+				<target>Index pro stránku "%s" (%s) byl vyprázdněn.</target>
+			</trans-unit>
+
+			<trans-unit id="solr.backend.index_administration.success.queue_emptied" xml:space="preserve">
+				<source>Index Queue emptied for Site "%s".</source>
+				<target>Fronta indexu pro stránku "%s" byla vyprázdněna.</target>
+			</trans-unit>
+
+			<trans-unit id="solr.backend.index_administration.error.on_empty_index" xml:space="preserve">
+				<source>An error occurred while trying to delete documents from the index: %s</source>
+				<target>Při pokusu o odstranění dokumentů z indexu došlo k chybě: %s</target>
+			</trans-unit>
+			<!-- End: Index Maintenance -->
+
+
+			<!-- From Backend/locallang.xlf //-->
+			<trans-unit id="module_indexinspector" xml:space="preserve">
+				<source>Search Index Inspector</source>
+				<target>Inspektor vyhledávacího indexu</target>
+			</trans-unit>
+			<trans-unit id="plugin_results" xml:space="preserve">
+				<source>Search</source>
+				<target>Hledat</target>
+			</trans-unit>
+			<trans-unit id="plugin_results_description" xml:space="preserve">
+				<source>A search form and results list.</source>
+				<target>Vyhledávací formulář a seznam výsledků.</target>
+			</trans-unit>
+
+			<!-- Backend Components -->
+			<!-- SiteSelector -->
+			<trans-unit id="siteselector_switched_successfully" xml:space="preserve">
+				<source>Successfully switched to Site "%s".</source>
+				<target>Úspěšně přepnuto na stránku "%s".</target>
+			</trans-unit>
+
+			<trans-unit id="siteselector_switched_to_first_available_site" xml:space="preserve">
+				<source>The previously selected Site "%s" does not exist or the indexing for that Site was disabled. Switched to "%s", which was the first available one.</source>
+				<target>Dříve vybraná stránka "%s" neexistuje nebo bylo indexování pro tuto stránku zakázáno. Přepnuto na „%s“ jako nejbližší dostupná stránka.</target>
+			</trans-unit>
+
+			<trans-unit id="siteselector_site_does_not_exist_anymore" xml:space="preserve">
+				<source>Couldn't switch to the Site "%s". This site does not exist anymore or the indexing for that Site was disabled. Switched to the first available Site "%s".</source>
+				<target>Nelze přepnout na stránku "%s". Tato stránka již neexistuje nebo bylo indexování této stránky zakázáno. Přepnuto na nejbližší stránku "%s".</target>
+			</trans-unit>
+
+			<!-- CoreSelector -->
+			<trans-unit id="coreselector_switched_to_default_core" xml:space="preserve">
+				<source>The previously selected core "%s" is not available in "%s" site, therefore switched to default core "%s".</source>
+				<target>Dříve vybrané jádro "%s" není dostupné na webu "%s", proto bylo přepnuto na výchozí jádro "%s".</target>
+			</trans-unit>
+
+			<trans-unit id="coreselector_switched_successfully" xml:space="preserve">
+				<source>Successfully switched to core "%s".</source>
+				<target>Úspěšně přepnuto na jádro "%s".</target>
+			</trans-unit>
+			<!-- End: Backend Components -->
+
+			<!-- From ModuleAdministration/locallang.xlf //-->
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Apache Solr Search Administration</source>
+				<target>Administrace vyhledávání Apache Solr</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>Allows you to manage Apache Solr from TYPO3.<br /><em>Access for 'admin' users only!</em></source>
+				<target>Umožňuje vám spravovat Apache Solr z TYPO3.<br /><em>Přístup pouze pro uživatele „admin“!</em></target>
+			</trans-unit>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Search</source>
+				<target>Hledat</target>
+			</trans-unit>
+
+			<!-- From ModuleReports/locallang.xlf //-->
+			<trans-unit id="index_title" xml:space="preserve">
+				<source>Apache Solr Index</source>
+				<target>Index Apache Solr</target>
+			</trans-unit>
+			<trans-unit id="index_description" xml:space="preserve">
+				<source>View the number of documents and fields in your index</source>
+				<target>Zobrazení počtu dokumentů a polí v indexu</target>
+			</trans-unit>
+			<trans-unit id="statistics_title" xml:space="preserve">
+				<source>Apache Solr Statistics</source>
+				<target>Statistiky Apache Solr</target>
+			</trans-unit>
+			<trans-unit id="statistics_description" xml:space="preserve">
+				<source>Provides several Solr usage statistics</source>
+				<target>Poskytuje několik statistik využití Solr</target>
+			</trans-unit>
+
+			<!-- From ModuleScheduler/locallang.xlf //-->
+			<trans-unit id="reindex_title" xml:space="preserve">
+				<source>Force Re-Indexing of a site</source>
+				<target>Vynutit opětovné indexování webu</target>
+			</trans-unit>
+			<trans-unit id="reindex_description" xml:space="preserve">
+				<source>Purges the Solr Index and initializes the Index Queue of a site.</source>
+				<target>Vyčistí index Solr a inicializuje frontu indexu webu.</target>
+			</trans-unit>
+			<trans-unit id="indexqueueworker_title" xml:space="preserve">
+				<source>Index Queue Worker</source>
+				<target>Pracovník indexové fronty</target>
+			</trans-unit>
+			<trans-unit id="indexqueueworker_description" xml:space="preserve">
+				<source>Processes the items in the Index Queue and sends them to Solr.</source>
+				<target>Zpracuje položky v indexové frontě a odešle je do Solr.</target>
+			</trans-unit>
+			<trans-unit id="indexqueueworker_field_documentsToIndexLimit" xml:space="preserve">
+				<source>Number of documents to index</source>
+				<target>Počet dokumentů k indexování</target>
+			</trans-unit>
+			<trans-unit id="indexqueueworker_field_forcedWebRoot" xml:space="preserve">
+				<source>Forced webroot (only needed when webroot is not PATH_site)</source>
+				<target>Vynucený webroot (potřebný pouze v případě, že webroot není PATH_site)</target>
+			</trans-unit>
+			<trans-unit id="field_host" xml:space="preserve">
+				<source>Solr Host</source>
+				<target>Solr Hostitel</target>
+			</trans-unit>
+			<trans-unit id="field_port" xml:space="preserve">
+				<source>Solr Port</source>
+				<target>Solr Port</target>
+			</trans-unit>
+			<trans-unit id="field_path" xml:space="preserve">
+				<source>Solr Path</source>
+				<target>Solr Cesta</target>
+			</trans-unit>
+			<trans-unit id="field_server" xml:space="preserve">
+				<source>Solr Server</source>
+				<target>Solr Server</target>
+			</trans-unit>
+			<trans-unit id="field_site" xml:space="preserve">
+				<source>Site</source>
+				<taregt>Stránka</taregt>
+			</trans-unit>
+
+			<!-- From PluginResults|PluginSearch|PluginFrequentSearches/locallang.xlf -->
+			<trans-unit id="searchUnavailable" xml:space="preserve">
+				<source>Search is currently not available.</source>
+				<target>Vyhledávání momentálně není k dispozici.</target>
+			</trans-unit>
+			<trans-unit id="searchFailed" xml:space="preserve">
+				<source>We're sorry. The request you tried to make could not be processed.</source>
+				<target>Omlouváme se. Požadavek, který jste se pokusili podat, nelze zpracovat.</target>
+			</trans-unit>
+			<trans-unit id="searchWord" xml:space="preserve">
+				<source>Search Term</source>
+				<target>Hledaný výraz</target>
+			</trans-unit>
+			<trans-unit id="didYouMean" xml:space="preserve">
+				<source>Did you mean</source>
+				<target>Máte na mysli</target>
+			</trans-unit>
+			<trans-unit id="submit" xml:space="preserve">
+				<source>Search</source>
+				<target>Hledat</target>
+			</trans-unit>
+			<trans-unit id="sorting_sortBy" xml:space="preserve">
+				<source>Sort by</source>
+				<target>Seřadit podle</target>
+			</trans-unit>
+			<trans-unit id="faceting_narrowSearch" xml:space="preserve">
+				<source>Narrow Search</source>
+				<target>Upřesnit výběr</target>
+			</trans-unit>
+			<trans-unit id="faceting_resultsNarrowedBy" xml:space="preserve">
+				<source>Search narrowed by</source>
+				<target>Výběr upřesněn podle</target>
+			</trans-unit>
+			<trans-unit id="faceting_showMore" xml:space="preserve">
+				<source>Show more</source>
+				<target>Zobrazit více</target>
+			</trans-unit>
+			<trans-unit id="faceting_showFewer" xml:space="preserve">
+				<source>Show fewer</source>
+				<target>Zobrazit méně</target>
+			</trans-unit>
+			<trans-unit id="faceting_removeAllFilters" xml:space="preserve">
+				<source>Remove all filters</source>
+				<target>Odstraň všechny filtry</target>
+			</trans-unit>
+			<trans-unit id="faceting_filter" xml:space="preserve">
+				<source>Filter</source>
+				<target>Filtr</target>
+			</trans-unit>
+			<trans-unit id="results_range" xml:space="preserve">
+				<source>Displaying results @resultsFrom to @resultsTo of @resultsTotal.</source>
+				<target>Ukaž výsledky @resultsFrom až @resultsTo z @resultsTotal.</target>
+			</trans-unit>
+			<trans-unit id="results_found" xml:space="preserve">
+				<source>Found @resultsTotal results in @resultsTime milliseconds.</source>
+				<target>Nalezeno @resultsTotal výsledků v @resultsTime milisekundách</target>
+			</trans-unit>
+			<trans-unit id="results_found.singular" xml:space="preserve">
+				<source>Found 1 result in @resultsTime milliseconds.</source>
+				<target>Najdi jeden výsledek z @resultsTime v milisekundách.</target>
+			</trans-unit>
+			<trans-unit id="results_searched_for" xml:space="preserve">
+				<source>Searched for &quot;@searchWord&quot;.</source>
+				<target>Hledáno pro "@searchWord".</target>
+			</trans-unit>
+			<trans-unit id="no_results_nothing_found" xml:space="preserve">
+				<source>Nothing found for &quot;@searchWord&quot;.</source>
+				<target>Nic nenalezeno pro "@searchWord".</target>
+			</trans-unit>
+			<trans-unit id="no_results_showing_results_suggestion" xml:space="preserve">
+				<source>Showing results for &quot;@suggestedWord&quot;.</source>
+				<target>Zobrazeny výsledky pro "@suggestedWord".</target>
+			</trans-unit>
+			<trans-unit id="no_results_search_for_original" xml:space="preserve">
+				<source>Search instead for &quot;@searchWord&quot;.</source>
+				<target>Místo toho hledej „@searchWord“.</target>
+			</trans-unit>
+			<trans-unit id="lastSearches" xml:space="preserve">
+				<source>Last searches</source>
+				<target>Poslední hledání</target>
+			</trans-unit>
+			<trans-unit id="frequentSearches" xml:space="preserve">
+				<source>Frequent searches</source>
+				<target>Časté hledání</target>
+			</trans-unit>
+			<trans-unit id="relevance" xml:space="preserve">
+				<source>Relevance</source>
+				<target>Relevance</target>
+			</trans-unit>
+			<trans-unit id="sponsored" xml:space="preserve">
+				<source>Sponsored</source>
+				<target>Sponzorováno</target>
+			</trans-unit>
+			<trans-unit id="file_mimetype" xml:space="preserve">
+				<source>File type</source>
+				<target>Typ souboru</target>
+			</trans-unit>
+			<trans-unit id="file_referenced" xml:space="preserve">
+				<source>Referenced at</source>
+				<target>Odkazováno na</target>
+			</trans-unit>
+			<trans-unit id="results_per_page" xml:space="preserve">
+				<source>Results per page:</source>
+				<target>Výsledek na stránku:</target>
+			</trans-unit>
+			<trans-unit id="error_errors" xml:space="preserve">
+				<source>We're sorry, there were some errors:</source>
+				<target>Omlouváme se, došlo k několika chybám:</target>
+			</trans-unit>
+			<trans-unit id="error_emptyQuery" xml:space="preserve">
+				<source>Please enter your search term in the box above.</source>
+				<target>Prosím, zadejte hledaný výraz do pole výše.</target>
+			</trans-unit>
+			<trans-unit id="pagebrowser_first" xml:space="preserve">
+				<source>First</source>
+				<target>První</target>
+			</trans-unit>
+			<trans-unit id="pagebrowser_prev" xml:space="preserve">
+				<source>Previous</source>
+				<target>Předchozí</target>
+			</trans-unit>
+			<trans-unit id="pagebrowser_next" xml:space="preserve">
+				<source>Next</source>
+				<target>Další</target>
+			</trans-unit>
+			<trans-unit id="pagebrowser_last" xml:space="preserve">
+				<source>Last</source>
+				<target>Poslední</target>
+			</trans-unit>
+			<trans-unit id="suggest_header" xml:space="preserve">
+				<source>Top Results</source>
+				<target>Nejlepší výsledky</target>
+			</trans-unit>
+			<!-- From locallang.xlf -->
+			<trans-unit id="solr.backend.index_queue_module.description" xml:space="preserve">
+				<source>The Index Queue manages content indexing. Content enters the Index Queue by initialization below or when new content is created based on configuration. Items in the Index Queue are indexed newest changes first until all items in the queue have been indexed.</source>
+				<target>Indexování obsahu spravuje Fronta indexů. Obsah vstupuje do indexové fronty inicializací níže nebo při vytvoření nového obsahu na základě konfigurace. Položky v indexové frontě jsou indexovány jako první nejnovější změny, dokud nebudou indexovány všechny položky ve frontě</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.reset_button" xml:space="preserve">
+				<source>Reset errors</source>
+				<target>Resetovat chyby</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.headline" xml:space="preserve">
+				<source>Indexing Errors</source>
+				<target>Chyba indexování</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.id" xml:space="preserve">
+				<source>ID</source>
+				<target>ID</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.item_type" xml:space="preserve">
+				<source>Item Type</source>
+				<target>Typ předmětu</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.item_uid" xml:space="preserve">
+				<source>Item UID</source>
+				<target>UID položky</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.errors.show_button" xml:space="preserve">
+				<source>Show error</source>
+				<target>Zobrazit chyby</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.index_manual" xml:space="preserve">
+				<source>An error occurred while indexing manual from the backend.</source>
+				<target>Při indexování manuálu z backendu došlo k chybě.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.reset_errors" xml:space="preserve">
+				<source>An error occurred while resetting the error log in the index queue.</source>
+				<target>Při resetování protokolu chyb ve frontě indexu došlo k chybě.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.single_item_not_requeued" xml:space="preserve">
+				<source>Single item was not requeued.</source>
+				<target>Jedna položka nebyla znovu zařazena do fronty.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.no_selection" xml:space="preserve">
+				<source>No indexing configurations selected.</source>
+				<target>Nejsou vybrány žádné konfigurace indexování.</target>
+			</trans-unit>
+
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.success" xml:space="preserve">
+				<source>Initialized indexing configurations: %s</source>
+				<target>Inicializované konfigurace indexování: %s</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.title" xml:space="preserve">
+				<source>Index Queue initialized</source>
+				<target>Indexová fronta inicializována</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.not_initialized.title" xml:space="preserve">
+				<source>Index Queue not initialized</source>
+				<target>Indexová fronta není inicializována</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.reset_errors" xml:space="preserve">
+				<source>All errors have been reset.</source>
+				<target>Všechny chyby byly resetovány.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.index_manual" xml:space="preserve">
+				<source>Indexing from the backend was successfully finished.</source>
+				<target>Indexování z backendu bylo úspěšně dokončeno.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.single_item_was_requeued" xml:space="preserve">
+				<source>Single item was successfully marked for reindexing.</source>
+				<target>Jedna položka byla úspěšně označena k reindexaci.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.title" xml:space="preserve">
+				<source>Index Queue</source>
+				<target>Indexová fronta</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.index_manual" xml:space="preserve">
+				<source>Manual Indexing</source>
+				<target>Manuální indexování</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.help" xml:space="preserve">
+				<source>Initializing the Index Queue is the most complete way to force re-indexing, or to build the Index Queue for the first time. The Index Queue Worker scheduler task will then index the items listed in the Index Queue.</source>
+				<target>Inicializace indexové fronty je nejúplnější způsob, jak vynutit opětovné indexování nebo poprvé vytvořit indexovou frontu. Úloha plánovače Index Queue Worker pak indexuje položky uvedené v Index Queue.</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.status.errors" xml:space="preserve">
+				<source> Errors</source>
+				<target> Chyby</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.status.header" xml:space="preserve">
+				<source>Indexing Progress</source>
+				<target>Průběh indexování</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.status.indexed" xml:space="preserve">
+				<source> Indexed</source>
+				<target> Indexováno</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.status.pending" xml:space="preserve">
+				<source> Pending</source>
+				<target> Čekající</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.header_init" xml:space="preserve">
+				<source>Index Queue Initialization</source>
+				<target>Inicializace indexové fronty</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.header_status" xml:space="preserve">
+				<source>Index Queue Status</source>
+				<target>Stav indexové fronty</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.button.clear_index_queue" xml:space="preserve">
+				<source>Clear Index Queue</source>
+				<target>Vymazat indexovou frontu</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.back" xml:space="preserve">
+				<source>Go back</source>
+				<target>Zpět</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.no_queue_item_for_queue_error" xml:space="preserve">
+				<source>No valid queue item passed to show the error information!</source>
+				<target>Nebyla předána žádná platná položka fronty k zobrazení informací o chybě!</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.error_details" xml:space="preserve">
+				<source>Error details for queue item</source>
+				<target>Podrobnosti o chybě položky fronty</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.index_now" xml:space="preserve">
+				<source>Index now</source>
+				<target>Indexuj nyní</target>
+			</trans-unit>
+
+			<!-- From locallang_db.xlf -->
+			<trans-unit id="tt_content.list_type_pi_frequentsearches" xml:space="preserve">
+				<source>Search: Frequent Searches</source>
+				<target>Hledat: Časté vyhledávání</target>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi_results" xml:space="preserve">
+				<source>Search: Form, Result, Additional Components</source>
+				<target>Hledat: Formulář, Výsledek, Další komponenty</target>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi_search" xml:space="preserve">
+				<source>Search: Form only</source>
+				<target>Hledat: Pouze formulář</target>
+			</trans-unit>
+
+			<trans-unit id="solr.backend.search_statistics_module.item_phrase" xml:space="preserve">
+				<source>Phrase</source>
+				<target>Fráze</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.item_count" xml:space="preserve">
+				<source>Number of Queries</source>
+				<target>Počet dotazů</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.results" xml:space="preserve">
+				<source>Number of Results (Average)</source>
+				<target>Počet výsledků (průměr)</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.percentage" xml:space="preserve">
+				<source>Percentage</source>
+				<target>Procenta</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.no_records_found" xml:space="preserve">
+				<source>No records found. Did you enabled 'plugin.tx_solr.statistics = 1' in the typoscript configuration of your site?</source>
+				<target>Nenalezeny žádné záznamy. Povolili jste 'plugin.tx_solr.statistics = 1' v konfiguraci typoscriptu vašeho webu?</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
+				<source>Top 5 Search Phrases</source>
+				<target>Top 5 vyhledaných frází</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
+				<source>Top 5 Search Phrases Without Hits</source>
+				<target>Top 5 vyhledávacích frází bez hitů</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
+				<source>Search Phrase Statistics</source>
+				<target>Statistika vyhledaných frází</target>
+			</trans-unit>
+
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
# What this pr does

This PR adds Czech locallang.xlf file.

The translations were provided by our customer and contributed to Ext:solr.

# How to test

Setup a TYPO3 installation with Czech language and Solr cores. Index some pages or records and use the search.
Labels from Ext:solr should now be displayed in Czech instead of English.

Fixes: #3132 (Please create an related issue first and mark it as fixed here with your pr)
