### PR TITLE
[FEATURE] Fix #3143: improve variant handling by sorting user groups

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -238,6 +238,10 @@ class UserGroupDetector extends AbstractFrontendHelper implements
             $frontendGroups[] = '0';
         }
 
+        // Index user groups first
+        sort($frontendGroups, SORT_NUMERIC);
+        $frontendGroups = array_reverse($frontendGroups);
+
         return $frontendGroups;
     }
 


### PR DESCRIPTION
# What this pr does

This PR improves variants handling by sorting user groups for the page in reverse order, which makes main variant to be from the user group instead of from the anonymous group.

# How to test

* Add content for a user group on the page
* Add `variants = 1` to the configuration ([ref](https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Configuration/Reference/TxSolrSearch.html#variants))
* Index the page
* Search for the keyword in the protected content
* The page will be found but the content will not be highlighted because the variant will be from the anonymous user
* Apply the patch
* Clear the index
* Reindex
* Try searching again and see highlighted variant

Fixes: #3143
