### PR TITLE
[BUGFIX] Fix #3145: exception in scheduler with php 8

### DIFF
--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -99,8 +99,8 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
      * @param SchedulerModuleController $schedulerModule
      */
     protected function initialize(
-        array $taskInfo = [],
-        AbstractTask $task = null,
+        array $taskInfo,
+        ?AbstractTask $task,
         SchedulerModuleController $schedulerModule
     )
     {


### PR DESCRIPTION
# What this pr does

This PR fixes exception in scheduler with TYPO3 v11 and PHP 8.

# How to test

Try to add a new task on YUPO3 v11 + PHP 8 + EXT:solr at `release-11.5.x`.

Fixes: #3145
