### PR TITLE
[FEATURE] Improve data update handling

### DIFF
--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -31,7 +31,6 @@ use ApacheSolrForTypo3\Solr\System\Records\SystemLanguage\SystemLanguageReposito
 use ApacheSolrForTypo3\Solr\System\Solr\Node;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use InvalidArgumentException;
-use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use function json_encode;

--- a/Classes/Domain/Index/Queue/GarbageRemover/StrategyFactory.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/StrategyFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
 
 /***************************************************************
@@ -25,6 +24,8 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Class StrategyFactory
  */
@@ -34,9 +35,11 @@ class StrategyFactory {
      * @param string $table
      * @return PageStrategy|RecordStrategy
      */
-    public static function getByTable($table)
+    public static function getByTable($table): AbstractStrategy
     {
         $isPageRelated = in_array($table, ['tt_content','pages']);
-        return $isPageRelated ? new PageStrategy() : new RecordStrategy();
+        return $isPageRelated
+            ? GeneralUtility::makeInstance(PageStrategy::class)
+            : GeneralUtility::makeInstance(RecordStrategy::class);
     }
 }

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -1,0 +1,547 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Util;
+
+/**
+ * Data update handler
+ *
+ * Handles update on potential relevant records e.g.
+ * an update might require index queue updates
+ */
+class DataUpdateHandler extends AbstractUpdateHandler
+{
+    /**
+     * List of fields in the update field array that
+     * are required for processing
+     *
+     * Note: For pages all fields except l10n_diffsource are
+     *       kept, as additional fields can be configured in
+     *       TypoScript, see AbstractDataUpdateEvent->_sleep.
+     *
+     * @var array
+     */
+    protected static $requiredUpdatedFields = [
+        'pid',
+    ];
+
+    /**
+     * Configuration used to check if recursive updates are required
+     *
+     * Holds the configuration when a recursive page queuing should be triggered, while processing record
+     * updates
+     *
+     * Note: The SQL transaction is already committed, so the current state covers only "non"-changed fields.
+     *
+     * @var array
+     */
+    protected $updateSubPagesRecursiveTriggerConfiguration = [
+        // the current page has the both fields "extendToSubpages" and "hidden" set from 1 to 0 => requeue subpages
+        'HiddenAndExtendToSubpageWereDisabled' => [
+            'changeSet' => [
+                'hidden' => '0',
+                'extendToSubpages' => '0'
+            ]
+        ],
+        // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 0 => requeue subpages
+        'extendToSubpageEnabledAndHiddenFlagWasRemoved' => [
+            'currentState' =>  ['extendToSubpages' => '1'],
+            'changeSet' => ['hidden' => '0']
+        ],
+        // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 0 => requeue subpages
+        'hiddenIsEnabledAndExtendToSubPagesWasRemoved' => [
+            'currentState' =>  ['hidden' => '1'],
+            'changeSet' => ['extendToSubpages' => '0']
+        ],
+        // the field "no_search_sub_entries" of current page was set to 0
+        'no_search_sub_entriesFlagWasAdded' => [
+            'changeSet' => ['no_search_sub_entries' => '0']
+        ],
+    ];
+
+    /**
+     * @var MountPagesUpdater
+     */
+    protected $mountPageUpdater;
+
+    /**
+     * @var RootPageResolver
+     */
+    protected $rootPageResolver = null;
+
+    /**
+     * @var PagesRepository
+     */
+    protected $pagesRepository;
+
+    /**
+     * @var SolrLogManager
+     */
+    protected $logger = null;
+
+    /**
+     * @var DataHandler
+     */
+    protected $dataHandler;
+
+    /**
+     * @param ConfigurationAwareRecordService $recordService
+     * @param FrontendEnvironment $frontendEnvironment
+     * @param TCAService $tcaService
+     * @param Queue $indexQueue
+     * @param MountPagesUpdater $mountPageUpdater
+     * @param RootPageResolver $rootPageResolver
+     * @param PagesRepository $pagesRepository
+     * @param SolrLogManager $solrLogManager
+     * @param DataHandler $dataHandler
+     */
+    public function __construct(
+        ConfigurationAwareRecordService $recordService ,
+        FrontendEnvironment $frontendEnvironment,
+        TCAService $tcaService,
+        Queue $indexQueue,
+        MountPagesUpdater $mountPageUpdater,
+        RootPageResolver $rootPageResolver,
+        PagesRepository $pagesRepository,
+        DataHandler $dataHandler,
+        SolrLogManager $solrLogManager = null
+    ) {
+        parent::__construct($recordService, $frontendEnvironment, $tcaService, $indexQueue);
+
+        $this->mountPageUpdater = $mountPageUpdater;
+        $this->rootPageResolver = $rootPageResolver;
+        $this->pagesRepository = $pagesRepository;
+        $this->dataHandler = $dataHandler;
+        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(
+            SolrLogManager::class,
+            /** @scrutinizer ignore-type */ __CLASS__
+        );
+    }
+
+    /**
+     * Handle content element update
+     *
+     * @param int $uid
+     * @param array $updatedFields
+     */
+    public function handleContentElementUpdate(int $uid, array $updatedFields = []): void
+    {
+        $pid = $updatedFields['pid'] ?? $this->getValidatedPid('tt_content', $uid);
+        if ($pid === null) {
+            return;
+        }
+
+        $this->processPageRecord($pid, (int)$pid, $updatedFields);
+    }
+
+    /**
+     * Handles the deletion of a content element
+     *
+     * @param int $uid
+     */
+    public function handleContentElementDeletion(int $uid): void
+    {
+        // @TODO: Should be checked, is possibly unnecessary as
+        //        also done via GarbageCollector & PageStrategy
+
+        $pid = $this->getValidatedPid('tt_content', $uid);
+        if ($pid === null) {
+            return;
+        }
+
+        $this->indexQueue->updateItem('pages', $pid, Util::getExectionTime());
+    }
+
+    /**
+     * Handles page updates
+     *
+     * @param int $uid
+     * @param array $updatedFields
+     */
+    public function handlePageUpdate(int $uid, array $updatedFields = []): void
+    {
+        try {
+            if (isset($updatedFields['l10n_parent']) && intval($updatedFields['l10n_parent']) > 0) {
+                $pid = $updatedFields['l10n_parent'];
+            } elseif ($this->rootPageResolver->getIsRootPageId($uid)) {
+                $pid = $uid;
+            } else {
+                $pid = $updatedFields['pid'] ?? $this->getValidatedPid('pages', $uid);
+            }
+        } catch (\Throwable $e) {
+            $pid = null;
+        }
+
+        if ($pid === null) {
+            $this->removeFromIndexAndQueueWhenItemInQueue('pages', $uid);
+            return;
+        }
+
+        $this->processPageRecord($uid, (int)$pid, $updatedFields);
+    }
+
+    /**
+     * Handles record updates
+     *
+     * @param int $uid
+     * @param string $table
+     */
+    public function handleRecordUpdate(int $uid, string $table): void
+    {
+        $rootPageIds = $this->getRecordRootPageIds($table, $uid);
+        $this->processRecord($table, $uid, $rootPageIds);
+    }
+
+    /**
+     * Handles a version swap
+     *
+     * @param int $uid
+     * @param string $table
+     */
+    public function handleVersionSwap(int $uid, string $table): void
+    {
+        $isPageRelatedRecord = ($table === 'tt_content' || $table === 'pages');
+        if($isPageRelatedRecord) {
+            $uid = ($table === 'tt_content' ? $this->getValidatedPid($table, $uid) : $uid);
+            if ($uid === null) {
+                return;
+            }
+            $this->applyPageChangesToQueue($uid);
+        } else {
+            $recordPageId = $this->getValidatedPid($table, $uid);
+            if ($recordPageId === null) {
+                return;
+            }
+            $this->applyRecordChangesToQueue($table, $uid, $recordPageId);
+        }
+    }
+
+    /**
+     * Handle page move
+     *
+     * @param int $uid
+     */
+    public function handleMovedPage(int $uid): void
+    {
+        $this->applyPageChangesToQueue($uid);
+    }
+
+    /**
+     * Handle record move
+     *
+     * @param int $uid
+     * @param string $table
+     */
+    public function handleMovedRecord(int $uid, string $table): void
+    {
+        $pid = $this->getValidatedPid($table, $uid);
+        if ($pid === null) {
+            return;
+        }
+
+        $this->applyRecordChangesToQueue($table, $uid, $pid);
+    }
+
+    /**
+     * Adds a page to the queue and updates mounts, when it is enabled, otherwise ensure that the page is removed
+     * from the queue.
+     *
+     * @param int $uid
+     */
+    protected function applyPageChangesToQueue(int $uid): void
+    {
+        $solrConfiguration = $this->getSolrConfigurationFromPageId($uid);
+        $record = $this->configurationAwareRecordService->getRecord('pages', $uid, $solrConfiguration);
+        if (!empty($record) && $this->tcaService->isEnabledRecord('pages', $record)) {
+            $this->mountPageUpdater->update($uid);
+            $this->indexQueue->updateItem('pages', $uid);
+        } else {
+            $this->removeFromIndexAndQueueWhenItemInQueue('pages', $uid);
+        }
+    }
+
+    /**
+     * Adds a record to the queue if it is monitored and enabled, otherwise it removes the record from the queue.
+     *
+     * @param string $table
+     * @param int $uid
+     * @param int $pid
+     */
+    protected function applyRecordChangesToQueue(string $table, int $uid, int $pid): void
+    {
+        $solrConfiguration = $this->getSolrConfigurationFromPageId($pid);
+        $isMonitoredTable = $solrConfiguration->getIndexQueueIsMonitoredTable($table);
+
+        if ($isMonitoredTable) {
+            $record = $this->configurationAwareRecordService->getRecord($table, $uid, $solrConfiguration);
+
+            if (!empty($record) && $this->tcaService->isEnabledRecord($table, $record)) {
+                $uid = $this->tcaService->getTranslationOriginalUidIfTranslated($table, $record, $uid);
+                $this->indexQueue->updateItem($table, $uid);
+            } else {
+                // TODO should be moved to garbage collector
+                $this->removeFromIndexAndQueueWhenItemInQueue($table, $uid);
+            }
+        }
+    }
+
+    /**
+     * Removes record from the index queue and from the solr index
+     *
+     * @param string $recordTable Name of table where the record lives
+     * @param int $recordUid Id of record
+     */
+    protected function removeFromIndexAndQueue(string $recordTable, int $recordUid): void
+    {
+        $this->getGarbageHandler()->collectGarbage($recordTable, $recordUid);
+    }
+
+    /**
+     * Removes record from the index queue and from the solr index when the item is in the queue.
+     *
+     * @param string $recordTable Name of table where the record lives
+     * @param int $recordUid Id of record
+     */
+    protected function removeFromIndexAndQueueWhenItemInQueue(string $recordTable, int $recordUid): void
+    {
+        if (!$this->indexQueue->containsItem($recordTable, $recordUid)) {
+            return;
+        }
+
+        $this->removeFromIndexAndQueue($recordTable, $recordUid);
+    }
+
+    /**
+     * @param $pageId
+     * @return TypoScriptConfiguration
+     */
+    protected function getSolrConfigurationFromPageId(int $pageId): TypoScriptConfiguration
+    {
+        return $this->frontendEnvironment->getSolrConfigurationFromPageId($pageId);
+    }
+
+    /**
+     * Fetch record root page ids
+     *
+     * @param string $recordTable The table the record belongs to
+     * @param int $recordUid
+     * @return int[]
+     */
+    protected function getRecordRootPageIds(string $recordTable, int $recordUid): array
+    {
+        try {
+            $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($recordTable, $recordUid);
+        } catch (\InvalidArgumentException $e) {
+            $rootPageIds = [];
+        }
+
+        return $rootPageIds;
+    }
+
+    /**
+     * Processes a page record
+     *
+     * Note: Also used if content element is updated, the page
+     * of the content element is processed here
+     *
+     * @param int $uid
+     * @param int $pid
+     * @param array $updatedFields
+     */
+    protected function processPageRecord(int $uid, int $pid, array $updatedFields = []): void
+    {
+        $configurationPageId = $this->getConfigurationPageId('pages', (int)$pid, $uid);
+        if ($configurationPageId === 0) {
+            $this->mountPageUpdater->update($uid);
+            return;
+        }
+        $rootPageIds = [$configurationPageId];
+
+        $this->processRecord('pages', $uid, $rootPageIds);
+
+        $this->updateCanonicalPages($uid);
+        $this->mountPageUpdater->update($uid);
+
+        $recursiveUpdateRequired = $this->isRecursivePageUpdateRequired($uid, $updatedFields);
+        if ($recursiveUpdateRequired) {
+            $treePageIds = $this->getSubPageIds($uid);
+            $this->updatePageIdItems($treePageIds);
+        }
+    }
+
+    /**
+     * Process a record
+     *
+     * @param string $recordTable
+     * @param int $recordUid
+     * @param array $rootPageIds
+     */
+    protected function processRecord(string $recordTable, int $recordUid, array $rootPageIds): void
+    {
+        if (empty($rootPageIds)) {
+            $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+            return;
+        }
+
+        foreach ($rootPageIds as $configurationPageId) {
+            $solrConfiguration = $this->getSolrConfigurationFromPageId($configurationPageId);
+            $isMonitoredRecord = $solrConfiguration->getIndexQueueIsMonitoredTable($recordTable);
+            if (!$isMonitoredRecord) {
+                // when it is a non monitored record, we can skip it.
+                continue;
+            }
+
+            $record = $this->configurationAwareRecordService->getRecord($recordTable, $recordUid, $solrConfiguration);
+            if (empty($record)) {
+                // TODO move this part to the garbage collector
+                // check if the item should be removed from the index because it no longer matches the conditions
+                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+                continue;
+            }
+            // Clear existing index queue items to prevent mount point duplicates.
+            // This needs to be done before the overlay handling, because handling an overlay record should
+            // not trigger a deletion.
+            $isTranslation = !empty($record['sys_language_uid']) && $record['sys_language_uid'] !== 0;
+            if ($recordTable === 'pages' && !$isTranslation) {
+                $this->indexQueue->deleteItem('pages', $recordUid);
+            }
+
+            // only update/insert the item if we actually found a record
+            $isLocalizedRecord = $this->tcaService->isLocalizedRecord($recordTable, $record);
+            $recordUid = $this->tcaService->getTranslationOriginalUidIfTranslated($recordTable, $record, $recordUid);
+
+            if ($isLocalizedRecord && !$this->getIsTranslationParentRecordEnabled($recordTable, $recordUid)) {
+                // we have a localized record without a visible parent record. Nothing to do.
+                continue;
+            }
+
+            if ($this->tcaService->isEnabledRecord($recordTable, $record)) {
+                $this->indexQueue->updateItem($recordTable, $recordUid);
+            }
+        }
+    }
+
+    /**
+     * This method is used to determine the pageId that should be used to retrieve the index queue configuration.
+     *
+     * @param string $recordTable
+     * @param int $recordPageId
+     * @param int $recordUid
+     * @return int
+     */
+    protected function getConfigurationPageId(string $recordTable, int $recordPageId, int $recordUid): int
+    {
+        $rootPageId = $this->rootPageResolver->getRootPageId($recordPageId);
+        if ($this->rootPageResolver->getIsRootPageId($rootPageId)) {
+            return $recordPageId;
+        }
+
+        $alternativeSiteRoots = $this->rootPageResolver->getAlternativeSiteRootPagesIds(
+            $recordTable,
+            $recordUid,
+            $recordPageId
+        );
+        return (int)array_pop($alternativeSiteRoots);
+    }
+
+    /**
+     * Checks if the parent record of the translated record is enabled.
+     *
+     * @param string $recordTable
+     * @param int $recordUid
+     * @return bool
+     */
+    protected function getIsTranslationParentRecordEnabled(string $recordTable, int $recordUid): bool
+    {
+        $l10nParentRecord = (array)BackendUtility::getRecord($recordTable, $recordUid, '*', '', false);
+        return $this->tcaService->isEnabledRecord($recordTable, $l10nParentRecord);
+    }
+
+    /**
+     * Applies the updateItem instruction on a collection of pageIds.
+     *
+     * @param array $treePageIds
+     */
+    protected function updatePageIdItems(array $treePageIds): void
+    {
+        foreach ($treePageIds as $treePageId) {
+            $this->indexQueue->updateItem('pages', $treePageId);
+        }
+    }
+
+    /**
+     * Triggers Index Queue updates for other pages showing content from the
+     * page currently being updated.
+     *
+     * @param int $pageId UID of the page currently being updated
+     */
+    protected function updateCanonicalPages(int $pageId): void
+    {
+        $canonicalPages = $this->pagesRepository->findPageUidsWithContentsFromPid((int)$pageId);
+        foreach ($canonicalPages as $page) {
+            $this->indexQueue->updateItem('pages', $page['uid']);
+        }
+    }
+
+    /**
+     * Retrieves the pid of a record, returns null if no pid could be found
+     *
+     * @param string $table
+     * @param int $uid
+     * @return int|null
+     */
+    protected function getValidatedPid(string $table, int $uid): ?int
+    {
+        $pid = $this->dataHandler->getPID($table, $uid);
+        if ($pid === false) {
+            $message = 'Record without valid pid was processed ' . $table . ':' . $uid;
+            $this->logger->log(SolrLogManager::WARNING, $message);
+            return null;
+        }
+
+        return (int)$pid;
+    }
+
+    /**
+     * @return GarbageHandler
+     */
+    protected function getGarbageHandler(): GarbageHandler
+    {
+        return GeneralUtility::makeInstance(GarbageHandler::class);
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/AbstractBaseEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/AbstractBaseEventListener.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEventInterface;
+
+/**
+ * Base Event listener
+ */
+abstract class AbstractBaseEventListener
+{
+    public const MONITORING_TYPE = -1;
+
+    /**
+     * @var ExtensionConfiguration
+     */
+    private $extensionConfiguration;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * Constructor
+     *
+     * @param ExtensionConfiguration $extensionConfiguration
+     * @param EventDispatcherInterface
+     */
+    public function __construct(
+        ExtensionConfiguration $extensionConfiguration,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->extensionConfiguration = $extensionConfiguration;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Returns the configured monitoring type
+     *
+     * @return int
+     */
+    final protected function getMonitoringType(): int
+    {
+        return $this->extensionConfiguration->getMonitoringType();
+    }
+
+    /**
+     * Returns the DataUpdateHandler
+     *
+     * @return DataUpdateHandler
+     */
+    final protected function getDataUpdateHandler(): DataUpdateHandler
+    {
+        return GeneralUtility::makeInstance(DataUpdateHandler::class);
+    }
+
+    /**
+     * Returns the GarbageHandler
+     *
+     * @return GarbageHandler
+     */
+    final protected function getGarbageHandler(): GarbageHandler
+    {
+        return GeneralUtility::makeInstance(GarbageHandler::class);
+    }
+
+    /**
+     * Dispatches a data update processing finished event
+     *
+     * @param string $eventClass
+     * @param DataUpdateEventInterface $event
+     * @throws \InvalidArgumentException
+     */
+    final protected function dispatchEvent(string $eventClass, DataUpdateEventInterface $event): void
+    {
+        if (!is_subclass_of($eventClass, ProcessingFinishedEventInterface::class)) {
+            throw new \InvalidArgumentException(
+                'Data update event listener can only dispatch processing finished events ('
+                . ProcessingFinishedEventInterface::class . ')',
+                1639987620
+            );
+        }
+
+        $this->eventDispatcher->dispatch(
+            new $eventClass($event)
+        );
+    }
+
+    /**
+     * Indicates if immediate monitoring is allowed
+     *
+     * @return bool
+     */
+    protected function isProcessingEnabled(): bool
+    {
+        return ($this->getMonitoringType() === static::MONITORING_TYPE);
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListener.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
+
+/**
+ * Event listener just queueing the data changes and stopping
+ * the propagation
+ */
+class DelayedProcessingEventListener extends AbstractBaseEventListener
+{
+    public const MONITORING_TYPE = 1;
+
+    /**
+     * Queues the data update event for delayed processing and
+     * stops propagation
+     *
+     * @param DataUpdateEventInterface $event
+     */
+    public function __invoke(DataUpdateEventInterface $event): void
+    {
+        if ($this->getMonitoringType() !== self::MONITORING_TYPE) {
+            return;
+        }
+
+        $this->getEventQueueItemRepository()->addEventToQueue($event);
+        $event->setStopProcessing(true);
+        $this->dispatchEvent(DelayedProcessingQueuingFinishedEvent::class, $event);
+    }
+
+    /**
+     * Return the EventQueueItemRepository
+     *
+     * @return EventQueueItemRepository
+     */
+    protected function getEventQueueItemRepository(): EventQueueItemRepository
+    {
+        return GeneralUtility::makeInstance(EventQueueItemRepository::class);
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEvent.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+
+/**
+ * Basic data update event processing finished event
+ */
+abstract class AbstractProcessingFinishedEvent implements ProcessingFinishedEventInterface
+{
+    /**
+     * The processed data update evetn
+     */
+    private $dataUpdateEvent;
+
+    /**
+     * @param DataUpdateEventInterface $dataUpdateEvent
+     */
+    public function __construct(DataUpdateEventInterface $dataUpdateEvent)
+    {
+        $this->dataUpdateEvent = $dataUpdateEvent;
+    }
+
+    /**
+     * Returns the processed data update event
+     *
+     * @return DataUpdateEventInterface
+     */
+    final public function getDataUpdateEvent(): DataUpdateEventInterface
+    {
+        return $this->dataUpdateEvent;
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Delayed processing finished event
+ */
+class DelayedProcessingFinishedEvent extends AbstractProcessingFinishedEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Delayed processing queuing finished event
+ */
+class DelayedProcessingQueuingFinishedEvent extends AbstractProcessingFinishedEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Processing finished event
+ */
+class ProcessingFinishedEvent extends AbstractProcessingFinishedEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventInterface.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventInterface.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+
+/**
+ * Defines a data update processing finished event
+ */
+interface ProcessingFinishedEventInterface
+{
+    /**
+     * Returns the processed data update event
+     *
+     * @return DataUpdateEventInterface
+     */
+    public function getDataUpdateEvent(): DataUpdateEventInterface;
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEvent;
+
+/**
+ * Event listener for immediate processing of
+ * record updates
+ */
+class ImmediateProcessingEventListener extends AbstractBaseEventListener
+{
+    public const MONITORING_TYPE = 0;
+
+    /**
+     * Handles the data update events
+     *
+     * @param DataUpdateEventInterface $event
+     */
+    public function __invoke(DataUpdateEventInterface $event): void
+    {
+        if (!$event->isImmediateProcessingForced() && !$this->isProcessingEnabled()) {
+            return;
+        }
+
+        $methodName = $this->getMethodNameByEvent($event);
+        if (method_exists($this, $methodName)) {
+            $this->{$methodName}($event);
+            $event->setStopProcessing(true);
+            $this->dispatchEvent(ProcessingFinishedEvent::class, $event);
+        }
+    }
+
+    /**
+     * Determines the right method by event name
+     *
+     * @param DataUpdateEventInterface $event
+     */
+    protected function getMethodNameByEvent(DataUpdateEventInterface $event): string
+    {
+        $eventClassName = get_class($event);
+        $methodName = substr($eventClassName, (int)strrpos($eventClassName, '\\') + 1);
+        return 'handle' . $methodName;
+    }
+
+    /**
+     * Handles the deletion of a content element
+     *
+     * @param ContentElementDeletedEvent $event
+     */
+    protected function handleContentElementDeletedEvent(ContentElementDeletedEvent $event): void
+    {
+        $this->getDataUpdateHandler()->handleContentElementDeletion($event->getUid());
+    }
+
+    /**
+     * Handles a version swap
+     *
+     * @param VersionSwappedEvent $event
+     */
+    protected function handleVersionSwappedEvent(VersionSwappedEvent $event): void
+    {
+        $this->getDataUpdateHandler()->handleVersionSwap($event->getUid(), $event->getTable());
+    }
+
+    /**
+     * Handles moved records, including pages
+     *
+     * @param RecordMovedEvent $event
+     */
+    protected function handleRecordMovedEvent(RecordMovedEvent $event): void
+    {
+        if ($event->isPageUpdate()) {
+            $this->getDataUpdateHandler()->handleMovedPage($event->getUid());
+        } else {
+            $this->getDataUpdateHandler()->handleMovedRecord($event->getUid(), $event->getTable());
+        }
+    }
+
+    /**
+     * Handles record updates
+     *
+     * @param RecordUpdatedEvent $event
+     */
+    protected function handleRecordUpdatedEvent(RecordUpdatedEvent $event): void
+    {
+        if ($event->isContentElementUpdate()) {
+            $this->getDataUpdateHandler()->handleContentElementUpdate($event->getUid(), $event->getFields());
+        } elseif ($event->isPageUpdate()) {
+            $this->getDataUpdateHandler()->handlePageUpdate($event->getUid(), $event->getFields());
+        } else {
+            $this->getDataUpdateHandler()->handleRecordUpdate($event->getUid(), $event->getTable());
+        }
+    }
+
+    /**
+     * Handles record deletion
+     *
+     * @param RecordDeletedEvent $event
+     */
+    protected function handleRecordDeletedEvent(RecordDeletedEvent $event): void
+    {
+        $this->getGarbageHandler()->collectGarbage($event->getTable(), $event->getUid());
+    }
+
+    /**
+     * Handles a page movement
+     *
+     * @param PageMovedEvent $event
+     */
+    protected function handlePageMovedEvent(PageMovedEvent $event): void
+    {
+        $this->getGarbageHandler()->handlePageMovement($event->getUid());
+    }
+
+    /**
+     * Performs garbage checks
+     *
+     * @param RecordGarbageCheckEvent $event
+     */
+    protected function handleRecordGarbageCheckEvent(RecordGarbageCheckEvent $event): void
+    {
+        $this->getGarbageHandler()->performRecordGarbageCheck(
+            $event->getUid(),
+            $event->getTable(),
+            $event->getFields(),
+            $event->frontendGroupsRemoved()
+        );
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListener.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+
+/**
+ * Event listener stopping the propagation of the data update
+ * events, if deactivated in extension configuration
+ */
+class NoProcessingEventListener extends AbstractBaseEventListener
+{
+    public const MONITORING_TYPE = 2;
+
+    /**
+     * Stops the event propagation if processing is configured
+     * See EM_CONF -> monitoringType
+     *
+     * @param DataUpdateEventInterface $event
+     */
+    public function __invoke(DataUpdateEventInterface $event): void
+    {
+        if (!$this->isProcessingEnabled()) {
+            return;
+        }
+
+        $event->setStopProcessing(true);
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEvent.php
@@ -1,0 +1,226 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+
+/**
+ * Abstract data update event
+ */
+abstract class AbstractDataUpdateEvent implements DataUpdateEventInterface, StoppableEventInterface
+{
+    /**
+     * Record uid
+     *
+     * @var int
+     */
+    protected $uid;
+
+    /**
+     * Record table
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Updated record fields
+     *
+     * @var array
+     */
+    protected $fields = [];
+
+    /**
+     * Flag indicating that propagation is stopped
+     *
+     * @var bool
+     */
+    protected $stopProcessing = false;
+
+    /**
+     * Flag indicating that immediate processing is forced
+     *
+     * @var bool
+     */
+    protected $forceImmediateProcessing = false;
+
+    /**
+     * Flag indicating that frontend groups were removed
+     *
+     * @var bool
+     */
+    protected $frontendGroupsRemoved = false;
+
+    /**
+     * Constructor
+     *
+     * @param int $uid
+     * @param string $uid
+     * @param array $fields
+     * @param bool $frontendGroupsRemoved
+     */
+    public function __construct(int $uid, string $table, array $fields = [], bool $frontendGroupsRemoved = false)
+    {
+        $this->uid = $uid;
+        $this->table = $table;
+        $this->fields = $fields;
+        $this->frontendGroupsRemoved = $frontendGroupsRemoved;
+    }
+
+    /**
+     * Cleans the event before serialisation
+     * e.g. only required fields should be kept
+     * in fields array
+     *
+     * @return array
+     */
+    public function __sleep(): array
+    {
+        // always remove l10n_diffsource
+        unset($this->fields['l10n_diffsource']);
+
+        $properties = array_keys(get_object_vars($this));
+        if ($this->table == 'pages') {
+            // skip cleanup for pages as there might be additional
+            // required update fields in TypoScript which
+            // we don't want to load here. (see: "recursiveUpdateFields")
+            return $properties;
+        }
+
+        $requiredUpdateFields = array_unique(array_merge(
+            DataUpdateHandler::getRequiredUpdatedFields(),
+            GarbageHandler::getRequiredUpdatedFields()
+        ));
+        $this->fields = array_intersect_key($this->fields, array_flip($requiredUpdateFields));
+
+        return $properties;
+    }
+
+    /**
+     * Returns the uid of the updated record
+     *
+     * @return int
+     */
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+
+    /**
+     * Returns the table of the updated record
+     *
+     * @return string
+     */
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    /**
+     * Returns the updated fields
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * Indicates if the event propagation is stopped
+     * If stopped, it prevents other listeners from being called
+     *
+     * {@inheritDoc}
+     * @see \Psr\EventDispatcher\StoppableEventInterface::isPropagationStopped()
+     */
+    final public function isPropagationStopped(): bool
+    {
+        return $this->stopProcessing;
+    }
+
+    /**
+     * Sets the stop rendering flag
+     *
+     * If set, event propagation is stopped
+     *
+     * @param bool $stopRendering
+     */
+    final public function setStopProcessing(bool $stopProcessing): void
+    {
+        $this->stopProcessing = $stopProcessing;
+    }
+
+    /**
+     * Indicates if event is a page update
+     *
+     * @return bool
+     */
+    public function isPageUpdate(): bool
+    {
+        return ($this->table === 'pages');
+    }
+
+    /**
+     * Indicates if event is a content element update
+     *
+     * @return bool
+     */
+    public function isContentElementUpdate(): bool
+    {
+        return ($this->table === 'tt_content');
+    }
+
+    /**
+     * Indicates if immediate processing is forced
+     *
+     * @return bool
+     */
+    final public function isImmediateProcessingForced(): bool
+    {
+        return $this->forceImmediateProcessing;
+    }
+
+    /**
+     * Sets the flag indicating if immediate processing is forced
+     *
+     * @param bool $forceImmediateProcessing
+     */
+    final public function setForceImmediateProcessing(bool $forceImmediateProcessing): void
+    {
+        $this->forceImmediateProcessing = $forceImmediateProcessing;
+    }
+
+    /**
+     * Indicates the removal of frontend groups
+     *
+     * @return bool
+     */
+    final public function frontendGroupsRemoved(): bool
+    {
+        return $this->frontendGroupsRemoved;
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEvent.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a content element is deleted
+ */
+class ContentElementDeletedEvent extends AbstractDataUpdateEvent
+{
+    /**
+     * Constructor
+     *
+     * @param int $uid
+     */
+    public function __construct(int $uid)
+    {
+        parent::__construct($uid, 'tt_content');
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/DataUpdateEventInterface.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/DataUpdateEventInterface.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Defines a data update event
+ */
+interface DataUpdateEventInterface
+{
+    /**
+     * Cleans the event before serialisation
+     * e.g. only required fields should be kept
+     * in fields array
+     *
+     * @return array
+     */
+    public function __sleep(): array;
+
+    /**
+     * Returns the uid of the updated record
+     *
+     * @return int
+     */
+    public function getUid(): int;
+
+    /**
+     * Returns the table of the updated record
+     *
+     * @return string
+     */
+    public function getTable(): string;
+
+    /**
+     * Returns the updated fields
+     *
+     * @return array
+     */
+    public function getFields(): array;
+
+    /**
+     * Indicates if record is a page
+     *
+     * @return bool
+     */
+    public function isPageUpdate(): bool;
+
+    /**
+     * Indicates if event is a content element update
+     *
+     * @return bool
+     */
+    public function isContentElementUpdate(): bool;
+
+    /**
+     * Sets the stop processing flag
+     *
+     * If set, event propagation is stopped
+     *
+     * @param bool $stopProcessing
+     */
+    public function setStopProcessing(bool $stopProcessing): void;
+
+    /**
+     * Indicates if immediate processing is forced
+     *
+     * @return bool
+     */
+    public function isImmediateProcessingForced(): bool;
+
+    /**
+     * Sets the flag indicating if immediate processing is forced
+     *
+     * @param bool $forceImmediateProcessing
+     */
+    public function setForceImmediateProcessing(bool $forceImmediateProcessing): void;
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/PageMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/PageMovedEvent.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a page is moved
+ */
+class PageMovedEvent extends AbstractDataUpdateEvent
+{
+    /**
+     * Constructor
+     *
+     * @param int $uid
+     */
+    public function __construct(int $uid)
+    {
+        parent::__construct($uid, 'pages');
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a record is deleted
+ */
+class RecordDeletedEvent extends AbstractDataUpdateEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a record garbage check is triggered
+ */
+class RecordGarbageCheckEvent extends AbstractDataUpdateEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a record is moved
+ */
+class RecordMovedEvent extends AbstractDataUpdateEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a record is created or updated
+ */
+class RecordUpdatedEvent extends AbstractDataUpdateEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Event fired if a version is swapped
+ */
+class VersionSwappedEvent extends AbstractDataUpdateEvent
+{
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
@@ -1,0 +1,251 @@
+<?php declare(strict_types = 1);
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\StrategyFactory;
+
+/**
+ * Garbage handler
+ *
+ * Handles updates on potential relevant records and
+ * collects the garbage, e.g. a deletion might require
+ * index and index queue updates.
+ */
+class GarbageHandler extends AbstractUpdateHandler
+{
+    /**
+     * Configuration used to check if recursive updates are required
+     *
+     * Holds the configuration when a recursive page queuing should be triggered, while processing record
+     * updates
+     *
+     * Note: The SQL transaction is already committed, so the current state covers only "non"-changed fields.
+     *
+     * @var array
+     */
+    protected $updateSubPagesRecursiveTriggerConfiguration = [
+        // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 1
+        // covers following scenarios:
+        //   'currentState' =>  ['hidden' => '0', 'extendToSubpages' => '0|1'], 'changeSet' => ['hidden' => '1', (optional)'extendToSubpages' => '1']
+        'extendToSubpageEnabledAndHiddenFlagWasAdded' => [
+            'currentState' =>  ['extendToSubpages' => '1'],
+            'changeSet' => ['hidden' => '1']
+        ],
+        // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 1
+        // covers following scenarios:
+        //   'currentState' =>  ['hidden' => '0|1', 'extendToSubpages' => '0'], 'changeSet' => [(optional)'hidden' => '1', 'extendToSubpages' => '1']
+        'hiddenIsEnabledAndExtendToSubPagesWasAdded' => [
+            'currentState' =>  ['hidden' => '1'],
+            'changeSet' => ['extendToSubpages' => '1']
+        ],
+        // the field "no_search_sub_entries" of current page was set to 1
+        'no_search_sub_entriesFlagWasAdded' => [
+            'changeSet' => ['no_search_sub_entries' => '1']
+        ],
+    ];
+
+    /**
+     * Tracks down index documents belonging to a particular record or page and
+     * removes them from the index and the Index Queue.
+     *
+     * @param string $table The record's table name.
+     * @param int $uid The record's uid.
+     * @throws \UnexpectedValueException if a hook object does not implement interface
+     *                                   \ApacheSolrForTypo3\Solr\GarbageCollectorPostProcessor
+     */
+    public function collectGarbage($table, $uid): void
+    {
+        $garbageRemoverStrategy = StrategyFactory::getByTable($table);
+        $garbageRemoverStrategy->removeGarbageOf($table, $uid);
+    }
+
+    /**
+     * Handles moved pages
+     *
+     * @param int $uid
+     */
+    public function handlePageMovement(int $uid): void
+    {
+        // TODO the below comment is not valid anymore, pid has been removed from doc ID
+        // ...still needed?
+
+        // must be removed from index since the pid changes and
+        // is part of the Solr document ID
+        $this->collectGarbage('pages', $uid);
+
+        // now re-index with new properties
+        $this->indexQueue->updateItem('pages', $uid);
+    }
+
+    /**
+     * Performs a record garbage check
+     *
+     * @param int $uid
+     * @param string $table
+     * @param array $updatedFields
+     * @param bool $frontendGroupsRemoved
+     */
+    public function performRecordGarbageCheck(
+        int $uid,
+        string $table,
+        array $updatedFields,
+        bool $frontendGroupsRemoved
+    ): void {
+        $record = $this->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
+
+        // If no record could be found skip further processing
+        if (empty($record)) {
+            return;
+        }
+
+        if ($table === 'pages') {
+            $this->deleteSubEntriesWhenRecursiveTriggerIsRecognized($table, $uid, $updatedFields);
+        }
+
+        $record = $this->tcaService->normalizeFrontendGroupField($table, $record);
+        $isGarbage = $this->getIsGarbageRecord($table, $record, $frontendGroupsRemoved);
+        if (!$isGarbage) {
+            return;
+        }
+
+        $this->collectGarbage($table, $uid);
+    }
+
+    /**
+     * @param string $table
+     * @param int $uid
+     * @param array $updatedFields
+     */
+    protected function deleteSubEntriesWhenRecursiveTriggerIsRecognized(
+        string $table,
+        int $uid,
+        array $updatedFields
+    ): void {
+        if (!$this->isRecursivePageUpdateRequired($uid, $updatedFields)) {
+            return;
+        }
+
+        // get affected subpages when "extendToSubpages" flag was set
+        $pagesToDelete = $this->getSubPageIds($uid);
+        // we need to at least remove this page
+        foreach ($pagesToDelete as $pageToDelete) {
+            $this->collectGarbage($table, $pageToDelete);
+        }
+    }
+
+    /**
+     * Determines if a record is garbage and can be deleted.
+     *
+     * @param string $table
+     * @param array $record
+     * @param bool $frontendGroupsRemoved
+     * @return bool
+     */
+    protected function getIsGarbageRecord(string $table, array $record, bool $frontendGroupsRemoved): bool
+    {
+        return $frontendGroupsRemoved
+            || $this->tcaService->isHidden($table, $record)
+            || $this->isInvisibleByStartOrEndtime($table, $record)
+            || ($table === 'pages' && $this->isPageExcludedFromSearch($record))
+            || ($table === 'pages' && !$this->isIndexablePageType($record));
+    }
+
+    /**
+     * Checks whether a page has a page type that can be indexed.
+     * Currently standard pages and mount pages can be indexed.
+     *
+     * @param array $record A page record
+     * @return bool TRUE if the page can be indexed according to its page type, FALSE otherwise
+     */
+    protected function isIndexablePageType(array $record): bool
+    {
+        return $this->frontendEnvironment->isAllowedPageType($record);
+    }
+
+    /**
+     * Checks whether the page has been excluded from searching.
+     *
+     * @param array $record An array with record fields that may affect visibility.
+     * @return bool True if the page has been excluded from searching, FALSE otherwise
+     */
+    protected function isPageExcludedFromSearch(array $record): bool
+    {
+        return (bool)$record['no_search'];
+    }
+
+
+    /**
+     * Check if a record is getting invisible due to changes in start or endtime. In addition it is checked that the related
+     * queue item was marked as indexed.
+     *
+     * @param string $table
+     * @param array $record
+     * @return bool
+     */
+    protected function isInvisibleByStartOrEndtime(string $table, array $record): bool
+    {
+        return (
+            ($this->tcaService->isStartTimeInFuture($table, $record)
+                || $this->tcaService->isEndTimeInPast($table, $record))
+            && $this->isRelatedQueueRecordMarkedAsIndexed($table, $record)
+        );
+    }
+
+    /**
+     * Checks if the related index queue item is indexed.
+     *
+     * * For tt_content the page from the pid is checked
+     * * For all other records the table it's self is checked
+     *
+     * @param string $table The table name.
+     * @param array $record An array with record fields that may affect visibility.
+     * @return bool True if the record is marked as being indexed
+     */
+    protected function isRelatedQueueRecordMarkedAsIndexed(string $table, array $record): bool
+    {
+        if ($table === 'tt_content') {
+            $table = 'pages';
+            $uid = $record['pid'];
+        } else {
+            $uid = $record['uid'];
+        }
+
+        return $this->indexQueue->containsIndexedItem($table, $uid);
+    }
+
+    /**
+     * Returns a record with all visibility affecting fields.
+     *
+     * @param string $table
+     * @param int $uid
+     * @return array
+     */
+    public function getRecordWithFieldRelevantForGarbageCollection(string $table, int $uid): array
+    {
+        $garbageCollectionRelevantFields = $this->tcaService->getVisibilityAffectingFieldsByTable($table);
+        return (array)BackendUtility::getRecord($table, $uid, $garbageCollectionRelevantFields, '', false);
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -17,6 +17,9 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\System\Solr\ParsingUtil;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 
 /**
  * Class AbstractRangeFacetParser
@@ -33,7 +36,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
      * @param string $facetClass
      * @param string $facetItemClass
      * @param string $facetRangeCountClass
-     * @return AbstractRangeFacet|null
+     * @return AbstractFacet|null
      */
     protected function getParsedFacet(SearchResultSet $resultSet, $facetName, array $facetConfiguration, $facetClass, $facetItemClass, $facetRangeCountClass)
     {
@@ -44,6 +47,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
 
         $valuesFromResponse = isset($response->facet_counts->facet_ranges->{$fieldName}) ? get_object_vars($response->facet_counts->facet_ranges->{$fieldName}) : [];
 
+        /** @var NumericRangeFacet|DateRangeFacet $facet */
         $facet = $this->objectManager->get(
             $facetClass,
             $resultSet,

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCount.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCount.php
@@ -14,7 +14,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Date
  * The TYPO3 project - inspiring people to share!
 */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
 use DateTime;
 
 /**

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParser.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Date
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\AbstractRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\System\Data\DateTime;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 
 /**
  * Class DateRangeFacetParser
@@ -45,7 +46,7 @@ class DateRangeFacetParser extends AbstractRangeFacetParser
      * @param SearchResultSet $resultSet
      * @param string $facetName
      * @param array $facetConfiguration
-     * @return DateRangeFacet|null
+     * @return AbstractFacet|null
      */
     public function parse(SearchResultSet $resultSet, $facetName, array $facetConfiguration)
     {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
@@ -13,8 +13,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Nume
  *
  * The TYPO3 project - inspiring people to share!
 */
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
-use DateTime;
 
 /**
  * Value object that represent an date range count. The count has a date and the count of documents

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParser.php
@@ -16,6 +16,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Nume
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\AbstractRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 
 /**
  * Class NumericRangeFacetParser
@@ -44,7 +45,7 @@ class NumericRangeFacetParser extends AbstractRangeFacetParser
      * @param SearchResultSet $resultSet
      * @param string $facetName
      * @param array $facetConfiguration
-     * @return NumericRangeFacet|null
+     * @return AbstractFacet|null
      */
     public function parse(SearchResultSet $resultSet, $facetName, array $facetConfiguration)
     {

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -24,13 +24,15 @@ namespace ApacheSolrForTypo3\Solr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\StrategyFactory;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
 
 /**
  * Garbage Collector, removes related documents from the index when a record is
@@ -41,7 +43,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Ingo Renner <ingo@typo3.org>
  * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
-class GarbageCollector extends AbstractDataHandlerListener implements SingletonInterface
+class GarbageCollector implements SingletonInterface
 {
     /**
      * @var array
@@ -54,13 +56,20 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
     protected $tcaService;
 
     /**
-     * GarbageCollector constructor.
-     * @param TCAService|null $TCAService
+     * @var EventDispatcherInterface
      */
-    public function __construct(TCAService $TCAService = null)
+    protected $eventDispatcher;
+
+    /**
+     * GarbageCollector constructor.
+     *
+     * @param TCAService|null $TCAService
+     * @param EventDispatcherInterface|null $eventDispatcher
+     */
+    public function __construct(TCAService $TCAService = null, EventDispatcherInterface $eventDispatcher = null)
     {
-        parent::__construct();
         $this->tcaService = $TCAService ?? GeneralUtility::makeInstance(TCAService::class);
+        $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);
     }
 
     /**
@@ -71,50 +80,15 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      * @param int $uid The record's uid
      * @param string $value Not used
      * @param DataHandler $tceMain TYPO3 Core Engine parent object, not used
-     * @return void
      */
-    public function processCmdmap_preProcess($command, $table, $uid, $value, DataHandler $tceMain)
+    public function processCmdmap_preProcess($command, $table, $uid, $value, DataHandler $tceMain): void
     {
         // workspaces: collect garbage only for LIVE workspace
         if ($command === 'delete' && $GLOBALS['BE_USER']->workspace == 0) {
-            $this->collectGarbage($table, $uid);
-
-            if ($table === 'pages') {
-                $this->getIndexQueue()->deleteItem($table, $uid);
-            }
+            $this->eventDispatcher->dispatch(
+                new RecordDeletedEvent((int)$uid, (string)$table)
+            );
         }
-    }
-
-    /**
-     * Holds the configuration when a recursive page deletion should be triggered.
-     *
-     * Note: The SQL transaction is already committed, so the current state covers only "non"-changed fields.
-     *
-     * @var array
-     * @return array
-     */
-    protected function getUpdateSubPagesRecursiveTriggerConfiguration()
-    {
-        return [
-            // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 1
-            // covers following scenarios:
-            //   'currentState' =>  ['hidden' => '0', 'extendToSubpages' => '0|1'], 'changeSet' => ['hidden' => '1', (optional)'extendToSubpages' => '1']
-            'extendToSubpageEnabledAndHiddenFlagWasAdded' => [
-                'currentState' =>  ['extendToSubpages' => '1'],
-                'changeSet' => ['hidden' => '1']
-            ],
-            // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 1
-            // covers following scenarios:
-            //   'currentState' =>  ['hidden' => '0|1', 'extendToSubpages' => '0'], 'changeSet' => [(optional)'hidden' => '1', 'extendToSubpages' => '1']
-            'hiddenIsEnabledAndExtendToSubPagesWasAdded' => [
-                'currentState' =>  ['hidden' => '1'],
-                'changeSet' => ['extendToSubpages' => '1']
-            ],
-            // the field "no_search_sub_entries" of current page was set to 1
-            'no_search_sub_entriesFlagWasAdded' => [
-                'changeSet' => ['no_search_sub_entries' => '1']
-            ],
-        ];
     }
 
     /**
@@ -125,32 +99,10 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      * @param int $uid The record's uid.
      * @throws \UnexpectedValueException if a hook object does not implement interface \ApacheSolrForTypo3\Solr\GarbageCollectorPostProcessor
      */
-    public function collectGarbage($table, $uid)
+    public function collectGarbage($table, $uid): void
     {
-        $garbageRemoverStrategy = StrategyFactory::getByTable($table);
-        $garbageRemoverStrategy->removeGarbageOf($table, $uid);
+        $this->getGarbageHandler()->collectGarbage((string)$table, (int)$uid);
     }
-
-    /**
-     * @param string $table
-     * @param int $uid
-     * @param array $changedFields
-     */
-    protected function deleteSubEntriesWhenRecursiveTriggerIsRecognized($table, $uid, $changedFields)
-    {
-        if (!$this->isRecursivePageUpdateRequired($uid, $changedFields)) {
-            return;
-        }
-
-        // get affected subpages when "extendToSubpages" flag was set
-        $pagesToDelete = $this->getSubPageIds($uid);
-        // we need to at least remove this page
-        foreach ($pagesToDelete as $pageToDelete) {
-            $this->collectGarbage($table, $pageToDelete);
-        }
-    }
-
-    // methods checking whether to trigger garbage collection
 
     /**
      * Hooks into TCE main and tracks page move commands.
@@ -164,15 +116,9 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
     public function processCmdmap_postProcess($command, $table, $uid, $value, DataHandler $tceMain) {
         // workspaces: collect garbage only for LIVE workspace
         if ($command === 'move' && $table === 'pages' && $GLOBALS['BE_USER']->workspace == 0) {
-            // TODO the below comment is not valid anymore, pid has been removed from doc ID
-            // ...still needed?
-
-            // must be removed from index since the pid changes and
-            // is part of the Solr document ID
-            $this->collectGarbage($table, $uid);
-
-            // now re-index with new properties
-            $this->getIndexQueue()->updateItem($table, $uid);
+            $this->eventDispatcher->dispatch(
+                new PageMovedEvent((int)$uid)
+            );
         }
     }
 
@@ -186,13 +132,15 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      * @param mixed $uid The record's uid, [integer] or [string] (like 'NEW...')
      * @param DataHandler $tceMain TYPO3 Core Engine parent object, not used
      */
-    public function processDatamap_preProcessFieldArray($incomingFields, $table, $uid, DataHandler $tceMain)
+    public function processDatamap_preProcessFieldArray($incomingFields, $table, $uid, DataHandler $tceMain): void
     {
         if (!is_int($uid)) {
             // a newly created record, skip
             return;
         }
 
+        $uid = (int)$uid;
+        $table = (string)$table;
         if (Util::isDraftRecord($table, $uid)) {
             // skip workspaces: collect garbage only for LIVE workspace
             return;
@@ -203,8 +151,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
             return;
         }
 
-        $visibilityAffectingFields = $this->tcaService->getVisibilityAffectingFieldsByTable($table);
-        $record = (array)BackendUtility::getRecord($table, $uid, $visibilityAffectingFields, '', false);
+        $record = $this->getGarbageHandler()->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
         // If no record could be found skip further processing
         if (empty($record)) {
             return;
@@ -227,82 +174,29 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      * @param array $fields The record's data, not used
      * @param DataHandler $tceMain TYPO3 Core Engine parent object, not used
      */
-    public function processDatamap_afterDatabaseOperations($status, $table, $uid, array $fields, DataHandler $tceMain)
+    public function processDatamap_afterDatabaseOperations($status, $table, $uid, array $fields, DataHandler $tceMain): void
     {
         if ($status === 'new') {
             // a newly created record, skip
             return;
         }
 
+        $uid = (int)$uid;
+        $table = (string)$table;
         if (Util::isDraftRecord($table, $uid)) {
             // skip workspaces: collect garbage only for LIVE workspace
             return;
         }
 
-        $record = $this->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
-
-        // If no record could be found skip further processing
-        if (empty($record)) {
-            return;
-        }
-
-        if ($table === 'pages') {
-            $this->deleteSubEntriesWhenRecursiveTriggerIsRecognized($table, $uid, $fields);
-        }
-
-        $record = $this->tcaService->normalizeFrontendGroupField($table, $record);
-        $isGarbage = $this->getIsGarbageRecord($table, $record);
-        if (!$isGarbage) {
-            return;
-        }
-
-        $this->collectGarbage($table, $uid);
-    }
-
-    /**
-     * Check if a record is getting invisible due to changes in start or endtime. In addition it is checked that the related
-     * queue item was marked as indexed.
-     *
-     * @param string $table
-     * @param array $record
-     * @return bool
-     */
-    protected function isInvisibleByStartOrEndtime($table, $record)
-    {
-        return (
-            ($this->tcaService->isStartTimeInFuture($table, $record) || $this->tcaService->isEndTimeInPast($table, $record)) &&
-            $this->isRelatedQueueRecordMarkedAsIndexed($table, $record)
+        $updatedRecord = $this->getGarbageHandler()->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
+        $this->eventDispatcher->dispatch(
+            new RecordGarbageCheckEvent(
+                $uid,
+                $table,
+                $fields,
+                $this->hasFrontendGroupsRemoved($table, $updatedRecord)
+            )
         );
-    }
-
-    /**
-     * Checks if the related index queue item is indexed.
-     *
-     * * For tt_content the page from the pid is checked
-     * * For all other records the table it's self is checked
-     *
-     * @param string $table The table name.
-     * @param array $record An array with record fields that may affect visibility.
-     * @return bool True if the record is marked as being indexed
-     */
-    protected function isRelatedQueueRecordMarkedAsIndexed($table, $record)
-    {
-        if ($table === 'tt_content') {
-            $table = 'pages';
-            $uid = $record['pid'];
-        } else {
-            $uid = $record['uid'];
-        }
-
-        return $this->getIndexQueue()->containsIndexedItem($table, $uid);
-    }
-
-    /**
-     * @return Queue
-     */
-    private function getIndexQueue()
-    {
-        return GeneralUtility::makeInstance(Queue::class);
     }
 
     /**
@@ -311,10 +205,10 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      * the record invisible to at least some people.
      *
      * @param string $table The table name.
-     * @param array $record An array with record fields that may affect visibility.
+     * @param array $updatedRecord An array with fields of the updated record that may affect visibility.
      * @return bool TRUE if frontend groups have been removed from access to the record, FALSE otherwise.
      */
-    protected function hasFrontendGroupsRemoved($table, $record)
+    protected function hasFrontendGroupsRemoved(string $table, array $updatedRecord): bool
     {
         if (!isset($GLOBALS['TCA'][$table]['ctrl']['enablecolumns']['fe_group'])) {
             return false;
@@ -322,63 +216,20 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
 
         $frontendGroupsField = $GLOBALS['TCA'][$table]['ctrl']['enablecolumns']['fe_group'];
 
-        $previousGroups = explode(',', (string)$this->trackedRecords[$table][$record['uid']][$frontendGroupsField]);
-        $currentGroups = explode(',', (string)$record[$frontendGroupsField]);
+        $previousGroups = explode(',', (string)$this->trackedRecords[$table][$updatedRecord['uid']][$frontendGroupsField]);
+        $currentGroups = explode(',', (string)$updatedRecord[$frontendGroupsField]);
         $removedGroups = array_diff($previousGroups, $currentGroups);
 
-        return (boolean)count($removedGroups);
+        return !empty($removedGroups);
     }
 
     /**
-     * Checks whether the page has been excluded from searching.
+     * Returns the GarbageHandler
      *
-     * @param array $record An array with record fields that may affect visibility.
-     * @return bool True if the page has been excluded from searching, FALSE otherwise
+     * @return GarbageHandler
      */
-    protected function isPageExcludedFromSearch($record)
+    protected function getGarbageHandler(): GarbageHandler
     {
-        return (boolean)$record['no_search'];
-    }
-
-    /**
-     * Checks whether a page has a page type that can be indexed.
-     * Currently standard pages and mount pages can be indexed.
-     *
-     * @param array $record A page record
-     * @return bool TRUE if the page can be indexed according to its page type, FALSE otherwise
-     */
-    protected function isIndexablePageType(array $record)
-    {
-        return $this->frontendEnvironment->isAllowedPageType($record);
-    }
-
-    /**
-     * Determines if a record is garbage and can be deleted.
-     *
-     * @param string $table
-     * @param array $record
-     * @return bool
-     */
-    protected function getIsGarbageRecord($table, $record):bool
-    {
-        return $this->tcaService->isHidden($table, $record) ||
-                $this->isInvisibleByStartOrEndtime($table, $record) ||
-                $this->hasFrontendGroupsRemoved($table, $record) ||
-                ($table === 'pages' && $this->isPageExcludedFromSearch($record)) ||
-                ($table === 'pages' && !$this->isIndexablePageType($record));
-    }
-
-    /**
-     * Returns a record with all visibility affecting fields.
-     *
-     * @param string $table
-     * @param int $uid
-     * @return array
-     */
-    protected function getRecordWithFieldRelevantForGarbageCollection($table, $uid):array
-    {
-        $garbageCollectionRelevantFields = $this->tcaService->getVisibilityAffectingFieldsByTable($table);
-        $record = (array)BackendUtility::getRecord($table, $uid, $garbageCollectionRelevantFields, '', false);
-        return $record;
+        return GeneralUtility::makeInstance(GarbageHandler::class);
     }
 }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -24,22 +24,16 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\AbstractDataHandlerListener;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
-use ApacheSolrForTypo3\Solr\FrontendEnvironment;
-use ApacheSolrForTypo3\Solr\GarbageCollector;
-use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
-use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
-use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use ApacheSolrForTypo3\Solr\Util;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Util;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 
 /**
  * A class that monitors changes to records so that the changed record gets
@@ -47,124 +41,21 @@ use TYPO3\CMS\Core\Utility\MathUtility;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class RecordMonitor extends AbstractDataHandlerListener
+class RecordMonitor
 {
     /**
-     * Index Queue
-     *
-     * @var Queue
+     * @var EventDispatcherInterface
      */
-    protected $indexQueue;
-
-    /**
-     * Mount Page Updater
-     *
-     * @var MountPagesUpdater
-     */
-    protected $mountPageUpdater;
-
-    /**
-     * TCA Service
-     *
-     * @var TCAService
-     */
-    protected $tcaService;
-
-    /**
-     * RootPageResolver
-     *
-     * @var RootPageResolver
-     */
-    protected $rootPageResolver;
-
-    /**
-     * @var PagesRepository
-     */
-    protected $pagesRepository;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $logger = null;
-
-    /**
-     * @var FrontendEnvironment
-     */
-    protected $frontendEnvironment = null;
+    protected $eventDispatcher;
 
     /**
      * RecordMonitor constructor.
      *
-     * @param Queue|null $indexQueue
-     * @param MountPagesUpdater|null $mountPageUpdater
-     * @param TCAService|null $TCAService
-     * @param RootPageResolver $rootPageResolver
-     * @param PagesRepository|null $pagesRepository
-     * @param SolrLogManager|null $solrLogManager
-     * @param ConfigurationAwareRecordService|null $recordService
+     * @param EventDispatcherInterface|null $eventDispatcher
      */
-    public function __construct(
-        Queue $indexQueue = null,
-        MountPagesUpdater $mountPageUpdater = null,
-        TCAService $TCAService = null,
-        RootPageResolver $rootPageResolver = null,
-        PagesRepository $pagesRepository = null,
-        SolrLogManager $solrLogManager = null,
-        ConfigurationAwareRecordService $recordService = null,
-        FrontendEnvironment $frontendEnvironment = null
-    )
+    public function __construct(EventDispatcherInterface $eventDispatcher = null)
     {
-        parent::__construct($recordService);
-        $this->indexQueue = $indexQueue ?? GeneralUtility::makeInstance(Queue::class);
-        $this->mountPageUpdater = $mountPageUpdater ?? GeneralUtility::makeInstance(MountPagesUpdater::class);
-        $this->tcaService = $TCAService ?? GeneralUtility::makeInstance(TCAService::class);
-        $this->rootPageResolver = $rootPageResolver ?? GeneralUtility::makeInstance(RootPageResolver::class);
-        $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
-        $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
-    }
-
-    /**
-     * @param SolrLogManager $logger
-     */
-    public function setLogger(SolrLogManager $logger)
-    {
-        $this->logger = $logger;
-    }
-
-    /**
-     * Holds the configuration when a recursive page queuing should be triggered.
-     *
-     * Note: The SQL transaction is already committed, so the current state covers only "non"-changed fields.
-     *
-     * @var array
-     * @return array
-     */
-    protected function getUpdateSubPagesRecursiveTriggerConfiguration()
-    {
-        return [
-            // the current page has the both fields "extendToSubpages" and "hidden" set from 1 to 0 => requeue subpages
-            'HiddenAndExtendToSubpageWereDisabled' => [
-                'changeSet' => [
-                    'hidden' => '0',
-                    'extendToSubpages' => '0'
-                ]
-            ],
-            // the current page has the field "extendToSubpages" enabled and the field "hidden" was set to 0 => requeue subpages
-            'extendToSubpageEnabledAndHiddenFlagWasRemoved' => [
-                'currentState' =>  ['extendToSubpages' => '1'],
-                'changeSet' => ['hidden' => '0']
-            ],
-            // the current page has the field "hidden" enabled and the field "extendToSubpages" was set to 0 => requeue subpages
-            'hiddenIsEnabledAndExtendToSubPagesWasRemoved' => [
-                'currentState' =>  ['hidden' => '1'],
-                'changeSet' => ['extendToSubpages' => '0']
-            ],
-            // the field "no_search_sub_entries" of current page was set to 0
-            'no_search_sub_entriesFlagWasAdded' => [
-                'changeSet' => ['no_search_sub_entries' => '0']
-            ],
-        ];
+        $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);
     }
 
     /**
@@ -173,21 +64,16 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param string $command The command.
      * @param string $table The table the record belongs to
      * @param int $uid The record's uid
-     * @param string $value
-     * @param DataHandler $tceMain TYPO3 Core Engine parent object
      */
     public function processCmdmap_preProcess(
         $command,
         $table,
-        $uid,
-        /** @noinspection PhpUnusedParameterInspection */
-        $value,
-        DataHandler $tceMain
-    ) {
+        $uid
+    ): void {
         if ($command === 'delete' && $table === 'tt_content' && $GLOBALS['BE_USER']->workspace == 0) {
-            // skip workspaces: index only LIVE workspace
-            $pid = $this->getValidatedPid($tceMain, $table, $uid);
-            $this->indexQueue->updateItem('pages', $pid, time());
+            $this->eventDispatcher->dispatch(
+                new ContentElementDeletedEvent((int)$uid)
+            );
         }
     }
 
@@ -199,11 +85,13 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param string $table The table the record belongs to
      * @param int $uid The record's uid
      * @param string $value
-     * @param DataHandler $tceMain TYPO3 Core Engine parent object
      */
-    public function processCmdmap_postProcess($command, $table, $uid, $value, DataHandler $tceMain)
+    public function processCmdmap_postProcess($command, $table, $uid, $value): void
     {
-        if ($this->isDraftRecord($table, $uid)) {
+        $uid = (int)$uid;
+        $table = (string)$table;
+
+        if (Util::isDraftRecord($table, $uid)) {
             // skip workspaces: index only LIVE workspace
             return;
         }
@@ -211,80 +99,16 @@ class RecordMonitor extends AbstractDataHandlerListener
         // track publish / swap events for records (workspace support)
         // command "version"
         if ($command === 'version' && $value['action'] === 'swap') {
-            $this->applyVersionSwap($table, $uid, $tceMain);
+            $this->eventDispatcher->dispatch(
+                new VersionSwappedEvent($uid, $table)
+            );
         }
 
         // moving pages/records in LIVE workspace
         if ($command === 'move' && $GLOBALS['BE_USER']->workspace == 0) {
-            if ($table === 'pages') {
-                $this->applyPageChangesToQueue($uid);
-            } else {
-                $this->applyRecordChangesToQueue($table, $uid, $value);
-            }
-
-        }
-    }
-
-    /**
-     * Apply's version swap to the IndexQueue.
-     *
-     * @param string $table
-     * @param integer $uid
-     * @param DataHandler $tceMain
-     */
-    protected function applyVersionSwap($table, $uid, DataHandler $tceMain)
-    {
-        $isPageRelatedRecord = $table === 'tt_content' || $table === 'pages';
-        if($isPageRelatedRecord) {
-            $uid = $table === 'tt_content' ? $this->getValidatedPid($tceMain, $table, $uid) : $uid;
-            $this->applyPageChangesToQueue($uid);
-        } else {
-            $recordPageId = $this->getValidatedPid($tceMain, $table, $uid);
-            $this->applyRecordChangesToQueue($table, $uid, $recordPageId);
-        }
-    }
-
-    /**
-     * Add's a page to the queue and updates mounts, when it is enabled, otherwise ensure that the page is removed
-     * from the queue.
-     *
-     * @param integer $uid
-     */
-    protected function applyPageChangesToQueue($uid)
-    {
-        $solrConfiguration = $this->getSolrConfigurationFromPageId($uid);
-        $record = $this->configurationAwareRecordService->getRecord('pages', $uid, $solrConfiguration);
-        if (!empty($record) && $this->tcaService->isEnabledRecord('pages', $record)) {
-            $this->mountPageUpdater->update($uid);
-            $this->indexQueue->updateItem('pages', $uid);
-        } else {
-            // TODO should be moved to garbage collector
-            $this->removeFromIndexAndQueueWhenItemInQueue('pages', $uid);
-        }
-    }
-
-    /**
-     * Add's a record to the queue if it is monitored and enabled, otherwise it removes the record from the queue.
-     *
-     * @param string $table
-     * @param integer $uid
-     * @param integer $pid
-     */
-    protected function applyRecordChangesToQueue($table, $uid, $pid)
-    {
-        $solrConfiguration = $this->getSolrConfigurationFromPageId($pid);
-        $isMonitoredTable = $solrConfiguration->getIndexQueueIsMonitoredTable($table);
-
-        if ($isMonitoredTable) {
-            $record = $this->configurationAwareRecordService->getRecord($table, $uid, $solrConfiguration);
-
-            if (!empty($record) && $this->tcaService->isEnabledRecord($table, $record)) {
-                $uid = $this->tcaService->getTranslationOriginalUidIfTranslated($table, $record, $uid);
-                $this->indexQueue->updateItem($table, $uid);
-            } else {
-                // TODO should be moved to garbage collector
-                $this->removeFromIndexAndQueueWhenItemInQueue($table, $uid);
-            }
+            $this->eventDispatcher->dispatch(
+                new RecordMovedEvent($uid, $table)
+            );
         }
     }
 
@@ -300,10 +124,10 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param DataHandler $tceMain TYPO3 Core Engine parent object
      * @return void
      */
-    public function processDatamap_afterDatabaseOperations($status, $table, $uid, array $fields, DataHandler $tceMain) {
-        $recordTable = $table;
+    public function processDatamap_afterDatabaseOperations($status, $table, $uid, array $fields, DataHandler $tceMain): void
+    {
         $recordUid = $uid;
-
+        $table = (string)$table;
         if ($this->skipMonitoringOfTable($table)) {
             return;
         }
@@ -311,25 +135,14 @@ class RecordMonitor extends AbstractDataHandlerListener
         if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];
         }
-        if ($this->isDraftRecord($table, $recordUid)) {
+        if (Util::isDraftRecord($table, (int)$recordUid)) {
             // skip workspaces: index only LIVE workspace
             return;
         }
 
-        try {
-            $recordPageId = $this->getRecordPageId($status, $recordTable, $recordUid, $uid, $fields, $tceMain);
-
-            // when a content element changes we need to updated the page instead
-            if ($recordTable === 'tt_content') {
-                $recordTable = 'pages';
-                $recordUid = $recordPageId;
-            }
-
-            $this->processRecord($recordTable, $recordPageId, $recordUid, $fields);
-        } catch (NoPidException $e) {
-            $message = 'Record without valid pid was processed ' . $table . ':' . $uid;
-            $this->logger->log(SolrLogManager::WARNING, $message);
-        }
+        $this->eventDispatcher->dispatch(
+            new RecordUpdatedEvent((int)$recordUid, $table, $fields)
+        );
     }
 
     /**
@@ -338,7 +151,7 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param string $table
      * @return bool
      */
-    protected function skipMonitoringOfTable($table)
+    protected function skipMonitoringOfTable(string $table): bool
     {
         static $configurationMonitorTables;
 
@@ -353,260 +166,5 @@ class RecordMonitor extends AbstractDataHandlerListener
         }
 
         return !in_array($table, $configurationMonitorTables);
-    }
-
-    /**
-     * Process the record located in processDatamap_afterDatabaseOperations
-     *
-     * @param string $recordTable The table the record belongs to
-     * @param int $recordPageId pageid
-     * @param mixed $recordUid The record's uid, [integer] or [string] (like 'NEW...')
-     * @param array $fields The record's data
-     */
-    protected function processRecord($recordTable, $recordPageId, $recordUid, $fields)
-    {
-        if ($recordTable === 'pages') {
-            $configurationPageId = $this->getConfigurationPageId($recordTable, $recordPageId, $recordUid);
-            if ($configurationPageId === 0) {
-                $this->mountPageUpdater->update($recordUid);
-                return;
-            }
-            $rootPageIds = [$configurationPageId];
-        } else {
-            try {
-                $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($recordTable, $recordUid);
-                if (empty($rootPageIds)) {
-                    $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
-                    return;
-                }
-            } catch ( \InvalidArgumentException $e) {
-                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
-                return;
-            }
-        }
-        foreach ($rootPageIds as $configurationPageId) {
-            $solrConfiguration = $this->getSolrConfigurationFromPageId($configurationPageId);
-            $isMonitoredRecord = $solrConfiguration->getIndexQueueIsMonitoredTable($recordTable);
-            if (!$isMonitoredRecord) {
-                // when it is a non monitored record, we can skip it.
-                continue;
-            }
-
-            $record = $this->configurationAwareRecordService->getRecord($recordTable, $recordUid, $solrConfiguration);
-            if (empty($record)) {
-                // TODO move this part to the garbage collector
-                // check if the item should be removed from the index because it no longer matches the conditions
-                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
-
-                // Handle sub entries for pages, which are not in index queue.
-                if ($recordTable === 'pages' && $this->isRecursivePageUpdateRequired($recordUid, $fields)) {
-                    $treePageIds = $this->getSubPageIds($recordUid);
-                    $this->updatePageIdItems($treePageIds);
-                }
-                continue;
-            }
-            // Clear existing index queue items to prevent mount point duplicates.
-            // This needs to be done before the overlay handling, because handling an overlay record should
-            // not trigger a deletion.
-            $isTranslation = !empty($record['sys_language_uid']) && $record['sys_language_uid'] !== 0;
-            if ($recordTable === 'pages' && !$isTranslation) {
-                $this->indexQueue->deleteItem('pages', $recordUid);
-            }
-
-            // only update/insert the item if we actually found a record
-            $isLocalizedRecord = $this->tcaService->isLocalizedRecord($recordTable, $record);
-            $recordUid = $this->tcaService->getTranslationOriginalUidIfTranslated($recordTable, $record, $recordUid);
-
-            if ($isLocalizedRecord && !$this->getIsTranslationParentRecordEnabled($recordTable, $recordUid)) {
-                // we have a localized record without a visible parent record. Nothing to do.
-                continue;
-            }
-
-            if ($this->tcaService->isEnabledRecord($recordTable, $record)) {
-                $this->indexQueue->updateItem($recordTable, $recordUid);
-            }
-
-            if ($recordTable === 'pages') {
-                $this->doPagesPostUpdateOperations($fields, $recordUid);
-            }
-        }
-    }
-
-    /**
-     * This method is used to determine the pageId that should be used to retrieve the index queue configuration.
-     *
-     * @param string $recordTable
-     * @param integer $recordPageId
-     * @param integer $recordUid
-     * @return integer
-     */
-    protected function getConfigurationPageId($recordTable, $recordPageId, $recordUid)
-    {
-        $rootPageId = $this->rootPageResolver->getRootPageId($recordPageId);
-        if ($this->rootPageResolver->getIsRootPageId($rootPageId)) {
-            return $recordPageId;
-        }
-
-        $alternativeSiteRoots = $this->rootPageResolver->getAlternativeSiteRootPagesIds($recordTable, $recordUid, $recordPageId);
-        $lastRootPage = array_pop($alternativeSiteRoots);
-        return empty($lastRootPage) ? 0 : $lastRootPage;
-    }
-
-    /**
-     * Checks if the parent record of the translated record is enabled.
-     *
-     * @param string $recordTable
-     * @param integer $recordUid
-     * @return bool
-     */
-    protected function getIsTranslationParentRecordEnabled($recordTable, $recordUid)
-    {
-        $l10nParentRecord = (array)BackendUtility::getRecord($recordTable, $recordUid, '*', '', false);
-        return $this->tcaService->isEnabledRecord($recordTable, $l10nParentRecord);
-    }
-
-    /**
-     * Applies needed updates when a pages record was processed by the RecordMonitor.
-     *
-     * @param array $fields
-     * @param int $recordUid
-     */
-    protected function doPagesPostUpdateOperations(array $fields, $recordUid)
-    {
-        $this->updateCanonicalPages($recordUid);
-        $this->mountPageUpdater->update($recordUid);
-
-        if ($this->isRecursivePageUpdateRequired($recordUid, $fields)) {
-            $treePageIds = $this->getSubPageIds($recordUid);
-            $this->updatePageIdItems($treePageIds);
-        }
-    }
-
-    /**
-     * Determines the recordPageId (pid) of a record.
-     *
-     * @param string $status
-     * @param string $recordTable
-     * @param int $recordUid
-     * @param int $originalUid
-     * @param array $fields
-     * @param DataHandler $tceMain
-     *
-     * @return int
-     */
-    protected function getRecordPageId($status, $recordTable, $recordUid, $originalUid, array $fields, DataHandler $tceMain)
-    {
-        if ($recordTable === 'pages' && isset($fields['l10n_parent']) && intval($fields['l10n_parent']) > 0) {
-            return $fields['l10n_parent'];
-        }
-
-        if ($status === 'update' && !isset($fields['pid'])) {
-            $recordPageId = $this->getValidatedPid($tceMain, $recordTable, $recordUid);
-            if (($recordTable === 'pages') && ($this->rootPageResolver->getIsRootPageId($recordUid))) {
-                $recordPageId = $originalUid;
-            }
-
-            return $recordPageId;
-        }
-
-        return $fields['pid'];
-    }
-
-    /**
-     * Applies the updateItem instruction on a collection of pageIds.
-     *
-     * @param array $treePageIds
-     */
-    protected function updatePageIdItems(array $treePageIds)
-    {
-        foreach ($treePageIds as $treePageId) {
-            $this->indexQueue->updateItem('pages', $treePageId);
-        }
-    }
-
-    /**
-     * Removes record from the index queue and from the solr index
-     *
-     * @param string $recordTable Name of table where the record lives
-     * @param int $recordUid Id of record
-     */
-    protected function removeFromIndexAndQueue($recordTable, $recordUid)
-    {
-        $garbageCollector = GeneralUtility::makeInstance(GarbageCollector::class);
-        $garbageCollector->collectGarbage($recordTable, $recordUid);
-    }
-
-    /**
-     * Removes record from the index queue and from the solr index when the item is in the queue.
-     *
-     * @param string $recordTable Name of table where the record lives
-     * @param int $recordUid Id of record
-     */
-    protected function removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid)
-    {
-        if (!$this->indexQueue->containsItem($recordTable, $recordUid)) {
-            return;
-        }
-
-        $this->removeFromIndexAndQueue($recordTable, $recordUid);
-    }
-
-    // Handle pages showing content from another page
-
-    /**
-     * Triggers Index Queue updates for other pages showing content from the
-     * page currently being updated.
-     *
-     * @param int $pageId UID of the page currently being updated
-     */
-    protected function updateCanonicalPages($pageId)
-    {
-        $canonicalPages = $this->pagesRepository->findPageUidsWithContentsFromPid((int)$pageId);
-        foreach ($canonicalPages as $page) {
-            $this->indexQueue->updateItem('pages', $page['uid']);
-        }
-    }
-
-    /**
-     * Retrieves the pid of a record and throws an exception when getPid returns false.
-     *
-     * @param DataHandler $tceMain
-     * @param string $table
-     * @param integer $uid
-     * @throws NoPidException
-     * @return integer
-     */
-    protected function getValidatedPid(DataHandler $tceMain, $table, $uid)
-    {
-        $pid = $tceMain->getPID($table, $uid);
-        if ($pid === false) {
-            throw new NoPidException('Pid should not be false');
-        }
-
-        $pid = intval($pid);
-        return $pid;
-    }
-
-    /**
-     * Checks if the record is a draft record.
-     *
-     * @param string $table
-     * @param int $uid
-     * @return bool
-     */
-    protected function isDraftRecord($table, $uid)
-    {
-        return Util::isDraftRecord($table, $uid);
-    }
-
-    /**
-     * @param $pageId
-     * @param bool $initializeTsfe
-     * @param int $language
-     * @return TypoScriptConfiguration
-     */
-    protected function getSolrConfigurationFromPageId($pageId)
-    {
-        return $this->frontendEnvironment->getSolrConfigurationFromPageId($pageId);
     }
 }

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -143,6 +143,19 @@ class ExtensionConfiguration
     }
 
     /**
+     * Returns the desired monitoring type
+     * 0 - immediate
+     * 1 - delayed
+     * 2 - no monitoring
+     *
+     * @return int
+     */
+    public function getMonitoringType(): int
+    {
+        return (int)$this->getConfigurationOrDefaultValue('monitoringType', 0);
+    }
+
+    /**
      * @param string $key
      * @param mixed $defaultValue
      * @return mixed|null

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -189,7 +189,7 @@ class TypoScriptConfiguration
      * Gets the parent TypoScript Object from a given TypoScript path and if not present return
      * the default value
      *
-     * @see getObjectByPath
+     * @see getObjectByPath()
      * @param string $path
      * @param array $defaultValue
      * @return array

--- a/Classes/System/Language/FrontendOverlayService.php
+++ b/Classes/System/Language/FrontendOverlayService.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 /**
  * Class FrontendOverlayService

--- a/Classes/System/Records/AbstractRepository.php
+++ b/Classes/System/Records/AbstractRepository.php
@@ -81,7 +81,7 @@ abstract class AbstractRepository
         return (int)$this->getQueryBuilder()
             ->count('*')
             ->from($this->table)
-            ->execute()->fetchColumn(0);
+            ->execute()->fetchColumn();
     }
 
     /**

--- a/Classes/System/Records/Queue/EventQueueItemRepository.php
+++ b/Classes/System/Records/Queue/EventQueueItemRepository.php
@@ -1,0 +1,153 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\System\Records\Queue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
+use TYPO3\CMS\Core\SingletonInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\Util;
+
+/**
+ * EventQueueItemRepository to encapsulate the database access for the event queue items
+ */
+class EventQueueItemRepository extends AbstractRepository implements SingletonInterface
+{
+    /**
+     * @var string
+     */
+    protected $table = 'tx_solr_eventqueue_item';
+
+    /**
+     * Add event to event queue
+     *
+     * @param DataUpdateEventInterface $event
+     */
+    public function addEventToQueue(DataUpdateEventInterface $event): void
+    {
+        $serializedEvent = serialize($event);
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->insert($this->table)
+            ->values([
+                'tstamp' => Util::getExectionTime(),
+                'event' => $serializedEvent
+
+            ])
+            ->execute();
+    }
+
+    /**
+     * Returns event queue items
+     *
+     * @param int $limit
+     * @param bool $excludeErroneousItems
+     * @return array
+     */
+    public function getEventQueueItems(int $limit = null, bool $excludeErroneousItems = true): array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->addOrderBy('uid');
+
+        if ($limit !== null) {
+            $queryBuilder->setMaxResults($limit);
+        }
+        if ($excludeErroneousItems) {
+            $queryBuilder->andWhere($queryBuilder->expr()->eq('error', 0));
+        }
+
+        return $queryBuilder->execute()->fetchAll();
+    }
+
+    /**
+     * Updates a event queue item
+     *
+     * @param int $uid
+     * @param array $data
+     */
+    public function updateEventQueueItem(int $uid, array $data): void
+    {
+        if (!$uid > 0) {
+            return;
+        }
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->update($this->table)
+            ->where(
+                $queryBuilder->expr()->eq('uid', $uid)
+            );
+
+        foreach($data as $column => $value) {
+            $queryBuilder->set($column, $value);
+        }
+
+        $queryBuilder->execute();
+    }
+
+    /**
+     * Deletes event queue items
+     *
+     * @param int[] $uids
+     */
+    public function deleteEventQueueItems(array $uids): void
+    {
+        if (empty($uids)) {
+            return;
+        }
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->delete($this->table)
+            ->where(
+                $queryBuilder->expr()->in('uid', array_map('intval', $uids))
+            )
+            ->execute();
+    }
+
+    /**
+     * Returns current count of last searches
+     *
+     * @param bool $excludeErroneousItems
+     * @return int
+     */
+    public function count($excludeErroneousItems = true): int
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->count('*')
+            ->from($this->table);
+
+        if ($excludeErroneousItems) {
+            $queryBuilder->andWhere($queryBuilder->expr()->eq('error', 0));
+        }
+
+        return (int)$queryBuilder->execute()->fetchColumn();
+    }
+}

--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -14,6 +14,7 @@ namespace ApacheSolrForTypo3\Solr\System\Solr;
  * The TYPO3 project - inspiring people to share!
  */
 
+use UnexpectedValueException;
 use Solarium\Core\Client\Endpoint;
 
 /**
@@ -93,12 +94,12 @@ class Node extends Endpoint
      *
      * @param array  $configuration
      * @param string $name
-     * @throws |UnexpectedValueException
+     * @throws UnexpectedValueException
      */
     protected static function checkIfRequiredKeyIsSet(array $configuration, string $name)
     {
         if (empty($configuration[$name])) {
-            throw new \UnexpectedValueException('Required solr connection property ' . $name. ' is missing.');
+            throw new UnexpectedValueException('Required solr connection property ' . $name. ' is missing.');
         }
     }
 

--- a/Classes/System/Solr/Parser/StopWordParser.php
+++ b/Classes/System/Solr/Parser/StopWordParser.php
@@ -56,12 +56,12 @@ class StopWordParser
     /**
      * @param string|array $stopWords
      * @return string
-     * @throws \Apache_Solr_InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function toJson($stopWords)
     {
         if (empty($stopWords)) {
-            throw new \Apache_Solr_InvalidArgumentException('Must provide stop word.');
+            throw new \InvalidArgumentException('Must provide stop word.');
         }
 
         if (is_string($stopWords)) {

--- a/Classes/System/Solr/Parser/SynonymParser.php
+++ b/Classes/System/Solr/Parser/SynonymParser.php
@@ -62,12 +62,12 @@ class SynonymParser
      * @param string $baseWord
      * @param array $synonyms
      * @return string
-     * @throws \Apache_Solr_InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function toJson($baseWord, $synonyms)
     {
         if (empty($baseWord) || empty($synonyms)) {
-            throw new \Apache_Solr_InvalidArgumentException('Must provide base word and synonyms.');
+            throw new \InvalidArgumentException('Must provide base word and synonyms.');
         }
 
         return json_encode([$baseWord => $synonyms]);

--- a/Classes/Task/EventQueueWorkerTask.php
+++ b/Classes/Task/EventQueueWorkerTask.php
@@ -1,0 +1,189 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Task;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingFinishedEvent;
+
+/**
+ * A worker processing the queued data update events
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+final class EventQueueWorkerTask extends AbstractTask
+{
+    const DEFAULT_PROCESSING_LIMIT = 100;
+
+    /**
+     * Processing limit, the number of events to process
+     *
+     * @var int
+     */
+    protected $limit = self::DEFAULT_PROCESSING_LIMIT;
+
+    /**
+     * Works through the indexing queue and indexes the queued items into Solr.
+     *
+     * @return bool Returns TRUE on success, FALSE if no items were indexed or none were found.
+     */
+    public function execute(): bool
+    {
+       $this->processEvents();
+       return true;
+    }
+
+    /**
+     * Process queued data update events
+     */
+    protected function processEvents(): void
+    {
+        $itemRepository = $this->getEventQueueItemRepository();
+        $dispatcher = $this->getEventDispatcher();
+
+        $queueItems = $itemRepository->getEventQueueItems($this->limit);
+        $processedItems = [];
+        foreach ($queueItems as $queueItem) {
+            try {
+                $event = unserialize($queueItem['event']);
+                if (!$event instanceof DataUpdateEventInterface) {
+                    throw new \InvalidArgumentException(
+                        'Unsupported event found: '
+                            . (is_object($event) ? get_class($event) : (string)$event),
+                        1639747163
+                    );
+                }
+
+                $event->setForceImmediateProcessing(true);
+                $dispatcher->dispatch($event);
+                $processedItems[] = $queueItem['uid'];
+
+                // dispatch event processing finished event
+                $dispatcher->dispatch(
+                    new DelayedProcessingFinishedEvent($event)
+                );
+            } catch (\Throwable $e) {
+                $this->getSolrLogManager()->log(
+                    SolrLogManager::ERROR,
+                    'Couldn\'t process queued event',
+                    [
+                        'eventQueueItemUid' => $queueItem['uid'],
+                        'error' => $e->getMessage(),
+                        'errorCode' => $e->getCode(),
+                        'errorFile' => $e->getFile() . ':' . $e->getLine()
+                    ]
+                );
+                $itemRepository->updateEventQueueItem(
+                    $queueItem['uid'],
+                    [
+                        'error' => 1,
+                        'error_message' => $e->getMessage() . '[' . $e->getCode() . ']'
+                    ]
+                );
+            }
+        }
+
+        // update event queue
+        $itemRepository->deleteEventQueueItems($processedItems);
+    }
+
+    /**
+     * Returns some additional information about indexing progress, shown in
+     * the scheduler's task overview list.
+     *
+     * @return string Information to display
+     */
+    public function getAdditionalInformation(): string
+    {
+        $message = LocalizationUtility::translate(
+            'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.statusMsg'
+        );
+
+        $fullItemCount = $this->getEventQueueItemRepository()->count(false);
+        $pendingItemsCount = $this->getEventQueueItemRepository()->count();
+        return sprintf(
+            $message,
+            $pendingItemsCount,
+            ($fullItemCount - $pendingItemsCount),
+            $this->limit
+        );
+    }
+
+    /**
+     * Sets the limit
+     *
+     * @param int $limit
+     */
+    public function setLimit(int $limit): void
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * Returns the limit
+     *
+     * @param int $limit
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * Return the SolrLogManager
+     *
+     * @return SolrLogManager
+     */
+    protected function getSolrLogManager(): SolrLogManager
+    {
+        return  GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+    }
+
+    /**
+     * Return the EventQueueItemRepository
+     *
+     * @return EventQueueItemRepository
+     */
+    protected function getEventQueueItemRepository(): EventQueueItemRepository
+    {
+        return GeneralUtility::makeInstance(EventQueueItemRepository::class);
+    }
+
+    /**
+     * Returns the EventDispatcher
+     *
+     * @return EventDispatcherInterface
+     */
+    protected function getEventDispatcher(): EventDispatcherInterface
+    {
+        return GeneralUtility::makeInstance(EventDispatcherInterface::class);
+    }
+}

--- a/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
@@ -1,0 +1,112 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Task;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Scheduler\AdditionalFieldProviderInterface;
+use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
+
+/**
+ * Additional field provider for the index queue worker task
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class EventQueueWorkerTaskAdditionalFieldProvider implements AdditionalFieldProviderInterface
+{
+    /**
+     * Used to define fields to provide the TYPO3 site to index and number of
+     * items to index per run when adding or editing a task.
+     *
+     * @param array $taskInfo reference to the array containing the info used in the add/edit form
+     * @param AbstractTask $task when editing, reference to the current task object. Null when adding.
+     * @param SchedulerModuleController $schedulerModule : reference to the calling object (Scheduler's BE module)
+     * @return array Array containing all the information pertaining to the additional fields
+     *                    The array is multidimensional, keyed to the task class name and each field's id
+     *                    For each field it provides an associative sub-array with the following:
+     */
+    public function getAdditionalFields(
+        array &$taskInfo,
+        $task,
+        SchedulerModuleController $schedulerModule
+    ): array {
+        /** @var $task EventQueueWorkerTask */
+        $additionalFields = [];
+
+        if (!$task instanceof EventQueueWorkerTask) {
+            return $additionalFields;
+        }
+
+        if ($schedulerModule->getCurrentAction()->equals(Action::EDIT)) {
+            $taskInfo['solr_eventqueueworkertask_limit'] = $task->getLimit();
+        }
+
+        $additionalFields['limit'] = [
+            'code' => '<input type="number" class="form-control" name="tx_scheduler[solr_eventqueueworkertask_limit]" value="' . (int)$taskInfo['solr_eventqueueworkertask_limit'] . '" />',
+            'label' => 'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.limit',
+            'cshKey' => '',
+            'cshLabel' => ''
+        ];
+
+        return $additionalFields;
+    }
+
+    /**
+     * Checks any additional data that is relevant to this task. If the task
+     * class is not relevant, the method is expected to return TRUE
+     *
+     * @param array $submittedData reference to the array containing the data submitted by the user
+     * @param SchedulerModuleController $schedulerModule reference to the calling object (Scheduler's BE module)
+     * @return bool True if validation was ok (or selected class is not relevant), FALSE otherwise
+     */
+    public function validateAdditionalFields(
+        array &$submittedData,
+        SchedulerModuleController $schedulerModule
+    ): bool {
+        $submittedData['solr_eventqueueworkertask_limit'] = max(
+            (int)($submittedData['solr_eventqueueworkertask_limit'] ?? EventQueueWorkerTask::DEFAULT_PROCESSING_LIMIT),
+            1
+        );
+        return true;
+    }
+
+    /**
+     * Saves the custom limit
+     *
+     * @param array $submittedData array containing the data submitted by the user
+     * @param AbstractTask $task reference to the current task object
+     */
+    public function saveAdditionalFields(
+        array $submittedData,
+        AbstractTask $task
+    ): void {
+        if (!$task instanceof EventQueueWorkerTask) {
+            return;
+        }
+
+        $task->setLimit($submittedData['solr_eventqueueworkertask_limit']);
+    }
+}

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -169,4 +169,14 @@ class Util
         $context = GeneralUtility::makeInstance(Context::class);
         return $context->getPropertyFromAspect('frontend.user', 'groupIds');
     }
+
+    /**
+     * Returns the current execution time (formerly known as EXEC_TIME)
+     * @return int
+     */
+    public static function getExectionTime(): int
+    {
+        $context = GeneralUtility::makeInstance(Context::class);
+        return (int)$context->getPropertyFromAspect('date', 'timestamp');
+    }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,4 +1,30 @@
 services:
+  _defaults:
+    autowire: false
+    autoconfigure: false
+
+  ApacheSolrForTypo3\Solr\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Eid/*'
+
+  ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler:
+    public: true
+    arguments:
+      $recordService: '@ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService'
+      $frontendEnvironment: '@ApacheSolrForTypo3\Solr\FrontendEnvironment'
+      $tcaService: '@ApacheSolrForTypo3\Solr\System\TCA\TCAService'
+      $indexQueue: '@ApacheSolrForTypo3\Solr\IndexQueue\Queue'
+      $mountPageUpdater: '@ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater'
+      $rootPageResolver: '@ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver'
+      $pagesRepository: '@ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository'
+      $dataHandler: '@TYPO3\CMS\Core\DataHandling\DataHandler'
+  ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler:
+    public: true
+    arguments:
+      $recordService: '@ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService'
+      $frontendEnvironment: '@ApacheSolrForTypo3\Solr\FrontendEnvironment'
+      $tcaService: '@ApacheSolrForTypo3\Solr\System\TCA\TCAService'
+      $indexQueue: '@ApacheSolrForTypo3\Solr\IndexQueue\Queue'
   ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\CachedUrlModifier:
     tags:
       - name: event.listener
@@ -14,3 +40,95 @@ services:
       - name: event.listener
         identifier: 'solr.routing.postenhanceduriprocessor-modifier'
         event: ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent
+  ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener:
+    arguments:
+      $extensionConfiguration: '@ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration'
+      $eventDispatcher: '@Psr\EventDispatcher\EventDispatcherInterface'
+    tags:
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.noprocessingeventlistener'
+        before: 'solr.index.updatehandler.immediateprocessingeventlistener,solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent
+  ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\ImmediateProcessingEventListener:
+    arguments:
+      $extensionConfiguration: '@ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration'
+      $eventDispatcher: '@Psr\EventDispatcher\EventDispatcherInterface'
+    tags:
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.immediateprocessingeventlistener'
+        before: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent
+  ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\DelayedProcessingEventListener:
+    arguments:
+      $extensionConfiguration: '@ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration'
+      $eventDispatcher: '@Psr\EventDispatcher\EventDispatcherInterface'
+    tags:
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent
+      - name: event.listener
+        identifier: 'solr.index.updatehandler.delayedprocessingeventlistener'
+        event: ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent

--- a/Documentation/Configuration/Reference/ExtensionSettings.rst
+++ b/Documentation/Configuration/Reference/ExtensionSettings.rst
@@ -52,3 +52,19 @@ allowLegacySiteMode
 :Default: 0
 
 Can be used to allow using classic TypoScript Configuration for Sites.
+
+monitoringType
+--------------
+
+:Type: Int
+:Since: 11.2
+:Default: 0
+
+Defines how data updates should be monitored
+
+By default (=0) recognized updates will be processed directly and the Solr index queue will be directly updated, also
+the Solr index where appropriate. As in huge instances the monitoring can slow down the TYPO3 backend, two more monitoring
+options are available:
+
+- Delayed: Record update events will be queue and processed later, the scheduler task "Event Queue Worker" is required for processing.
+- No monitoring: Monitoring is completely disabled, please note that you have to take care of Solr index updates yourself.

--- a/Documentation/Development/Events.rst
+++ b/Documentation/Development/Events.rst
@@ -1,0 +1,57 @@
+======
+Events
+======
+
+In version 11 we started with the implementation of events, using the EventDispatcher (PSR-14 Events).
+
+Step by step the events will replace older hooks and signals. In the following you will find a description of the available events
+
+Monitoring
+^^^^^^^^^^
+
+Observing and processing of data updates is controlled by the following events:
+
+- ContentElementDeletedEvent, fired if a content element is deleted
+- PageMovedEvent, fired if a page is moved
+- RecordDeletedEvent, fired if a record is deleted
+- RecordGarbageCheckEvent, fired if a record garbage check is triggered
+- RecordMovedEvent, fired if a record is moved
+- VersionSwappedEvent, fired if a version is swapped
+
+All events implement the DataUpdateEventInterface and at least provide information about the elements uid, table and modified fields.
+
+Data update processing
+^^^^^^^^^^^^^^^^^^^^^^
+
+ProcessingFinishedEvent
+-----------------------
+
+The ProcessingFinishedEvent indicates that the processing of a data update event is finished, if you want to implement an own monitoring you
+can use the ProcessingFinishedEvent to start the processing. The event provides the originally fired data update events listed above, so that
+you have all the required information about the update to process.
+
+If you're using the event you're indepent of the monitoring setting, as this event if fired in the immediate and delayed monitoring mode as
+soon as an event is processed.
+
+DelayedProcessingQueuingFinishedEvent / DelayedProcessingFinishedEvent
+----------------------------------------------------------------------
+
+If you're using the delayed processing (see "monitoringType"), you can use one of the following events:
+
+DelayedProcessingQueuingFinishedEvent
+This event is fired as soon as the update event is queued in the event queue (tx_solr_eventqueue_item), you can e.g. use this event to
+register own events or to implement processing that has to executed immediately even in delayed monitoring mode.
+
+DelayedProcessingFinishedEvent
+The Scheduler task "Event Queue Worker" is required to process the data updates in delayed monitoring mode and will fire the DelayedProcessingFinishedEvent
+as soon as an event has been processed. If you require to perform actions only during delayed processing, the event can be used.
+
+SearchUriBuilder
+^^^^^^^^^^^^^^^^
+
+The SearchUriBuilder is responsible to build uris, that are used in the searchContext. Since the route enhancer is introduced you can use the following
+event to influence the build uris:
+
+- BeforeReplaceVariableInCachedUrlEvent
+- BeforeProcessCachedVariablesEvent
+- PostProcessUriEvent

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:solr/Resources/Private/Language/locallang_be.xlf" date="2021-12-15T13:10:00Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="extConf.monitoringType" xml:space="preserve">
+				<source>Monitoring: Define how data updates should be monitored</source>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.0" xml:space="preserve">
+				<source>Immediate</source>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.1" xml:space="preserve">
+				<source>Delayed (Scheduler task)</source>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.2" xml:space="preserve">
+				<source>No monitoring at all</source>
+			</trans-unit>
+
+			<trans-unit id="task.eventQueueWorkerTask.title" xml:space="preserve">
+				<source>Event Queue Worker</source>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.description" xml:space="preserve">
+				<source>Task handling the queue data update events. Required if monitoringType is set to "Delayed".</source>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.limit" xml:space="preserve">
+				<source>Processing limit, the number of events to process</source>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.statusMsg" xml:space="preserve">
+				<source>Data update events to process: %1$d, Errors: %2$d. %3$d events will be processed per run.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Tests/Integration/Controller/AbstractFrontendControllerTest.php
+++ b/Tests/Integration/Controller/AbstractFrontendControllerTest.php
@@ -22,7 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 use TYPO3\CMS\Extbase\Mvc\Web\Response;
 use TYPO3\CMS\Frontend\Http\RequestHandler;
-use TYPO3\CMS\Frontend\Page\PageGenerator;
 
 abstract class AbstractFrontendControllerTest  extends IntegrationTest {
 

--- a/Tests/Integration/Fixtures/does_not_remove_updated_content_element_with_not_set_endtime.xml
+++ b/Tests/Integration/Fixtures/does_not_remove_updated_content_element_with_not_set_endtime.xml
@@ -1,102 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dataset>
 
-    <sys_template>
-        <uid>1</uid>
-        <pid>1</pid>
-        <root>1</root>
-        <clear>3</clear>
-        <config>
-            <![CDATA[
-                config.disableAllHeaderCode = 1
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+				config.disableAllHeaderCode = 1
 
-                page = PAGE
-                page.typeNum = 0
-                page.bodyTag = <body>
+				page = PAGE
+				page.typeNum = 0
+				page.bodyTag = <body>
 
-                # very simple rendering
-                page.10 = CONTENT
-                page.10 {
-                    table = tt_content
-                    select.orderBy = sorting
-                    select.where = colPos=0
-                    renderObj = COA
-                    renderObj {
-                        10 = TEXT
-                        10.field = bodytext
-                    }
-                }
+				# very simple rendering
+				page.10 = CONTENT
+				page.10 {
+					table = tt_content
+					select.orderBy = sorting
+					select.where = colPos=0
+					renderObj = COA
+					renderObj {
+						10 = TEXT
+						10.field = bodytext
+					}
+				}
 
-                page.10.wrap = <!--TYPO3SEARCH_begin--><html><body>|</body></html><!--TYPO3SEARCH_end-->
+				page.10.wrap = <!--TYPO3SEARCH_begin--><html><body>|</body></html><!--TYPO3SEARCH_end-->
 
 
-                plugin.tx_solr {
+				plugin.tx_solr {
 
-                    enabled = 1
+					enabled = 1
 
-                    index {
-                        fieldProcessingInstructions {
-                            changed = timestampToIsoDate
-                            created = timestampToIsoDate
-                            endtime = timestampToUtcIsoDate
-                            rootline = pageUidToHierarchy
-                        }
+					index {
+						fieldProcessingInstructions {
+							changed = timestampToIsoDate
+							created = timestampToIsoDate
+							endtime = timestampToUtcIsoDate
+							rootline = pageUidToHierarchy
+						}
 
-                        queue {
+						queue {
 
-                            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+							// mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
 
-                            pages = 1
-                            pages {
-                                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
 
-                                // allowed page types (doktype) when indexing records from table "pages"
-                                allowedPageTypes = 1,7
+								// allowed page types (doktype) when indexing records from table "pages"
+								allowedPageTypes = 1,7
 
-                                indexingPriority = 0
+								indexingPriority = 0
 
-                                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
-                                indexer {
-                                    // add options for the indexer here
-                                }
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+								indexer {
+									// add options for the indexer here
+								}
 
-                                // Only index standard pages and mount points that are not overlayed.
-                                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
-                            }
-                        }
-                    }
-                }
-            ]]>
-        </config>
-        <sorting>100</sorting>
-    </sys_template>
-    <pages>
-        <uid>1</uid>
-        <is_siteroot>1</is_siteroot>
-        <doktype>1</doktype>
-        <hidden>0</hidden>
-        <title>Testpage</title>
-    </pages>
+								// Only index standard pages and mount points that are not overlayed.
+								additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+							}
+						}
+					}
+				}
+			]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>Testpage</title>
+	</pages>
 
-    <tt_content>
-        <uid>88</uid>
-        <pid>1</pid>
-        <bodytext>Will stay after update!</bodytext>
-        <colPos>0</colPos>
-        <endtime>0</endtime>
-    </tt_content>
+	<tt_content>
+		<uid>88</uid>
+		<pid>1</pid>
+		<bodytext>will stay! still present after update!</bodytext>
+		<colPos>0</colPos>
+		<endtime>0</endtime>
+	</tt_content>
 
-    <tx_solr_indexqueue_item>
-        <uid>4711</uid>
-        <root>1</root>
-        <item_type>pages</item_type>
-        <item_uid>1</item_uid>
-        <indexing_configuration>pages</indexing_configuration>
-        <has_indexing_properties>0</has_indexing_properties>
-        <indexing_priority>0</indexing_priority>
-        <changed>1449151778</changed>
-        <indexed>1</indexed>
-        <errors/>
-        <pages_mountidentifier/>
-    </tx_solr_indexqueue_item>
+	<tx_solr_indexqueue_item>
+		<uid>4711</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<item_uid>1</item_uid>
+		<indexing_configuration>pages</indexing_configuration>
+		<has_indexing_properties>0</has_indexing_properties>
+		<indexing_priority>0</indexing_priority>
+		<changed>1449151778</changed>
+		<indexed>1</indexed>
+		<errors/>
+		<pages_mountidentifier/>
+	</tx_solr_indexqueue_item>
 </dataset>

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -24,15 +24,18 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\GarbageCollector;
-use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
-use ApacheSolrForTypo3\Solr\IndexQueue\Item;
-use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Scheduler\Scheduler;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\GarbageCollector;
+use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 
 /**
  * This testcase is used to check if the GarbageCollector can delete garbage from the
@@ -42,6 +45,13 @@ use TYPO3\CMS\Core\Localization\LanguageService;
  */
 class GarbageCollectorTest extends IntegrationTest
 {
+    /**
+     * @var array
+     */
+    protected $coreExtensionsToLoad = [
+        'extensionmanager',
+        'scheduler'
+    ];
 
     /**
      * @var RecordMonitor
@@ -68,7 +78,17 @@ class GarbageCollectorTest extends IntegrationTest
      */
     protected $indexer;
 
-    public function setUp()
+    /**
+     * @var ExtensionConfiguration
+     */
+    protected $extensionConfiguration;
+
+    /**
+     * @var EventQueueItemRepository
+     */
+    protected $eventQueue;
+
+    public function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -77,12 +97,31 @@ class GarbageCollectorTest extends IntegrationTest
         $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
         $this->garbageCollector = GeneralUtility::makeInstance(GarbageCollector::class);
         $this->indexer = GeneralUtility::makeInstance(Indexer::class);
+        $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $this->eventQueue = GeneralUtility::makeInstance(EventQueueItemRepository::class);
+    }
+
+
+    public function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        $this->extensionConfiguration->setAll([]);
+        unset(
+            $this->recordMonitor,
+            $this->dataHandler,
+            $this->indexQueue,
+            $this->garbageCollector,
+            $this->indexer,
+            $this->extensionConfiguration,
+            $this->eventQueue
+        );
+        parent::tearDown();
     }
 
     /**
      * @return void
      */
-    protected function assertEmptyIndexQueue()
+    protected function assertEmptyIndexQueue(): void
     {
         $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
     }
@@ -90,7 +129,7 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @return void
      */
-    protected function assertNotEmptyIndexQueue()
+    protected function assertNotEmptyIndexQueue(): void
     {
         $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
             'Index queue is empty and was expected to be not empty.');
@@ -99,30 +138,79 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @param $amount
      */
-    protected function assertIndexQueryContainsItemAmount($amount)
+    protected function assertIndexQueueContainsItemAmount($amount): void
     {
-        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to contain ' . (int) $amount . ' items.');
+        $itemsInQueue = $this->indexQueue->getAllItemsCount();
+        $this->assertEquals(
+            $amount,
+            $itemsInQueue,
+            'Index queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertEmptyEventQueue(): void
+    {
+        $this->assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
+    }
+
+    /**
+     * @param int $amount
+     */
+    protected function assertEventQueueContainsItemAmount(int $amount): void
+    {
+        $itemsInQueue = $this->eventQueue->count();
+        $this->assertEquals(
+            $amount,
+            $itemsInQueue,
+            'Event queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
+        );
     }
 
     /**
      * @test
      */
-    public function queueItemStaysWhenOverlayIsSetToHidden()
+    public function queueItemStaysWhenOverlayIsSetToHidden(): void
+    {
+        $this->prepareQueueItemStaysWhenOverlayIsSetToHidden();
+
+        // index queue not modified
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function queueItemStaysWhenOverlayIsSetToHiddenInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareQueueItemStaysWhenOverlayIsSetToHidden();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - queueItemStaysWhenOverlayIsSetToHidden
+     * - queueItemStaysWhenOverlayIsSetToHiddenInDelayedProcessingMode
+     */
+    protected function prepareQueueItemStaysWhenOverlayIsSetToHidden(): void
     {
         $this->importDataSetFromFixture('queue_item_stays_when_overlay_set_to_hidden.xml');
 
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
 
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 2, ['hidden' => 1], $this->dataHandler);
-        // index queue not modified
-        $this->assertIndexQueryContainsItemAmount(1);
     }
 
     /**
      * @test
      */
-    public function canQueueAPageAndRemoveItWithTheGarbageCollector()
+    public function canQueueAPageAndRemoveItWithTheGarbageCollector(): void
     {
         $this->importDataSetFromFixture('can_queue_a_page_and_remove_it_with_the_garbage_collector.xml');
 
@@ -133,7 +221,7 @@ class GarbageCollectorTest extends IntegrationTest
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, [], $dataHandler);
 
         // we expect that one item is now in the solr server
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
 
         $this->garbageCollector->collectGarbage('pages', 1);
 
@@ -144,7 +232,34 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet()
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet(): void
+    {
+        $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet();
+
+        // finally we expect that the index is empty again because the root page with "extendToSubPages" has been set to
+        // hidden = 1
+        $this->assertEmptyIndexQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet
+     * - canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetInDelayedProcessingMode
+     */
+    protected function prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet(): void
     {
         $this->importDataSetFromFixture('can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set.xml');
 
@@ -156,7 +271,7 @@ class GarbageCollectorTest extends IntegrationTest
         $this->indexQueue->updateItem('pages', 100);
 
         // we expected that three pages are now in the index
-        $this->assertIndexQueryContainsItemAmount(3);
+        $this->assertIndexQueueContainsItemAmount(3);
 
         // simulate the database change and build a faked changeset
         $connection = $this->getDatabaseConnection();
@@ -166,6 +281,14 @@ class GarbageCollectorTest extends IntegrationTest
 
         $dataHandler = $this->dataHandler;
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
+    }
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages(): void
+    {
+        $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages();
 
         // finally we expect that the index is empty again because the root page with "extendToSubPages" has been set to
         // hidden = 1
@@ -175,7 +298,22 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages()
+    public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpagesInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages
+     * - canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpagesInDelayedProcessingMode
+     */
+    protected function prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages(): void
     {
         $this->importDataSetFromFixture('can_collect_garbage_from_subPages_when_page_is_set_to_hidden_and_extendToSubpages_is_set_multiple_subpages.xml');
 
@@ -188,7 +326,7 @@ class GarbageCollectorTest extends IntegrationTest
         $this->indexQueue->updateItem('pages', 12);
 
         // we expected that three pages are now in the index
-        $this->assertIndexQueryContainsItemAmount(4);
+        $this->assertIndexQueueContainsItemAmount(4);
 
         // simulate the database change and build a faked changeset
         $connection = $this->getDatabaseConnection();
@@ -197,44 +335,21 @@ class GarbageCollectorTest extends IntegrationTest
 
         $dataHandler = $this->dataHandler;
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
-
-        // finally we expect that the index is empty again because the root page with "extendToSubPages" has been set to
-        // hidden = 1
-        $this->assertEmptyIndexQueue();
     }
 
     /**
      * @test
      */
-    public function canRemoveDeletedContentElement()
+    public function canRemoveDeletedContentElement(): void
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('can_remove_content_element.xml');
-
-        $this->indexPageIds([1]);
-
-        // we index a page with two content elements and expect solr contains the content of both
-        $this->waitToBeVisibleInSolr();
-
-        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
-
-        // we delete the second content element
-        $beUser = $this->fakeBEUser(1, 0);
-
-        $cmd['tt_content'][88]['delete'] = 1;
-        $this->dataHandler->start([], $cmd, $beUser);
-        $this->dataHandler->stripslashes_values = 0;
-        $this->dataHandler->process_cmdmap();
-        $this->dataHandler->process_datamap();
+        $this->prepareCanRemoveDeletedContentElement();
 
         // after applying the commands solr should be empty (because the page was removed from solr and queued for indexing)
         $this->waitToBeVisibleInSolr();
         $this->assertSolrIsEmpty();
 
         // we expect the is one item in the indexQueue
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
         $this->assertSame(1, count($items));
 
@@ -251,7 +366,23 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canRemoveHiddenContentElement()
+    public function canRemoveDeletedContentElementInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertEmptyEventQueue();
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrIsEmpty();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canRemoveDeletedContentElement
+     * - canRemoveDeletedContentElementInDelayedProcessingMode
+     */
+    protected function prepareCanRemoveDeletedContentElement(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
         $this->importDataSetFromFixture('can_remove_content_element.xml');
@@ -265,26 +396,30 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
         $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
 
-        // we hide the second content element
+        // we delete the second content element
         $beUser = $this->fakeBEUser(1, 0);
-        $data = [
-            'tt_content' => [
-                '88' => [
-                    'hidden' => 1
-                ]
-            ]
-        ];
-        $this->dataHandler->start($data, [], $beUser);
+
+        $cmd = ['tt_content' => [88 => ['delete' => 1 ]]];
+        $this->dataHandler->start([], $cmd, $beUser);
         $this->dataHandler->stripslashes_values = 0;
         $this->dataHandler->process_cmdmap();
         $this->dataHandler->process_datamap();
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveHiddenContentElement(): void
+    {
+        $data = ['tt_content' => ['88' => ['hidden' => 1]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
 
         // after applying the commands solr should be empty (because the page was removed from solr and queued for indexing)
         $this->waitToBeVisibleInSolr();
         $this->assertSolrIsEmpty();
 
         // we expect the is one item in the indexQueue
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
         $this->assertSame(1, count($items));
 
@@ -301,43 +436,37 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canRemoveContentElementWithEndTimeSetToPast()
+    public function canRemoveHiddenContentElementInDelayedProcessingMode(): void
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('can_remove_content_element.xml');
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $data = ['tt_content' => ['88' => ['hidden' => 1]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
 
-        $this->indexPageIds([1]);
+        $this->assertEventQueueContainsItemAmount(2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertNull($this->indexQueue->getItem(4711));
+        $item = $this->indexQueue->getAllItems()[0];
+        $this->assertGreaterThan(1449151778, $item->getChanged());
+        $this->assertEmptyEventQueue();
+    }
 
-        // we index a page with two content elements and expect solr contains the content of both
-        $this->waitToBeVisibleInSolr();
-
-        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
-
-        // we hide the second content element
-        $beUser = $this->fakeBEUser(1, 0);
-
+    /**
+     * @test
+     */
+    public function canRemoveContentElementWithEndTimeSetToPast(): void
+    {
         $timeStampInPast = time() - (60 * 60 * 24);
-        $data = [
-            'tt_content' => [
-                '88' => [
-                    'endtime' => $timeStampInPast
-                ]
-            ]
-        ];
-        $this->dataHandler->start($data, [], $beUser);
-        $this->dataHandler->stripslashes_values = 0;
-        $this->dataHandler->process_cmdmap();
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->clear_cacheCmd('all');
+        $data = ['tt_content' => ['88' => ['endtime' => $timeStampInPast]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
 
         // after applying the commands solr should be empty (because the page was removed from solr and queued for indexing)
         $this->waitToBeVisibleInSolr();
         $this->assertSolrIsEmpty();
 
         // we expect the is one item in the indexQueue
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
         $this->assertSame(1, count($items));
 
@@ -354,43 +483,38 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function doesNotRemoveUpdatedContentElementWithNotSetEndTime()
+    public function canRemoveContentElementWithEndTimeSetToPastInDelayedProcessingMode(): void
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('does_not_remove_updated_content_element_with_not_set_endtime.xml');
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $timeStampInPast = time() - (60 * 60 * 24);
+        $data = ['tt_content' => ['88' => ['endtime' => $timeStampInPast]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
 
-        $this->indexPageIds([1]);
+        $this->assertEventQueueContainsItemAmount(2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertNull($this->indexQueue->getItem(4711));
+        $item = $this->indexQueue->getAllItems()[0];
+        $this->assertGreaterThan(1449151778, $item->getChanged());
+        $this->assertEmptyEventQueue();
+    }
 
-        // we index a page with two content elements and expect solr contains the content of both
-        $this->waitToBeVisibleInSolr();
-
-        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('Will stay after update!', $solrContent, 'solr did not contain rendered page content, which is needed for test.');
-
-        // we hide the second content element
-        $beUser = $this->fakeBEUser(1, 0);
-
-        $data = [
-            'tt_content' => [
-                '88' => [
-                    'bodytext' => 'Updated! Will stay after update!'
-                ]
-            ]
-        ];
-
-        $this->dataHandler->start($data, [], $beUser);
-        $this->dataHandler->stripslashes_values = 0;
-        $this->dataHandler->process_cmdmap();
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->clear_cacheCmd('all');
+    /**
+     * @test
+     */
+    public function doesNotRemoveUpdatedContentElementWithNotSetEndTime(): void
+    {
+        $data = ['tt_content' => ['88' => ['bodytext' => 'Updated! Will stay after update!' ]]];
+        $this->prepareCanRemoveContentElementTests($data, [], 'does_not_remove_updated_content_element_with_not_set_endtime.xml');
 
         // document should stay in the index, because endtime was not in past but empty
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('Will stay after update!', $solrContent, 'solr did not contain rendered page content, which is needed for test.');
+        $this->assertContains('will stay! still present after update!', $solrContent, 'solr did not contain rendered page content, which is needed for test.');
 
         $this->waitToBeVisibleInSolr();
 
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
         $this->assertSame(1, count($items));
 
@@ -406,43 +530,37 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canRemoveContentElementWithStartDateSetToFuture()
+    public function doesNotRemoveUpdatedContentElementWithNotSetEndTimeInDelayedProcessingMode(): void
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('can_remove_content_element.xml');
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $data = ['tt_content' => ['88' => ['bodytext' => 'Updated! Will stay after update!' ]]];
+        $this->prepareCanRemoveContentElementTests($data, [], 'does_not_remove_updated_content_element_with_not_set_endtime.xml');
 
-        $this->indexPageIds([1]);
+        $this->assertEventQueueContainsItemAmount(2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertNull($this->indexQueue->getItem(4711));
+        $item = $this->indexQueue->getAllItems()[0];
+        $this->assertGreaterThan(1449151778, $item->getChanged());
+        $this->assertEmptyEventQueue();
+    }
 
-        // we index a page with two content elements and expect solr contains the content of both
-        $this->waitToBeVisibleInSolr();
-
-        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
-
-        // we hide the second content element
-        $beUser = $this->fakeBEUser(1, 0);
-
+    /**
+     * @test
+     */
+    public function canRemoveContentElementWithStartDateSetToFuture(): void
+    {
         $timestampInFuture = time() +  (60 * 60 * 24);
-        $data = [
-            'tt_content' => [
-                '88' => [
-                    'starttime' => $timestampInFuture
-                ]
-            ]
-        ];
-        $this->dataHandler->start($data, [], $beUser);
-        $this->dataHandler->stripslashes_values = 0;
-        $this->dataHandler->process_cmdmap();
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->clear_cacheCmd('all');
+        $data = ['tt_content' => ['88' => ['starttime' => $timestampInFuture]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
 
         // after applying the commands solr should be empty (because the page was removed from solr and queued for indexing)
         $this->waitToBeVisibleInSolr();
         $this->assertSolrIsEmpty();
 
         // we expect the is one item in the indexQueue
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
         $this->assertSame(1, count($items));
 
@@ -456,43 +574,76 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
-
     /**
      * @test
      */
-    public function canRemovePageWhenPageIsHidden()
+    public function canRemoveContentElementWithStartDateSetToFutureInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $timeStampInPast = time() - (60 * 60 * 24);
+        $data = ['tt_content' => ['88' => ['endtime' => $timeStampInPast]]];
+        $this->prepareCanRemoveContentElementTests($data, []);
+
+        $this->assertEventQueueContainsItemAmount(2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertNull($this->indexQueue->getItem(4711));
+        $item = $this->indexQueue->getAllItems()[0];
+        $this->assertGreaterThan(1449151778, $item->getChanged());
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canRemoveHiddenContentElement
+     * - canRemoveHiddenContentElementInDelayedProcessingMode
+     * - canRemoveContentElementWithEndTimeSetToPast
+     * - canRemoveContentElementWithEndTimeSetToPastInDelayedProcessingMode
+     * - doesNotRemoveUpdatedContentElementWithNotSetEndTime
+     * - doesNotRemoveUpdatedContentElementWithNotSetEndTimeInDelayedProcessingMode
+     * - canRemoveContentElementWithStartDateSetToFuture
+     * - canRemoveContentElementWithStartDateSetToFutureInDelayedProcessingMode
+     *
+     * @param array $dataMap
+     * @param array $cmdMap
+     * @param string $fixture
+     */
+    protected function prepareCanRemoveContentElementTests(array $dataMap, array $cmdMap, $fixture = 'can_remove_content_element.xml'): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('can_remove_page.xml');
+        $this->importDataSetFromFixture($fixture);
 
-        $this->indexPageIds([1,2]);
+        $this->indexPageIds([1]);
 
-        // we index two pages and check that both are visible
+        // we index a page with two content elements and expect solr contains the content of both
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('"numFound":2', $solrContent, 'Expected to have two documents in the index');
+        if ($fixture === 'can_remove_content_element.xml') {
+            $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
+        }
+        $this->assertContains('will stay!', $solrContent, 'solr did not contain required page or content element content');
 
-        // we hide the seconde page
+        // we hide the second content element
         $beUser = $this->fakeBEUser(1, 0);
-
-        $data = [
-            'pages' => [
-                '2' => [
-                    'hidden' => 1
-                ]
-            ]
-        ];
-        $this->dataHandler->start($data, [], $beUser);
+        $this->dataHandler->start($dataMap, $cmdMap, $beUser);
         $this->dataHandler->stripslashes_values = 0;
         $this->dataHandler->process_cmdmap();
         $this->dataHandler->process_datamap();
         $this->dataHandler->clear_cacheCmd('all');
+    }
+
+    /**
+     * @test
+     */
+    public function canRemovePageWhenPageIsHidden(): void
+    {
+        $dataMap = ['pages' => ['2' => ['hidden' => 1]]];
+        $this->prepareCanRemovePagesTests($dataMap, []);
 
         $this->waitToBeVisibleInSolr();
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
 
         // we reindex all queue items
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
@@ -515,33 +666,29 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canRemovePageWhenPageIsDeleted()
+    public function canRemovePageWhenPageIsHiddenInDelayedProcessingMode(): void
     {
-        $this->cleanUpSolrServerAndAssertEmpty();
-        $this->importDataSetFromFixture('can_remove_page.xml');
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $dataMap = ['pages' => ['2' => ['hidden' => 1]]];
 
-        $this->indexPageIds([1,2]);
+        $this->assertEmptyEventQueue();
+        $this->prepareCanRemovePagesTests($dataMap, []);
+        $this->assertIndexQueueContainsItemAmount(2);
+        $this->processEventQueue();
+        $this->assertEmptyEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
 
-        // we index two pages and check that both are visible
-        $this->waitToBeVisibleInSolr();
-
-        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertContains('"numFound":2', $solrContent, 'Expected to have two documents in the index');
-
-        // we hide the seconde page
-        $beUser = $this->fakeBEUser(1, 0);
-
-        $cmd['pages'][2]['delete'] = 1;
-        $this->dataHandler->start([], $cmd, $beUser);
-        $this->dataHandler->stripslashes_values = 0;
-        $this->dataHandler->process_cmdmap();
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->clear_cacheCmd('all');
+    /**
+     * @test
+     */
+    public function canRemovePageWhenPageIsDeleted(): void
+    {
+        $cmd = ['pages' => [2 => ['delete' => 1 ]]];
+        $this->prepareCanRemovePagesTests([], $cmd);
 
         $this->waitToBeVisibleInSolr();
-        $this->assertIndexQueryContainsItemAmount(1);
+        $this->assertIndexQueueContainsItemAmount(1);
 
         // we reindex all queue items
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
@@ -564,7 +711,94 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canTriggerHookAfterRecordDeletion()
+    public function canRemovePageWhenPageIsDeletedInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $cmdMap = ['pages' => [2 => ['delete' => 1 ]]];
+
+        $this->assertEmptyEventQueue();
+        $this->prepareCanRemovePagesTests([], $cmdMap);
+        $this->assertIndexQueueContainsItemAmount(2);
+        $this->processEventQueue();
+        $this->assertEmptyEventQueue();
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canRemovePageWhenPageIsHidden
+     * - canRemovePageWhenPageIsHiddenInDelayedProcessingMode
+     * - canRemovePageWhenPageIsDeleted
+     * - canRemovePageWhenPageIsDeletedInDelayedProcessingMode
+     *
+     * @param array $dataMap
+     * @param array $cmdMap
+     */
+    protected function prepareCanRemovePagesTests(array $dataMap, array $cmdMap): void
+    {
+        $this->cleanUpSolrServerAndAssertEmpty();
+        $this->importDataSetFromFixture('can_remove_page.xml');
+
+        $this->indexPageIds([1,2]);
+
+        // we index two pages and check that both are visible
+        $this->waitToBeVisibleInSolr();
+
+        $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
+        $this->assertContains('will be removed!', $solrContent, 'solr did not contain rendered page content');
+        $this->assertContains('will stay!', $solrContent, 'solr did not contain rendered page content');
+        $this->assertContains('"numFound":2', $solrContent, 'Expected to have two documents in the index');
+
+        // we hide the second page
+        $beUser = $this->fakeBEUser(1, 0);
+
+        $this->dataHandler->start($dataMap, $cmdMap, $beUser);
+        $this->dataHandler->stripslashes_values = 0;
+        $this->dataHandler->process_cmdmap();
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->clear_cacheCmd('all');
+    }
+
+    /**
+     * @test
+     */
+    public function canTriggerHookAfterRecordDeletion(): void
+    {
+        $this->prepareCanTriggerHookAfterRecordDeletion();
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrIsEmpty();
+
+            // since our hook is a singleton we check here if it was called.
+            /** @var TestGarbageCollectorPostProcessor $hook */
+        $hook = GeneralUtility::makeInstance(TestGarbageCollectorPostProcessor::class);
+        $this->assertTrue($hook->isHookWasCalled());
+
+            // reset the hooks
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'] = [];
+    }
+
+    /**
+     * @test
+     */
+    public function canTriggerHookAfterRecordDeletionInDelayedProcessingMode(): void
+    {
+        /** @var TestGarbageCollectorPostProcessor $hook */
+        $hook = GeneralUtility::makeInstance(TestGarbageCollectorPostProcessor::class);
+
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanTriggerHookAfterRecordDeletion();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->assertFalse($hook->isHookWasCalled());
+        $this->processEventQueue();
+        $this->assertTrue($hook->isHookWasCalled());
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canTriggerHookAfterRecordDeletion
+     * - canTriggerHookAfterRecordDeletionInDelayedProcessingMode
+     */
+    protected function prepareCanTriggerHookAfterRecordDeletion(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'][] = TestGarbageCollectorPostProcessor::class;
 
@@ -582,31 +816,20 @@ class GarbageCollectorTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
         $this->assertSolrContainsDocumentCount(1);
 
-        $cmd['tx_fakeextension_domain_model_foo'][111]['delete'] = 1;
+        $cmd = ['tx_fakeextension_domain_model_foo' => [111 => ['delete' => 1 ]]];
         $this->dataHandler->start([], $cmd, $beUser);
         $this->dataHandler->stripslashes_values = 0;
         $this->dataHandler->process_cmdmap();
         $this->dataHandler->process_datamap();
         $this->dataHandler->clear_cacheCmd('all');
-
-        $this->waitToBeVisibleInSolr();
-        $this->assertSolrIsEmpty();
-
-            // since our hook is a singleton we check here if it was called.
-            /** @var TestGarbageCollectorPostProcessor $hook */
-        $hook = GeneralUtility::makeInstance(TestGarbageCollectorPostProcessor::class);
-        $this->assertTrue($hook->isHookWasCalled());
-
-            // reset the hooks
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'] = [];
     }
 
     /**
      * @param string $table
      * @param int $uid
-     * @return ResponseAdapter
+     * @return bool
      */
-    protected function addToQueueAndIndexRecord($table, $uid)
+    protected function addToQueueAndIndexRecord($table, $uid): bool
     {
         // write an index queue item
         $this->indexQueue->updateItem($table, $uid);
@@ -615,19 +838,34 @@ class GarbageCollectorTest extends IntegrationTest
         $items = $this->indexQueue->getItems($table, $uid);
         foreach ($items as $item) {
             $result = $this->indexer->index($item);
+            if ($result === false) {
+                break;
+            }
         }
 
         return $result;
     }
 
-
     /**
-     *
+     * Prepares a LanguageService object
      */
-    protected function fakeLanguageService()
+    protected function fakeLanguageService(): void
     {
         /** @var $languageService  \TYPO3\CMS\Core\Localization\LanguageService */
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $GLOBALS['LANG'] = $languageService;
+    }
+
+    /**
+     * Triggers event queue processing
+     */
+    protected function processEventQueue(): void
+    {
+        /** @var EventQueueWorkerTask $task */
+        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
+
+        /** @var Scheduler $scheduler */
+        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler->executeTask($task);
     }
 }

--- a/Tests/Integration/IndexQueue/Fixtures/exception_is_triggered_without_pid.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/exception_is_triggered_without_pid.xml
@@ -1,44 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dataset>
 
-    <sys_template>
-        <uid>1</uid>
-        <pid>1</pid>
-        <root>1</root>
-        <clear>3</clear>
-        <config>
-            <![CDATA[
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
 
-                plugin.tx_solr {
+				plugin.tx_solr {
 
-                    enabled = 1
-
-                    index {
-                        queue {
-                            foo = 1
-                            foo {
-                                table = tx_fakeextension_domain_model_foo
-
-                                fields {
-                                    title = title
-                                }
-
-                        }
-                    }
-                }
-            ]]>
-        </config>
-        <sorting>100</sorting>
-    </sys_template>
-    <pages>
-        <uid>1</uid>
-        <is_siteroot>1</is_siteroot>
-        <doktype>1</doktype>
-        <pid>0</pid>
-    </pages>
-    <tx_fakeextension_domain_model_foo>
-        <uid>8</uid>
-        <title>testnews</title>
-    </tx_fakeextension_domain_model_foo>
-
+					enabled = 1
+					index {
+						queue {
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+								allowedPageTypes = 1,4,7
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+							}
+						}
+					}
+				}
+			]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<pid>0</pid>
+	</pages>
 </dataset>

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -27,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -24,13 +24,24 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Scheduler\Scheduler;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 
 /**
  * Testcase for the record monitor
@@ -39,6 +50,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RecordMonitorTest extends IntegrationTest
 {
+    /**
+     * @var array
+     */
+    protected $coreExtensionsToLoad = [
+        'extensionmanager',
+        'scheduler'
+    ];
 
     /**
      * @var RecordMonitor
@@ -55,25 +73,46 @@ class RecordMonitorTest extends IntegrationTest
      */
     protected $indexQueue;
 
-    public function setUp()
+    /**
+     * @var ExtensionConfiguration
+     */
+    protected $extensionConfiguration;
+
+    /**
+     * @var EventQueueItemRepository
+     */
+    protected $eventQueue;
+
+    public function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
         $this->recordMonitor = GeneralUtility::makeInstance(RecordMonitor::class);
         $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
+        $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $this->eventQueue = GeneralUtility::makeInstance(EventQueueItemRepository::class);
+        $this->extensionConfiguration->set('solr', 'monitoringType', 0);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        unset($this->recordMonitor, $this->dataHandler, $this->indexQueue);
+        GeneralUtility::purgeInstances();
+        $this->extensionConfiguration->setAll([]);
+        unset(
+            $this->recordMonitor,
+            $this->dataHandler,
+            $this->indexQueue,
+            $this->extensionConfiguration,
+            $this->eventQueue
+        );
         parent::tearDown();
     }
 
     /**
      * @return void
      */
-    protected function assertEmptyIndexQueue()
+    protected function assertEmptyIndexQueue(): void
     {
         $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
     }
@@ -81,19 +120,44 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @return void
      */
-    protected function assertNotEmptyIndexQueue()
+    protected function assertNotEmptyIndexQueue(): void
     {
         $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
             'Index queue is empty and was expected to be not empty.');
     }
 
     /**
-     * @param $amount
+     * @param int $amount
      */
-    protected function assertIndexQueueContainsItemAmount($amount)
+    protected function assertIndexQueueContainsItemAmount(int $amount): void
     {
-        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to contain ' . (int)$amount . ' items.');
+        $itemsInQueue = $this->indexQueue->getAllItemsCount();
+        $this->assertEquals(
+            $amount,
+            $itemsInQueue,
+            'Index queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function assertEmptyEventQueue(): void
+    {
+        $this->assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
+    }
+
+    /**
+     * @param int $amount
+     */
+    protected function assertEventQueueContainsItemAmount(int $amount): void
+    {
+        $itemsInQueue = $this->eventQueue->count();
+        $this->assertEquals(
+            $amount,
+            $itemsInQueue,
+            'Event queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
+        );
     }
 
     /**
@@ -107,8 +171,10 @@ class RecordMonitorTest extends IntegrationTest
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/155
      * @test
      */
-    public function canUpdateRootPageRecordWithoutSQLErrorFromMountPages()
+    public function canUpdateRootPageRecordWithoutSQLErrorFromMountPages(): void
     {
+        print_r($this->extensionConfiguration->get('solr', 'monitoringType'));
+
         $this->importDataSetFromFixture('update_mount_point_is_updating_the_mount_point_correctly.xml');
 
         // we expect that the index queue is empty before we start
@@ -140,7 +206,63 @@ class RecordMonitorTest extends IntegrationTest
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/48
      * @test
      */
-    public function canUseCorrectIndexingConfigurationForANewNonPagesRecord()
+    public function canUseCorrectIndexingConfigurationForANewNonPagesRecord(): void
+    {
+        $this->prepareCanUseCorrectIndexingConfigurationForANewNonPagesRecord();
+
+        // we expect to have an index queue item now
+        $this->assertNotEmptyIndexQueue();
+
+        // and we check that the record in the queue has the expected configuration name
+        $items = $this->indexQueue->getItems('tx_fakeextension_domain_model_foo', 8);
+        $this->assertSame(1, count($items));
+        $this->assertSame('foo', $items[0]->getIndexingConfigurationName(),
+            'Item was queued with unexpected configuration');
+    }
+
+    /**
+     * @test
+     */
+    public function canUseCorrectIndexingConfigurationForANewNonPagesRecordInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanUseCorrectIndexingConfigurationForANewNonPagesRecord();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        // we expect to have an index queue item now
+        $this->assertNotEmptyIndexQueue();
+
+        // and we check that the record in the queue has the expected configuration name
+        $items = $this->indexQueue->getItems('tx_fakeextension_domain_model_foo', 8);
+        $this->assertSame(1, count($items));
+        $this->assertSame('foo', $items[0]->getIndexingConfigurationName(),
+            'Item was queued with unexpected configuration');
+    }
+
+    /**
+     * @test
+     */
+    public function canIgnoreCorrectIndexingConfigurationForANewNonPagesRecordInNoProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 2);
+        $this->prepareCanUseCorrectIndexingConfigurationForANewNonPagesRecord();
+
+        $this->assertEmptyIndexQueue();
+
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - canUseCorrectIndexingConfigurationForANewNonPagesRecord
+     * - canUseCorrectIndexingConfigurationForANewNonPagesRecordInDelayedProcessingMode
+     * - canIgnoreCorrectIndexingConfigurationForANewNonPagesRecordInNoProcessingMode
+     */
+    protected function prepareCanUseCorrectIndexingConfigurationForANewNonPagesRecord(): void
     {
         // create fake extension database table and TCA
         $this->importExtTablesDefinition('fake_extension_table.sql');
@@ -163,23 +285,51 @@ class RecordMonitorTest extends IntegrationTest
 
         // we expect that the index queue is empty before we start
         $this->assertEmptyIndexQueue();
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
-            $this->dataHandler);
-
-        // we expect to have an index queue item now
-        $this->assertNotEmptyIndexQueue();
-
-        // and we check that the record in the queue has the expected configuration name
-        $items = $this->indexQueue->getItems('tx_fakeextension_domain_model_foo', 8);
-        $this->assertSame(1, count($items));
-        $this->assertSame('foo', $items[0]->getIndexingConfigurationName(),
-            'Item was queued with unexpected configuration');
+        $this->recordMonitor->processDatamap_afterDatabaseOperations(
+            $status,
+            $table,
+            $uid,
+            $fields,
+            $this->dataHandler
+        );
     }
 
     /**
      * @test
      */
-    public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved()
+    public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved(): void
+    {
+        $this->prepareCanQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved();
+
+        // we expect that all subpages of 1 and 1 its selft have been requeued but not more
+        // pages with uid 1, 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueueContainsItemAmount(3);
+    }
+
+    /**
+     * @test
+     */
+    public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemovedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        // we expect that all subpages of 1 and 1 its selft have been requeued but not more
+        // pages with uid 1, 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueueContainsItemAmount(3);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved and
+     * canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemovedInDelayedMode
+     */
+    protected function prepareCanQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved(): void
     {
         $this->importDataSetFromFixture('reindex_subpages_when_extendToSubpages_set_and_hidden_removed.xml');
 
@@ -193,16 +343,44 @@ class RecordMonitorTest extends IntegrationTest
 
         $dataHandler = $this->dataHandler;
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
-
-        // we expect that all subpages of 1 and 1 its selft have been requeued but not more
-        // pages with uid 1, 10 and 100 should be in index, but 11 not
-        $this->assertIndexQueueContainsItemAmount(3);
     }
 
     /**
      * @test
      */
-    public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved()
+    public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved(): void
+    {
+        $this->prepareCanQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved();
+
+        // we expect that all subpages of 1 have been requeued, but 1 not because it is still hidden
+        // pages with uid 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
+
+    /**
+     * @test
+     */
+    public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemovedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        // we expect that all subpages of 1 have been requeued, but 1 not because it is still hidden
+        // pages with uid 10 and 100 should be in index, but 11 not
+        $this->assertIndexQueueContainsItemAmount(2);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved and
+     * canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemovedInDelayedMode
+     */
+    protected function prepareCanQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved(): void
     {
         $this->importDataSetFromFixture('reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml');
 
@@ -214,18 +392,45 @@ class RecordMonitorTest extends IntegrationTest
         $connection->updateArray('pages', ['uid' => 1], ['extendToSubpages' => 0]);
         $changeSet = ['extendToSubpages' => 0];
 
-        $dataHandler = $this->dataHandler;
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
-
-        // we expect that all subpages of 1 have been requeued, but 1 not because it is still hidden
-        // pages with uid 10 and 100 should be in index, but 11 not
-        $this->assertIndexQueueContainsItemAmount(2);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $this->dataHandler);
     }
 
     /**
      * @test
      */
-    public function canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved()
+    public function canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved(): void
+    {
+        $this->prepareCanQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved();
+
+        // we expect that page 1 incl. subpages has been requeued
+        // pages with uid 10, 11 and 100 should be in index
+        $this->assertIndexQueueContainsItemAmount(3);
+    }
+
+    /**
+     * @test
+     */
+    public function canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemovedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        // we expect that page 1 incl. subpages has been requeued
+        // pages with uid 10, 11 and 100 should be in index
+        $this->assertIndexQueueContainsItemAmount(3);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved and
+     * canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemovedInDelayedMode
+     */
+    protected function prepareCanQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved(): void
     {
         $this->importDataSetFromFixture('reindex_subpages_when_hidden_and_extendToSubpage_flags_removed.xml');
 
@@ -237,18 +442,41 @@ class RecordMonitorTest extends IntegrationTest
         $connection->updateArray('pages', ['uid' => 1], ['extendToSubpages' => 0, 'hidden' => 0]);
         $changeSet = ['extendToSubpages' => 0, 'hidden' => 0];
 
-        $dataHandler = $this->dataHandler;
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
-
-        // we expect that page 1 incl. subpages has been requeued
-        // pages with uid 10, 11 and 100 should be in index
-        $this->assertIndexQueueContainsItemAmount(3);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $this->dataHandler);
     }
 
     /**
      * @test
      */
-    public function queueIsNotFilledWhenItemIsSetToHidden()
+    public function queueIsNotFilledWhenItemIsSetToHidden(): void
+    {
+        $this->prepareQueueIsNotFilledWhenItemIsSetToHidden();
+
+        // we assert that the index queue is still empty because the page was only set to hidden
+        $this->assertEmptyIndexQueue();
+    }
+    /**
+     * @test
+     */
+    public function queueIsNotFilledWhenItemIsSetToHiddenInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareQueueIsNotFilledWhenItemIsSetToHidden();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases queueIsNotFilledWhenItemIsSetToHidden and
+     * queueIsNotFilledWhenItemIsSetToHiddenInDelayedMode
+     */
+    protected function prepareQueueIsNotFilledWhenItemIsSetToHidden(): void
     {
         $this->importDataSetFromFixture('reindex_subpages_when_hidden_set_and_extendToSubpage_removed.xml');
 
@@ -261,39 +489,46 @@ class RecordMonitorTest extends IntegrationTest
 
         $changeSet = ['hidden' => 1];
 
-        $dataHandler = $this->dataHandler;
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $dataHandler);
-
-        // we assert that the index queue is still empty because the page was only set to hidden
-        $this->assertEmptyIndexQueue();
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 1, $changeSet, $this->dataHandler);
     }
 
     /**
-     * When a record without pid is processed an exception should be thrown.
+     * When a record without pid is processed a warning should be logged
      *
      * @test
      */
-    public function logMessageIsCreatedWhenRecordWithoutPidIsCreated()
+    public function logMessageIsCreatedWhenRecordWithoutPidIsCreated(): void
     {
         $loggerMock = $this->getMockBuilder(SolrLogManager::class)->setMethods([])->disableOriginalConstructor()->getMock();
 
         $expectedSeverity = SolrLogManager::WARNING;
-        $expectedMessage = 'Record without valid pid was processed tx_fakeextension_domain_model_foo:NEW566a9eac309d8193936351';
+        $expectedMessage = 'Record without valid pid was processed tt_content:123';
         $loggerMock->expects($this->once())->method('log')->with($expectedSeverity, $expectedMessage);
-        $this->recordMonitor->setLogger($loggerMock);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->substNEWwithIDs['NEW566a9eac309d8193936351'] = 123;
+        $dataUpdateHandler = GeneralUtility::makeInstance(
+            DataUpdateHandler::class,
+            GeneralUtility::makeInstance(ConfigurationAwareRecordService::class),
+            GeneralUtility::makeInstance(FrontendEnvironment::class),
+            GeneralUtility::makeInstance(TCAService::class),
+            GeneralUtility::makeInstance(Queue::class),
+            GeneralUtility::makeInstance(MountPagesUpdater::class),
+            GeneralUtility::makeInstance(RootPageResolver::class),
+            GeneralUtility::makeInstance(PagesRepository::class),
+            $dataHandler,
+            $loggerMock
+        );
+        GeneralUtility::addInstance(DataUpdateHandler::class, $dataUpdateHandler);
 
         // we expect that this exception is getting thrown, because a record without pid was updated
 
-        // create fake extension database table and TCA
-        $this->importExtTablesDefinition('fake_extension_table.sql');
-        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
-
         // create faked tce main call data
-        $status = 'update';
-        $table = 'tx_fakeextension_domain_model_foo';
+        $status = 'new';
+        $table = 'tt_content';
         $uid = 'NEW566a9eac309d8193936351';
         $fields = [
-            'title' => 'testnews',
+            'title' => 'testce',
             'starttime' => 1000000,
             'endtime' => 1100000,
             'tsstamp' => 1000000
@@ -304,7 +539,7 @@ class RecordMonitorTest extends IntegrationTest
         // we expect that the index queue is empty before we start
         $this->assertEmptyIndexQueue();
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
-            $this->dataHandler);
+            $dataHandler);
     }
 
     /**
@@ -312,7 +547,35 @@ class RecordMonitorTest extends IntegrationTest
      *
      * @test
      */
-    public function queueEntryIsRemovedWhenUnExistingRecordWasUpdated()
+    public function queueEntryIsRemovedWhenUnExistingRecordWasUpdated(): void
+    {
+        $this->prepareQueueEntryIsRemovedWhenUnExistingRecordWasUpdated();
+        // the queue entry should be removed since the record itself does not exist
+        $this->assertEmptyIndexQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function queueEntryIsRemovedWhenUnExistingRecordWasUpdatedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareQueueEntryIsRemovedWhenUnExistingRecordWasUpdated();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases queueEntryIsRemovedWhenUnExistingRecordWasUpdated and
+     * queueEntryIsRemovedWhenUnExistingRecordWasUpdatedInDelayedMode
+     */
+    protected function prepareQueueEntryIsRemovedWhenUnExistingRecordWasUpdated(): void
     {
         // create faked tce main call data
         $status = 'update';
@@ -333,16 +596,13 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        // the queue entry should be removed since the record itself does not exist
-        $this->assertEmptyIndexQueue();
     }
 
     /**
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/639
      * @test
      */
-    public function canUseCorrectIndexingConfigurationForANewCustomPageTypeRecord()
+    public function canUseCorrectIndexingConfigurationForANewCustomPageTypeRecord(): void
     {
         $this->importDataSetFromFixture('can_use_correct_indexing_configuration_for_a_new_custom_page_type_record.xml');
 
@@ -387,21 +647,9 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function canQueueUpdatePagesWithCustomPageType()
+    public function canQueueUpdatePagesWithCustomPageType(): void
     {
-        $this->importDataSetFromFixture('can_use_correct_indexing_configuration_for_a_new_custom_page_type_record.xml');
-
-        // we expect that the index queue is empty before we start
-        $this->assertEmptyIndexQueue();
-
-        // simulate the database change and build a faked changeset
-        $connection = $this->getDatabaseConnection();
-        $connection->updateArray('pages', ['uid' => 8], ['hidden' => 0]);
-
-        $changeSet = ['hidden' => 0];
-
-        $dataHandler = $this->dataHandler;
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 8, $changeSet, $dataHandler);
+        $this->prepareCanQueueUpdatePagesWithCustomPageType();
 
         // we expect to have an index queue item now
         $this->assertNotEmptyIndexQueue();
@@ -417,34 +665,65 @@ class RecordMonitorTest extends IntegrationTest
     }
 
     /**
-     *
-     *
      * @test
      */
-    public function mountPointIsOnlyAddedOnceForEachTree()
+    public function canQueueUpdatePagesWithCustomPageTypeInDelayedMode(): void
     {
-        $this->importDataSetFromFixture('mount_pages_are_added_once.xml');
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareCanQueueUpdatePagesWithCustomPageType();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertNotEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+
+        // and we check that the record in the queue has the expected configuration name
+        $items = $this->indexQueue->getItems('pages', 8);
+        $this->assertSame(1, count($items));
+        $this->assertSame(
+            'custom_page_type',
+            $items[0]->getIndexingConfigurationName(),
+            'Item was queued with unexpected configuration'
+        );
+    }
+
+    /**
+     * Prepares the test cases canQueueUpdatePagesWithCustomPageType and
+     * canQueueUpdatePagesWithCustomPageTypeInDelayedMode
+     */
+    protected function prepareCanQueueUpdatePagesWithCustomPageType(): void
+    {
+        $this->importDataSetFromFixture('can_use_correct_indexing_configuration_for_a_new_custom_page_type_record.xml');
+
+        // we expect that the index queue is empty before we start
         $this->assertEmptyIndexQueue();
 
-        $status = 'update';
-        $table = 'pages';
-        $uid = 40;
-        $fields = [
-            'title' => 'testpage',
-            'starttime' => 1000000,
-            'endtime' => 1100000,
-            'tsstamp' => 1000000,
-            'pid' => 4
-        ];
+        // simulate the database change and build a faked changeset
+        $connection = $this->getDatabaseConnection();
+        $connection->updateArray('pages', ['uid' => 8], ['hidden' => 0]);
 
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
-            $this->dataHandler);
+        $changeSet = ['hidden' => 0];
+
+        $dataHandler = $this->dataHandler;
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 8, $changeSet, $dataHandler);
+    }
+
+    /**
+     * @test
+     */
+    public function mountPointIsOnlyAddedOnceForEachTree(): void
+    {
+        $data = $this->prepareMountPointIsOnlyAddedOnceForEachTree();
 
         // we assert that the page is added twice, once for the original tree and once for the mounted tree
         $this->assertIndexQueueContainsItemAmount(2);
-        /* @var $indexQueue Queue */
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($data['status'], $data['table'], $data['uid'], $data['fields'],
             $this->dataHandler);
+
         // we assert that the page is added twice, once for the original tree and once for the mounted tree
         $this->assertIndexQueueContainsItemAmount(2);
     }
@@ -452,7 +731,98 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function localizedPageIsAddedToTheQueue()
+    public function mountPointIsOnlyAddedOnceForEachTreeInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $data = $this->prepareMountPointIsOnlyAddedOnceForEachTree();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(2);
+        $this->assertEmptyEventQueue();
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($data['status'], $data['table'], $data['uid'], $data['fields'],
+            $this->dataHandler);
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
+
+    /**
+     * Prepares the test cases mountPointIsOnlyAddedOnceForEachTree and
+     * mountPointIsOnlyAddedOnceForEachTreeInDelayedMode
+     *
+     * @return array
+     */
+    protected function prepareMountPointIsOnlyAddedOnceForEachTree(): array
+    {
+        $this->importDataSetFromFixture('mount_pages_are_added_once.xml');
+        $this->assertEmptyIndexQueue();
+
+        $data = [
+            'status' => 'update',
+            'table' => 'pages',
+            'uid' => 40,
+            'fields' => [
+                'title' => 'testpage',
+                'starttime' => 1000000,
+                'endtime' => 1100000,
+                'tsstamp' => 1000000,
+                'pid' => 4
+            ]
+        ];
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($data['status'], $data['table'], $data['uid'], $data['fields'],
+            $this->dataHandler);
+
+        return $data;
+    }
+
+    /**
+     * @test
+     */
+    public function localizedPageIsAddedToTheQueue(): void
+    {
+        $this->prepareLocalizedPageIsAddedToTheQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $firstQueueItem = $this->indexQueue->getItem(1);
+
+        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
+        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
+            'First queue item has unexpected indexingConfigurationName');
+    }
+
+    /**
+     * @test
+     */
+    public function localizedPageIsAddedToTheQueueInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareLocalizedPageIsAddedToTheQueue();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $firstQueueItem = $this->indexQueue->getItem(1);
+
+        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
+        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
+            'First queue item has unexpected indexingConfigurationName');
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases localizedPageIsAddedToTheQueue and
+     * localizedPageIsAddedToTheQueueInDelayedMode
+     */
+    protected function prepareLocalizedPageIsAddedToTheQueue(): void
     {
         $this->importDataSetFromFixture('localized_page_is_added_to_the_queue.xml');
         $this->assertEmptyIndexQueue();
@@ -468,20 +838,12 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $this->assertIndexQueueContainsItemAmount(1);
-        $firstQueueItem = $this->indexQueue->getItem(1);
-
-        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
-        $this->assertSame('pages', $firstQueueItem->getIndexingConfigurationName(),
-            'First queue item has unexpected indexingConfigurationName');
     }
-
 
     /**
      * @test
      */
-    public function queueItemStaysWhenOverlayIsSetToHidden()
+    public function queueItemStaysWhenOverlayIsSetToHidden(): void
     {
         $this->importDataSetFromFixture('queue_entry_stays_when_overlay_set_to_hidden.xml');
         $this->assertIndexQueueContainsItemAmount(1);
@@ -506,7 +868,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function localizedPageIsNotAddedToTheQueueWhenL10ParentIsHidden()
+    public function localizedPageIsNotAddedToTheQueueWhenL10ParentIsHidden(): void
     {
         $this->importDataSetFromFixture('localized_page_is_not_added_to_the_queue_when_parent_hidden.xml');
         $this->assertEmptyIndexQueue();
@@ -524,7 +886,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function pageIsQueueWhenContentElementIsChanged()
+    public function pageIsQueuedWhenContentElementIsChanged(): void
     {
         $this->importDataSetFromFixture('change_content_element.xml');
         $this->assertEmptyIndexQueue();
@@ -547,7 +909,36 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function pageIsQueueWhenTranslatedContentElementIsChanged()
+    public function pageIsQueuedWhenTranslatedContentElementIsChanged(): void
+    {
+        $this->preparePageIsQueuedWhenTranslatedContentElementIsChanged();
+        $firstQueueItem = $this->indexQueue->getItem(1);
+        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
+    }
+
+    /**
+     * @test
+     */
+    public function pageIsQueuedWhenTranslatedContentElementIsChangedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->preparePageIsQueuedWhenTranslatedContentElementIsChanged();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $firstQueueItem = $this->indexQueue->getItem(1);
+        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases pageIsQueuedWhenTranslatedContentElementIsChanged and
+     * pageIsQueuedWhenTranslatedContentElementIsChangedInDelayedMode
+     */
+    protected function preparePageIsQueuedWhenTranslatedContentElementIsChanged(): void
     {
         $this->importDataSetFromFixture('change_translated_content_element.xml');
         $this->assertEmptyIndexQueue();
@@ -562,15 +953,39 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $firstQueueItem = $this->indexQueue->getItem(1);
-        $this->assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
     }
 
     /**
      * @test
      */
-    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
+    {
+        $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForTitle();
+        $this->assertIndexQueueContainsItemAmount(5);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForTitle();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(5);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle and
+     * updateRootPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode
+     */
+    protected function prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -584,14 +999,12 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $this->assertIndexQueueContainsItemAmount(5);
     }
 
     /**
      * @test
      */
-    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -612,7 +1025,34 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle()
+    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
+    {
+        $this->prepareUpdateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle();
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle and
+     * updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode
+     */
+    protected function prepareUpdateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -626,14 +1066,39 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
+    }
 
+    /**
+     * @test
+     */
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
+    {
+        $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForDokType();
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
     /**
      * @test
      */
-    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokTypeInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForDokType();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType and
+     * updateRootPageWithRecursiveUpdateFieldsConfiguredForDokTypeInDelayedMode
+     */
+    protected function prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -647,14 +1112,12 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $this->assertIndexQueueContainsItemAmount(1);
     }
 
     /**
      * @test
      */
-    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -675,7 +1138,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType()
+    public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->importDataSetFromFixture('update_page_with_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -696,7 +1159,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateRootPageWithoutRecursiveUpdateFieldsConfigured()
+    public function updateRootPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -717,7 +1180,34 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateSubChildPageWithoutRecursiveUpdateFieldsConfigured()
+    public function updateSubChildPageWithoutRecursiveUpdateFieldsConfigured(): void
+    {
+        $this->prepareUpdateSubChildPageWithoutRecursiveUpdateFieldsConfigured();
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateSubChildPageWithoutRecursiveUpdateFieldsConfiguredInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateSubChildPageWithoutRecursiveUpdateFieldsConfigured();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateSubChildPageWithoutRecursiveUpdateFieldsConfigured and
+     * updateSubChildPageWithoutRecursiveUpdateFieldsConfiguredInDelayedMode
+     */
+    protected function prepareUpdateSubChildPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -731,14 +1221,12 @@ class RecordMonitorTest extends IntegrationTest
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $this->assertIndexQueueContainsItemAmount(1);
     }
 
     /**
      * @test
      */
-    public function updateSubSubChildPageWithoutRecursiveUpdateFieldsConfigured()
+    public function updateSubSubChildPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->importDataSetFromFixture('update_page_without_recursive_update_fields_configured.xml');
         $this->assertEmptyIndexQueue();
@@ -776,8 +1264,50 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
      * @test
+     *
+     * @param int $uid
+     * @param int $root
      */
-    public function updateRecordOutsideSiteRootWithAdditionalWhereClause($uid, $root)
+    public function updateRecordOutsideSiteRootWithAdditionalWhereClause(int $uid, int $root): void
+    {
+        $this->prepareUpdateRecordOutsideSiteRootWithAdditionalWhereClause($uid);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $firstQueueItem = $this->indexQueue->getItem(1);
+        $this->assertSame($uid, $firstQueueItem->getRecordUid());
+        $this->assertSame($root, $firstQueueItem->getRootPageUid());
+    }
+
+    /**
+     * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
+     * @test
+     *
+     * @param int $uid
+     * @param int $root
+     */
+    public function updateRecordOutsideSiteRootWithAdditionalWhereClauseInDelayedMode(int $uid, int $root): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateRecordOutsideSiteRootWithAdditionalWhereClause($uid);
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $firstQueueItem = $this->indexQueue->getItem(1);
+        $this->assertSame($uid, $firstQueueItem->getRecordUid());
+        $this->assertSame($root, $firstQueueItem->getRootPageUid());
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateRecordOutsideSiteRootWithAdditionalWhereClause and
+     * updateRecordOutsideSiteRootWithAdditionalWhereClauseInDelayedMode
+     *
+     * @param int $uid
+     */
+    protected function prepareUpdateRecordOutsideSiteRootWithAdditionalWhereClause(int $uid): void
     {
         $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
@@ -794,17 +1324,12 @@ class RecordMonitorTest extends IntegrationTest
             'pid' => 2
         ];
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
-        $this->assertIndexQueueContainsItemAmount(1);
-        $firstQueueItem = $this->indexQueue->getItem(1);
-        $this->assertSame($uid, $firstQueueItem->getRecordUid());
-        $this->assertSame($root, $firstQueueItem->getRootPageUid());
-
     }
 
     /**
      * @test
      */
-    public function updateRecordOutsideSiteRoot()
+    public function updateRecordOutsideSiteRoot(): void
     {
         $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
@@ -832,7 +1357,34 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateRecordOutsideSiteRootReferencedInTwoSites()
+    public function updateRecordOutsideSiteRootReferencedInTwoSites(): void
+    {
+        $this->prepareUpdateRecordOutsideSiteRootReferencedInTwoSites();
+        $this->assertIndexQueueContainsItemAmount(2);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRecordOutsideSiteRootReferencedInTwoSitesInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareUpdateRecordOutsideSiteRootReferencedInTwoSites();
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(2);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases updateRecordOutsideSiteRootReferencedInTwoSites and
+     * updateRecordOutsideSiteRootReferencedInTwoSitesInDelayedMode
+     */
+    protected function prepareUpdateRecordOutsideSiteRootReferencedInTwoSites(): void
     {
         $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
@@ -854,13 +1406,12 @@ class RecordMonitorTest extends IntegrationTest
         ];
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
-        $this->assertIndexQueueContainsItemAmount(2);
     }
 
     /**
      * @test
      */
-    public function updateRecordOutsideSiteRootLocatedInOtherSite()
+    public function updateRecordOutsideSiteRootLocatedInOtherSite(): void
     {
         $this->importExtTablesDefinition('fake_extension_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
@@ -888,7 +1439,7 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateRecordMonitoringTablesConfiguredDefault()
+    public function updateRecordMonitoringTablesConfiguredDefault(): void
     {
         $this->importDataSetFromFixture('update_page_use_configuration_monitor_tables.xml');
         $this->assertEmptyIndexQueue();
@@ -909,57 +1460,75 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
-    public function updateRecordMonitoringTablesConfiguredNotForTableBeingUpdated()
+    public function updateRecordMonitoringTablesConfiguredNotForTableBeingUpdated(): void
     {
-        $this->importDataSetFromFixture('update_page_use_configuration_monitor_tables.xml');
-        $this->assertEmptyIndexQueue();
-
-        $testConfig = [];
-        $testConfig['useConfigurationMonitorTables'] = 'tt_content';
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = $testConfig;
-
-        $status = 'update';
-        $table = 'pages';
-        $uid = 5;
-        $fields = [
-            'title' => 'Update updateRecordMonitoringTablesConfiguredNotForTableBeingUpdated'
-        ];
-
-        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
-            $this->dataHandler);
-
-        $testConfig = [];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = $testConfig;
-
+        $this->prepareupdateRecordMonitoringTablesTests('tt_content');
         $this->assertEmptyIndexQueue();
     }
 
     /**
      * @test
      */
-    public function updateRecordMonitoringTablesConfiguredForTableBeingUpdated()
+    public function updateRecordMonitoringTablesConfiguredNotForTableBeingUpdatedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->prepareupdateRecordMonitoringTablesTests('tt_content');
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function updateRecordMonitoringTablesConfiguredForTableBeingUpdated(): void
+    {
+        $this->prepareupdateRecordMonitoringTablesTests('pages, tt_content');
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRecordMonitoringTablesConfiguredForTableBeingUpdatedInDelayedMode(): void
+    {
+        $this->extensionConfiguration->set('solr', 'monitoringType', 1);
+        $this->assertEmptyIndexQueue();
+        $this->prepareupdateRecordMonitoringTablesTests('pages, tt_content');
+
+        $this->assertEmptyIndexQueue();
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->assertEmptyEventQueue();
+    }
+
+    /**
+     * Prepares the test cases:
+     * - updateRecordMonitoringTablesConfiguredNotForTableBeingUpdated
+     * - updateRecordMonitoringTablesConfiguredNotForTableBeingUpdatedInDelayedModed
+     * - updateRecordMonitoringTablesConfiguredForTableBeingUpdated
+     * - updateRecordMonitoringTablesConfiguredForTableBeingUpdatedInDelayedModed
+     *
+     * @param string $useConfigurationMonitorTables
+     */
+    protected function prepareupdateRecordMonitoringTablesTests(string $useConfigurationMonitorTables): void
     {
         $this->importDataSetFromFixture('update_page_use_configuration_monitor_tables.xml');
         $this->assertEmptyIndexQueue();
 
-        $testConfig = [];
-        $testConfig['useConfigurationMonitorTables'] = 'pages, tt_content';
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = $testConfig;
+        $this->extensionConfiguration->set('solr', 'useConfigurationMonitorTables', $useConfigurationMonitorTables);
 
         $status = 'update';
         $table = 'pages';
         $uid = 5;
         $fields = [
-            'title' => 'Update updateRecordMonitoringTablesConfiguredForTableBeingUpdated'
+            'title' => 'Lorem ipsum dolor sit amet'
         ];
 
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields,
             $this->dataHandler);
-
-        $testConfig = [];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = $testConfig;
-
-        $this->assertIndexQueueContainsItemAmount(1);
     }
 
     /**
@@ -967,7 +1536,7 @@ class RecordMonitorTest extends IntegrationTest
      *
      * @test
      */
-    public function canCreateSiteOneRootLevel()
+    public function canCreateSiteOneRootLevel(): void
     {
         $this->importDataSetFromFixture('can_create_new_page.xml');
         $this->setUpBackendUserFromFixture(1);
@@ -986,7 +1555,7 @@ class RecordMonitorTest extends IntegrationTest
      *
      * @test
      */
-    public function canCreateSubPageBelowSiteRoot()
+    public function canCreateSubPageBelowSiteRoot(): void
     {
         $this->importDataSetFromFixture('can_create_new_page.xml');
         $this->setUpBackendUserFromFixture(1);
@@ -998,5 +1567,18 @@ class RecordMonitorTest extends IntegrationTest
 
         // we should have one item in the solr queue
         $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
+     * Triggers event queue processing
+     */
+    protected function processEventQueue(): void
+    {
+        /** @var EventQueueWorkerTask $task */
+        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
+
+        /** @var Scheduler $scheduler */
+        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler->executeTask($task);
     }
 }

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -50,7 +50,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Http\RequestHandler;
-use TYPO3\CMS\Frontend\Page\PageGenerator;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use function getenv;
 

--- a/Tests/Integration/TSFETestBootstrapper.php
+++ b/Tests/Integration/TSFETestBootstrapper.php
@@ -2,24 +2,15 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
-use ApacheSolrForTypo3\Solr\Util;
-use Composer\Autoload\ClassLoader;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Routing\PageArguments;
-use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
-use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
-use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\Utility\EidUtility;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Http\ServerRequest;
-use TYPO3\CMS\Frontend\Http\RequestHandler;
 
 /**
  * Class TSFETestBootstrapper
@@ -27,64 +18,6 @@ use TYPO3\CMS\Frontend\Http\RequestHandler;
  */
 class TSFETestBootstrapper
 {
-    /**
-     * @deprecated this code can be dropped when TYPO3 9 support will be dropped
-     * @return TSFEBootstrapResult
-     */
-    public function legacyBootstrap($pageId = 1, $MP = '', $language = 0)
-    {
-        $result = new TSFEBootstrapResult();
-
-        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-        $request = GeneralUtility::makeInstance(ServerRequest::class);
-
-        $site = null;
-        $siteLanguage = null;
-        if ($pageId !== null) {
-            try {
-                $site = $siteFinder->getSiteByPageId($pageId);
-                $siteLanguage = $site->getLanguageById($language);
-                $request = $request->withAttribute('site', $site);
-                $request = $request->withAttribute('language', $siteLanguage);
-            } catch (SiteNotFoundException $e) {
-            }
-        }
-
-        $GLOBALS['TYPO3_REQUEST'] = $request;
-
-        /** @var $TSFE \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController */
-        $TSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class, [], $pageId, 0, '', '', null, $MP);
-        $TSFE->set_no_cache();
-        $GLOBALS['TSFE'] = $TSFE;
-
-
-        EidUtility::initLanguage();
-        $TSFE->initFEuser();
-        $TSFE->checkAlternativeIdMethods();
-
-        $TSFE->id = $pageId;
-        $TSFE->clear_preview();
-
-        try {
-            $TSFE->determineId();
-        } catch (\TYPO3\CMS\Core\Http\ImmediateResponseException $e) {
-            $result->addExceptions($e);
-        }
-
-        $TSFE->getConfigArray();
-
-        Bootstrap::getInstance();
-
-        // only needed for FrontendGroupRestriction.php
-        $GLOBALS['TSFE']->gr_list =  $TSFE->gr_list;
-        $TSFE->settingLanguage();
-        $TSFE->settingLocale();
-
-        $result->setTsfe($TSFE);
-
-        return $result;
-    }
-
     /**
      * @return TSFEBootstrapResult
      */

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Scheduler\Scheduler;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+
+/**
+ * Test case to check if the scheduler task EventQueueWorkerTask can process
+ * event queue entries
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class EventQueueWorkerTaskTest extends IntegrationTest
+{
+    /**
+     * @var array
+     */
+    protected $coreExtensionsToLoad = [
+        'extensionmanager',
+        'scheduler'
+    ];
+
+    /**
+     * @var EventQueueItemRepository
+     */
+    protected $eventQueue;
+
+    /**
+     * @var Queue
+     */
+    protected $indexQueue;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
+        $this->eventQueue = GeneralUtility::makeInstance(EventQueueItemRepository::class);
+
+        /** @var ExtensionConfiguration $task */
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $extConf->set('solr', 'monitoringType', 1);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->indexQueue);
+        unset($this->eventQueue);
+        unset($GLOBALS['TYPO3_CONF_VARS']);
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function canProcessEventQueueItems(): void
+    {
+        $this->importDataSetFromFixture('can_process_event_queue.xml');
+        $this->eventQueue->addEventToQueue(new RecordUpdatedEvent(1, 'tt_content'));
+
+        /** @var EventQueueWorkerTask $task */
+        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
+
+        /** @var Scheduler $scheduler */
+        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler->executeTask($task);
+
+        $this->assertEquals(1, $this->indexQueue->getAllItemsCount());
+        $this->assertEmpty($this->eventQueue->getEventQueueItems(null, false));
+    }
+
+    /**
+     * @test
+     */
+    public function canHandleErroneousEventQueueItems(): void
+    {
+        $this->importDataSetFromFixture('can_handle_erroneous_event_queue_items.xml');
+
+        /** @var EventQueueWorkerTask $task */
+        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
+
+        /** @var Scheduler $scheduler */
+        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler->executeTask($task);
+
+        $this->assertEquals(0, $this->indexQueue->getAllItemsCount());
+        $this->assertEmpty($this->eventQueue->getEventQueueItems());
+        $queueItems = $this->eventQueue->getEventQueueItems(null, false);
+        $this->assertEquals(1, count($queueItems));
+        $this->assertEquals(1, $queueItems[0]['error']);
+        $this->assertNotEmpty($queueItems[0]['error_message']);
+    }
+}

--- a/Tests/Integration/Task/Fixtures/can_handle_erroneous_event_queue_items.xml
+++ b/Tests/Integration/Task/Fixtures/can_handle_erroneous_event_queue_items.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+				page = PAGE
+				page.typeNum = 0
+				page.bodyTag = <body>
+
+				plugin.tx_solr {
+					enabled = 1
+
+					index {
+						fieldProcessingInstructions {
+							changed = timestampToIsoDate
+							created = timestampToIsoDate
+							endtime = timestampToUtcIsoDate
+							rootline = pageUidToHierarchy
+						}
+
+						queue {
+
+							// mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+								// allowed page types (doktype) when indexing records from table "pages"
+								allowedPageTypes = 1,7
+
+								indexingPriority = 0
+
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+								indexer {
+									// add options for the indexer here
+								}
+
+								// Only index standard pages and mount points that are not overlayed.
+								additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+								fields {
+									sortSubTitle_stringS = subtitle
+								}
+							}
+
+						}
+					}
+				}
+			]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<title>Rootpage</title>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<title>Childpage</title>
+	</pages>
+	<tx_solr_eventqueue_item>
+		<uid>1</uid>
+		<tstamp>1641888246</tstamp>
+		<event>O:8:"stdClass":0:{}</event>
+	</tx_solr_eventqueue_item>
+</dataset>

--- a/Tests/Integration/Task/Fixtures/can_process_event_queue.xml
+++ b/Tests/Integration/Task/Fixtures/can_process_event_queue.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_template>
+		<uid>1</uid>
+		<pid>1</pid>
+		<root>1</root>
+		<clear>3</clear>
+		<config>
+			<![CDATA[
+				page = PAGE
+				page.typeNum = 0
+				page.bodyTag = <body>
+
+				plugin.tx_solr {
+					enabled = 1
+
+					index {
+						fieldProcessingInstructions {
+							changed = timestampToIsoDate
+							created = timestampToIsoDate
+							endtime = timestampToUtcIsoDate
+							rootline = pageUidToHierarchy
+						}
+
+						queue {
+
+							// mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
+
+							pages = 1
+							pages {
+								initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
+
+								// allowed page types (doktype) when indexing records from table "pages"
+								allowedPageTypes = 1,7
+
+								indexingPriority = 0
+
+								indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
+								indexer {
+									// add options for the indexer here
+								}
+
+								// Only index standard pages and mount points that are not overlayed.
+								additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+
+								fields {
+									sortSubTitle_stringS = subtitle
+								}
+							}
+
+						}
+					}
+				}
+			]]>
+		</config>
+		<sorting>100</sorting>
+	</sys_template>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<title>Rootpage</title>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<title>Childpage</title>
+	</pages>
+	<tt_content>
+		<uid>1</uid>
+		<pid>10</pid>
+		<CType>text</CType>
+		<bodytext>Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</bodytext>
+		<colPos>0</colPos>
+	</tt_content>
+</dataset>

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -29,17 +29,14 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Charset\CharsetConverter;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Lang\LanguageService;
 
 /**
  * TestCase to check if we can indexer from a index queue worker task into a solr server
  *
  * @author Timo Schmidt
  */
-class IndexQueueWorkerTest extends IntegrationTest
+class IndexQueueWorkerTaskTest extends IntegrationTest
 {
     /**
      * @var Queue

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -33,7 +33,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use Dkd\DkdReports\Reports\Status;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use PHPUnit\Framework\MockObject\MockObject;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use TYPO3\CMS\Core\Database\QueryGenerator;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+
+/**
+ * Abstract testcase for the update handlers
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+abstract class AbstractUpdateHandlerTest extends UnitTest
+{
+    /**
+     * @var ConfigurationAwareRecordService|MockObject
+     */
+    protected $recordServiceMock;
+
+    /**
+     * @var FrontendEnvironment|MockObject
+     */
+    protected $frontendEnvironmentMock;
+
+    /**
+     * @var TypoScriptConfiguration|MockObject
+     */
+    protected $typoScriptConfigurationMock;
+
+    /**
+     * @var TCAService|MockObject
+     */
+    protected $tcaServiceMock;
+
+    /**
+     * @var Queue|MockObject
+     */
+    protected $indexQueueMock;
+
+    /**
+     * @var QueryGenerator|MockObject
+     */
+    protected $queryGeneratorMock;
+
+    public function setUp(): void
+    {
+        $this->recordServiceMock = $this->createMock(ConfigurationAwareRecordService::class);
+        $this->frontendEnvironmentMock = $this->createMock(FrontendEnvironment::class);
+        $this->tcaServiceMock = $this->createMock(TCAService::class);
+        $this->indexQueueMock = $this->createMock(Queue::class);
+
+        $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->frontendEnvironmentMock
+            ->expects($this->any())
+            ->method('getSolrConfigurationFromPageId')
+            ->willReturn($this->typoScriptConfigurationMock);
+
+        $this->queryGeneratorMock = $this->createMock(QueryGenerator::class);
+
+        GeneralUtility::addInstance(QueryGenerator::class, $this->queryGeneratorMock);
+    }
+
+    public function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        unset($GLOBALS['TCA']);
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -1,0 +1,990 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Doctrine\DBAL\Driver\Statement;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+
+/**
+ * Testcase for the DataUpdateHandler class.
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
+{
+    private const DUMMY_PAGE_ID = 10;
+
+    /**
+     * @var DataUpdateHandler
+     */
+    protected $dataUpdateHandler;
+
+    /**
+     * @var MountPagesUpdater|MockObject
+     */
+    protected $mountPagesUpdaterMock;
+
+    /**
+     * @var RootPageResolver|MockObject
+     */
+    protected $rootPageResolverMock;
+
+    /**
+     * @var PagesRepository|MockObject
+     */
+    protected $pagesRepositoryMock;
+
+    /**
+     * @var DataHandler|MockObject
+     */
+    protected $dataHandlerMock;
+
+    /**
+     * @var SolrLogManager|MockObject
+     */
+    protected $solrLogManagerMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mountPagesUpdaterMock = $this->createMock(MountPagesUpdater::class);
+        $this->rootPageResolverMock = $this->createMock(RootPageResolver::class);
+        $this->pagesRepositoryMock = $this->createMock(PagesRepository::class);
+        $this->dataHandlerMock = $this->createMock(DataHandler::class);
+        $this->loggerMock = $this->createMock(SolrLogManager::class);
+
+        $this->dataUpdateHandler = new DataUpdateHandler(
+            $this->recordServiceMock,
+            $this->frontendEnvironmentMock,
+            $this->tcaServiceMock,
+            $this->indexQueueMock,
+            $this->mountPagesUpdaterMock,
+            $this->rootPageResolverMock,
+            $this->pagesRepositoryMock,
+            $this->dataHandlerMock,
+            $this->loggerMock
+        );
+
+        $this->dataHandlerMock
+            ->expects($this->any())
+            ->method('getPID')
+            ->willReturn(self::DUMMY_PAGE_ID);
+    }
+
+    /**
+     * Init the rootPageResolverMock to simulate a valid
+     * root page (self::DUMMY_PAGE_ID)
+     */
+    protected function initRootPageResolverforValidDummyRootPage(): void
+    {
+        $this->rootPageResolverMock
+            ->expects($this->any())
+            ->method('getRootPageId')
+            ->willReturn(self::DUMMY_PAGE_ID);
+
+        $this->rootPageResolverMock
+            ->expects($this->any())
+            ->method('getIsRootPageId')
+            ->willReturn(true);
+
+        $this->rootPageResolverMock
+            ->expects($this->any())
+            ->method('getResponsibleRootPageIds')
+            ->willReturn([self::DUMMY_PAGE_ID]);
+    }
+
+    /**
+     * @test
+     */
+    public function handleContentElementUpdateTriggersSinglePageProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page on which dummy ce is placed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('deleteItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('pages')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyPageRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isLocalizedRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(false);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->with(
+                'pages',
+                $dummyPageRecord,
+                $dummyPageRecord['uid']
+            )
+            ->willReturn($dummyPageRecord['uid']);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(true);
+
+        $this->inject($this->dataUpdateHandler, 'updateSubPagesRecursiveTriggerConfiguration', []);
+        $this->dataUpdateHandler->handleContentElementUpdate(123);
+    }
+
+    /**
+     * @test
+     */
+    public function handleContentElementUpdateTriggersInvalidPageProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'invalid page on which dummy ce is placed',
+            'sys_language_uid' => 0
+        ];
+
+        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
+        $garbageHandlerMock
+            ->expects($this->once())
+            ->method('collectGarbage')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('containsItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            )
+            ->willReturn(true);
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('pages')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn([]);
+
+        $this->inject($this->dataUpdateHandler, 'updateSubPagesRecursiveTriggerConfiguration', []);
+        $this->dataUpdateHandler->handleContentElementUpdate(123);
+    }
+
+    /**
+     * @test
+     */
+    public function handleContentElementDeletionTriggersPageUpdate(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->expects($this->any())->method('getPropertyFromAspect')->willReturn(1641472388);
+        GeneralUtility::setSingletonInstance(Context::class, $contextMock);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with(
+                'pages',
+                self::DUMMY_PAGE_ID,
+                1641472388
+            )
+            ->willReturn(true);
+
+        $this->dataUpdateHandler->handleContentElementDeletion(123);
+    }
+
+    /**
+     * @test
+     */
+    public function handlePageUpdateTriggersSinglePageProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->initBasicPageUpdateExpectations($dummyPageRecord);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+
+        $this->inject($this->dataUpdateHandler, 'updateSubPagesRecursiveTriggerConfiguration', []);
+        $this->dataUpdateHandler->handlePageUpdate($dummyPageRecord['uid']);
+    }
+
+    /**
+     * Init basic page update expectations
+     *
+     * @param array $dummyPageRecord
+     */
+    protected function initBasicPageUpdateExpectations(array $dummyPageRecord): void
+    {
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('deleteItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('pages')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyPageRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isLocalizedRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(false);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->with(
+                'pages',
+                $dummyPageRecord,
+                $dummyPageRecord['uid']
+            )
+            ->willReturn($dummyPageRecord['uid']);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(true);
+    }
+
+    /**
+     * @test
+     */
+    public function handlePageUpdateTriggersRecursivePageProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0,
+            'extendToSubpages' => 1
+        ];
+
+        $GLOBALS['TCA']['pages'] = ['columns' => []];
+
+        $this->queryGeneratorMock
+            ->expects($this->any())
+            ->method('getTreeList')
+            ->willReturn($dummyPageRecord['uid'] . ',100,200');
+
+        $statementMock = $this->createMock(Statement::class);
+        $statementMock->expects($this->once())->method('fetch')->willReturn($dummyPageRecord);
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects($this->once())->method('execute')->willReturn($statementMock);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->expects($this->any())->method('getExpressionBuilder')->willReturn($this->createMock(ExpressionBuilder::class));
+
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->expects($this->once())->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        $connectionPoolMock->expects($this->once())->method('getConnectionForTable')->willReturn($connectionMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+
+        $this->initBasicPageUpdateExpectations($dummyPageRecord);
+
+        $this->indexQueueMock
+            ->expects($this->exactly(3))
+            ->method('updateItem')
+            ->withConsecutive(
+                [
+                    'pages',
+                    $dummyPageRecord['uid']
+                ],
+                [
+                    'pages',
+                    100
+                ],
+                [
+                    'pages',
+                    200
+                ]
+            );
+
+        $this->dataUpdateHandler->handlePageUpdate($dummyPageRecord['uid'], ['hidden' => 0]);
+    }
+
+    /**
+     * Tests if the processing of a page with no connection to a valid root page
+     * triggers just the mount page updater
+     *
+     * @test
+     */
+    public function handlePageUpdateTriggersUnconnectedPageProcessing(): void
+    {
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->rootPageResolverMock
+            ->expects($this->once())
+            ->method('getAlternativeSiteRootPagesIds')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $dummyPageRecord['uid']
+            )
+            ->willReturn([]);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->frontendEnvironmentMock
+            ->expects($this->never())
+            ->method('getSolrConfigurationFromPageId');
+
+        $this->dataUpdateHandler->handlePageUpdate($dummyPageRecord['uid']);
+    }
+
+    /**
+     * @test
+     */
+    public function handleRecordUpdateTriggersRecordProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('tx_foo_bar')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyRecord);
+
+        $this->indexQueueMock
+            ->expects($this->never())
+            ->method('deleteItem');
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isLocalizedRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord
+            )
+            ->willReturn(false);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord,
+                $dummyRecord['uid']
+            )
+            ->willReturn($dummyRecord['uid']);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord
+            )
+            ->willReturn(true);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            );
+
+        $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
+    }
+
+    /**
+     * Tests if the processing of a record that couldn't be found in database
+     * triggers the removal from index and queue
+     *
+     * @test
+     */
+    public function handleRecordUpdateTriggersInvalidRecordProcessing(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
+        $garbageHandlerMock
+            ->expects($this->once())
+            ->method('collectGarbage')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            );
+        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('tx_foo_bar')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn([]);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('containsItem')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            )
+            ->willReturn(true);
+
+        $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
+    }
+
+    /**
+     * @test
+     */
+    public function handleRecordUpdateTriggersMultipleRootPagesRecordProcessing(): void
+    {
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $this->rootPageResolverMock
+            ->expects($this->once())
+            ->method('getResponsibleRootPageIds')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            )
+            ->willReturn([self::DUMMY_PAGE_ID, 20]);
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->exactly(2))
+            ->method('getIndexQueueIsMonitoredTable')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->exactly(2))
+            ->method('getRecord')
+            ->willReturn($dummyRecord);
+
+        $this->indexQueueMock
+            ->expects($this->never())
+            ->method('deleteItem');
+
+        $this->tcaServiceMock
+            ->expects($this->exactly(2))
+            ->method('isLocalizedRecord')
+            ->willReturn(false);
+
+        $this->tcaServiceMock
+            ->expects($this->exactly(2))
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->willReturn($dummyRecord['uid']);
+
+        $this->tcaServiceMock
+            ->expects($this->exactly(2))
+            ->method('isEnabledRecord')
+            ->willReturn(true);
+
+        $this->indexQueueMock
+            ->expects($this->exactly(2))
+            ->method('updateItem');
+
+        $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
+    }
+
+    /**
+     * @test
+     */
+    public function handleVersionSwapAppliesPageChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyPageRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(true);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('pages', $dummyPageRecord['uid']);
+
+        $this->dataUpdateHandler->handleVersionSwap($dummyPageRecord['uid'], 'pages');
+    }
+
+    /**
+     * @test
+     */
+    public function handleVersionSwapAppliesContentElementChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecordId = 123;
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyPageRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(true);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('pages', $dummyPageRecord['uid']);
+
+        $this->dataUpdateHandler->handleVersionSwap($dummyRecordId, 'tt_content');
+    }
+
+    /**
+     * @test
+     */
+    public function handleVersionSwapAppliesInvalidPageChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'invalid dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn([]);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('containsItem')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            )
+            ->willReturn(true);
+
+        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
+        $garbageHandlerMock
+            ->expects($this->once())
+            ->method('collectGarbage')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid']
+            );
+        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
+
+        $this->dataUpdateHandler->handleVersionSwap($dummyPageRecord['uid'], 'pages');
+    }
+
+    /**
+     * @test
+     */
+    public function handleVersionSwapAppliesRecordChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('tx_foo_bar')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord
+            )
+            ->willReturn(true);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord,
+                $dummyRecord['uid']
+            )
+            ->willReturn($dummyRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('tx_foo_bar', $dummyRecord['uid']);
+
+        $this->dataUpdateHandler->handleVersionSwap($dummyRecord['uid'], 'tx_foo_bar');
+    }
+
+    /**
+     * @test
+     */
+    public function handleVersionSwapAppliesInvalidRecordChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('tx_foo_bar')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+        ->expects($this->once())
+        ->method('getRecord')
+        ->with(
+            'tx_foo_bar',
+            $dummyRecord['uid'],
+            $this->typoScriptConfigurationMock
+        )
+        ->willReturn([]);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('containsItem')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            )
+            ->willReturn(true);
+
+        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
+        $garbageHandlerMock
+            ->expects($this->once())
+            ->method('collectGarbage')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid']
+            );
+        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
+
+        $this->dataUpdateHandler->handleVersionSwap($dummyRecord['uid'], 'tx_foo_bar');
+    }
+
+
+    /**
+     * @test
+     */
+    public function handleMovedPageAppliesPageChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyPageRecord = [
+            'uid' => self::DUMMY_PAGE_ID,
+            'title' => 'dummy page to be processed',
+            'sys_language_uid' => 0
+        ];
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyPageRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'pages',
+                $dummyPageRecord
+            )
+            ->willReturn(true);
+
+        $this->mountPagesUpdaterMock
+            ->expects($this->once())
+            ->method('update')
+            ->with($dummyPageRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('pages', $dummyPageRecord['uid']);
+
+        $this->dataUpdateHandler->handleMovedPage($dummyPageRecord['uid']);
+    }
+
+    /**
+     * @test
+     */
+    public function handleMovedRecordAppliesRecordChangesToQueue(): void
+    {
+        $this->initRootPageResolverforValidDummyRootPage();
+        $dummyRecord = [
+            'uid' => 789,
+            'pid' => self::DUMMY_PAGE_ID
+        ];
+
+        $this->typoScriptConfigurationMock
+            ->expects($this->once())
+            ->method('getIndexQueueIsMonitoredTable')
+            ->with('tx_foo_bar')
+            ->willReturn(true);
+
+        $this->recordServiceMock
+            ->expects($this->once())
+            ->method('getRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord['uid'],
+                $this->typoScriptConfigurationMock
+            )
+            ->willReturn($dummyRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnabledRecord')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord
+            )
+            ->willReturn(true);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getTranslationOriginalUidIfTranslated')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord,
+                $dummyRecord['uid']
+            )
+            ->willReturn($dummyRecord['uid']);
+
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('tx_foo_bar', $dummyRecord['uid']);
+
+        $this->dataUpdateHandler->handleMovedRecord($dummyRecord['uid'], 'tx_foo_bar');
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/AbstractEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/AbstractEventListenerTest.php
@@ -1,0 +1,132 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Abstract testcase for the event listeners
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+abstract class AbstractEventListenerTest extends UnitTest
+{
+    private const MONITORING_TYPES_TO_TEST = [0,1,2,99];
+
+    /**
+     * @var AbstractBaseEventListener
+     */
+    protected $listener;
+
+    /**
+     * @var MockObject|ExtensionConfiguration
+     */
+    protected $extensionConfigurationMock;
+
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    protected $eventDispatcherMock;
+
+    public function setUp(): void
+    {
+        $this->extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->listener = $this->initListener();
+    }
+
+    public function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+    }
+
+    /**
+     * Init listener
+     *
+     * @return AbstractBaseEventListener
+     */
+    abstract protected function initListener(): AbstractBaseEventListener;
+
+    /**
+     * @test
+     */
+    public function canIndicateActiveMonitoring(): void
+    {
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn($this->getMonitoringType());
+
+        $status = $this->callInaccessibleMethod($this->listener, 'isProcessingEnabled');
+        $this->assertTrue($status);
+    }
+
+    /**
+     * @param int $currentType
+     *
+     * @test
+     * @dataProvider inactiveMonitoringDataProvider
+     */
+    public function canIndicateInactiveMonitoring(int $currentType): void
+    {
+        $this->extensionConfigurationMock
+        ->expects($this->once())
+        ->method('getMonitoringType')
+        ->willReturn($currentType);
+
+        $status = $this->callInaccessibleMethod($this->listener, 'isProcessingEnabled');
+        $this->assertFalse($status);
+    }
+
+    /**
+     * Data provider for canIndicateInactiveMonitoring
+     */
+    public function inactiveMonitoringDataProvider(): array
+    {
+        $invalidTypes = array_diff(
+            self::MONITORING_TYPES_TO_TEST,
+            [$this->getMonitoringType()]
+        );
+
+        $testData = [];
+        foreach ($invalidTypes as $type) {
+            $testData[] = [$type];
+        }
+
+        return $testData;
+    }
+
+    /**
+     * Returns the current monitoring type
+     *
+     * @return int
+     */
+    abstract protected function getMonitoringType(): int;
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\DelayedProcessingEventListener;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+
+/**
+ * Testcase for the DelayedProcessingEventListener
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class DelayedProcessingEventListenerTest extends AbstractEventListenerTest
+{
+    /**
+     * @test
+     */
+    public function canHandleEvents(): void {
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn(1);
+
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+
+        $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('addEventToQueue')
+            ->with($event);
+        GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
+
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+
+        $this->listener->__invoke($event);
+        $this->assertTrue($dispatchedEvent instanceof DelayedProcessingQueuingFinishedEvent);
+        $this->assertEquals($event, $dispatchedEvent->getDataUpdateEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function canSkipEventHandlingIfDisabled(): void {
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn(2);
+
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+
+        $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
+        $eventQueueItemRepositoryMock
+            ->expects($this->never())
+            ->method('addEventToQueue');
+        GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
+
+        $this->eventDispatcherMock
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->listener->__invoke($event);
+    }
+
+    /**
+     * Init listener
+     *
+     * @return AbstractBaseEventListener
+     */
+    protected function initListener(): AbstractBaseEventListener
+    {
+        return new DelayedProcessingEventListener($this->extensionConfigurationMock, $this->eventDispatcherMock);
+    }
+
+    /**
+     * Returns the current monitoring type
+     *
+     * @return int
+     */
+    protected function getMonitoringType(): int
+    {
+        return DelayedProcessingEventListener::MONITORING_TYPE;
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEventTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEventInterface;
+
+/**
+ * Abstract testcase for the processing finished events
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+abstract class AbstractProcessingFinishedEventTest extends UnitTest
+{
+    /**
+     * @test
+     */
+    public function canSetAndReturnProcessedEvent(): void
+    {
+        $processedEvent = new RecordUpdatedEvent(123, 'tx_foo_bar');
+
+        /** @var ProcessingFinishedEventInterface $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass($processedEvent);
+
+        $this->assertEquals($processedEvent, $event->getDataUpdateEvent());
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingFinishedEvent;
+
+/**
+ * Testcase for the DelayedProcessingFinishedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class DelayedProcessingFinishedEventTest extends AbstractProcessingFinishedEventTest
+{
+    protected const EVENT_CLASS = DelayedProcessingFinishedEvent::class;
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
+
+/**
+ * Testcase for the DelayedProcessingQueuingFinishedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class DelayedProcessingQueuingFinishedEventTest extends AbstractProcessingFinishedEventTest
+{
+    protected const EVENT_CLASS = DelayedProcessingQueuingFinishedEvent::class;
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEvent;
+
+/**
+ * Testcase for the ProcessingFinishedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class ProcessingFinishedEventTest extends AbstractProcessingFinishedEventTest
+{
+    protected const EVENT_CLASS = ProcessingFinishedEvent::class;
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
@@ -1,0 +1,183 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\ImmediateProcessingEventListener;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+
+/**
+ * Testcase for the ImmediateProcessingEventListener
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class ImmediateProcessingEventListenerTest extends AbstractEventListenerTest
+{
+    /**
+     * @param string $eventClass
+     * @param string $handlerClass
+     * @param array $eventArguments
+     * @param bool $eventHandled
+     *
+     * @test
+     * @dataProvider canHandleEventsDataProvider
+     */
+    public function canHandleEvents(
+        string $eventClass,
+        string $handlerClass,
+        array $eventArguments,
+        bool $eventHandled
+    ): void {
+
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn(0);
+
+        /** @var DataUpdateEventInterface $event */
+        $event = new $eventClass(...$eventArguments);
+        $this->checkEventHandling($event, $handlerClass, $eventHandled);
+    }
+
+    /**
+     * @param string $eventClass
+     * @param string $handlerClass
+     * @param array $eventArguments
+     * @param bool $eventHandled
+     *
+     * @test
+     * @dataProvider canHandleEventsDataProvider
+     */
+    public function canHandleEventsIfHandlingInactiveButForced(
+        string $eventClass,
+        string $handlerClass,
+        array $eventArguments,
+        bool $eventHandled
+        ): void {
+
+        $this->extensionConfigurationMock
+            ->expects($this->any())
+            ->method('getMonitoringType')
+            ->willReturn(2);
+
+        /** @var DataUpdateEventInterface $event */
+        $event = new $eventClass(...$eventArguments);
+        $event->setForceImmediateProcessing(true);
+        $this->checkEventHandling($event, $handlerClass, $eventHandled);
+    }
+
+    /**
+     * Checks the event handling
+     *
+     * @param DataUpdateEventInterface $event
+     * @param bool $eventHandled
+     */
+    protected function checkEventHandling(
+        DataUpdateEventInterface $event,
+        string $handlerClass,
+        bool $eventHandled
+    ): void {
+        $handlerMock = $this->createMock($handlerClass);
+        GeneralUtility::addInstance($handlerClass, $handlerMock);
+
+        $dispatchedEvent = null;
+        if ($eventHandled) {
+            $this->eventDispatcherMock
+                ->expects($this->once())
+                ->method('dispatch')
+                ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                    $dispatchedEvent = func_get_arg(0);
+                }));
+        } else {
+            $this->eventDispatcherMock
+                ->expects($this->never())
+                ->method('dispatch');
+        }
+
+        $this->listener->__invoke($event);
+        if ($eventHandled) {
+            $this->assertTrue($dispatchedEvent instanceof ProcessingFinishedEvent);
+            $this->assertEquals($dispatchedEvent->getDataUpdateEvent(), $event);
+            $this->assertTrue($dispatchedEvent->getDataUpdateEvent()->isPropagationStopped());
+        }
+    }
+
+    /**
+     * Data provider for canDispatchEvents
+     *
+     * @return array
+     */
+    public function canHandleEventsDataProvider(): array
+    {
+        if (!class_exists('SolrUnitTestsInvalidDataUpdateEvent')) {
+            eval(
+                'use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;'
+                . 'class SolrUnitTestsInvalidDataUpdateEvent extends ContentElementDeletedEvent {}'
+            );
+        }
+
+        return [
+            [ContentElementDeletedEvent::class, DataUpdateHandler::class, [1], true],
+            [VersionSwappedEvent::class, DataUpdateHandler::class, [1, 'pages'], true],
+            [RecordMovedEvent::class, DataUpdateHandler::class, [1, 'pages'], true],
+            [RecordUpdatedEvent::class, DataUpdateHandler::class, [1, 'pages'], true],
+            [RecordDeletedEvent::class, GarbageHandler::class, [1, 'pages'], true],
+            [PageMovedEvent::class, GarbageHandler::class, [1], true],
+            [RecordGarbageCheckEvent::class, GarbageHandler::class, [1, 'pages', ['hidden'], false], true],
+            ['SolrUnitTestsInvalidDataUpdateEvent', DataUpdateHandler::class, [1], false]
+        ];
+    }
+
+    /**
+     * Init listener
+     *
+     * @return AbstractBaseEventListener
+     */
+    protected function initListener(): AbstractBaseEventListener
+    {
+        return new ImmediateProcessingEventListener($this->extensionConfigurationMock, $this->eventDispatcherMock);
+    }
+
+    /**
+     * Returns the current monitoring type
+     *
+     * @return int
+     */
+    protected function getMonitoringType(): int
+    {
+        return ImmediateProcessingEventListener::MONITORING_TYPE;
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+
+/**
+ * Testcase for the NoProcessingEventListener
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class NoProcessingEventListenerTest extends AbstractEventListenerTest
+{
+    /**
+     * @test
+     */
+    public function canHandleEvents(): void {
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn(2);
+
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+        $this->listener->__invoke($event);
+        $this->assertTrue($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function canSkipEventHandlingIfDisabled(): void {
+        $this->extensionConfigurationMock
+            ->expects($this->once())
+            ->method('getMonitoringType')
+            ->willReturn(0);
+
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+        $this->listener->__invoke($event);
+        $this->assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * Init listener
+     *
+     * @return AbstractBaseEventListener
+     */
+    protected function initListener(): AbstractBaseEventListener
+    {
+        return new NoProcessingEventListener($this->extensionConfigurationMock, $this->eventDispatcherMock);
+    }
+
+    /**
+     * Returns the current monitoring type
+     *
+     * @return int
+     */
+    protected function getMonitoringType(): int
+    {
+        return NoProcessingEventListener::MONITORING_TYPE;
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEventTest.php
@@ -1,0 +1,180 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+
+/**
+ * Abstract testcase for the data update events
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+abstract class AbstractDataUpdateEventTest extends UnitTest
+{
+    /**
+     * @return AbstractDataUpdateEventTest
+     *
+     * @test
+     */
+    public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, static::EVENT_TEST_TABLE);
+
+        $this->assertEquals(123, $event->getUid());
+        $this->assertEquals(static::EVENT_TEST_TABLE, $event->getTable());
+
+        // initial values
+        $this->assertEmpty($event->getFields());
+        $this->assertFalse($event->isPropagationStopped());
+        $this->assertFalse($event->isImmediateProcessingForced());
+
+        return $event;
+    }
+
+    /**
+     * @test
+     */
+    public function canInitAndReturnFields(): void
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, static::EVENT_TEST_TABLE, $fields = ['hidden' => 1]);
+
+        $this->assertEquals($fields, $event->getFields());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicatePageUpdate(): void
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'tx_foo_bar');
+        $this->assertFalse($event->isPageUpdate());
+
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'pages');
+        $this->assertTrue($event->isPageUpdate());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicateContentElementUpdate(): void
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'tx_foo_bar');
+        $this->assertFalse($event->isContentElementUpdate());
+
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'tt_content');
+        $this->assertTrue($event->isContentElementUpdate());
+    }
+
+    /**
+     * @test
+     */
+    public function canMarkAndIndicateStoppedProcessing(): void
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'tx_foo_bar');
+
+        $this->assertFalse($event->isPropagationStopped());
+        $event->setStopProcessing(true);
+        $this->assertTrue($event->isPropagationStopped());
+        $event->setStopProcessing(false);
+        $this->assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function canMarkAndIndicateForcedProcessing(): void
+    {
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'tx_foo_bar');
+
+        $this->assertFalse($event->isImmediateProcessingForced());
+        $event->setForceImmediateProcessing(true);
+        $this->assertTrue($event->isImmediateProcessingForced());
+        $event->setForceImmediateProcessing(false);
+        $this->assertFalse($event->isImmediateProcessingForced());
+    }
+
+    /**
+     * @test
+     */
+    public function canCleanEventOnSerialization(): void
+    {
+        $fields = [
+            'uid' => 123,
+            'pid' => 10,
+            'title' => 'dummy title',
+            'l10n_diffsource' => 'dummy l10n_diffsource'
+        ];
+
+        /** @var AbstractDataUpdateEvent $event */
+        $eventClass = static::EVENT_CLASS;
+        $event = new $eventClass(123, 'pages', $fields);
+
+        $properties = $event->__sleep();
+        $this->assertNotEmpty($properties);
+
+        /** @var AbstractDataUpdateEvent $processedEvent */
+        $processedEvent = unserialize(serialize($event));
+        $this->assertIsObject($processedEvent);
+        $this->assertArrayNotHasKey('l10n_diffsource', $processedEvent->getFields());
+
+        if ($event->getFields() !== []) {
+            $requiredUpdateFields = array_unique(array_merge(
+                DataUpdateHandler::getRequiredUpdatedFields(),
+                GarbageHandler::getRequiredUpdatedFields()
+            ));
+
+            foreach ($requiredUpdateFields as $requiredUpdateField) {
+                $this->assertArrayHasKey($requiredUpdateField, $processedEvent->getFields());
+            }
+
+            if ($event->getTable() === 'pages') {
+                $processedFields = $fields;
+                unset($processedFields['l10n_diffsource']);
+                $this->assertEquals($processedFields, $processedEvent->getFields());
+            }
+
+            $this->assertEquals(10, $processedEvent->getFields()['pid']);
+        }
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
+
+/**
+ * Testcase for the ContentElementDeletedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class ContentElementDeletedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = ContentElementDeletedEvent::class;
+    protected const EVENT_TEST_TABLE = 'tt_content';
+
+    /**
+     * @test
+     */
+    public function canInitAndReturnFields(): void
+    {
+        $event = new ContentElementDeletedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
+        $this->assertEmpty($event->getFields());
+    }
+
+    /**
+     * @test
+     */
+    public function canForceTable(): void
+    {
+        $event = new ContentElementDeletedEvent(123, 'tx_foo_bar');
+        $this->assertEquals('tt_content', $event->getTable());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicatePageUpdate(): void
+    {
+        $event = new ContentElementDeletedEvent(123);
+        $this->assertFalse($event->isPageUpdate());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicateContentElementUpdate(): void
+    {
+        $event = new ContentElementDeletedEvent(123);
+        $this->assertTrue($event->isContentElementUpdate());
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+
+/**
+ * Testcase for the PageMovedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class PageMovedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = PageMovedEvent::class;
+    protected const EVENT_TEST_TABLE = 'pages';
+
+    /**
+     * @test
+     */
+    public function canInitAndReturnFields(): void
+    {
+        $event = new PageMovedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
+        $this->assertEmpty($event->getFields());
+    }
+
+    /**
+     * @test
+     */
+    public function canForceTable(): void
+    {
+        $event = new PageMovedEvent(123, 'tx_foo_bar');
+        $this->assertEquals('pages', $event->getTable());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicatePageUpdate(): void
+    {
+        $event = new PageMovedEvent(123);
+        $this->assertTrue($event->isPageUpdate());
+    }
+
+    /**
+     * @test
+     */
+    public function canIndicateContentElementUpdate(): void
+    {
+        $event = new PageMovedEvent(123);
+        $this->assertFalse($event->isContentElementUpdate());
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+
+/**
+ * Testcase for the RecordDeletedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class RecordDeletedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = RecordDeletedEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
+
+/**
+ * Testcase for the RecordGarbageCheckEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class RecordGarbageCheckEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = RecordGarbageCheckEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+
+    /**
+     * @test
+     *
+     * @return AbstractDataUpdateEvent
+     */
+    public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
+    {
+       /** @var RecordGarbageCheckEvent $event */
+        $event = parent::canInitAndReturnBasicProperties();
+
+        // initial values
+        $this->assertFalse($event->frontendGroupsRemoved());
+
+        return $event;
+    }
+
+    /**
+     * @test
+     */
+    public function canInitAndReturnFrontendGroupsRemovedFlag(): void
+    {
+        $event = new RecordGarbageCheckEvent(123, 'tx_foo_bar', [], true);
+        $this->assertTrue($event->frontendGroupsRemoved());
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
+
+/**
+ * Testcase for the RecordMovedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class RecordMovedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = RecordMovedEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+
+/**
+ * Testcase for the RecordUpdatedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class RecordUpdatedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = RecordUpdatedEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
+
+/**
+ * Testcase for the VersionSwappedEvent
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class VersionSwappedEventTest extends AbstractDataUpdateEventTest
+{
+    protected const EVENT_CLASS = VersionSwappedEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+}

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -1,0 +1,243 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\PageStrategy;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\RecordStrategy;
+use Doctrine\DBAL\Statement;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Testcase for the GarbageHandler class.
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class GarbageHandlerTest extends AbstractUpdateHandlerTest
+{
+    /**
+     * @var GarbageHandler
+     */
+    protected $garbageHandler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->garbageHandler = new GarbageHandler(
+            $this->recordServiceMock,
+            $this->frontendEnvironmentMock,
+            $this->tcaServiceMock,
+            $this->indexQueueMock
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function collectGarbageTriggersGarbageCollectionForPages(): void
+    {
+        $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
+        $this->garbageHandler->collectGarbage('pages', 123);
+    }
+
+    /**
+     * @test
+     */
+    public function collectGarbageTriggersGarbageCollectionForRecords(): void
+    {
+        $this->initGarbageCollectionExpectations(RecordStrategy::class, 'tx_foo_bar', 789);
+        $this->garbageHandler->collectGarbage('tx_foo_bar', 789);
+    }
+
+    /**
+     * Inits garbage collection expectations
+     *
+     * @param string $strategy Class name of strategy to expect
+     * @param string $table
+     * @param int $uid
+     */
+    protected function initGarbageCollectionExpectations(string $strategy, string $table, int $uid): void
+    {
+        $strategyMock = $this->createMock($strategy);
+        GeneralUtility::addInstance($strategy, $strategyMock);
+
+        $strategyMock
+            ->expects($this->once())
+            ->method('removeGarbageOf')
+            ->with(
+                $table,
+                $uid
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function handlePageMovementTriggersGarbageCollectionAndReindexing(): void
+    {
+        $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
+        $this->indexQueueMock
+            ->expects($this->once())
+            ->method('updateItem')
+            ->with('pages', 123);
+
+        $this->garbageHandler->handlePageMovement(123);
+    }
+
+    /**
+     * @test
+     */
+    public function performRecordGarbageCheckTriggersRecordGarbageCollection(): void
+    {
+        $dummyRecord = [
+            'uid' => 789,
+            'title' => 'dummy record to collect garbage for',
+            'hidden' => 1
+        ];
+
+        $this->initGarbageCollectionExpectations(RecordStrategy::class, 'tx_foo_bar', $dummyRecord['uid']);
+
+        $GLOBALS['TCA']['tx_foo_bar'] = ['columns' => []];
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getVisibilityAffectingFieldsByTable')
+            ->with('tx_foo_bar')
+            ->willReturn('hidden,fe_group');
+
+        $statementMock = $this->createMock(Statement::class);
+        $statementMock->expects($this->once())->method('fetch')->willReturn($dummyRecord);
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects($this->once())->method('execute')->willReturn($statementMock);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->expects($this->any())->method('getExpressionBuilder')->willReturn($this->createMock(ExpressionBuilder::class));
+
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->expects($this->once())->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('normalizeFrontendGroupField')
+            ->with('tx_foo_bar', $dummyRecord)
+            ->willReturn($dummyRecord);
+
+        $this->garbageHandler->performRecordGarbageCheck($dummyRecord['uid'], 'tx_foo_bar', [], true);
+    }
+
+    /**
+     * @test
+     */
+    public function performRecordGarbageCheckTriggersPageGarbageCollection(): void
+    {
+        $dummyPageRecord = [
+            'uid' => 789,
+            'title' => 'dummy record to collect garbage for',
+            'hidden' => 1,
+            'extendToSubpages' => 1
+        ];
+
+        $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 100);
+        $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 200);
+        $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', $dummyPageRecord['uid']);
+
+        $GLOBALS['TCA']['pages'] = ['columns' => []];
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getVisibilityAffectingFieldsByTable')
+            ->with('pages')
+            ->willReturn('hidden,fe_group');
+
+        $statementMock = $this->createMock(Statement::class);
+        $statementMock->expects($this->exactly(2))->method('fetch')->willReturn($dummyPageRecord);
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->expects($this->exactly(2))->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects($this->exactly(2))->method('execute')->willReturn($statementMock);
+
+        $connectionMock = $this->createMock(Connection::class);
+        $connectionMock->expects($this->any())->method('getExpressionBuilder')->willReturn($this->createMock(ExpressionBuilder::class));
+
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->expects($this->exactly(2))->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        $connectionPoolMock->expects($this->once())->method('getConnectionForTable')->willReturn($connectionMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('normalizeFrontendGroupField')
+            ->with('pages', $dummyPageRecord)
+            ->willReturn($dummyPageRecord);
+
+        $this->queryGeneratorMock
+            ->expects($this->any())
+            ->method('getTreeList')
+            ->willReturn($dummyPageRecord['uid'] . ',100,200');
+
+        $this->garbageHandler->performRecordGarbageCheck($dummyPageRecord['uid'], 'pages', ['hidden' => 1], true);
+    }
+
+    /**
+     * @test
+     */
+    public function getRecordWithFieldRelevantForGarbageCollectionDeterminesFields(): void
+    {
+        $GLOBALS['TCA']['tx_foo_bar'] = ['columns' => []];
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('getVisibilityAffectingFieldsByTable')
+            ->with('tx_foo_bar')
+            ->willReturn('hidden,fe_group');
+
+        $dummyRecord = ['uid' => 123];
+        $statementMock = $this->createMock(Statement::class);
+        $statementMock->expects($this->once())->method('fetch')->willReturn($dummyRecord);
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects($this->once())->method('execute')->willReturn($statementMock);
+        $queryBuilderMock
+            ->expects($this->once())
+            ->method('select')
+            ->with('hidden', 'fe_group');
+
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->expects($this->once())->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
+
+        $record = $this->garbageHandler->getRecordWithFieldRelevantForGarbageCollection('tx_foo_bar', 123);
+        $this->assertEquals($dummyRecord, $record);
+    }
+}

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -28,11 +28,10 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Repository;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DocumentEscapeService;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
-use ApacheSolrForTypo3\Solr\SolrService;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
@@ -116,9 +115,9 @@ class RepositoryTest extends UnitTest
     public function findByPageIdAndByLanguageIdReturnsResultFromSearch()
     {
 
-        $solrServiceMock = $this->getDumbMock(SolrService::class);
+        $solrConnectionMock = $this->getDumbMock(SolrConnection::class);
         $solrConnectionManager = $this->getAccessibleMock(ConnectionManager::class, ['getConnectionByPageId'], [], '', false);
-        $solrConnectionManager->expects($this->any())->method('getConnectionByPageId')->will($this->returnValue($solrServiceMock));
+        $solrConnectionManager->expects($this->any())->method('getConnectionByPageId')->will($this->returnValue($solrConnectionMock));
         $mockedSingletons = [ConnectionManager::class => $solrConnectionManager];
 
         $search = $this->getAccessibleMock(Search::class, ['search', 'getResultDocumentsEscaped'], [], '', false);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -28,7 +28,7 @@ class UrlFacetContainerTest extends UnitTest
     /**
      * Test data for index based url parameters
      *
-     * @var \string[][][]
+     * @var string[][][]
      */
     protected $indexParameters = [
         'tx_solr' => [
@@ -43,7 +43,7 @@ class UrlFacetContainerTest extends UnitTest
     /**
      * Test data for assoc based url parameters
      *
-     * @var \string[][][]
+     * @var string[][][]
      */
     protected $assocParameters = [
         'tx_solr' => [

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -24,7 +24,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Statistics;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\QueryStringContainer;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -26,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\QueryStringContainer;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -1,0 +1,277 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2022 Markus Friedrich <markus.friedrich@dkd.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\GarbageCollector;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+
+/**
+ * Testcase for the GarbageCollector class.
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class GarbageCollectorTest extends UnitTest
+{
+    /**
+     * @var GarbageCollector
+     */
+    protected $garbageCollector;
+
+    /**
+     * @var TCAService|MockObject
+     */
+    protected $tcaServiceMock;
+
+    /**
+     * @var EventDispatcherInterface|MockObject
+     */
+    protected $eventDispatcherMock;
+
+    /**
+     * @var GarbageHandler|MockObject
+     */
+    protected $garbageHandlerMock;
+
+    public function setUp(): void
+    {
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->tcaServiceMock = $this->createMock(TCAService::class);
+        $this->garbageCollector = new GarbageCollector($this->tcaServiceMock, $this->eventDispatcherMock);
+
+        $this->garbageHandlerMock = $this->createMock(GarbageHandler::class);
+        GeneralUtility::addInstance(GarbageHandler::class, $this->garbageHandlerMock);
+
+        $GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
+        $GLOBALS['BE_USER']->workspace = 0;
+    }
+
+    public function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        unset($GLOBALS['TCA']);
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_preProcessUHandlesRecordDeletion(): void
+    {
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+        $this->garbageCollector->processCmdmap_preProcess('delete', 'pages', 123, '', $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof RecordDeletedEvent);
+        $this->assertEquals('pages', $dispatchedEvent->getTable());
+        $this->assertEquals(123, $dispatchedEvent->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_preProcessIgnoresDraftWorkspace(): void
+    {
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+
+        $GLOBALS['BE_USER']->workspace = 1;
+        $this->eventDispatcherMock
+            ->expects($this->never())
+            ->method('dispatch');
+        $this->garbageCollector->processCmdmap_preProcess('delete', 'pages', 123, '', $dataHandlerMock);
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_postProcessHandlesPageMovement(): void
+    {
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+
+        $this->garbageCollector->processCmdmap_postProcess('move', 'pages', 1011, '', $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof PageMovedEvent);
+        $this->assertEquals('pages', $dispatchedEvent->getTable());
+        $this->assertEquals(1011, $dispatchedEvent->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_postProcessIgnoresPageMovementInDraftWorkspace(): void
+    {
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+
+        $GLOBALS['BE_USER']->workspace = 1;
+        $this->eventDispatcherMock
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->garbageCollector->processCmdmap_postProcess('move', 'pages', 1011, '', $dataHandlerMock);
+    }
+
+    /**
+     * @test
+     */
+    public function processDatamap_preProcessFieldArrayStoresRecordData(): void
+    {
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dummyRecord = [
+            'uid' => 123,
+            'pid' => 1,
+            'hidden' => 0,
+            'fe_group' => '1,2'
+        ];
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('isEnableColumn')
+            ->with(
+                'tx_foo_bar',
+                'fe_group'
+            )
+            ->willReturn(true);
+
+        $this->garbageHandlerMock
+            ->expects($this->once())
+            ->method('getRecordWithFieldRelevantForGarbageCollection')
+            ->with(
+                'tx_foo_bar',
+                123
+            )
+            ->willReturn($dummyRecord);
+
+        $this->tcaServiceMock
+            ->expects($this->once())
+            ->method('normalizeFrontendGroupField')
+            ->with(
+                'tx_foo_bar',
+                $dummyRecord
+            )
+            ->willReturn($dummyRecord);
+
+        $this->garbageCollector->processDatamap_preProcessFieldArray([], 'tx_foo_bar', 123, $dataHandlerMock);
+
+        $objectReflection = new \ReflectionObject($this->garbageCollector);
+        $property = $objectReflection->getProperty('trackedRecords');
+        $property->setAccessible(true);
+        $trackedRecords = $property->getValue($this->garbageCollector);
+
+        $this->assertEquals($dummyRecord, $trackedRecords['tx_foo_bar'][123]);
+    }
+
+    /**
+     * @test
+     */
+    public function processDatamap_afterDatabaseOperationsTriggersRecordGarbageCheck(): void
+    {
+        $GLOBALS['TCA']['tx_foo_bar']['ctrl']['enablecolumns']['fe_group'] = 'fe_group';
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dummyRecord = [
+            'uid' => 123,
+            'pid' => 1,
+            'hidden' => 0,
+            'fe_group' => '1,2'
+        ];
+        $trackedRecords = [
+            'tx_foo_bar' => [
+                123 => $dummyRecord
+            ]
+        ];
+        $this->inject($this->garbageCollector, 'trackedRecords', $trackedRecords);
+        $dummyRecord['fe_group'] = '1';
+
+        $this->garbageHandlerMock
+            ->expects($this->once())
+            ->method('getRecordWithFieldRelevantForGarbageCollection')
+            ->with(
+                'tx_foo_bar',
+                123
+            )
+            ->willReturn($dummyRecord);
+
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+
+        $this->garbageCollector->processDatamap_afterDatabaseOperations(
+            'update',
+            'tx_foo_bar',
+            123,
+            ['uid' => 123, 'pid' => 1, 'title' => 'test'],
+            $dataHandlerMock
+        );
+
+        $this->assertTrue($dispatchedEvent instanceof RecordGarbageCheckEvent);
+        $this->assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
+        $this->assertEquals(123, $dispatchedEvent->getUid());
+        $this->assertTrue($dispatchedEvent->frontendGroupsRemoved());
+    }
+
+    /**
+     * @test
+     */
+    public function collectGarbageTriggersGarbageCollection(): void
+    {
+        $this->garbageHandlerMock
+            ->expects($this->once())
+            ->method('collectGarbage')
+            ->with(
+                'pages',
+                123
+            );
+
+        $this->garbageCollector->collectGarbage('pages', 123);
+    }
+}

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -24,17 +24,16 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
-use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
-use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
 
 /**
  * Testcase for the RecordMonitor class.
@@ -43,211 +42,203 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  */
 class RecordMonitorTest extends UnitTest
 {
-
     /**
      * @var RecordMonitor
      */
     protected $recordMonitor;
 
     /**
-     * @var Queue
+     * @var EventDispatcherInterface|MockObject
      */
-    protected $queueMock;
+    protected $eventDispatcherMock;
 
-    /**
-     * @var MountPagesUpdater
-     */
-    protected $mountPageUpdaterMock;
-
-    /**
-     * @var TCAService
-     */
-    protected $tcaServiceMock;
-
-    /**
-     * @var RootPageResolver
-     */
-    protected $rootPageResolverMock;
-
-    /**
-     * @var PagesRepository
-     */
-    protected $pageRepositoryMock;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $logManagerMock;
-
-    /**
-     * @var ConfigurationAwareRecordService
-     */
-    protected $recordServiceMock;
-
-    public function setUp()
+    public function setUp(): void
     {
-        $this->queueMock = $this->getDumbMock(Queue::class);
-        $this->mountPageUpdaterMock = $this->getDumbMock(MountPagesUpdater::class);
-        $this->tcaServiceMock = $this->getDumbMock(TCAService::class);
-        $this->rootPageResolverMock = $this->getDumbMock(RootPageResolver::class);
-        $this->pageRepositoryMock = $this->getDumbMock(PagesRepository::class);
-        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
-        $this->recordServiceMock = $this->getDumbMock(ConfigurationAwareRecordService::class);
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->recordMonitor = new RecordMonitor($this->eventDispatcherMock);
 
-        $this->recordMonitor = $this->getMockBuilder(RecordMonitor::class)
-            ->setMethods(
-                [
-                     'isDraftRecord',
-                     'getSolrConfigurationFromPageId',
-                     'removeFromIndexAndQueueWhenItemInQueue',
-                     'getRecordPageId'
-                ]
-            )->setConstructorArgs([
-                $this->queueMock,
-                $this->mountPageUpdaterMock,
-                $this->tcaServiceMock,
-                $this->rootPageResolverMock,
-                $this->pageRepositoryMock,
-                $this->logManagerMock,
-                $this->recordServiceMock
-            ])
-            ->getMock();
+        $GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
+        $GLOBALS['BE_USER']->workspace = 0;
+    }
+
+    public function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        parent::tearDown();
     }
 
     /**
      * @test
      */
-    public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfEnabledPage()
+    public function processCmdmap_preProcessUHandlesDeletedContentElements(): void
+    {
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+        $this->recordMonitor->processCmdmap_preProcess('delete', 'tt_content', 123);
+
+        $this->assertTrue($dispatchedEvent instanceof ContentElementDeletedEvent);
+        $this->assertEquals('tt_content', $dispatchedEvent->getTable());
+        $this->assertEquals(123, $dispatchedEvent->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_preProcessIgnoresDraftWorkspace(): void
+    {
+        $GLOBALS['BE_USER']->workspace = 1;
+        $this->eventDispatcherMock
+            ->expects($this->never())
+            ->method('dispatch');
+        $this->recordMonitor->processCmdmap_preProcess('delete', 'tt_content', 123);
+    }
+
+    /**
+     * @test
+     */
+    public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfPageRecord(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(4711)->willReturn($configurationMock);
-        $this->recordMonitor->expects($this->never())->method('removeFromIndexAndQueueWhenItemInQueue');
-
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 4711, 'pid' => 999]);
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(true);
-
-
-        $this->queueMock->expects($this->once())->method('updateItem')->with('pages', 4711);
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
         $this->recordMonitor->processCmdmap_postProcess('version', 'pages', 4711, ['action' => 'swap'], $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof VersionSwappedEvent);
+        $this->assertEquals('pages', $dispatchedEvent->getTable());
+        $this->assertEquals(4711, $dispatchedEvent->getUid());
     }
 
     /**
      * @test
      */
-    public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfEnabledRecord()
+    public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfRecord(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-        $dataHandlerMock->expects($this->once())->method('getPID')->willReturn(999);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getIndexQueueIsMonitoredTable')->willReturn(true);
-
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(999)->willReturn($configurationMock);
-        $this->recordMonitor->expects($this->never())->method('removeFromIndexAndQueueWhenItemInQueue');
-
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 888, 'pid' => 999]);
-
-        $this->tcaServiceMock->expects($this->once())->method('getTranslationOriginalUidIfTranslated')->willReturn(888);
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(true);
-
-
-        $this->queueMock->expects($this->once())->method('updateItem')->with('tx_foo_bar', 888);
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
         $this->recordMonitor->processCmdmap_postProcess('version', 'tx_foo_bar', 888, ['action' => 'swap'], $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof VersionSwappedEvent);
+        $this->assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
+        $this->assertEquals(888, $dispatchedEvent->getUid());
     }
 
     /**
      * @test
      */
-    public function processCmdmap_postProcessRemovesQueueItemForVersionSwapOfDisabledPage()
+    public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecord(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(4711)->willReturn($configurationMock);
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, [], $dataHandlerMock);
 
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 4711, 'pid' => 999]);
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(false);
-
-        $this->queueMock->expects($this->never())->method('updateItem');
-        $this->recordMonitor->expects($this->once())->method('removeFromIndexAndQueueWhenItemInQueue')->with('pages', 4711);
-
-        $this->recordMonitor->processCmdmap_postProcess('version', 'pages', 4711, ['action' => 'swap'], $dataHandlerMock);
+        $this->assertTrue($dispatchedEvent instanceof RecordMovedEvent);
+        $this->assertEquals('pages', $dispatchedEvent->getTable());
+        $this->assertEquals(4711, $dispatchedEvent->getUid());
     }
 
     /**
      * @test
      */
-    public function processCmdmap_postProcessRemovesQueueItemForVersionSwapOfDisabledRecord()
+    public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecordInDraftWorkspace(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-        $dataHandlerMock->expects($this->once())->method('getPID')->willReturn(999);
+        $GLOBALS['BE_USER']->workspace = 1;
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getIndexQueueIsMonitoredTable')->willReturn(true);
-
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(999)->willReturn($configurationMock);
-
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 888, 'pid' => 999]);
-
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(false);
-
-        $this->queueMock->expects($this->never())->method('updateItem');
-        $this->recordMonitor->expects($this->once())->method('removeFromIndexAndQueueWhenItemInQueue')->with('tx_foo_bar', 888);
-        $this->recordMonitor->processCmdmap_postProcess('version', 'tx_foo_bar', 888, ['action' => 'swap'], $dataHandlerMock);
-    }
-
-    /**
-     * @test
-     */
-    public function processCmdmap_postProcessUpdatesQueueItemForMoveOfEnabledPage()
-    {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(4711)->willReturn($configurationMock);
-        $this->recordMonitor->expects($this->never())->method('removeFromIndexAndQueueWhenItemInQueue');
-
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 4711, 'pid' => 999]);
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(true);
-
-        $this->queueMock->expects($this->once())->method('updateItem')->with('pages', 4711);
+        $this->eventDispatcherMock
+            ->expects($this->never())
+            ->method('dispatch');
         $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, [], $dataHandlerMock);
     }
 
     /**
      * @test
      */
-    public function processCmdmap_postProcessRemovesQueueItemForMoveOfDisabledPage()
+    public function processCmdmap_postProcessUpdatesQueueItemForMoveOfRecord(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->recordMonitor->expects($this->once())->method('getSolrConfigurationFromPageId')->with(4711)->willReturn($configurationMock);
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+        $this->recordMonitor->processCmdmap_postProcess('move', 'tx_foo_bar', 888, [], $dataHandlerMock);
 
-        $this->recordServiceMock->expects($this->once())->method('getRecord')->willReturn(['uid' => 4711, 'pid' => 999]);
-        $this->tcaServiceMock->expects($this->once())->method('isEnabledRecord')->willReturn(false);
-
-        $this->queueMock->expects($this->never())->method('updateItem');
-        $this->recordMonitor->expects($this->once())->method('removeFromIndexAndQueueWhenItemInQueue')->with('pages', 4711);
-
-        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, [], $dataHandlerMock);
+        $this->assertTrue($dispatchedEvent instanceof RecordMovedEvent);
+        $this->assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
+        $this->assertEquals(888, $dispatchedEvent->getUid());
     }
 
     /**
      * @test
      * For more infos, please refer https://github.com/TYPO3-Solr/ext-solr/pull/2836
      */
-    public function processDatamap_afterDatabaseOperationsUsesAlreadyResolvedNextAutoIncrementValueForNewStatus()
+    public function processDatamap_afterDatabaseOperationsUsesAlreadyResolvedNextAutoIncrementValueForNewStatus(): void
     {
         $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-        $this->rootPageResolverMock->expects($this->once())->method('getAlternativeSiteRootPagesIds')->willReturn([]);
 
-        $this->recordMonitor->expects($this->once())
-            ->method('getRecordPageId')
-            ->with('new', 'tt_content', 4711, 4711, ['pid' => 1], $dataHandlerMock);
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
         $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', 4711, ['pid' => 1], $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof RecordUpdatedEvent);
+        $this->assertEquals('tt_content', $dispatchedEvent->getTable());
+        $this->assertEquals(4711, $dispatchedEvent->getUid());
     }
 
+    /**
+     * @test
+     * For more infos, please refer https://github.com/TYPO3-Solr/ext-solr/pull/2836
+     */
+    public function processDatamap_afterDatabaseOperationsUsesNotYetResolvedNextAutoIncrementValueForNewStatus(): void
+    {
+        $newId = 'NEW1';
+        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock->substNEWwithIDs[$newId] = 123;
+
+        $dispatchedEvent = null;
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+                $dispatchedEvent = func_get_arg(0);
+            }));
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', $newId, ['pid' => 1], $dataHandlerMock);
+
+        $this->assertTrue($dispatchedEvent instanceof RecordUpdatedEvent);
+        $this->assertEquals('tt_content', $dispatchedEvent->getTable());
+        $this->assertEquals(123, $dispatchedEvent->getUid());
+    }
 }

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -26,8 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Test\System\Service;
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions;
-use TYPO3\CMS\Extbase\Service\TypoScriptService;
-use TYPO3\CMS\Lang\LanguageService;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -1,0 +1,167 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2021 Markus Friedrich <markus.friedrich@dkd.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Scheduler;
+use TYPO3\CMS\Scheduler\Execution;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingFinishedEvent;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+
+/**
+ * Testcase for EventQueueWorkerTask
+ *
+ * @author Markus Friedrich <markus.friedrich@dkd.de>
+ */
+class EventQueueWorkerTaskTest extends UnitTest
+{
+    /**
+     * @var EventQueueWorkerTask
+     */
+    protected  $task;
+
+    public function setUp(): void
+    {
+        GeneralUtility::setSingletonInstance(Scheduler::class, $this->createMock(Scheduler::class));
+        GeneralUtility::addInstance(Execution::class, $this->createMock(Execution::class));
+
+        $this->task = new EventQueueWorkerTask();
+        $this->task->setLimit(99);
+    }
+
+    public function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function canProcessEventQueue(): void
+    {
+        $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
+        GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        GeneralUtility::addInstance(EventDispatcherInterface::class, $eventDispatcherMock);
+
+        /** @var RecordUpdatedEvent $event */
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+        $serializedEvent = serialize($event);
+        /** @var RecordUpdatedEvent $unserializedEvent */
+        $unserializedEvent = unserialize($serializedEvent);
+        $queueItem = [
+            'uid' => 10,
+            'event' => $serializedEvent
+        ];
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('getEventQueueItems')
+            ->with(99)
+            ->willReturn([$queueItem]);
+
+        $dispatchedEvents = [];
+        $eventDispatcherMock
+            ->expects($this->exactly(2))
+            ->method('dispatch')
+            ->will($this->returnCallback(function() use (&$dispatchedEvents) {
+                $dispatchedEvents[] = func_get_arg(0);
+            }));
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->never())
+            ->method('updateEventQueueItem');
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('deleteEventQueueItems')
+            ->with([10]);
+
+        $this->task->execute();
+
+        $unserializedEvent->setForceImmediateProcessing(true);
+        $this->assertCount(2, $dispatchedEvents);
+        $this->assertEquals($unserializedEvent, $dispatchedEvents[0]);
+        $this->assertTrue($dispatchedEvents[1] instanceof DelayedProcessingFinishedEvent);
+    }
+
+    /**
+     * @test
+     */
+    public function canHandleErrors(): void
+    {
+        $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
+        GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        GeneralUtility::addInstance(EventDispatcherInterface::class, $eventDispatcherMock);
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
+        GeneralUtility::addInstance(SolrLogManager::class, $solrLogManagerMock);
+
+        /** @var RecordUpdatedEvent $event */
+        $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
+        $serializedEvent = serialize($event);
+        /** @var RecordUpdatedEvent $unserializedEvent */
+        $unserializedEvent = unserialize($serializedEvent);
+        $queueItem = [
+            'uid' => 10,
+            'event' => $serializedEvent
+        ];
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('getEventQueueItems')
+            ->with(99)
+            ->willReturn([$queueItem]);
+
+        $eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->willThrowException(new \Exception('', 1641889238));
+
+        $solrLogManagerMock
+            ->expects($this->once())
+            ->method('log')
+            ->with(SolrLogManager::ERROR, $this->anything(), $this->anything());
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('updateEventQueueItem')
+            ->with(10, ['error' => 1, 'error_message' => '[1641889238]']);
+
+        $eventQueueItemRepositoryMock
+            ->expects($this->once())
+            ->method('deleteEventQueueItems')
+            ->with([]);
+
+        $this->task->execute();
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -15,3 +15,6 @@ useConfigurationMonitorTables =
 
 # cat=basic/enable/40; type=boolean; label=Allow self signed certificates
 allowSelfSignedCertificates = 0
+
+# cat=basic/enable/50; type=options[LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.0=0,LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.1=1,LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.2=2]; label=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType
+monitoringType = 0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -116,6 +116,13 @@ if (!function_exists('strptime')) {
         'additionalFields' => \ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTaskAdditionalFieldProvider::class
     ];
 
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask::class] = [
+        'extension' => 'solr',
+        'title' => 'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.title',
+        'description' => 'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.description',
+        'additionalFields' => \ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTaskAdditionalFieldProvider::class
+    ];
+
     if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_solr_statistics'])) {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask::class]['options']['tables']['tx_solr_statistics'] = [
             'dateField' => 'tstamp',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -113,10 +113,26 @@ CREATE TABLE tx_solr_cache_tags (
 ) ENGINE=InnoDB;
 
 #
+# Table structure for table 'tx_solr_eventqueue_item'
+#
+CREATE TABLE tx_solr_eventqueue_item (
+	uid int(11) NOT NULL auto_increment,
+
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	event longblob,
+	error tinyint(3) unsigned DEFAULT '0' NOT NULL,
+	error_message text,
+
+	PRIMARY KEY (uid),
+	KEY tstamp (tstamp),
+	KEY error (error),
+) ENGINE=InnoDB;
+
+#
 # Update size of entry_value for table 'sys_registry'
 #
 CREATE TABLE sys_registry (
-  entry_value longblob
+	entry_value longblob
 ) ENGINE=InnoDB;
 
 #


### PR DESCRIPTION
# What this pr does

Decouples the monitoring and data update handling and introduces 3 options of data monitoring

- immediate (status quo)
- delayed
- no monitoring

# How to test

Configure the different `monitoringType`s in the extension manager and perform data updates, in the end the index queue and data updates should be performed as usual, but the execution moment differs.

By default (`immediate`) all updates will be performed immediately, like in all prior versions of the Solr extension. In the delayed mode the events will be queued and processed by the Scheduler `Event Queue Worker` task. If this option is active the queue and index updates will be delayed and take place as soon as the task is executed.

To implement an own monitoring the monitoring can also be disabled, if you choose the no monitoring option, no updates will be processed.

Resolves: #3153 

