### PR TITLE
Allow to generate indexing error log from throwable

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -156,9 +156,9 @@ class IndexService
      * Generates a message in the error log when an error occured.
      *
      * @param Item $itemToIndex
-     * @param \Exception  $e
+     * @param \Throwable $e
      */
-    protected function generateIndexingErrorLog(Item $itemToIndex, \Exception $e)
+    protected function generateIndexingErrorLog(Item $itemToIndex, \Throwable $e)
     {
         $message = 'Failed indexing Index Queue item ' . $itemToIndex->getIndexQueueUid();
         $data = ['code' => $e->getCode(), 'message' => $e->getMessage(), 'trace' => $e->getTraceAsString(), 'item' => (array)$itemToIndex];


### PR DESCRIPTION
Since we catch \Throwable instead of \Exception, we should change the typehint of the error log generating method, too. This will prevent errors while catching \Error instances.

# What this pr does

This pr will change the method signature of ApacheSolrForTypo3\Solr\Domain\Index\IndexService::generateIndexingErrorLog 


Fixes: #3161
