### PR TITLE
[BUGFIX] Prevent some "undefined array key" warnings with php 8

### DIFF
--- a/Build/Test/IntegrationFrontendTests.xml
+++ b/Build/Test/IntegrationFrontendTests.xml
@@ -7,8 +7,8 @@
     convertWarningsToExceptions="true"
     forceCoversAnnotation="false"
     processIsolation="true"
-    stopOnError="true"
-    stopOnFailure="true"
+    stopOnError="false"
+    stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
     verbose="false">

--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -180,6 +180,7 @@ class IndexingConfigurationSelectorField
     {
         $parameterArray = [
             'fieldChangeFunc' => [],
+            'itemFormElID' => $this->formElementName,
             'itemFormElName' => $this->formElementName,
             'itemFormElValue' => $selectedValues,
             'fieldConf' => ['config' => ['items' => $items]],
@@ -188,8 +189,11 @@ class IndexingConfigurationSelectorField
 
         $nodeFactory = GeneralUtility::makeInstance(NodeFactory::class);
         $options = [
-            'renderType' => 'selectCheckBox', 'table' => 'tx_solr_classes_backend_indexingconfigurationselector',
-            'fieldName' => 'additionalFields', 'databaseRow' => [], 'parameterArray' => $parameterArray
+            'type' => 'select', 'renderType' => 'selectCheckBox',
+            'table' => 'tx_solr_classes_backend_indexingconfigurationselector',
+            'tableName' => 'tx_solr_classes_backend_indexingconfigurationselector',
+            'fieldName' => 'additionalFields', 'databaseRow' => ['uid' => 0], 'parameterArray' => $parameterArray,
+            'processedTca' => ['columns' => ['additionalFields' => ['config' => ['type' => 'select']]]]
         ];
         $options['parameterArray']['fieldConf']['config']['items'] = $items;
         $options['parameterArray']['fieldTSConfig']['noMatchingValue_label'] = '';

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -173,7 +173,7 @@ class Relation extends AbstractContentObject
         $mmTableName = $localFieldTca['config']['MM'];
 
         // Remove the first option of foreignLabelField for recursion
-        if (strpos($this->configuration['foreignLabelField'], '.') !== false) {
+        if (strpos($this->configuration['foreignLabelField'] ?? '', '.') !== false) {
             $foreignTableLabelFieldArr = explode('.', $this->configuration['foreignLabelField']);
             unset($foreignTableLabelFieldArr[0]);
             $this->configuration['foreignLabelField'] = implode('.', $foreignTableLabelFieldArr);
@@ -189,7 +189,7 @@ class Relation extends AbstractContentObject
         $relatedRecords = $this->getRelatedRecords($foreignTableName, ...$selectUids);
         foreach ($relatedRecords as $record) {
             if (isset($foreignTableTca['columns'][$foreignTableLabelField]['config']['foreign_table'])
-                && $this->configuration['enableRecursiveValueResolution']
+                && !empty($this->configuration['enableRecursiveValueResolution'])
             ) {
                 if (strpos($this->configuration['foreignLabelField'], '.') !== false) {
                     $foreignTableLabelFieldArr = explode('.', $this->configuration['foreignLabelField']);
@@ -227,11 +227,11 @@ class Relation extends AbstractContentObject
         $foreignTableLabelField = $foreignTableTca['ctrl']['label'] ?? null;
 
         // when foreignLabelField is not enabled we can return directly
-        if (empty($this->configuration['foreignLabelField'] ?? null)) {
+        if (empty($this->configuration['foreignLabelField'])) {
             return $foreignTableLabelField;
         }
 
-        if (strpos($this->configuration['foreignLabelField'], '.') !== false) {
+        if (strpos($this->configuration['foreignLabelField'] ?? '', '.') !== false) {
             list($foreignTableLabelField) = explode('.', $this->configuration['foreignLabelField'], 2);
         } else {
             $foreignTableLabelField = $this->configuration['foreignLabelField'];

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -186,11 +186,13 @@ abstract class AbstractBaseController extends ActionController
             );
         }
 
-        $this->objectManager->get(ConfigurationService::class)
-            ->overrideConfigurationWithFlexFormSettings(
-                $this->contentObjectRenderer->data['pi_flexform'],
-                $this->typoScriptConfiguration
-            );
+        if (!empty($this->contentObjectRenderer->data['pi_flexform'])) {
+            $this->objectManager->get(ConfigurationService::class)
+                ->overrideConfigurationWithFlexFormSettings(
+                    $this->contentObjectRenderer->data['pi_flexform'],
+                    $this->typoScriptConfiguration
+                );
+        }
 
         parent::initializeAction();
         $this->typoScriptFrontendController = $GLOBALS['TSFE'];

--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -281,9 +281,9 @@ class InfoModuleController extends AbstractModuleController
     protected function getCoreMetrics(ResponseAdapter $lukeData, array $fields): array
     {
         return [
-            'numberOfDocuments' => $lukeData->index->numDocs,
-            'numberOfDeletedDocuments' => $lukeData->index->deletedDocs,
-            'numberOfTerms' => $lukeData->index->numTerms,
+            'numberOfDocuments' => $lukeData->index->numDocs ?? 0,
+            'numberOfDeletedDocuments' => $lukeData->index->deletedDocs ?? 0,
+            'numberOfTerms' => $lukeData->index->numTerms ?? 0,
             'numberOfFields' => count($fields)
         ];
     }

--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -155,7 +155,7 @@ abstract class AbstractStrategy
      */
     protected function callPostProcessGarbageCollectorHook($table, $uid)
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'] ?? null)) {
             return;
         }
 

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -918,7 +918,7 @@ class QueueItemRepository extends AbstractRepository
      */
     protected function hookPostProcessFetchRecordsForIndexQueueItem(string $table, array $uids, array &$tableRecords)
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'] ?? null)) {
             return;
         }
         $params = ['table' => $table, 'uids' => $uids, 'tableRecords' => &$tableRecords];

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -72,7 +72,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
             $fromInResponse = $this->parseResponseValue($valuesFromResponse['start']);
             $toInResponse = $this->parseResponseValue($valuesFromResponse['end']);
 
-            if (preg_match('/(-?\d*?)-(-?\d*)/', $activeValue[0], $rawValues) == 1) {
+            if (isset($activeValue[0]) && preg_match('/(-?\d*?)-(-?\d*)/', $activeValue[0], $rawValues) == 1) {
                 $rawFrom = $rawValues[1];
                 $rawTo = $rawValues[2];
             } else {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilder.php
@@ -30,25 +30,25 @@ class DateRangeFacetQueryBuilder implements FacetQueryBuilderInterface {
         $facetConfiguration = $configuration->getSearchFacetingFacetByName($facetName);
 
         $tag = '';
-        if ($facetConfiguration['keepAllOptionsOnSelection'] == 1) {
+        if (($facetConfiguration['keepAllOptionsOnSelection'] ?? 0) == 1) {
             $tag = '{!ex=' . $facetConfiguration['field'] . '}';
         }
         $facetParameters['facet.range'][] = $tag . $facetConfiguration['field'];
 
         $start = 'NOW/DAY-1YEAR';
-        if ($facetConfiguration['dateRange.']['start']) {
+        if (!empty($facetConfiguration['dateRange.']['start'])) {
             $start = $facetConfiguration['dateRange.']['start'];
         }
         $facetParameters['f.' . $facetConfiguration['field'] . '.facet.range.start'] = $start;
 
         $end = 'NOW/DAY+1YEAR';
-        if ($facetConfiguration['dateRange.']['end']) {
+        if (!empty($facetConfiguration['dateRange.']['end'])) {
             $end = $facetConfiguration['dateRange.']['end'];
         }
         $facetParameters['f.' . $facetConfiguration['field'] . '.facet.range.end'] = $end;
 
         $gap = '+1DAY';
-        if ($facetConfiguration['dateRange.']['gap']) {
+        if (!empty($facetConfiguration['dateRange.']['gap'])) {
             $gap = $facetConfiguration['dateRange.']['gap'];
         }
         $facetParameters['f.' . $facetConfiguration['field'] . '.facet.range.gap'] = $gap;

--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -189,7 +189,7 @@ class SearchResult extends Document
      */
     public function getContent()
     {
-        return $this->fields['content'];
+        return $this->fields['content'] ?? '';
     }
 
     /**
@@ -197,7 +197,7 @@ class SearchResult extends Document
      */
     public function getIsElevated()
     {
-        return $this->fields['isElevated'];
+        return $this->fields['isElevated'] ?? false;
     }
 
     /**
@@ -205,7 +205,7 @@ class SearchResult extends Document
      */
     public function getType()
     {
-        return $this->fields['type'];
+        return $this->fields['type'] ?? '';
     }
 
     /**
@@ -213,7 +213,7 @@ class SearchResult extends Document
      */
     public function getId()
     {
-        return $this->fields['id'];
+        return $this->fields['id'] ?? 0;
     }
 
     /**
@@ -221,7 +221,7 @@ class SearchResult extends Document
      */
     public function getScore()
     {
-        return $this->fields['score'];
+        return $this->fields['score'] ?? 0;
     }
 
     /**
@@ -229,7 +229,7 @@ class SearchResult extends Document
      */
     public function getUrl()
     {
-        return $this->fields['url'];
+        return $this->fields['url'] ?? '';
     }
 
     /**
@@ -237,6 +237,6 @@ class SearchResult extends Document
      */
     public function getTitle()
     {
-        return $this->fields['title'];
+        return $this->fields['title'] ?? '';
     }
 }

--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -68,10 +68,15 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
         $results = [];
 
         foreach ($values as $value) {
-            list($rootPageUid, $mountPoint) = GeneralUtility::trimExplode(',',
-                $value, true, 2);
-            $results[] = $this->getSolrRootlineForPageId($rootPageUid,
-                $mountPoint);
+            $results[] = $this->getSolrRootlineForPageId(
+                /** @scrutinizer ignore-type */
+                ...GeneralUtility::trimExplode(
+                    ',',
+                    $value,
+                    true,
+                    2
+                )
+            );
         }
 
         return $results;

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -270,7 +270,7 @@ abstract class AbstractIndexer
      */
     protected static function isSerializedResultFromRegisteredHook(array $indexingConfiguration, $solrFieldName)
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'] ?? null)) {
             return false;
         }
 

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -204,7 +204,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
     {
         $highestPriority = 0;
 
-        if (is_array($GLOBALS['T3_SERVICES']['auth'])) {
+        if (is_array($GLOBALS['T3_SERVICES']['auth'] ?? null)) {
             foreach ($GLOBALS['T3_SERVICES']['auth'] as $service) {
                 if ($service['priority'] > $highestPriority) {
                     $highestPriority = $service['priority'];

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -480,7 +480,7 @@ class Indexer extends AbstractIndexer
     {
         $documents = [];
 
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'])) {
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'] ?? null)) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'] as $classReference) {
                 if (!class_exists($classReference)) {
                     throw new \InvalidArgumentException('Class does not exits' . $classReference, 1490363487);
@@ -515,7 +515,7 @@ class Indexer extends AbstractIndexer
      */
     protected function preAddModifyDocuments(Item $item, int $language, array $documents)
     {
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'])) {
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'] ?? null)) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'] as $classReference) {
                 $documentsModifier = GeneralUtility::makeInstance($classReference);
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -230,8 +230,7 @@ class Queue
      */
     protected function postProcessIndexQueueUpdateItem($itemType, $itemUid, $updateCount, $forcedChangeTime = 0)
     {
-        if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'])
-            || !is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'] ?? null)) {
             return $updateCount;
         }
 

--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -119,7 +119,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
             $site
         );
 
-        if ((int)$page['uid'] === 0) {
+        if (empty($page['uid'])) {
             return $handler->handle($request);
         }
 

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -204,7 +204,7 @@ class Faceting implements Modifier, SearchRequestAware
         }
 
         foreach ($filterValues as $filterValue) {
-            $filterOptions = isset($facetConfiguration['type']) ? $facetConfiguration[$facetConfiguration['type'] . '.'] : null;
+            $filterOptions = isset($facetConfiguration['type']) ? ($facetConfiguration[$facetConfiguration['type'] . '.'] ?? null) : null;
             if (empty($filterOptions)) {
                 $filterOptions = [];
             }

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -262,7 +262,7 @@ class Typo3PageIndexer
      */
     protected function applyIndexPagePostProcessors($pageDocument)
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument'] ?? null)) {
             return;
         }
 
@@ -326,7 +326,7 @@ class Typo3PageIndexer
      */
     protected function substitutePageDocument(Document $pageDocument)
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'] ?? null)) {
             return $pageDocument;
         }
 
@@ -376,7 +376,7 @@ class Typo3PageIndexer
     {
         $documents = $existingDocuments;
 
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageAddDocuments'])) {
+        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageAddDocuments'] ?? null)) {
             return $documents;
         }
 

--- a/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
+++ b/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
@@ -72,7 +72,13 @@ class DocumentScoreAnalyzerViewHelper extends AbstractSolrFrontendViewHelper
 
         /** @var $resultSet SearchResultSet */
         $resultSet = self::getUsedSearchResultSetFromRenderingContext($renderingContext);
-        $debugData = $resultSet->getUsedSearch()->getDebugResponse()->explain->{$document->getId()};
+        $debugData = '';
+        if (
+            null !== $resultSet->getUsedSearch()->getDebugResponse()
+            && !empty($resultSet->getUsedSearch()->getDebugResponse()->explain)
+        ) {
+            $debugData = $resultSet->getUsedSearch()->getDebugResponse()->explain->{$document->getId()} ?? '';
+        }
 
         /** @var $scoreService ScoreCalculationService */
         $scoreService = self::getScoreService();

--- a/Classes/ViewHelpers/Debug/QueryViewHelper.php
+++ b/Classes/ViewHelpers/Debug/QueryViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Debug;
 
 /*
@@ -15,7 +16,9 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers\Debug;
  */
 
 use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
+use Closure;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
@@ -25,6 +28,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
+ *
+ * @noinspection PhpUnused used in Fluid templates <s:debug.query />
  */
 class QueryViewHelper extends AbstractSolrFrontendViewHelper
 {
@@ -37,17 +42,23 @@ class QueryViewHelper extends AbstractSolrFrontendViewHelper
 
     /**
      * @param array $arguments
-     * @param \Closure $renderChildrenClosure
+     * @param Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return string
+     * @throws AspectNotFoundException
+     * @noinspection PhpMissingReturnTypeInspection
+     * @noinspection PhpUnused
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public static function renderStatic(array $arguments, Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $content = '';
         $resultSet = self::getUsedSearchResultSetFromRenderingContext($renderingContext);
         $backendUserIsLoggedIn = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('backend.user', 'isLoggedIn');
-        if ($backendUserIsLoggedIn === true && $resultSet && $resultSet->getUsedSearch() !== null) {
-            $content = '<br><strong>Parsed Query:</strong><br>' . htmlspecialchars($resultSet->getUsedSearch()->getDebugResponse()->parsedquery);
+        if (true === $backendUserIsLoggedIn && $resultSet && null !== $resultSet->getUsedSearch()) {
+            if (true === $resultSet->getHasSearched() && null !== $resultSet->getUsedSearch()->getDebugResponse()
+                && !empty($resultSet->getUsedSearch()->getDebugResponse()->parsedquery)) {
+                $content = '<br><strong>Parsed Query:</strong><br>' . htmlspecialchars($resultSet->getUsedSearch()->getDebugResponse()->parsedquery);
+            }
         }
         return $content;
     }


### PR DESCRIPTION
In TYPO11 with PHP 8 there are some Errors like *PHP Warning: Undefined array key*.
This PR adds some additional checks and prevents this errors.

The additional options in IndexingConfigurationSelectorField are required to prevent warnings in TYPO3 core Backend FormElements and FieldWizards.