### PR TITLE
[FIX] Undefined array key "TSFE" in class RootPageResolver

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -158,7 +158,7 @@ class RootPageResolver implements SingletonInterface
     {
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
-        $rootPageId = intval($pageId) ?: intval($GLOBALS['TSFE']->id);
+        $rootPageId = intval($pageId) || !isset($GLOBALS['TSFE']) ? intval($pageId) : intval($GLOBALS['TSFE']->id);
 
         // frontend
         if (!empty($GLOBALS['TSFE']->rootLine)) {


### PR DESCRIPTION
Fixes: #3173

# What this pr does

Avoiding call on $GLOBALS['TSFE'] if not set

# How to test
Running TYPO3 11.5 with php 8

1. Open page with uid=0 in list mode
2. Open record for editing (e.g. be_groups, be_users)
3. Save the record
4. No PHP warning should appear

Fixes: #3173
