### PR TITLE
[BUGFIX] Change backend index queue amount to 10

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -223,7 +223,7 @@ class IndexQueueModuleController extends AbstractModuleController
     {
         /* @var IndexService $indexService */
         $indexService = GeneralUtility::makeInstance(IndexService::class, /** @scrutinizer ignore-type */ $this->selectedSite);
-        $indexWithoutErrors = $indexService->indexItems(1);
+        $indexWithoutErrors = $indexService->indexItems(10);
 
         $label = 'solr.backend.index_queue_module.flashmessage.success.index_manual';
         $severity = FlashMessage::OK;


### PR DESCRIPTION
In a246cb8e34d80da6227445c0c800620f16264a00 the amount changed to 1 but should be 10.
In the long run it should be configurable

