### PR TITLE
[BUGFIX] Fix notice in TranslateViewHelper

### DIFF
--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -91,7 +91,7 @@ class TranslateViewHelper extends CoreTranslateViewHelper
      */
     protected static function replaceTranslationPrefixesWithAtWithStringMarker($result)
     {
-        if (strpos($result, '@') !== false) {
+        if (strpos((string)$result, '@') !== false) {
             $result = preg_replace('~\"?@[a-zA-Z]*\"?~', '%s', $result);
         }
         return $result;


### PR DESCRIPTION
If using PHP 8.1, the following exception is thrown

```
PHP Runtime Deprecation Notice: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in
```

Cast the value to a string to avoid the exception

