### PR TITLE
[TASK] TYPO3 11 LTS compatibility :: part 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
           echo -e "matrix : "
           echo $matrix
           echo ::set-output name=matrix::$(echo $matrix)
+          >&2 echo -e "Example Annotation on error. Is visible in Actions wokflow view."
+          >&2 echo -e "Non-stable releases can not be published to TER. The tag 11.5.0-beta-1 is invalid for TER."
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -232,8 +234,9 @@ jobs:
         name: Check tag
         run: |
           TAGGED_VERSION=$(echo "${{ github.ref }}" | awk '{print tolower($0)}')
-          if ! [[ "$TAGGED_VERSION" =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}((-pre)?-(alpha|beta|rc)(-?[0-9]{1,3})?)?$ ]]; then
-            exit 1
+          if ! [[ "${TAGGED_VERSION}" =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}((-pre)?-(alpha|beta|rc)(-?[0-9]{1,3})?)?$ ]]; then
+            >&2 echo -e "Non-stable releases can not be published to TER. The tag ${TAGGED_VERSION} is invalid for TER."
+            exit 0
           fi
       -
         name: Resolve PHP version to use
@@ -262,7 +265,7 @@ jobs:
           echo "Following message will be printed in TER as release description:"
           echo -e "$TER_COMMENT"
           if ! composer extension-build; then
-            echo "Something went wrong on bulding EXT:solr for NON-Composer mode."
-            exit 1
+            >&2 echo -e "Something went wrong on bulding EXT:solr for NON-Composer mode. Please look in the job."
+            exit 13
           fi
           php ~/.composer/vendor/bin/tailor ter:publish --comment "$TER_COMMENT" "$RELEASE_VERSION"

--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -1,4 +1,18 @@
 <?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace ApacheSolrForTypo3\Solr\FrontendEnvironment;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
@@ -11,14 +25,22 @@ use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * Class TypoScript
+ */
 class TypoScript implements SingletonInterface
 {
 
-    private $configurationObjectCache = [];
+    /**
+     * Holds the TypoScript values for given page-id language and TypoScript path.
+     *
+     * @var array
+     */
+    private array $configurationObjectCache = [];
 
 
     /**
-     * Loads the TypoScript configuration for a given page id and language.
+     * Loads the TypoScript configuration for a given page-id and language.
      * Language usage may be disabled to get the default TypoScript
      * configuration.
      *

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -31,8 +31,8 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use UnexpectedValueException;
 
 /**
  * An abstract indexer class to collect a few common methods shared with other
@@ -221,15 +221,10 @@ abstract class AbstractIndexer
      * @param string $solrFieldName Current field being indexed
      * @return bool TRUE if the value is expected to be serialized, FALSE otherwise
      */
-    public static function isSerializedValue(array $indexingConfiguration, $solrFieldName)
+    public static function isSerializedValue(array $indexingConfiguration, string $solrFieldName): bool
     {
-        $isSerialized = static::isSerializedResultFromRegisteredHook($indexingConfiguration, $solrFieldName);
-        if ($isSerialized === true) {
-            return $isSerialized;
-        }
-
-        $isSerialized = static::isSerializedResultFromCustomContentElement($indexingConfiguration, $solrFieldName);
-        return $isSerialized;
+        return static::isSerializedResultFromRegisteredHook($indexingConfiguration, $solrFieldName)
+            || static::isSerializedResultFromCustomContentElement($indexingConfiguration, $solrFieldName);
     }
 
     /**
@@ -239,7 +234,7 @@ abstract class AbstractIndexer
      * @param string $solrFieldName
      * @return bool
      */
-    protected static function isSerializedResultFromCustomContentElement(array $indexingConfiguration, $solrFieldName): bool
+    protected static function isSerializedResultFromCustomContentElement(array $indexingConfiguration, string $solrFieldName): bool
     {
         $isSerialized = false;
 
@@ -268,7 +263,7 @@ abstract class AbstractIndexer
      * @param string $solrFieldName
      * @return bool
      */
-    protected static function isSerializedResultFromRegisteredHook(array $indexingConfiguration, $solrFieldName)
+    protected static function isSerializedResultFromRegisteredHook(array $indexingConfiguration, string $solrFieldName): bool
     {
         if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'] ?? null)) {
             return false;
@@ -278,7 +273,7 @@ abstract class AbstractIndexer
             $serializedValueDetector = GeneralUtility::makeInstance($classReference);
             if (!$serializedValueDetector instanceof SerializedValueDetector) {
                 $message = get_class($serializedValueDetector) . ' must implement interface ' . SerializedValueDetector::class;
-                throw new \UnexpectedValueException($message, 1404471741);
+                throw new UnexpectedValueException($message, 1404471741);
             }
 
             $isSerialized = (boolean)$serializedValueDetector->isSerializedValue($indexingConfiguration, $solrFieldName);
@@ -286,6 +281,7 @@ abstract class AbstractIndexer
                 return true;
             }
         }
+        return false;
     }
 
     /**

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -166,7 +166,7 @@ class Indexer extends AbstractIndexer
      * @throws ServiceUnavailableException
      * @throws SiteNotFoundException
      */
-    protected function indexItem(Item $item, int $language = 0)
+    protected function indexItem(Item $item, int $language = 0): bool
     {
         $itemIndexed = false;
         $documents = [];

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -84,7 +84,7 @@ class RecordMonitor
      * @param string $command The command.
      * @param string $table The table the record belongs to
      * @param int $uid The record's uid
-     * @param string $value
+     * @param mixed $value
      */
     public function processCmdmap_postProcess($command, $table, $uid, $value): void
     {

--- a/Classes/System/TCA/TCAService.php
+++ b/Classes/System/TCA/TCAService.php
@@ -120,13 +120,13 @@ class TCAService
     /**
      * This method can be used to check if there is a configured key in
      *
-     * $GLOBALS['TCA']['mytable']['ctrl']['enablecolumns']
+     * $GLOBALS['TCA']['my_table']['ctrl']['enablecolumns']
      *
      * Example:
      *
-     * $GLOBALS['TCA']['mytable']]['ctrl']['enablecolumns']['fe_group'] = 'mygroupfield'
+     * $GLOBALS['TCA']['my_table']]['ctrl']['enablecolumns']['fe_group'] = 'mygroupfield'
      *
-     * ->isEnableColumn('mytable', 'fe_group') will return true, because 'mygroupfield' is
+     * ->isEnableColumn('my_table', 'fe_group') will return true, because 'mygroupfield' is
      * configured as column.
      *
      * @params string $table

--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -121,7 +121,7 @@ class UrlHelper extends Uri
      * @param string $parameterName
      * @throws \InvalidArgumentException
      * @return UrlHelper
-     * @deprecated Will be removed with v12. Use withoutQueryParameter instead.
+     * @deprecated Will be removed with v12. Use {@link withoutQueryParameter} instead.
      */
     public function removeQueryParameter(string $parameterName): UrlHelper
     {

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -204,13 +204,13 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     /**
      * @return string
      */
-    protected function getQueryString()
+    protected function getQueryString(): string
     {
         $resultSet = $this->getSearchResultSet();
         if ($resultSet === null) {
             return '';
         }
-        return trim($this->getSearchResultSet()->getUsedSearchRequest()->getRawUserQuery());
+        return trim($this->getSearchResultSet()->getUsedSearchRequest()->getRawUserQuery() ?? '');
     }
 
     /**
@@ -226,9 +226,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
 
         /* @var UrlHelper $urlService */
         $urlService = GeneralUtility::makeInstance(UrlHelper::class, $suggestUrl);
-        $suggestUrl = $urlService->removeQueryParameter('cHash')->getUrl();
-
-        return $suggestUrl;
+        return $urlService->removeQueryParameter('cHash')->__toString();
     }
 
     /**

--- a/Tests/Integration/Access/RootlineTest.php
+++ b/Tests/Integration/Access/RootlineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Access;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
@@ -7,7 +8,8 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 /**
  * Class RootlineTest
  */
-class RootlineTest extends IntegrationTest {
+class RootlineTest extends IntegrationTest
+{
 
     /**
      * @test
@@ -16,9 +18,9 @@ class RootlineTest extends IntegrationTest {
     {
         $this->importDataSetFromFixture('user_protected_page.xml');
         $accessRootline = Rootline::getAccessRootlineByPageId(10);
-        $this->assertSame('10:4711', (string)$accessRootline, 'Did not determine expected access rootline for fe_group protected page');
+        self::assertSame('10:4711', (string)$accessRootline, 'Did not determine expected access rootline for fe_group protected page');
 
         $accessRootline = Rootline::getAccessRootlineByPageId(1);
-        $this->assertSame('', (string)$accessRootline, 'Access rootline for non protected page should be empty');
+        self::assertSame('', (string)$accessRootline, 'Access rootline for non protected page should be empty');
     }
 }

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 /***************************************************************
@@ -46,7 +47,7 @@ class ConnectionManagerTest extends IntegrationTest
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -55,11 +56,11 @@ class ConnectionManagerTest extends IntegrationTest
     /**
      * @return array
      */
-    public function  canFindSolrConnectionsByRootPageIdDataProvider()
+    public function canFindSolrConnectionsByRootPageIdDataProvider()
     {
         return [
             ['rootPageId' => 1, 'siteName' => 'integration_tree_one', 'expectedSolrHost' => 'solr.testone.endpoint'],
-            ['rootPageId' => 111, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint']
+            ['rootPageId' => 111, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint'],
         ];
     }
 
@@ -90,23 +91,22 @@ class ConnectionManagerTest extends IntegrationTest
         /** @var $connectionManager ConnectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
-        foreach ([0,1,2] as $languageID) {
+        foreach ([0, 1, 2] as $languageID) {
             $solrService = $connectionManager->getConnectionByRootPageId($rootPageId, $languageID);
-            $this->assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for root page "%s" and language "%s"', [$rootPageId, $languageID]));
-            $this->assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
+            self::assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for root page "%s" and language "%s"', [$rootPageId, $languageID]));
+            self::assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
                 ' Wrong connection is used. I expected "%s" as Host for "%s" Site with Root-Page ID "%s".', [$expectedSolrHost, $siteName, $rootPageId]));
         }
     }
 
-
     /**
      * @return array
      */
-    public function  canFindSolrConnectionsByPageIdDataProvider()
+    public function canFindSolrConnectionsByPageIdDataProvider()
     {
         return [
             ['pageId' => 11, 'siteName' => 'integration_tree_one', 'expectedSolrHost' => 'solr.testone.endpoint'],
-            ['ageId' => 21, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint']
+            ['ageId' => 21, 'siteName' => 'integration_tree_two', 'expectedSolrHost' => 'solr.testtwo.endpoint'],
         ];
     }
 
@@ -148,10 +148,10 @@ class ConnectionManagerTest extends IntegrationTest
         /** @var $connectionManager ConnectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
-        foreach ([0,1,2] as $languageID) {
+        foreach ([0, 1, 2] as $languageID) {
             $solrService = $connectionManager->getConnectionByPageId($pageId, $languageID);
-            $this->assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for page id "%s" and language "%s"', [$pageId, $languageID]));
-            $this->assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
+            self::assertInstanceOf(SolrConnection::class, $solrService, vsprintf('Should find solr connection for page id "%s" and language "%s"', [$pageId, $languageID]));
+            self::assertEquals($expectedSolrHost, $solrService->getNode('read')->getHost(), vsprintf('Apache Solr host must be the same as configured.' .
                 ' Wrong connection is used. I expected "%s" as Host for "%s" Site with Root-Page ID "%s".', [$expectedSolrHost, $siteName, $pageId]));
         }
     }
@@ -176,10 +176,10 @@ class ConnectionManagerTest extends IntegrationTest
             'integration_tree_three',
             $this->buildSiteConfiguration(3, 'http://testthree.site/'),
             [
-                $defaultLanguage, $german, $danish
+                $defaultLanguage, $german, $danish,
             ],
             [
-                $this->buildErrorHandlingConfiguration('Fluid', [404])
+                $this->buildErrorHandlingConfiguration('Fluid', [404]),
             ]
         );
     }
@@ -259,9 +259,9 @@ class ConnectionManagerTest extends IntegrationTest
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         $solrService = $connectionManager->getConnectionByPageId(24, 0, '24-14');
-        $this->assertInstanceOf(SolrConnection::class, $solrService, 'Should find solr connection for level 0 of mounted page.');
+        self::assertInstanceOf(SolrConnection::class, $solrService, 'Should find solr connection for level 0 of mounted page.');
 
         $solrService1 = $connectionManager->getConnectionByPageId(25, 0, '24-14');
-        $this->assertInstanceOf(SolrConnection::class, $solrService1, 'Should find solr connection for level 1 of mounted page.');
+        self::assertInstanceOf(SolrConnection::class, $solrService1, 'Should find solr connection for level 1 of mounted page.');
     }
 }

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 /***************************************************************
@@ -25,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -49,9 +49,7 @@ class RelationTest extends IntegrationTest
     {
         $this->importDataSetFromFixture($fixtureName);
         /* @var TypoScriptFrontendController|MockObject $tsfe */
-        $GLOBALS['TSFE'] = $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $GLOBALS['TSFE'] = $tsfe = $this->createMock(TypoScriptFrontendController::class);
         $tsfe->sys_page = GeneralUtility::makeInstance(PageRepository::class);
         /* @var ContentObjectRenderer $contentObjectRendererMock */
         $contentObjectRendererMock = $this->getMockBuilder(ContentObjectRenderer::class)->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
@@ -61,7 +59,7 @@ class RelationTest extends IntegrationTest
         $solrRelation = GeneralUtility::makeInstance(Relation::class, $contentObjectRendererMock);
         $actual = $solrRelation->render(['localField' => 'categories']);
 
-        $this->assertSame('Some Category', $actual, 'Can not fallback to table "pages" on non existent column configuration in TCA for table "pages_language_overlay".');
+        self::assertSame('Some Category', $actual, 'Can not fallback to table "pages" on non existent column configuration in TCA for table "pages_language_overlay".');
     }
 
     /**
@@ -73,7 +71,7 @@ class RelationTest extends IntegrationTest
     {
         return [
             ['solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml'],
-            ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml']
+            ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml'],
         ];
     }
 }

--- a/Tests/Integration/Controller/AbstractFrontendControllerTest.php
+++ b/Tests/Integration/Controller/AbstractFrontendControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
 /*
@@ -27,16 +28,14 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 
-
-abstract class AbstractFrontendControllerTest  extends IntegrationTest
+abstract class AbstractFrontendControllerTest extends IntegrationTest
 {
     /**
-     * @return void
      * @throws NoSuchCacheException
      * @throws DBALException
      * @throws TestingFrameworkCoreException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $_SERVER['HTTP_HOST'] = 'testone.site';
         $_SERVER['REQUEST_URI'] = '/en/search/';
@@ -46,9 +45,9 @@ abstract class AbstractFrontendControllerTest  extends IntegrationTest
     }
 
     /**
-     * Executed after each test. Emptys solr and checks if the index is empty
+     * Executed after each test. Empties solr and checks if the index is empty
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
@@ -91,7 +90,6 @@ abstract class AbstractFrontendControllerTest  extends IntegrationTest
     {
         return (new InternalRequest('http://testone.site/'))->withPageId($pageId);
     }
-
 
     /**
      * @return Response

--- a/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
+++ b/Tests/Integration/Controller/Backend/PageModuleSummaryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Backend;
 
 /***************************************************************
@@ -26,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Backend;
 
 use ApacheSolrForTypo3\Solr\Controller\Backend\PageModuleSummary;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -40,39 +40,38 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 class PageModuleSummaryTest extends IntegrationTest
 {
     /**
-     * @return void
      * @throws NoSuchCacheException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
-        $GLOBALS['LANG'] = $this->getMockBuilder(LanguageService::class)
-            ->disableOriginalConstructor()->getMock();
+        $GLOBALS['LANG'] = $this->createMock(LanguageService::class);
     }
 
     /**
      * @test
      */
-    public function canGetSummary() {
+    public function canGetSummary()
+    {
         $flexFormData = $this->getFixtureContentByName('fakeFlexform.xml');
 
         $fakeRow = ['pi_flexform' => $flexFormData];
-        $pageLayoutViewMock = $this->getMockBuilder(PageLayoutView::class)->disableOriginalConstructor()->getMock();
-        $pageLayoutViewMock->expects($this->any())->method('linkEditContent')->will($this->returnValue('fakePluginLabel'));
+        $pageLayoutViewMock = $this->createMock(PageLayoutView::class);
+        $pageLayoutViewMock->expects(self::any())->method('linkEditContent')->willReturn('fakePluginLabel');
         $data = [
             'row' => $fakeRow,
-            'pObj' => $pageLayoutViewMock
+            'pObj' => $pageLayoutViewMock,
         ];
         $summary = new PageModuleSummary();
         $result = $summary->getSummary($data);
 
-        $this->assertStringContainsString('fakePluginLabel', $result, 'Summary did not contain plugin label');
-        $this->assertStringContainsString('>Filter appKey</td>', $result, 'Summary did not contain filter label');
-        $this->assertStringContainsString('<td>test</td>', $result, 'Summary did not contain filter value');
-        $this->assertStringContainsString('<td>sorting</td>', $result, 'Summary did not contain sorting');
-        $this->assertStringContainsString('<td>boostFunction</td>', $result, 'Summary did not contain boostFunction');
-        $this->assertStringContainsString('<td>boostQuery</td>', $result, 'Summary did not contain boostQuery');
-        $this->assertStringContainsString('<td>10</td>', $result, 'Summary did not contain resultsPerPage');
-        $this->assertStringContainsString('<td>myTemplateFile.html</td>', $result, 'Templatefile not in summary');
+        self::assertStringContainsString('fakePluginLabel', $result, 'Summary did not contain plugin label');
+        self::assertStringContainsString('>Filter appKey</td>', $result, 'Summary did not contain filter label');
+        self::assertStringContainsString('<td>test</td>', $result, 'Summary did not contain filter value');
+        self::assertStringContainsString('<td>sorting</td>', $result, 'Summary did not contain sorting');
+        self::assertStringContainsString('<td>boostFunction</td>', $result, 'Summary did not contain boostFunction');
+        self::assertStringContainsString('<td>boostQuery</td>', $result, 'Summary did not contain boostQuery');
+        self::assertStringContainsString('<td>10</td>', $result, 'Summary did not contain resultsPerPage');
+        self::assertStringContainsString('<td>myTemplateFile.html</td>', $result, 'Templatefile not in summary');
     }
 }

--- a/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Backend\Search;
 
 /***************************************************************
@@ -44,7 +45,6 @@ use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
 
 /**
  * Class IndexAdministrationModuleControllerTest
- * @package ApacheSolrForTypo3\Solr\Tests\Integration\Controller\Search
  */
 class IndexAdministrationModuleControllerTest extends IntegrationTest
 {
@@ -60,9 +60,10 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
      * @throws NoSuchCacheException
      * @throws TestingFrameworkCoreException
      */
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
-        $GLOBALS['LANG'] = $this->getMockBuilder(LanguageService::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['LANG'] = $this->createMock(LanguageService::class);
 
         $this->writeDefaultSolrTestSiteConfiguration();
 
@@ -75,13 +76,14 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
                     'siteFinder' => GeneralUtility::makeInstance(SiteFinder::class),
                     'solrConnectionManager' => GeneralUtility::makeInstance(ConnectionManager::class),
                     'indexQueue' => GeneralUtility::makeInstance(Queue::class),
-                ])
+                ]
+            )
             ->onlyMethods(['addFlashMessage'])
             ->getMock();
         $uriBuilderMock = $this->getMockBuilder(UriBuilder::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['uriFor'])->getMock();
-        $uriBuilderMock->expects($this->any())->method('uriFor')->will($this->returnValue('index'));
+        $uriBuilderMock->expects(self::any())->method('uriFor')->willReturn('index');
         $this->controller->injectUriBuilder($uriBuilderMock);
     }
 
@@ -94,7 +96,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $selectedSite = $siteRepository->getFirstAvailableSite();
         $this->controller->setSelectedSite($selectedSite);
-        $this->controller->expects($this->exactly(1))
+        $this->controller->expects(self::exactly(1))
             ->method('addFlashMessage')
             ->with('Core configuration reloaded (core_en, core_de, core_da).', '', FlashMessage::OK);
         $this->controller->reloadIndexConfigurationAction();
@@ -109,7 +111,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $selectedSite = $siteRepository->getFirstAvailableSite();
         $this->controller->setSelectedSite($selectedSite);
-        $this->controller->expects($this->atLeastOnce())
+        $this->controller->expects(self::atLeastOnce())
             ->method('addFlashMessage')
             ->with('Index emptied for Site "Root of Testpage testone.site aka integration_tree_one, Root Page ID: 1" (core_en, core_de, core_da).', '', FlashMessage::OK);
 

--- a/Tests/Integration/Controller/CategoryPathProvider.php
+++ b/Tests/Integration/Controller/CategoryPathProvider.php
@@ -1,22 +1,21 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
 /**
  * Class CategoryPathProvider
  *
  * Test class that returns a fixture path list just for testing.
- *
- * @package ApacheSolrForTypo3\Solr\Tests\Integration\Controller
  */
-class CategoryPathProvider {
+class CategoryPathProvider
+{
 
     /**
      * Returns a list of paths concatenated with , only for testing
      * @return string
      */
-    public function getPaths() {
-
+    public function getPaths()
+    {
         if ($GLOBALS['TSFE']->id === 2) {
             return 'Men/Shoes \/ Socks,Accessoires/Socks';
         }

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -15,20 +15,20 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
+use ApacheSolrForTypo3\Solr\Controller\SearchController;
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
 use DOMDocument;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
-use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
-use ApacheSolrForTypo3\Solr\Controller\SearchController;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager as ExtbaseConfigurationManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Service\EnvironmentService;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Integration testcase to test for the SearchController
@@ -53,7 +53,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     protected $searchResponse;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->bootstrapSearchResultsPluginOnPage();
@@ -62,7 +62,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
     /**
      * @param int $pageId
-     * @return void
      * @throws TestingFrameworkCoreException
      */
     protected function bootstrapSearchResultsPluginOnPage(): void
@@ -92,7 +91,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $response = $this->executeFrontendSubRequest($this->getPreparedRequest(2022));
         $content = (string)$response->getBody();
-        $this->assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
+        self::assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
     }
 
     /**
@@ -103,7 +102,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $response = $this->executeFrontendSubRequest($this->getPreparedRequest());
         $content = (string)$response->getBody();
-        $this->assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
+        self::assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
     }
 
     /**
@@ -119,9 +118,9 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             $this->getPreparedRequest()->withQueryParameter('q', 'prices')
         )->getBody();
 
-        $this->assertMatchesRegularExpression('/Found [0-9]+ results in [0-9]+ milliseconds/i', $result);
-        $this->assertStringContainsString('pages/3/0/0/0', $result, 'Could not find page 3 in result set');
-        $this->assertStringContainsString('pages/2/0/0/0', $result, 'Could not find page 2 in result set');
+        self::assertMatchesRegularExpression('/Found [0-9]+ results in [0-9]+ milliseconds/i', $result);
+        self::assertStringContainsString('pages/3/0/0/0', $result, 'Could not find page 3 in result set');
+        self::assertStringContainsString('pages/2/0/0/0', $result, 'Could not find page 2 in result set');
     }
 
     /**
@@ -138,7 +137,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             plugin.tx_solr.search.results.resultsPerPage = 5'
         );
 
-
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
         $resultPage1 = (string)$this->executeFrontendSubRequest(
@@ -146,7 +144,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         )->getBody();
 
         $this->assertPaginationVisible($resultPage1);
-        $this->assertStringContainsString('Displaying results 1 to 5 of 8', $resultPage1, 'Wrong result count indicated in template of pagination page 1.');
+        self::assertStringContainsString('Displaying results 1 to 5 of 8', $resultPage1, 'Wrong result count indicated in template of pagination page 1.');
 
         $this->assertCanOpenSecondPageOfPaginatedSearch();
         $this->assertCanChangeResultsPerPage();
@@ -160,8 +158,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[page]', 2)
         )->getBody();
 
-        $this->assertStringContainsString('pages/8/0/0/0', $resultPage2, 'Could not find page(PID) 8 in result set.');
-        $this->assertStringContainsString('Displaying results 6 to 8 of 8', $resultPage2, 'Wrong result count indicated in template of pagination page 2.');
+        self::assertStringContainsString('pages/8/0/0/0', $resultPage2, 'Could not find page(PID) 8 in result set.');
+        self::assertStringContainsString('Displaying results 6 to 8 of 8', $resultPage2, 'Wrong result count indicated in template of pagination page 2.');
     }
 
     protected function assertCanChangeResultsPerPage()
@@ -172,7 +170,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[resultsPerPage]', 10)
         )->getBody();
 
-        $this->assertStringContainsString("Displaying results 1 to 8 of 8", $resultPage, '');
+        self::assertStringContainsString('Displaying results 1 to 8 of 8', $resultPage, '');
         $this->assertContainerByIdContains('<option selected="selected" value="10">10</option>', $resultPage, 'results-per-page');
     }
 
@@ -198,8 +196,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', 'shoo')
         )->getBody();
 
-        $this->assertStringContainsString("Did you mean", $resultPage1, 'Could not find did you mean in response');
-        $this->assertStringContainsString("shoes", $resultPage1, 'Could not find shoes in response');
+        self::assertStringContainsString('Did you mean', $resultPage1, 'Could not find did you mean in response');
+        self::assertStringContainsString('shoes', $resultPage1, 'Could not find shoes in response');
     }
 
     /**
@@ -228,8 +226,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', 'shoo')
         )->getBody();
 
-        $this->assertStringContainsString("Nothing found for shoo", $resultPage1, 'Could not find nothing found message');
-        $this->assertStringContainsString("Showing results for shoes", $resultPage1, 'Could not find correction message');
+        self::assertStringContainsString('Nothing found for shoo', $resultPage1, 'Could not find nothing found message');
+        self::assertStringContainsString('Showing results for shoes', $resultPage1, 'Could not find correction message');
     }
 
     /**
@@ -258,8 +256,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
     }
 
     /**
@@ -269,7 +267,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canDoAnInitialEmptySearchWithoutResults()
     {
-        $this->markTestSkipped('Something is wrong with refactored pagination. See https://github.com/TYPO3-Solr/ext-solr/issues/3150');
+        self::markTestSkipped('Something is wrong with refactored pagination. See https://github.com/TYPO3-Solr/ext-solr/issues/3150');
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
@@ -290,8 +288,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $resultPage1 = (string)$this->executeFrontendSubRequest($this->getPreparedRequest())->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialEmptyQuery was set to false');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialEmptyQuery was set to false');
     }
 
     /**
@@ -320,8 +318,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $resultPage1 = (string)$this->executeFrontendSubRequest($this->getPreparedRequest())->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialEmptyQuery was set to true');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialEmptyQuery was set to true');
     }
 
     /**
@@ -331,7 +329,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canDoAnInitialSearchWithoutResults()
     {
-        $this->markTestSkipped('Something is wrong with refactored pagination. See https://github.com/TYPO3-Solr/ext-solr/issues/3150');
+        self::markTestSkipped('Something is wrong with refactored pagination. See https://github.com/TYPO3-Solr/ext-solr/issues/3150');
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
@@ -352,10 +350,9 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $resultPage1 = (string)$this->executeFrontendSubRequest($this->getPreparedRequest())->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'fluidfacet should be generated since initializeWithQuery was configured with a query that should produce results');
-        $this->assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialQuery was set to false');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'fluidfacet should be generated since initializeWithQuery was configured with a query that should produce results');
+        self::assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialQuery was set to false');
     }
-
 
     /**
      * @test
@@ -383,8 +380,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $resultPage1 = (string)$this->executeFrontendSubRequest($this->getPreparedRequest())->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'fluidfacet should be generated since initializeWithQuery was configured with a query that should produce results');
-        $this->assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialQuery was set to true');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'fluidfacet should be generated since initializeWithQuery was configured with a query that should produce results');
+        self::assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialQuery was set to true');
     }
 
     /**
@@ -415,8 +412,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[filter][0]', 'type:pages')
         )->getBody();
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
 
     /**
@@ -447,7 +444,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[filter][0]', 'type:my_jobs')
         )->getBody();
 
-        $this->assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
+        self::assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
 
     /**
@@ -472,7 +469,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         )->getBody();
 
         // we should only find 2 results since a __pageSections filter should be applied
-        $this->assertStringContainsString('Found 2 results', $resultPage1, 'No link to remove facet option found');
+        self::assertStringContainsString('Found 2 results', $resultPage1, 'No link to remove facet option found');
     }
 
     /**
@@ -527,7 +524,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             (new InternalRequestContext())->withBackendUserId(1)
         )->getBody();
 
-        $this->assertStringContainsString('document-score-analysis', $resultPage1, 'No score analysis in response');
+        self::assertStringContainsString('document-score-analysis', $resultPage1, 'No score analysis in response');
     }
 
     /**
@@ -553,7 +550,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             '
         );
 
-        $womanPages = [4,5,8];
+        $womanPages = [4, 5, 8];
         $menPages = [2];
         $this->indexPages($womanPages);
         $this->indexPages($menPages);
@@ -566,12 +563,12 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $subtitleMenPosition = strpos($resultPage1, '>men</a> <span class="facet-result-count badge">1</span>');
         $subtitleWomanPosition =  strpos($resultPage1, '>woman</a> <span class="facet-result-count badge">3</span>');
 
-        $this->assertGreaterThan(0, $subtitleMenPosition);
-        $this->assertGreaterThan(0, $subtitleWomanPosition);
-        $this->assertGreaterThan($subtitleMenPosition, $subtitleWomanPosition);
+        self::assertGreaterThan(0, $subtitleMenPosition);
+        self::assertGreaterThan(0, $subtitleWomanPosition);
+        self::assertGreaterThan($subtitleMenPosition, $subtitleWomanPosition);
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
     }
 
     /**
@@ -595,7 +592,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             '
         );
 
-        $womanPages = [4,5,8];
+        $womanPages = [4, 5, 8];
         $menPages = [2];
         $this->indexPages($womanPages);
         $this->indexPages($menPages);
@@ -608,12 +605,12 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $subtitleMenPosition = strpos($resultPage1, '>men</a> <span class="facet-result-count badge">1</span>');
         $subtitleWomanPosition =  strpos($resultPage1, '>woman</a> <span class="facet-result-count badge">3</span>');
 
-        $this->assertGreaterThan(0, $subtitleMenPosition);
-        $this->assertGreaterThan(0, $subtitleWomanPosition);
-        $this->assertGreaterThan($subtitleWomanPosition, $subtitleMenPosition);
+        self::assertGreaterThan(0, $subtitleMenPosition);
+        self::assertGreaterThan(0, $subtitleWomanPosition);
+        self::assertGreaterThan($subtitleWomanPosition, $subtitleMenPosition);
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
     }
 
     /**
@@ -674,20 +671,17 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('Small (1 &amp; 2)', $resultPage1, 'Response did not contain expected small option of query facet');
-        $this->assertStringContainsString('Medium (2 to 5)', $resultPage1, 'Response did not contain expected medium option of query facet');
-        $this->assertStringContainsString('Large (5 to *)', $resultPage1, 'Response did not contain expected large option of query facet');
+        self::assertStringContainsString('Small (1 &amp; 2)', $resultPage1, 'Response did not contain expected small option of query facet');
+        self::assertStringContainsString('Medium (2 to 5)', $resultPage1, 'Response did not contain expected medium option of query facet');
+        self::assertStringContainsString('Large (5 to *)', $resultPage1, 'Response did not contain expected large option of query facet');
     }
 
-
-    /**
-     * @return void
-     */
     protected function addPageHierarchyFacetConfiguration(): void
     {
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search {
                 faceting = 1
                 faceting.facets.pageHierarchy {
@@ -732,12 +726,11 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('Found 8 results', $resultPage1, 'Assert to find 8 results without faceting');
-        $this->assertStringContainsString('facet-type-hierarchy', $resultPage1, 'Did not render hierarchy facet in the response');
-        $this->assertStringContainsString('data-facet-item-value="/1/2/"', $resultPage1, 'Hierarchy facet item did not contain expected data item');
+        self::assertStringContainsString('Found 8 results', $resultPage1, 'Assert to find 8 results without faceting');
+        self::assertStringContainsString('facet-type-hierarchy', $resultPage1, 'Did not render hierarchy facet in the response');
+        self::assertStringContainsString('data-facet-item-value="/1/2/"', $resultPage1, 'Hierarchy facet item did not contain expected data item');
 
-        $this->assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
-
+        self::assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
     }
 
     /**
@@ -756,10 +749,10 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[filter][0]', 'pageHierarchy:/1/2/')
         )->getBody();
 
-        $this->assertStringContainsString('Found 1 result', $resultPage1, 'Assert to only find one result after faceting');
-        $this->assertStringContainsString('facet-type-hierarchy', $resultPage1, 'Did not render hierarchy facet in the response');
-        $this->assertStringContainsString('data-facet-item-value="/1/2/"', $resultPage1, 'Hierarchy facet item did not contain expected data item');
-        $this->assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
+        self::assertStringContainsString('Found 1 result', $resultPage1, 'Assert to only find one result after faceting');
+        self::assertStringContainsString('facet-type-hierarchy', $resultPage1, 'Did not render hierarchy facet in the response');
+        self::assertStringContainsString('data-facet-item-value="/1/2/"', $resultPage1, 'Hierarchy facet item did not contain expected data item');
+        self::assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
     }
 
     /**
@@ -772,7 +765,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr {
                 index {
                     fieldProcessingInstructions.categoryPaths_stringM = pathToHierarchy
@@ -800,7 +794,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->indexPages([2, 3, 4]);
         // we should have 3 documents in solr
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":3', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":3', $solrContent, 'Could not index document into solr');
 
         // but when we facet on the categoryPaths:/Men/Shoes \/ Socks/ we should only have one result since the others
         // do not have the category assigned
@@ -810,7 +804,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[filter][0]', 'categoryPaths:/Men/Shoes \/ Socks/')
         )->getBody();
 
-        $this->assertStringContainsString('Found 1 result', $resultPage1, 'Assert to only find one result after faceting');
+        self::assertStringContainsString('Found 1 result', $resultPage1, 'Assert to only find one result after faceting');
     }
 
     /**
@@ -822,7 +816,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.faceting = 1
             plugin.tx_solr.search.faceting.facets.subtitle {
                 label = Subtitle
@@ -833,7 +828,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             '
         );
 
-        $womanPages = [4,5,8];
+        $womanPages = [4, 5, 8];
         $menPages = [2];
         $this->indexPages($womanPages);
         $this->indexPages($menPages);
@@ -846,12 +841,12 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $subtitleMenPosition = strpos($resultPage1, '>men</a> <span class="facet-result-count badge">1</span>');
         $subtitleWomanPosition =  strpos($resultPage1, '>woman</a> <span class="facet-result-count badge">3</span>');
 
-        $this->assertGreaterThan(0, $subtitleMenPosition);
-        $this->assertGreaterThan(0, $subtitleWomanPosition);
-        $this->assertGreaterThan($subtitleMenPosition, $subtitleWomanPosition);
+        self::assertGreaterThan(0, $subtitleMenPosition);
+        self::assertGreaterThan(0, $subtitleWomanPosition);
+        self::assertGreaterThan($subtitleMenPosition, $subtitleWomanPosition);
 
-        $this->assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
-        $this->assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
+        self::assertStringContainsString('fluidfacet', $resultPage1, 'Could not find fluidfacet class that indicates the facet was rendered with fluid');
+        self::assertStringContainsString('pages</a> <span class="facet-result-count badge">', $resultPage1, 'Could not find facet option for pages');
     }
 
     /**
@@ -863,7 +858,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.enableDebugMode = 1
             '
         );
@@ -876,7 +872,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             (new InternalRequestContext())->withBackendUserId(1)
         )->getBody();
 
-        $this->assertStringContainsString('Parsed Query:', $resultPage1, 'No parsed query in response');
+        self::assertStringContainsString('Parsed Query:', $resultPage1, 'No parsed query in response');
     }
 
     /**
@@ -910,18 +906,18 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             [
                 'solr_scheme_read' => 'http',
                 'solr_host_read' => 'localhost',
-                'solr_port_read' => 4711
+                'solr_port_read' => 4711,
             ]
         );
 
         $response = $this->executeFrontendSubRequest(
             $this->getPreparedRequest()
                 ->withQueryParameter('tx_solr[action]', $action)
-                ->withQueryParameter('tx_solr[' . key($getArguments). ']', current($getArguments))
+                ->withQueryParameter('tx_solr[' . key($getArguments) . ']', current($getArguments))
         );
 
-        $this->assertStringContainsString("Search is currently not available.", (string)$response->getBody(), 'Response did not contain solr unavailable error message');
-        $this->markTestIncomplete('The status code can not be checked currently. See: https://github.com/TYPO3/testing-framework/issues/324');
+        self::assertStringContainsString('Search is currently not available.', (string)$response->getBody(), 'Response did not contain solr unavailable error message');
+        self::markTestIncomplete('The status code can not be checked currently. See: https://github.com/TYPO3/testing-framework/issues/324');
         //$this->assertEquals(503, $response->getStatusCode());
     }
 
@@ -933,14 +929,15 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function canShowLastSearchesFromSessionInResponse()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Last searches component seems to be fine, but the test does not fit that case currently.
             The last-searches component is not rendered. See: https://github.com/TYPO3-Solr/ext-solr/issues/3160'
         );
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.lastSearches = 1
             plugin.tx_solr.search.lastSearches {
                 limit = 10
@@ -972,7 +969,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.lastSearches = 1
             plugin.tx_solr.search.lastSearches {
                 limit = 10
@@ -1003,7 +1001,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.lastSearches = 1
             plugin.tx_solr.search.lastSearches {
                 limit = 10
@@ -1048,7 +1047,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('Displaying results 1 to 4 of 4', $resultSearch);
+        self::assertStringContainsString('Displaying results 1 to 4 of 4', $resultSearch);
     }
 
     /**
@@ -1060,7 +1059,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.faceting = 1
             plugin.tx_solr.search.faceting.facets.myCreatedFacet {
                 label = Created Between
@@ -1077,7 +1077,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('facet-type-dateRange', $resultSearch);
+        self::assertStringContainsString('facet-type-dateRange', $resultSearch);
     }
 
     /**
@@ -1089,7 +1089,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.faceting = 1
             plugin.tx_solr.search.faceting.facets {
                 type {
@@ -1111,8 +1112,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[q]', '*')
         )->getBody();
 
-        $this->assertStringContainsString('id="facetmyType"', $resultSearch);
-        $this->assertStringContainsString('id="facettype"', $resultSearch);
+        self::assertStringContainsString('id="facetmyType"', $resultSearch);
+        self::assertStringContainsString('id="facettype"', $resultSearch);
     }
 
     /**
@@ -1126,7 +1127,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.search.faceting = 1
             plugin.tx_solr.search.faceting.facets {
                 pid {
@@ -1153,10 +1155,10 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $pid1OptionPosition = strpos($content, $pid1Option);
         $pid2OptionPosition = strpos($content, $pid2Option);
 
-        $this->assertGreaterThan(0, $pid1OptionPosition, 'Pid 1 option does not appear in the content');
-        $this->assertGreaterThan(0, $pid2OptionPosition, 'Pid 2 option does not appear in the content');
+        self::assertGreaterThan(0, $pid1OptionPosition, 'Pid 1 option does not appear in the content');
+        self::assertGreaterThan(0, $pid2OptionPosition, 'Pid 2 option does not appear in the content');
         $isPid2OptionBefore1Option = $pid2OptionPosition < $pid1OptionPosition;
-        $this->assertTrue($isPid2OptionBefore1Option);
+        self::assertTrue($isPid2OptionBefore1Option);
     }
 
     /**
@@ -1178,9 +1180,9 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $formContent = (string)$this->executeFrontendSubRequest(
             $this->getPreparedRequest()
         )->getBody();
-        $this->assertStringContainsString('<div class="tx-solr-search-form">', $formContent);
-        $this->assertStringNotContainsString('id="tx-solr-search"', $formContent);
-        $this->assertStringNotContainsString('id="tx-solr-search-functions"', $formContent);
+        self::assertStringContainsString('<div class="tx-solr-search-form">', $formContent);
+        self::assertStringNotContainsString('id="tx-solr-search"', $formContent);
+        self::assertStringNotContainsString('id="tx-solr-search-functions"', $formContent);
     }
 
     /**
@@ -1190,7 +1192,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     public function searchingAndRenderingFrequentSearchesIsShowingTheTermAsFrequentSearch()
     {
-        $this->markTestIncomplete('See: https://github.com/TYPO3-Solr/ext-solr/issues/3166');
+        self::markTestIncomplete('See: https://github.com/TYPO3-Solr/ext-solr/issues/3166');
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->indexPages([2]);
 
@@ -1200,7 +1202,6 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ['list_type' => 'solr_pi_frequentlysearched'],
                 ['uid' => 2022]
             );
-
 
         $resultPage = (string)$this->executeFrontendSubRequest(
             $this->getPreparedRequest()
@@ -1225,9 +1226,9 @@ class SearchControllerTest extends AbstractFrontendControllerTest
                 ->withQueryParameter('tx_solr[documentId]', '002de2729efa650191f82900ea02a0a3189dfabb/pages/2/0/0/0')
         )->getBody();
 
-        $this->assertStringContainsString("<h1>Socks</h1>", $resultPage);
-        $this->assertStringContainsString("<p>Our awesome new sock products prices starting at 10 euro</p>", $resultPage);
-        $this->assertStringContainsString("open</a>", $resultPage);
+        self::assertStringContainsString('<h1>Socks</h1>', $resultPage);
+        self::assertStringContainsString('<p>Our awesome new sock products prices starting at 10 euro</p>', $resultPage);
+        self::assertStringContainsString('open</a>', $resultPage);
     }
 
     /**
@@ -1240,7 +1241,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.view {
                 templateRootPaths.20 = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/
                 partialRootPaths.20 = EXT:solr/Tests/Integration/Controller/Fixtures/customPartials/
@@ -1252,8 +1254,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             $this->getPreparedRequest()
         )->getBody();
 
-        $this->assertStringContainsString('<h1>From custom "Results" template</h1>', $result, 'Can not overwrite template path');
-        $this->assertStringContainsString('<h1>From custom "RelevanceBar" partial</h1>', $result, 'Can not overwrite partial path');
+        self::assertStringContainsString('<h1>From custom "Results" template</h1>', $result, 'Can not overwrite template path');
+        self::assertStringContainsString('<h1>From custom "RelevanceBar" partial</h1>', $result, 'Can not overwrite partial path');
     }
 
     /**
@@ -1266,7 +1268,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $this->addTypoScriptConstantsToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.view {
                 templateRootPath = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/
                 partialRootPath = EXT:solr/Tests/Integration/Controller/Fixtures/customPartials/
@@ -1278,8 +1281,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             $this->getPreparedRequest()
         )->getBody();
 
-        $this->assertStringContainsString('<h1>From custom "Results" template</h1>', $result, 'Can not overwrite template path');
-        $this->assertStringContainsString('<h1>From custom "RelevanceBar" partial</h1>', $result, 'Can not overwrite partial path');
+        self::assertStringContainsString('<h1>From custom "Results" template</h1>', $result, 'Can not overwrite template path');
+        self::assertStringContainsString('<h1>From custom "RelevanceBar" partial</h1>', $result, 'Can not overwrite partial path');
     }
 
     /**
@@ -1290,7 +1293,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr {
                 settings.foo.bar = mytestsetting
                 view {
@@ -1305,7 +1309,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             $this->getPreparedRequest()
         )->getBody();
 
-        $this->assertStringContainsString('mytestsetting', $result, 'Can not output passed test setting');
+        self::assertStringContainsString('mytestsetting', $result, 'Can not output passed test setting');
     }
 
     /**
@@ -1318,7 +1322,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $this->addTypoScriptToTemplateRecord(
             1,
-            /* @lang typoScript */ '
+            /* @lang typoScript */
+            '
             plugin.tx_solr.view.templateFiles {
                 results = EXT:solr/Tests/Integration/Controller/Fixtures/customTemplates/Search/MyResults.html
             }
@@ -1328,9 +1333,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
             $this->getPreparedRequest()
         )->getBody();
 
-        $this->assertStringContainsString('<h1>From custom entry template</h1>', $result, 'Can not set entry template file name in typoscript');
+        self::assertStringContainsString('<h1>From custom entry template</h1>', $result, 'Can not set entry template file name in typoscript');
     }
-
 
     /**
      * @param string $content
@@ -1357,7 +1361,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     protected function assertContainerByIdContains($expectedToContain, $content, $id)
     {
         $containerContent = $this->getIdContent($content, $id);
-        $this->assertStringContainsString($expectedToContain, $containerContent, 'Failed asserting that container with id ' . $id .' contains ' . $expectedToContain);
+        self::assertStringContainsString($expectedToContain, $containerContent, 'Failed asserting that container with id ' . $id . ' contains ' . $expectedToContain);
     }
 
     /**
@@ -1370,9 +1374,8 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     protected function assertContainerByIdNotContains($expectedToContain, $content, $id)
     {
         $containerContent = $this->getIdContent($content, $id);
-        $this->assertStringNotContainsString($expectedToContain, $containerContent, 'Failed asserting that container with id ' . $id .' not contains ' . $expectedToContain);
+        self::assertStringNotContainsString($expectedToContain, $containerContent, 'Failed asserting that container with id ' . $id . ' not contains ' . $expectedToContain);
     }
-
 
     /**
      * Assertion to check if the pagination markup is present in the response.
@@ -1381,39 +1384,36 @@ class SearchControllerTest extends AbstractFrontendControllerTest
      */
     protected function assertPaginationVisible($content)
     {
-        $this->assertStringContainsString('class="solr-pagination"', $content, 'No pagination container visible');
-        $this->assertStringContainsString('ul class="pagination"', $content, 'Could not see pagination list');
+        self::assertStringContainsString('class="solr-pagination"', $content, 'No pagination container visible');
+        self::assertStringContainsString('ul class="pagination"', $content, 'Could not see pagination list');
     }
 
     /**
      * We fake in the frontend context, that a backend user is logged in.
-     *
-     * @return void
      */
     protected function fakeBackendUserLoggedInInFrontend()
     {
         /** @var  $context \TYPO3\CMS\Core\Context\Context::class */
         $context = GeneralUtility::makeInstance(Context::class);
-        $userAspect = $this->getMockBuilder(UserAspect::class)->setMethods([])->getMock();
-        $userAspect->expects($this->any())->method('get')->with('isLoggedIn')->willReturn(true);
+        $userAspect = $this->getMockBuilder(UserAspect::class)->onlyMethods([])->getMock();
+        $userAspect->expects(self::any())->method('get')->with('isLoggedIn')->willReturn(true);
         $context->setAspect('backend.user', $userAspect);
     }
 
     /**
      * In this method we initialize a few singletons with mocked classes to be able to generate links
      * for the frontend in the testing context.
-     * @return void
      */
     protected function fakeSingletonsForFrontendContext()
     {
-        $environmentServiceMock = $this->getMockBuilder(EnvironmentService::class)->setMethods([])->disableOriginalConstructor()->getMock();
-        $environmentServiceMock->expects($this->any())->method('isEnvironmentInFrontendMode')->willReturn(true);
-        $environmentServiceMock->expects($this->any())->method('isEnvironmentInBackendMode')->willReturn(false);
+        $environmentServiceMock = $this->getMockBuilder(EnvironmentService::class)->onlyMethods([])->disableOriginalConstructor()->getMock();
+        $environmentServiceMock->expects(self::any())->method('isEnvironmentInFrontendMode')->willReturn(true);
+        $environmentServiceMock->expects(self::any())->method('isEnvironmentInBackendMode')->willReturn(false);
 
         $configurationManagerMock = $this->getMockBuilder(ExtbaseConfigurationManager::class)->onlyMethods(['getContentObject'])
             ->setConstructorArgs([$this->getContainer()])->getMock();
 
-        $configurationManagerMock->expects($this->any())->method('getContentObject')->willReturn(GeneralUtility::makeInstance(ContentObjectRenderer::class));
+        $configurationManagerMock->expects(self::any())->method('getContentObject')->willReturn(GeneralUtility::makeInstance(ContentObjectRenderer::class));
 
         GeneralUtility::setSingletonInstance(EnvironmentService::class, $environmentServiceMock);
         GeneralUtility::setSingletonInstance(ExtbaseConfigurationManager::class, $configurationManagerMock);

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
 /*
@@ -14,8 +15,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
 use ApacheSolrForTypo3\Solr\Controller\SuggestController;
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
 use TYPO3\CMS\Core\Http\Response;
 
 /**
@@ -27,7 +28,7 @@ use TYPO3\CMS\Core\Http\Response;
  */
 class SuggestControllerTest extends AbstractFrontendControllerTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->addTypoScriptToTemplateRecord(
@@ -50,7 +51,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
         $result = (string)($this->executeFrontendSubRequestForSuggestQueryString('Sweat', 'rand')->getBody());
 
         //we assume to get suggestions like Sweatshirt
-        $this->assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
+        self::assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
     }
 
     /**
@@ -64,7 +65,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
         $result = (string)($this->executeFrontendSubRequestForSuggestQueryString('Sweat')->getBody());
 
         //we assume to get suggestions like Sweatshirt
-        $this->assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
+        self::assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
     }
 
     /**
@@ -88,11 +89,11 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
         $testCases = [
             [
                 'prefix' => 'Some/',
-                'expected' => 'suggestions":{"some/":1,"some/larg":1,"some/large/path":1}'
+                'expected' => 'suggestions":{"some/":1,"some/larg":1,"some/large/path":1}',
             ],
             [
                 'prefix' => 'Some/Large',
-                'expected' => 'suggestions":{"some/large/path":1}'
+                'expected' => 'suggestions":{"some/large/path":1}',
             ],
         ];
         foreach ($testCases as $testCase) {
@@ -105,7 +106,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
         $result = (string)($this->executeFrontendSubRequestForSuggestQueryString($prefix, 'rand')->getBody());
 
         //we assume to get suggestions like some/large/path
-        $this->assertStringContainsString($expected, $result, 'Response did not contain expected suggestions: ' . $expected);
+        self::assertStringContainsString($expected, $result, 'Response did not contain expected suggestions: ' . $expected);
     }
 
     protected function executeFrontendSubRequestForSuggestQueryString(string $queryString, string $callback = null): Response

--- a/Tests/Integration/Domain/Index/Fixtures/fake_extension2_bar_tca.php
+++ b/Tests/Integration/Domain/Index/Fixtures/fake_extension2_bar_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,title',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'title' => [
             'exclude' => 0,
@@ -134,14 +134,14 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
         ],
         'tags' => [
             'exclude' => 1,
@@ -155,8 +155,8 @@ return [
                 'foreign_table' => 'tx_fakeextension_domain_model_mmrelated',
                 'size' => '5',
                 'maxitems' => '200',
-                'minitems' => '0'
-              ]
+                'minitems' => '0',
+              ],
          ],
         'category' => [
             'exclude' => 1,
@@ -170,11 +170,11 @@ return [
                     'expandSingle' => 1,
                 ],
             ],
-        ]
+        ],
      ],
      'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,title,tags'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,title,tags',
+        ],
+    ],
 ];

--- a/Tests/Integration/Domain/Index/Fixtures/fake_extension2_directrelated_tca.php
+++ b/Tests/Integration/Domain/Index/Fixtures/fake_extension2_directrelated_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,category',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'category' => [
             'exclude' => 0,
@@ -134,19 +134,19 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,category'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,category',
+        ],
+    ],
 ];

--- a/Tests/Integration/Domain/Index/Fixtures/fake_extension2_mmrelated_tca.php
+++ b/Tests/Integration/Domain/Index/Fixtures/fake_extension2_mmrelated_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,tag',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'tag' => [
             'exclude' => 0,
@@ -134,19 +134,19 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,tag'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,tag',
+        ],
+    ],
 ];

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Index;
 
 /***************************************************************
@@ -38,8 +39,8 @@ use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\Schema\Exception\StatementException;
 use TYPO3\CMS\Core\Database\Schema\Exception\UnexpectedSignalReturnValueTypeException;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
 
 /**
@@ -61,13 +62,11 @@ class IndexServiceTest extends IntegrationTest
     protected $indexQueue;
 
     /**
-     * @return void
-     *
      * @throws DBALException
      * @throws NoSuchCacheException
      * @throws TestingFrameworkCoreException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -87,7 +86,6 @@ class IndexServiceTest extends IntegrationTest
     /**
      * @param string $table
      * @param int $uid
-     * @return void
      */
     protected function addToIndexQueue($table, $uid): void
     {
@@ -101,7 +99,7 @@ class IndexServiceTest extends IntegrationTest
             'absRefPrefixIsFoo' => [
                 'absRefPrefix' => 'foo',
                 'expectedUrl' => '/foo/en/?tx_ttnews%5Btt_news%5D=111&cHash=a14e458509b71459d1edaafd1d5a84a1',
-            ]
+            ],
         ];
     }
 
@@ -154,8 +152,8 @@ class IndexServiceTest extends IntegrationTest
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"url":"' . $expectedUrl, $solrContent, 'Generated unexpected url with absRefPrefix = auto');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"url":"' . $expectedUrl, $solrContent, 'Generated unexpected url with absRefPrefix = auto');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 }

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Index\Queue;
 
 /***************************************************************
@@ -43,7 +44,8 @@ class QueueItemRepositoryTest extends IntegrationTest
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
     }
@@ -58,17 +60,17 @@ class QueueItemRepositoryTest extends IntegrationTest
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
 
         $queueItem = $queueItemRepository->findItemByUid(4711);
-        $this->assertFalse($queueItem->hasIndexingProperties());
+        self::assertFalse($queueItem->hasIndexingProperties());
 
         $queueItemRepository->updateHasIndexingPropertiesFlagByItemUid(4711, true);
 
         $queueItem = $queueItemRepository->findItemByUid(4711);
-        $this->assertTrue($queueItem->hasIndexingProperties());
+        self::assertTrue($queueItem->hasIndexingProperties());
 
         $queueItemRepository->updateHasIndexingPropertiesFlagByItemUid(4711, false);
 
         $queueItem = $queueItemRepository->findItemByUid(4711);
-        $this->assertFalse($queueItem->hasIndexingProperties());
+        self::assertFalse($queueItem->hasIndexingProperties());
     }
 
     /**
@@ -79,10 +81,10 @@ class QueueItemRepositoryTest extends IntegrationTest
         $this->importDataSetFromFixture('can_delete_item_by_type_and_uid.xml');
         /** @var $queueItemRepository QueueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
-        $this->assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
+        self::assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
         $queueItemRepository->deleteItem('pages', 1);
 
-        $this->assertSame(3, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type and uid');
+        self::assertSame(3, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type and uid');
     }
 
     /**
@@ -93,10 +95,10 @@ class QueueItemRepositoryTest extends IntegrationTest
         $this->importDataSetFromFixture('can_delete_item_by_type.xml');
         /** @var $queueItemRepository QueueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
-        $this->assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
+        self::assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
         $queueItemRepository->deleteItem('pages');
 
-        $this->assertSame(2, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type and uid');
+        self::assertSame(2, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type and uid');
     }
 
     /**
@@ -107,10 +109,10 @@ class QueueItemRepositoryTest extends IntegrationTest
         $this->importDataSetFromFixture('can_count_items.xml');
         /** @var $queueItemRepository QueueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
-        $this->assertSame(6, $queueItemRepository->countItems(), 'Unexpected amount of items counted when no filter was passed');
-        $this->assertSame(4, $queueItemRepository->countItems([], ['pages']), 'Unexpected amount of counted pages');
-        $this->assertSame(2, $queueItemRepository->countItems([], ['pages'], [], [3,4]), 'Unexpected amount of counted pages and item uids');
-        $this->assertSame(1, $queueItemRepository->countItems([], ['pages'], [], [], [4713]), 'Unexpected amount of counted pages and uids');
+        self::assertSame(6, $queueItemRepository->countItems(), 'Unexpected amount of items counted when no filter was passed');
+        self::assertSame(4, $queueItemRepository->countItems([], ['pages']), 'Unexpected amount of counted pages');
+        self::assertSame(2, $queueItemRepository->countItems([], ['pages'], [], [3, 4]), 'Unexpected amount of counted pages and item uids');
+        self::assertSame(1, $queueItemRepository->countItems([], ['pages'], [], [], [4713]), 'Unexpected amount of counted pages and uids');
     }
 
     /**
@@ -123,10 +125,10 @@ class QueueItemRepositoryTest extends IntegrationTest
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         $items = $queueItemRepository->findItems([], ['pages']);
 
-            /** @var Item $firstItem */
+        /** @var Item $firstItem */
         $firstItem = $items[0];
-        $this->assertSame(4, count($items));
-        $this->assertSame('pages', $firstItem->getType(), 'First item has unexpected type');
+        self::assertSame(4, count($items));
+        self::assertSame('pages', $firstItem->getType(), 'First item has unexpected type');
     }
 
     /**
@@ -141,51 +143,51 @@ class QueueItemRepositoryTest extends IntegrationTest
 
         $currentSite = $siteRepository->getSiteByPageId(4711);
 
-
         /** @var $queueItemRepository  QueueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         $queueItemRepository->add('pages', 4711, 1, 2, 'news_pages');
         $queueItemRepository->add('pages', 4711, 1, 2, 'product_pages');
 
         $items = $queueItemRepository->findItemsByItemTypeAndItemUid('pages', 4711);
-        $this->assertCount(2, $items, 'Retrieved unexpected amount of records from queue item repository');
+        self::assertCount(2, $items, 'Retrieved unexpected amount of records from queue item repository');
 
-        foreach($items as $item) {
-            $this->assertSame([], $item->getIndexingProperties(), 'New added item should have empty indexing properties');
-            $this->assertFalse($item->hasIndexingProperty('sense_of_live'), 'New indexing property should not exist');
+        foreach ($items as $item) {
+            self::assertSame([], $item->getIndexingProperties(), 'New added item should have empty indexing properties');
+            self::assertFalse($item->hasIndexingProperty('sense_of_live'), 'New indexing property should not exist');
 
             $item->setIndexingProperty('shared_property', 'hello solr');
             $item->storeIndexingProperties();
-            $this->assertSame('hello solr', $item->getIndexingProperty('shared_property'), 'New indexing property be retrieved');
+            self::assertSame('hello solr', $item->getIndexingProperty('shared_property'), 'New indexing property be retrieved');
         }
 
         $queueItemRepository->deleteItemsBySite($currentSite, 'news_pages');
 
         $items = $queueItemRepository->findAll();
-        $this->assertCount(1, $items, 'Queue should only contain on more item after deletion with index queue configuration');
+        self::assertCount(1, $items, 'Queue should only contain on more item after deletion with index queue configuration');
 
         $items = $queueItemRepository->findItemsByItemTypeAndItemUid('pages', 4711);
-        $this->assertCount(1, $items, 'Retrieved unexpected amount of records from queue item repository');
+        self::assertCount(1, $items, 'Retrieved unexpected amount of records from queue item repository');
 
-        foreach($items as $item) {
-            $this->assertSame('hello solr', $item->getIndexingProperty('shared_property'), 'Previous added indexing property was lost');
+        foreach ($items as $item) {
+            self::assertSame('hello solr', $item->getIndexingProperty('shared_property'), 'Previous added indexing property was lost');
         }
     }
 
     /**
      * @test
      */
-    public function canFlushErrorByItem() {
+    public function canFlushErrorByItem()
+    {
         $this->importDataSetFromFixture('can_flush_error_by_item.xml');
         /** @var $queueItemRepository QueueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
 
         $item = $queueItemRepository->findItemByUid(4714);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
         $queueItemRepository->flushErrorByItem($item);
 
         $item = $queueItemRepository->findItemByUid(4714);
-        $this->assertInstanceOf(Item::class, $item);
-        $this->assertEmpty($item->getErrors());
+        self::assertInstanceOf(Item::class, $item);
+        self::assertEmpty($item->getErrors());
     }
 }

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ApacheSolrDocument;
 
 /***************************************************************
@@ -42,7 +43,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTest
      */
     protected $apacheSolrDocumentRepository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -61,7 +62,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTest
     /**
      * Executed after each test. Emptys solr and checks if the index is empty
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
@@ -74,9 +75,9 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTest
     {
         $apacheSolrDocumentsCollection = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId(3, 0);
 
-        $this->assertIsArray($apacheSolrDocumentsCollection, 'Repository did not get Document collection from pageId 3.');
-        $this->assertNotEmpty($apacheSolrDocumentsCollection, 'Repository did not get apache solr documents from pageId 3.');
-        $this->assertInstanceOf(Document::class, $apacheSolrDocumentsCollection[0], 'ApacheSolrDocumentRepository returned not an array of type Document.');
+        self::assertIsArray($apacheSolrDocumentsCollection, 'Repository did not get Document collection from pageId 3.');
+        self::assertNotEmpty($apacheSolrDocumentsCollection, 'Repository did not get apache solr documents from pageId 3.');
+        self::assertInstanceOf(Document::class, $apacheSolrDocumentsCollection[0], 'ApacheSolrDocumentRepository returned not an array of type Document.');
     }
 
     /**
@@ -85,6 +86,6 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTest
     public function canReturnEmptyCollectionIfNoConnectionToSolrServerIsEstablished()
     {
         $apacheSolrDocumentsCollection = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId(3, 777);
-        $this->assertEmpty($apacheSolrDocumentsCollection, 'ApacheSolrDocumentRepository does not return empty collection if no connection to core can be established.');
+        self::assertEmpty($apacheSolrDocumentsCollection, 'ApacheSolrDocumentRepository does not return empty collection if no connection to core can be established.');
     }
 }

--- a/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\LastSearches;
 
 /***************************************************************
@@ -28,7 +29,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-
 class LastSearchesRepositoryTest extends IntegrationTest
 {
     /**
@@ -36,7 +36,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
      */
     protected $lastSearchesRepository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->lastSearchesRepository = GeneralUtility::makeInstance(LastSearchesRepository::class);
@@ -49,7 +49,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_find_and_add_last_searches.xml');
         $actual = $this->lastSearchesRepository->findAllKeywords(10);
-        $this->assertSame(['4', '3', '2', '1', '0'], $actual);
+        self::assertSame(['4', '3', '2', '1', '0'], $actual);
     }
 
     /**
@@ -62,7 +62,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
         $this->lastSearchesRepository->add('5', 6);
 
         $actual = $this->lastSearchesRepository->findAllKeywords(10);
-        $this->assertSame(['5', '4', '3', '2', '1', '0'], $actual);
+        self::assertSame(['5', '4', '3', '2', '1', '0'], $actual);
     }
 
     /**
@@ -75,7 +75,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
         $this->lastSearchesRepository->add('5', 5);
 
         $actual = $this->lastSearchesRepository->findAllKeywords();
-        $this->assertSame(['5', '4', '3', '2', '1'], $actual);
+        self::assertSame(['5', '4', '3', '2', '1'], $actual);
     }
 
     /**
@@ -88,6 +88,6 @@ class LastSearchesRepositoryTest extends IntegrationTest
         $this->lastSearchesRepository->add('1', 5);
 
         $actual = $this->lastSearchesRepository->findAllKeywords();
-        $this->assertSame(['1', '4', '3', '2'], $actual);
+        self::assertSame(['1', '4', '3', '2'], $actual);
     }
 }

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ResultSet;
 
 /***************************************************************
@@ -24,12 +25,12 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ResultSet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\ResultSetReconstitutionProcessor;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -63,7 +64,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -73,20 +74,20 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
                     'renderingInstruction' => 'CASE',
                     'renderingInstruction.' => [
                         'key.' => [
-                            'field' => 'optionValue'
+                            'field' => 'optionValue',
                         ],
                         'page' => 'TEXT',
                         'page.' => [
-                            'value' => 'Pages'
+                            'value' => 'Pages',
                         ],
                         'event' => 'TEXT',
                         'event.' => [
-                            'value' => 'Events'
-                        ]
+                            'value' => 'Events',
+                        ],
 
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -98,7 +99,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
 
         /** @var $option1 Option */ // @extensionScannerIgnoreLine
         $option1 = $facet->getOptions()->getByPosition(0);
-        $this->assertSame('Pages', $option1->getLabel(), 'Rendering instructions have not been applied on the facet options');
+        self::assertSame('Pages', $option1->getLabel(), 'Rendering instructions have not been applied on the facet options');
     }
 
     /**
@@ -117,7 +118,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -125,11 +126,11 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
                     'label' => 'TEXT',
                     'label.' => [
                         'value' => 'My Type with special rendering',
-                        'stdWrap.' => ['case' => 'upper']
+                        'stdWrap.' => ['case' => 'upper'],
                     ],
                     'field' => 'type_stringS',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -138,7 +139,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
 
         /** @var $facet OptionsFacet */
         $facet = $searchResultSet->getFacets()->getByPosition(0);
-        $this->assertSame('MY TYPE WITH SPECIAL RENDERING', $facet->getLabel(), 'Rendering instructions have not been applied on the facet options');
+        self::assertSame('MY TYPE WITH SPECIAL RENDERING', $facet->getLabel(), 'Rendering instructions have not been applied on the facet options');
     }
 
     /**
@@ -147,7 +148,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
      */
     protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile): SearchResultSet
     {
-        $searchRequestMock = $this->getMockBuilder(SearchRequest::class)->getMock();
+        $searchRequestMock = $this->createMock(SearchRequest::class);
 
         $fakeResponseJson = $this->getFixtureContentByName($fixtureFile);
         $fakeResponse = new ResponseAdapter($fakeResponseJson);
@@ -181,8 +182,8 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
 
         /* @var SearchRequest|MockObject $usedSearchRequestMock */
         $usedSearchRequestMock = $searchResultSet->getUsedSearchRequest();
-        $usedSearchRequestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfiguration));
-        $usedSearchRequestMock->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue([]));
+        $usedSearchRequestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+        $usedSearchRequestMock->expects(self::any())->method('getActiveFacetNames')->willReturn([]);
 
         $processor = new ResultSetReconstitutionProcessor();
         $fakeObjectManager = $this->getFakeObjectManager();

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ResultSet;
 
 /***************************************************************
@@ -25,13 +26,13 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ResultSet;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 
 class SearchResultSetServiceTest extends IntegrationTest
 {
@@ -41,7 +42,8 @@ class SearchResultSetServiceTest extends IntegrationTest
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
     }
@@ -49,7 +51,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * Executed after each test. Emptys solr and checks if the index is empty
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
@@ -66,7 +68,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0', $solrContent);
+        self::assertStringContainsString('002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0', $solrContent);
 
         $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1, 0, 0);
 
@@ -77,7 +79,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $searchResultsSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
         $document = $searchResultsSetService->getDocumentById('002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0');
 
-        $this->assertSame($document->getTitle(), 'Products', 'Could not get document from solr by id');
+        self::assertSame($document->getTitle(), 'Products', 'Could not get document from solr by id');
     }
 
     /**
@@ -97,34 +99,34 @@ class SearchResultSetServiceTest extends IntegrationTest
                'variants.' => [
                    'variantField' => 'pid',
                    'expand' => 1,
-                   'limit' => 11
-               ]
-           ]
+                   'limit' => 11,
+               ],
+           ],
         ]);
 
-        $this->assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
-        $this->assertEquals('pid', $typoScriptConfiguration->getSearchVariantsField());
-        $this->assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
+        self::assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
+        self::assertEquals('pid', $typoScriptConfiguration->getSearchVariantsField());
+        self::assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
 
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
-        $this->assertSame(4, count($searchResults), 'There should be three results at all');
+        self::assertSame(4, count($searchResults), 'There should be three results at all');
 
         // We assume that the first result (pid=0) has no variants.
         $firstResult = $searchResults[0];
-        $this->assertSame(0, count($firstResult->getVariants()));
+        self::assertSame(0, count($firstResult->getVariants()));
 
         // We assume that the second result (pid=1) has 1 variant.
         $secondResult = $searchResults[1];
-        $this->assertSame(1, count($secondResult->getVariants()));
+        self::assertSame(1, count($secondResult->getVariants()));
 
         // We assume that the third result (pid=3) has 3 variants.
         $thirdResult = $searchResults[2];
-        $this->assertSame(3, count($thirdResult->getVariants()));
-        $this->assertSame('Men Socks', $thirdResult->getTitle());
+        self::assertSame(3, count($thirdResult->getVariants()));
+        self::assertSame('Men Socks', $thirdResult->getTitle());
 
         // And every variant is indicated to be a variant.
         foreach ($thirdResult->getVariants() as $variant) {
-            $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
+            self::assertTrue($variant->getIsVariant(), 'Document should be a variant');
         }
     }
 
@@ -145,56 +147,56 @@ class SearchResultSetServiceTest extends IntegrationTest
                 'variants.' => [
                     'variantField' => 'author',
                     'expand' => 1,
-                    'limit' => 11
+                    'limit' => 11,
                 ],
                 'query.' => [
                     'filter.' => [
-                        'skipRootPage' => '-pid:0'
-                    ]
-                ]
-            ]
+                        'skipRootPage' => '-pid:0',
+                    ],
+                ],
+            ],
         ]);
 
-        $this->assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
-        $this->assertEquals('author', $typoScriptConfiguration->getSearchVariantsField());
-        $this->assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
+        self::assertTrue($typoScriptConfiguration->getSearchVariants(), 'Variants are not enabled');
+        self::assertEquals('author', $typoScriptConfiguration->getSearchVariantsField());
+        self::assertEquals(11, $typoScriptConfiguration->getSearchVariantsLimit());
 
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
-        $this->assertSame(3, count($searchResults), 'There should be three results at all');
+        self::assertSame(3, count($searchResults), 'There should be three results at all');
 
         // We assume that the first result has 2 variants.
         /* @var SearchResult $firstResult */
         $firstResult = $searchResults[0];
-        $this->assertSame(2, count($firstResult->getVariants()));
-        $this->assertSame('Jane Doe', $firstResult->getAuthor());
-        $this->assertSame(2, $firstResult->getVariantsNumFound());
-        $this->assertSame('Jane Doe', $firstResult->getVariantFieldValue());
+        self::assertSame(2, count($firstResult->getVariants()));
+        self::assertSame('Jane Doe', $firstResult->getAuthor());
+        self::assertSame(2, $firstResult->getVariantsNumFound());
+        self::assertSame('Jane Doe', $firstResult->getVariantFieldValue());
 
         // We assume that the second result has 5 variants.
         /* @var SearchResult $secondResult */
         $secondResult = $searchResults[1];
-        $this->assertSame(5, count($secondResult->getVariants()));
-        $this->assertSame('John Doe', $secondResult->getAuthor());
-        $this->assertSame(5, $secondResult->getVariantsNumFound());
+        self::assertSame(5, count($secondResult->getVariants()));
+        self::assertSame('John Doe', $secondResult->getAuthor());
+        self::assertSame(5, $secondResult->getVariantsNumFound());
 
         // We assume that the third result has no variants.
         /* @var SearchResult $secondResult */
         $thirdResult = $searchResults[2];
-        $this->assertSame(0, count($thirdResult->getVariants()));
-        $this->assertSame('Baby Doe', $thirdResult->getAuthor());
-        $this->assertSame(0, $thirdResult->getVariantsNumFound());
-        $this->assertSame('Baby Doe', $thirdResult->getVariantFieldValue());
+        self::assertSame(0, count($thirdResult->getVariants()));
+        self::assertSame('Baby Doe', $thirdResult->getAuthor());
+        self::assertSame(0, $thirdResult->getVariantsNumFound());
+        self::assertSame('Baby Doe', $thirdResult->getVariantFieldValue());
 
         // And every variant is indicated to be a variant.
         foreach ($firstResult->getVariants() as $variant) {
-            $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
-            $this->assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
-            $this->assertSame($firstResult, $variant->getVariantParent(), 'Variant parent should be set');
+            self::assertTrue($variant->getIsVariant(), 'Document should be a variant');
+            self::assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
+            self::assertSame($firstResult, $variant->getVariantParent(), 'Variant parent should be set');
         }
         foreach ($secondResult->getVariants() as $variant) {
-            $this->assertTrue($variant->getIsVariant(), 'Document should be a variant');
-            $this->assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
-            $this->assertSame($secondResult, $variant->getVariantParent(), 'Variant parent should be set');
+            self::assertTrue($variant->getIsVariant(), 'Document should be a variant');
+            self::assertSame(0, $variant->getVariantsNumFound(), 'Variant shouldn\'t have variants itself');
+            self::assertSame($secondResult, $variant->getVariantParent(), 'Variant parent should be set');
         }
     }
 
@@ -215,13 +217,13 @@ class SearchResultSetServiceTest extends IntegrationTest
                 'variants.' => [
                     'variantField' => 'pid',
                     'expand' => 1,
-                    'limit' => 11
-                ]
-            ]
+                    'limit' => 11,
+                ],
+            ],
         ]);
 
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration, 'nomatchfound');
-        $this->assertSame(0, count($searchResults), 'There should zero results when the index is empty');
+        self::assertSame(0, count($searchResults), 'There should zero results when the index is empty');
     }
 
     /**
@@ -232,7 +234,6 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->applyUsingErrorControllerForCMS9andAbove();
         $this->importFrontendRestrictedPageScenario();
 
-
         $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1, 0, 0);
         $typoScriptConfiguration = Util::getSolrConfiguration();
 
@@ -240,7 +241,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->simulateFrontedUserGroups([0]);
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
 
-        $this->assertSame(2, count($searchResults), 'We should only see two documents because the restricted element should be filtered out');
+        self::assertSame(2, count($searchResults), 'We should only see two documents because the restricted element should be filtered out');
     }
 
     /**
@@ -258,9 +259,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->simulateFrontedUserGroups([0, 1]);
         $searchResults = $this->doSearchWithResultSetService($solrConnection, $typoScriptConfiguration);
 
-        $this->assertSame(3, count($searchResults), 'We should see all content, because nothing should be filtered');
-
-
+        self::assertSame(3, count($searchResults), 'We should see all content, because nothing should be filtered');
     }
 
     /**
@@ -271,7 +270,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         $this->indexPageIdsFromFixture('fe_user_page.xml', [1, 2, 3], [1]);
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":3', $solrContent);
+        self::assertStringContainsString('"numFound":3', $solrContent);
     }
 
     /**

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\StatisticsRepository;
 
 /***************************************************************
@@ -45,10 +46,10 @@ class StatisticsRepositoryTest extends IntegrationTest
         $topHits = $repository->getTopKeyWordsWithHits(1, $daysSinceFixture);
         $expectedResult = [
             ['keywords' => 'content', 'count' => 2, 'hits' => '5.0000', 'percent' => '50.0000'],
-            ['keywords' => 'typo3', 'count' => 1, 'hits' => '6.0000', 'percent' => '25.0000']
+            ['keywords' => 'typo3', 'count' => 1, 'hits' => '6.0000', 'percent' => '25.0000'],
         ];
 
-        $this->assertSame($expectedResult, $topHits);
+        self::assertSame($expectedResult, $topHits);
     }
 
     /**
@@ -60,15 +61,15 @@ class StatisticsRepositoryTest extends IntegrationTest
         $fixtureTimestamp = 1471203378;
         $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
 
-            /** @var $repository StatisticsRepository */
+        /** @var $repository StatisticsRepository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
 
         $expectedResult = [
-            ['keywords' => 'cms', 'count' => 1, 'hits' => '0.0000', 'percent' => '25.0000']
+            ['keywords' => 'cms', 'count' => 1, 'hits' => '0.0000', 'percent' => '25.0000'],
         ];
 
-        $this->assertSame($expectedResult, $topHits);
+        self::assertSame($expectedResult, $topHits);
     }
 
     /**
@@ -86,7 +87,7 @@ class StatisticsRepositoryTest extends IntegrationTest
 
         $expectedResult = [];
 
-        $this->assertSame($expectedResult, $topHits);
+        self::assertSame($expectedResult, $topHits);
     }
 
     /**
@@ -104,7 +105,7 @@ class StatisticsRepositoryTest extends IntegrationTest
 
         $expectedResult = [];
 
-        $this->assertSame($expectedResult, $topHits);
+        self::assertSame($expectedResult, $topHits);
     }
 
     /**
@@ -116,7 +117,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         /** @var $repository StatisticsRepository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
 
-        $this->assertEquals(4, $repository->countByRootPageId(1), 'Does not contain all statistics records from fixtures.');
+        self::assertEquals(4, $repository->countByRootPageId(1), 'Does not contain all statistics records from fixtures.');
 
         $statisticRecord = [
             'pid' => 317,
@@ -135,11 +136,11 @@ class StatisticsRepositoryTest extends IntegrationTest
             'keywords' => 'inserted record',
             'filters' => 'a:0:{}',
             'sorting' => '',
-            'parameters' => ''
+            'parameters' => '',
         ];
         $repository->saveStatisticsRecord($statisticRecord);
 
-        $this->assertEquals(5, $repository->countByRootPageId(1), 'Does not contain shortly inserted statistic record.');
+        self::assertEquals(5, $repository->countByRootPageId(1), 'Does not contain shortly inserted statistic record.');
     }
 
     /**

--- a/Tests/Integration/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Integration/Domain/Site/SiteHashServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Site;
 
 /***************************************************************
@@ -46,7 +47,8 @@ class SiteHashServiceTest extends IntegrationTest
      * @throws TestingFrameworkCoreException
      * @throws DBALException
      */
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
     }
@@ -59,7 +61,7 @@ class SiteHashServiceTest extends IntegrationTest
         return [
             'siteHashDisabled' => ['*', '*'],
             'allSitesInSystem' => ['__all', 'testone.site,testtwo.site'],
-            'currentSiteOnly' => ['__current_site', 'testone.site']
+            'currentSiteOnly' => ['__current_site', 'testone.site'],
         ];
     }
 
@@ -67,10 +69,10 @@ class SiteHashServiceTest extends IntegrationTest
      * @dataProvider canResolveSiteHashAllowedSitesDataProvider
      * @test
      */
-    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration , $expectedAllowedSites)
+    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration, $expectedAllowedSites)
     {
         $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
         $allowedSites = $siteHashService->getAllowedSitesForPageIdAndAllowedSitesConfiguration(1, $allowedSitesConfiguration);
-        $this->assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
+        self::assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
     }
 }

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Site;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Site;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use Doctrine\DBAL\DBALException;
 use Exception;
@@ -47,12 +48,11 @@ class SiteRepositoryTest extends IntegrationTest
     protected $siteRepository;
 
     /**
-     * @return void
      * @throws NoSuchCacheException
      * @throws TestingFrameworkCoreException
      * @throws DBALException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -66,7 +66,7 @@ class SiteRepositoryTest extends IntegrationTest
     public function canGetAllSites()
     {
         $sites = $this->siteRepository->getAvailableSites();
-        $this->assertSame(2, count($sites), 'Expected to retrieve two sites from default tests setup. Note: The third site is not enabled for EXT:solr.');
+        self::assertSame(2, count($sites), 'Expected to retrieve two sites from default tests setup. Note: The third site is not enabled for EXT:solr.');
     }
 
     /**
@@ -78,7 +78,7 @@ class SiteRepositoryTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_get_all_pages_from_sites.xml');
         $site = $this->siteRepository->getFirstAvailableSite();
-        $this->assertSame([1,2,21,22,3,30], $site->getPages(), 'Can not get all pages from site');
+        self::assertSame([1, 2, 21, 22, 3, 30], $site->getPages(), 'Can not get all pages from site');
     }
 
     /**
@@ -87,7 +87,7 @@ class SiteRepositoryTest extends IntegrationTest
     public function canGetSiteByRootPageIdExistingRoot()
     {
         $site = $this->siteRepository->getSiteByRootPageId(1);
-        $this->assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from root page');
+        self::assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from root page');
     }
 
     /**
@@ -108,7 +108,7 @@ class SiteRepositoryTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_get_site_by_page_id.xml');
         $site = $this->siteRepository->getSiteByPageId(2);
-        $this->assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from page');
+        self::assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from page');
     }
 
     /**
@@ -131,6 +131,6 @@ class SiteRepositoryTest extends IntegrationTest
         $this->importDataSetFromFixture('can_get_site_by_page_id.xml');
         $site = $this->siteRepository->getSiteByPageId(1);
         $domain = $site->getDomain();
-        $this->assertSame('testone.site', $domain, 'Can not configured domain with sys_domain record');
+        self::assertSame('testone.site', $domain, 'Can not configured domain with sys_domain record');
     }
 }

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Site;
 
 /***************************************************************
@@ -37,7 +38,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SiteTest extends IntegrationTest
 {
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
     }
@@ -50,23 +52,25 @@ class SiteTest extends IntegrationTest
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         /* @var Site $site */
         $site = $siteRepository->getFirstAvailableSite();
-        $this->assertEquals(0, $site->getDefaultLanguageId(), 'Could not get default language from site');
+        self::assertEquals(0, $site->getDefaultLanguageId(), 'Could not get default language from site');
     }
 
     /**
      * @test
      */
-    public function canCreateInstanceWithRootSiteUidOK() {
+    public function canCreateInstanceWithRootSiteUidOK()
+    {
         /* @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByRootPageId(1);
-        $this->assertEquals(1, $site->getRootPageId());
+        self::assertEquals(1, $site->getRootPageId());
     }
 
     /**
      * @test
      */
-    public function canCreateInstanceWithRootSiteUidNOK() {
+    public function canCreateInstanceWithRootSiteUidNOK()
+    {
         $this->expectException(InvalidArgumentException::class);
         /* @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
@@ -76,7 +80,8 @@ class SiteTest extends IntegrationTest
     /**
      * @test
      */
-    public function canCreateInstanceWithNonRootSiteUidOK() {
+    public function canCreateInstanceWithNonRootSiteUidOK()
+    {
         $this->importDataSetFromFixture('can_create_instance_with_non_root_site.xml');
         $this->expectException(InvalidArgumentException::class);
 
@@ -88,7 +93,8 @@ class SiteTest extends IntegrationTest
     /**
      * @test
      */
-    public function canCreateInstanceWithNonRootSiteUidNOK() {
+    public function canCreateInstanceWithNonRootSiteUidNOK()
+    {
         $this->importDataSetFromFixture('can_create_instance_with_non_root_site.xml');
         $this->expectException(InvalidArgumentException::class);
 
@@ -100,7 +106,8 @@ class SiteTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetAvailableLanguageIds() {
+    public function canGetAvailableLanguageIds()
+    {
         $this->importDataSetFromFixture('can_get_translations_for_root_site.xml');
 
         /* @var SiteRepository $siteRepository */
@@ -108,6 +115,6 @@ class SiteTest extends IntegrationTest
         $site = $siteRepository->getSiteByRootPageId(1);
         $languageIds = $site->getAvailableLanguageIds();
 
-        $this->assertEquals([0, 1, 2], $languageIds);
+        self::assertEquals([0, 1, 2], $languageIds);
     }
 }

--- a/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
+++ b/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\FieldProcessor;
 
 /***************************************************************
@@ -41,10 +42,10 @@ class CategoryUidToHierarchyTest extends IntegrationTest
     public function canConvertToCategoryIdToHierarchy()
     {
         $this->importDataSetFromFixture('sys_category.xml');
-            /** @var $processor CategoryUidToHierarchy */
+        /** @var $processor CategoryUidToHierarchy */
         $processor = GeneralUtility::makeInstance(CategoryUidToHierarchy::class);
         $result = $processor->process([2]);
-        $expectedResult = ['0-1/','1-1/2/'];
-        $this->assertSame($result, $expectedResult, 'Hierarchy processor did not build expected hierarchy');
+        $expectedResult = ['0-1/', '1-1/2/'];
+        self::assertSame($result, $expectedResult, 'Hierarchy processor did not build expected hierarchy');
     }
 }

--- a/Tests/Integration/Fixtures/fake_extension_tca.php
+++ b/Tests/Integration/Fixtures/fake_extension_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,title',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'title' => [
             'exclude' => 0,
@@ -134,19 +134,19 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,title'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,title',
+        ],
+    ],
 ];

--- a/Tests/Integration/FrontendEnvironment/TsfeTest.php
+++ b/Tests/Integration/FrontendEnvironment/TsfeTest.php
@@ -1,6 +1,6 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Tests\Integration\FrontendEnvironment;
 
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\FrontendEnvironment;
 
 use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
@@ -11,14 +11,13 @@ class TsfeTest extends IntegrationTest
 {
     /**
      * @test
-     *
      */
     public function initializeTsfeWithNoDefaultPageAndPageErrorHandlerDoNotThrowAnError()
     {
-        $this->markTestSkipped("Since TSFE is isolated/capsuled, no exceptions are thrown or delegated to else where.
+        self::markTestSkipped('Since TSFE is isolated/capsuled, no exceptions are thrown or delegated to else where.
         Other scenario is wanted for:
         https://github.com/TYPO3-Solr/ext-solr/issues/2914
-        https://github.com/TYPO3-Solr/ext-solr/pull/2915/files");
+        https://github.com/TYPO3-Solr/ext-solr/pull/2915/files');
         $this->expectException(RuntimeException::class);
         $this->importDataSetFromFixture('initialize_tsfe_with_no_default_page_and_page_error_handler_do_not_throw_an_error.xml');
 
@@ -54,5 +53,4 @@ class TsfeTest extends IntegrationTest
         $tsfeManager = GeneralUtility::makeInstance(Tsfe::class);
         $tsfeManager->getTsfeByPageIdAndLanguageId(1);
     }
-
 }

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 /***************************************************************
@@ -24,20 +25,20 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Scheduler\Scheduler;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Connection;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
-use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * This testcase is used to check if the GarbageCollector can delete garbage from the
@@ -52,7 +53,7 @@ class GarbageCollectorTest extends IntegrationTest
      */
     protected $coreExtensionsToLoad = [
         'extensionmanager',
-        'scheduler'
+        'scheduler',
     ];
 
     /**
@@ -90,7 +91,7 @@ class GarbageCollectorTest extends IntegrationTest
      */
     protected $eventQueue;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -104,8 +105,7 @@ class GarbageCollectorTest extends IntegrationTest
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
     }
 
-
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
         unset($GLOBALS['TYPO3_CONF_VARS']);
@@ -122,21 +122,18 @@ class GarbageCollectorTest extends IntegrationTest
         parent::tearDown();
     }
 
-    /**
-     * @return void
-     */
     protected function assertEmptyIndexQueue(): void
     {
-        $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
+        self::assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
     }
 
-    /**
-     * @return void
-     */
     protected function assertNotEmptyIndexQueue(): void
     {
-        $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to be not empty.');
+        self::assertGreaterThan(
+            0,
+            $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to be not empty.'
+        );
     }
 
     /**
@@ -145,19 +142,16 @@ class GarbageCollectorTest extends IntegrationTest
     protected function assertIndexQueueContainsItemAmount($amount): void
     {
         $itemsInQueue = $this->indexQueue->getAllItemsCount();
-        $this->assertEquals(
+        self::assertEquals(
             $amount,
             $itemsInQueue,
             'Index queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
         );
     }
 
-    /**
-     * @return void
-     */
     protected function assertEmptyEventQueue(): void
     {
-        $this->assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
+        self::assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
     }
 
     /**
@@ -166,7 +160,7 @@ class GarbageCollectorTest extends IntegrationTest
     protected function assertEventQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->eventQueue->count();
-        $this->assertEquals(
+        self::assertEquals(
             $amount,
             $itemsInQueue,
             'Event queue contains ' . $itemsInQueue . ' but was expected to contain ' . $amount . ' items.'
@@ -357,7 +351,7 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
-        $this->assertSame(1, count($items));
+        self::assertSame(1, count($items));
 
         // we index this item
         $this->indexPageIds([1]);
@@ -365,8 +359,8 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now the content of the deleted content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove deleted content');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove deleted content');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
     /**
@@ -399,8 +393,8 @@ class GarbageCollectorTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringContainsString('will be removed!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
 
         // we delete the second content element
         $beUser = $this->fakeBEUser(1, 0);
@@ -427,7 +421,7 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
-        $this->assertSame(1, count($items));
+        self::assertSame(1, count($items));
 
         // we index this item
         $this->indexPageIds([1]);
@@ -435,8 +429,8 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now the content of the deletec content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove hidden content');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove hidden content');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
     /**
@@ -452,9 +446,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
         $this->processEventQueue();
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->assertNull($this->indexQueue->getItem(4711));
+        self::assertNull($this->indexQueue->getItem(4711));
         $item = $this->indexQueue->getAllItems()[0];
-        $this->assertGreaterThan(1449151778, $item->getChanged());
+        self::assertGreaterThan(1449151778, $item->getChanged());
         $this->assertEmptyEventQueue();
     }
 
@@ -474,7 +468,7 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
-        $this->assertSame(1, count($items));
+        self::assertSame(1, count($items));
 
         // we index this item
         $this->indexPageIds([1]);
@@ -482,8 +476,8 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now the content of the deletec content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content hidden by endtime in past');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content hidden by endtime in past');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
     /**
@@ -500,9 +494,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
         $this->processEventQueue();
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->assertNull($this->indexQueue->getItem(4711));
+        self::assertNull($this->indexQueue->getItem(4711));
         $item = $this->indexQueue->getAllItems()[0];
-        $this->assertGreaterThan(1449151778, $item->getChanged());
+        self::assertGreaterThan(1449151778, $item->getChanged());
         $this->assertEmptyEventQueue();
     }
 
@@ -516,13 +510,13 @@ class GarbageCollectorTest extends IntegrationTest
 
         // document should stay in the index, because endtime was not in past but empty
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('will stay! still present after update!', $solrContent, 'solr did not contain rendered page content, which is needed for test.');
+        self::assertStringContainsString('will stay! still present after update!', $solrContent, 'solr did not contain rendered page content, which is needed for test.');
 
         $this->waitToBeVisibleInSolr();
 
         $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 2);
-        $this->assertSame(1, count($items));
+        self::assertSame(1, count($items));
 
         // we index this item
         $this->indexPageIds([2]);
@@ -530,7 +524,7 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now the content of the deleted content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('Updated! Will stay after update!', $solrContent, 'solr did not remove content hidden by endtime in past');
+        self::assertStringContainsString('Updated! Will stay after update!', $solrContent, 'solr did not remove content hidden by endtime in past');
     }
 
     /**
@@ -546,9 +540,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
         $this->processEventQueue();
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->assertNull($this->indexQueue->getItem(4711));
+        self::assertNull($this->indexQueue->getItem(4711));
         $item = $this->indexQueue->getAllItems()[0];
-        $this->assertGreaterThan(1449151778, $item->getChanged());
+        self::assertGreaterThan(1449151778, $item->getChanged());
         $this->assertEmptyEventQueue();
     }
 
@@ -568,7 +562,7 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueueContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
-        $this->assertSame(1, count($items));
+        self::assertSame(1, count($items));
 
         // we index this item
         $this->indexPageIds([1]);
@@ -576,8 +570,8 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now the content of the deletec content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content hidden by starttime in future');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content hidden by starttime in future');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
     /**
@@ -594,9 +588,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
         $this->processEventQueue();
         $this->assertIndexQueueContainsItemAmount(1);
-        $this->assertNull($this->indexQueue->getItem(4711));
+        self::assertNull($this->indexQueue->getItem(4711));
         $item = $this->indexQueue->getAllItems()[0];
-        $this->assertGreaterThan(1449151778, $item->getChanged());
+        self::assertGreaterThan(1449151778, $item->getChanged());
         $this->assertEmptyEventQueue();
     }
 
@@ -628,9 +622,9 @@ class GarbageCollectorTest extends IntegrationTest
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         if ($fixture === 'can_remove_content_element.xml') {
-            $this->assertStringContainsString('will be removed!', $solrContent, 'Solr did not contain rendered page content');
+            self::assertStringContainsString('will be removed!', $solrContent, 'Solr did not contain rendered page content');
         }
-        $this->assertStringContainsString('will stay!', $solrContent, 'Solr did not contain required page or content element content');
+        self::assertStringContainsString('will stay!', $solrContent, 'Solr did not contain required page or content element content');
 
         // we hide the second content element
         $beUser = $this->fakeBEUser(1, 0);
@@ -657,7 +651,7 @@ class GarbageCollectorTest extends IntegrationTest
         $site = $siteRepository->getFirstAvailableSite();
         $items = $this->indexQueue->getItemsToIndex($site);
         $pages = [];
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $pages[] = $item->getRecordUid();
         }
         $this->indexPageIds($pages);
@@ -665,9 +659,9 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now only one document should be left with the content of the first content element
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'Solr did not remove content from hidden page');
-        $this->assertStringContainsString('will stay!', $solrContent, 'Solr did not contain rendered page content');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'Solr did not remove content from hidden page');
+        self::assertStringContainsString('will stay!', $solrContent, 'Solr did not contain rendered page content');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
     }
 
     /**
@@ -702,7 +696,7 @@ class GarbageCollectorTest extends IntegrationTest
         $site = $siteRepository->getFirstAvailableSite();
         $items = $this->indexQueue->getItemsToIndex($site);
         $pages = [];
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $pages[] = $item->getRecordUid();
         }
         $this->indexPageIds($pages);
@@ -710,9 +704,9 @@ class GarbageCollectorTest extends IntegrationTest
 
         // now only one document should be left with the content of the first content element
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content from deleted page');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
+        self::assertStringNotContainsString('will be removed!', $solrContent, 'solr did not remove content from deleted page');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
     }
 
     /**
@@ -746,15 +740,15 @@ class GarbageCollectorTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty();
         $this->importDataSetFromFixture('can_remove_page.xml');
 
-        $this->indexPageIds([1,2]);
+        $this->indexPageIds([1, 2]);
 
         // we index two pages and check that both are visible
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('will be removed!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Expected to have two documents in the index');
+        self::assertStringContainsString('will be removed!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Expected to have two documents in the index');
 
         // we hide the second page
         $beUser = $this->fakeBEUser(1, 0);
@@ -778,7 +772,7 @@ class GarbageCollectorTest extends IntegrationTest
         // since our hook is a singleton we check here if it was called.
         /** @var TestGarbageCollectorPostProcessor $hook */
         $hook = GeneralUtility::makeInstance(TestGarbageCollectorPostProcessor::class);
-        $this->assertTrue($hook->isHookWasCalled());
+        self::assertTrue($hook->isHookWasCalled());
 
         // reset the hooks
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'] = [];
@@ -795,9 +789,9 @@ class GarbageCollectorTest extends IntegrationTest
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
         $this->prepareCanTriggerHookAfterRecordDeletion();
         $this->assertEventQueueContainsItemAmount(1);
-        $this->assertFalse($hook->isHookWasCalled());
+        self::assertFalse($hook->isHookWasCalled());
         $this->processEventQueue();
-        $this->assertTrue($hook->isHookWasCalled());
+        self::assertTrue($hook->isHookWasCalled());
     }
 
     /**
@@ -852,7 +846,7 @@ class GarbageCollectorTest extends IntegrationTest
         // write an index queue item
         $updatedItems = $this->indexQueue->updateItem($table, $uid);
 
-        $this->assertEquals(1, $updatedItems);
+        self::assertEquals(1, $updatedItems);
 
         // run the indexer
         $items = $this->indexQueue->getItems($table, $uid);

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_bar_tca.php
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_bar_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,title',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'title' => [
             'exclude' => 0,
@@ -134,14 +134,14 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
         ],
         // mm relation
         'tags' => [
@@ -156,8 +156,8 @@ return [
                 'foreign_table' => 'tx_fakeextension_domain_model_mmrelated',
                 'size' => '5',
                 'maxitems' => '200',
-                'minitems' => '0'
-              ]
+                'minitems' => '0',
+              ],
         ],
         // mm relation to a page
         'page_relations' => [
@@ -192,7 +192,7 @@ return [
      ],
      'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,title,tags'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,title,tags',
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_directrelated_tca.php
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_directrelated_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,category',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'category_label' => [
             'exclude' => 0,
@@ -134,7 +134,7 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'sys_category' => [
             'exclude' => 0,
@@ -148,19 +148,19 @@ return [
                 'minitems' => 0,
                 'maxitems' => 1,
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,category,sys_category'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,category,sys_category',
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension2_mmrelated_tca.php
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension2_mmrelated_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,tag',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'tag' => [
             'exclude' => 0,
@@ -134,19 +134,19 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,tag'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,tag',
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/Fixtures/fake_extension_tca.php
+++ b/Tests/Integration/IndexQueue/Fixtures/fake_extension_tca.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
         'searchFields' => 'uid,title',
     ],
@@ -39,11 +39,11 @@ return [
                     [
                         'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
                         -1,
-                        'flags-multiple'
+                        'flags-multiple',
                     ],
                 ],
                 'default' => 0,
-            ]
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -55,52 +55,52 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_fakeextension_domain_model_foo',
-                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)'
-            ]
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'cruser_id' => [
             'label' => 'cruser_id',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'pid' => [
             'label' => 'pid',
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'crdate' => [
             'label' => 'crdate',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'tstamp' => [
             'label' => 'tstamp',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'sorting' => [
             'label' => 'sorting',
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'starttime' => [
             'exclude' => 1,
@@ -112,7 +112,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'endtime' => [
             'exclude' => 1,
@@ -124,7 +124,7 @@ return [
                 'default' => 0,
                 'renderType' => 'inputDateTime',
                 ['behaviour' => ['allowLanguageSynchronization' => true]],
-            ]
+            ],
         ],
         'title' => [
             'exclude' => 0,
@@ -134,19 +134,19 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
-            ]
+            ],
         ],
         'editlock' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
-                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]]
-            ]
-        ]
+                'type' => 'check', ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'l10n_parent, l10n_diffsource,title'
-        ]
-    ]
+            'showitem' => 'l10n_parent, l10n_diffsource,title',
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_language_overlay_tca.php
@@ -14,7 +14,7 @@ return [
                 'MM_opposite_field' => 'relations',
                 'MM_match_fields' => [
                     'tablenames' => 'pages',
-                    'fieldname' => 'page_relations'
+                    'fieldname' => 'page_relations',
                 ],
                 'size' => 10,
                 'autoSizeMax' => 30,
@@ -35,8 +35,8 @@ return [
                         'page_relations',
                     ],
                 ],
-                'readOnly' => true
-            ]
-        ]
-    ]
+                'readOnly' => true,
+            ],
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/fake_extension3_pages_tca.php
@@ -14,7 +14,7 @@ return [
                 'MM_opposite_field' => 'relations',
                 'MM_match_fields' => [
                     'tablenames' => 'pages',
-                    'fieldname' => 'page_relations'
+                    'fieldname' => 'page_relations',
                 ],
                 'size' => 10,
                 'autoSizeMax' => 30,
@@ -35,8 +35,8 @@ return [
                         'page_relations',
                     ],
                 ],
-                'readOnly' => true
-            ]
-        ]
-    ]
+                'readOnly' => true,
+            ],
+        ],
+    ],
 ];

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -44,10 +44,10 @@ class PageIndexerTest extends IntegrationTest
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
     /**
-     * @return void
      * @throws NoSuchCacheException
      */
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
     }
@@ -55,7 +55,7 @@ class PageIndexerTest extends IntegrationTest
     /**
      * Executed after each test. Emptys solr and checks if the index is empty
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
@@ -76,10 +76,10 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
-        $this->assertStringContainsString('"custom_stringS":"my text"', $solrContent, 'Document does not contains value build with typoscript');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
+        self::assertStringContainsString('"custom_stringS":"my text"', $solrContent, 'Document does not contains value build with typoscript');
     }
 
     /**
@@ -97,11 +97,10 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"custom_stringS":"my text from custom page type"', $solrContent, 'Document does not contains value build with typoscript');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"custom_stringS":"my text from custom page type"', $solrContent, 'Document does not contains value build with typoscript');
     }
-
 
     /**
      * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.
@@ -130,12 +129,12 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr('core_de');
 
         $solrContentEn = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"title":"Page"', $solrContentEn, 'Solr did not contain the english page');
-        $this->assertStringNotContainsString('relatedPageTitles_stringM', $solrContentEn, 'There is no relation for the original, so ther should not be a related field');
+        self::assertStringContainsString('"title":"Page"', $solrContentEn, 'Solr did not contain the english page');
+        self::assertStringNotContainsString('relatedPageTitles_stringM', $solrContentEn, 'There is no relation for the original, so ther should not be a related field');
 
         $solrContentDe = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
-        $this->assertStringContainsString('"title":"Seite"', $solrContentDe, 'Solr did not contain the translated page');
-        $this->assertStringContainsString('"relatedPageTitles_stringM":["Verwante Seite"]', $solrContentDe, 'Did not get content of releated field');
+        self::assertStringContainsString('"title":"Seite"', $solrContentDe, 'Solr did not contain the translated page');
+        self::assertStringContainsString('"relatedPageTitles_stringM":["Verwante Seite"]', $solrContentDe, 'Did not get content of releated field');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
@@ -156,8 +155,8 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr('core_en');
 
         $solrContentEn = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"title":"Sub page"', $solrContentEn, 'Solr did not contain the english page');
-        $this->assertStringContainsString('"categories_stringM":["Test"]', $solrContentEn, 'There is no relation for the original, so ther should not be a related field');
+        self::assertStringContainsString('"title":"Sub page"', $solrContentEn, 'Solr did not contain the english page');
+        self::assertStringContainsString('"categories_stringM":["Test"]', $solrContentEn, 'There is no relation for the original, so ther should not be a related field');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
     }
@@ -168,7 +167,7 @@ class PageIndexerTest extends IntegrationTest
     public function canIndexPageIntoSolrWithAdditionalFields()
     {
         //@todo additional fields indexer requires the hook to be activated which is normally done in ext_localconf.php
-            // this needs to be unified with the PageFieldMappingIndexer registration.
+        // this needs to be unified with the PageFieldMappingIndexer registration.
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument']['ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer'] = AdditionalFieldsIndexer::class;
 
         $this->importDataSetFromFixture('can_index_with_additional_fields_into_solr.xml');
@@ -179,14 +178,14 @@ class PageIndexerTest extends IntegrationTest
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-            // field values from index.queue.pages.fields.
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
+        // field values from index.queue.pages.fields.
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"hello solr"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"sortSubTitle_stringS":"the subtitle"', $solrContent, 'Document does not contain subtitle');
 
-            // field values from index.additionalFields
-        $this->assertStringContainsString('"additional_sortSubTitle_stringS":"subtitle"', $solrContent, 'Document does not contains value from index.additionFields');
-        $this->assertStringContainsString('"additional_custom_stringS":"my text"', $solrContent, 'Document does not contains value from index.additionFields');
+        // field values from index.additionalFields
+        self::assertStringContainsString('"additional_sortSubTitle_stringS":"subtitle"', $solrContent, 'Document does not contains value from index.additionFields');
+        self::assertStringContainsString('"additional_custom_stringS":"my text"', $solrContent, 'Document does not contains value from index.additionFields');
     }
 
     /**
@@ -203,9 +202,9 @@ class PageIndexerTest extends IntegrationTest
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
         // field values from index.queue.pages.fields.
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"hello subpage"', $solrContent, 'Could not index subpage with custom field configuration into solr');
-        $this->assertStringContainsString('"additional_stringS":"from rootline"', $solrContent, 'Document does not contain custom field from rootline');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"hello subpage"', $solrContent, 'Could not index subpage with custom field configuration into solr');
+        self::assertStringContainsString('"additional_stringS":"from rootline"', $solrContent, 'Document does not contain custom field from rootline');
     }
 
     /**
@@ -222,8 +221,8 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"postProcessorField_stringS":"postprocessed"', $solrContent, 'Field from post processor was not added');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"postProcessorField_stringS":"postprocessed"', $solrContent, 'Field from post processor was not added');
     }
 
     /**
@@ -240,9 +239,9 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"custom_stringS":"my text"', $solrContent, 'Field from post processor was not added');
-        $this->assertStringContainsString('"custom_stringS":"additional text"', $solrContent, 'Field from post processor was not added');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"custom_stringS":"my text"', $solrContent, 'Field from post processor was not added');
+        self::assertStringContainsString('"custom_stringS":"additional text"', $solrContent, 'Field from post processor was not added');
     }
 
     /**
@@ -274,7 +273,7 @@ class PageIndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"title":"FirstShared (Not root)"', $solrContent, 'Could not find content from mounted page in solr');
+        self::assertStringContainsString('"title":"FirstShared (Not root)"', $solrContent, 'Could not find content from mounted page in solr');
     }
 
     /**
@@ -310,10 +309,10 @@ class PageIndexerTest extends IntegrationTest
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Unexpected amount of documents in the core');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Unexpected amount of documents in the core');
 
-        $this->assertStringContainsString('/pages/44/44-14/', $solrContent, 'Could not find document of first mounted page');
-        $this->assertStringContainsString('/pages/44/44-24/', $solrContent, 'Could not find document of second mounted page');
+        self::assertStringContainsString('/pages/44/44-14/', $solrContent, 'Could not find document of first mounted page');
+        self::assertStringContainsString('/pages/44/44-24/', $solrContent, 'Could not find document of second mounted page');
     }
 
     /**
@@ -322,9 +321,10 @@ class PageIndexerTest extends IntegrationTest
      *
      * @test
      */
-    public function phpProcessDoesNotDieIfPageIsNotAvailable() {
+    public function phpProcessDoesNotDieIfPageIsNotAvailable()
+    {
         // @todo: 1636120156
-        $this->markTestIncomplete('The behaviour since TYPO3 11 and EXT:solr 11.5 must be checked twice, to be able to finalize request properly and mark items failed.');
+        self::markTestIncomplete('The behaviour since TYPO3 11 and EXT:solr 11.5 must be checked twice, to be able to finalize request properly and mark items failed.');
         $this->applyUsingErrorControllerForCMS9andAbove();
         $this->registerShutdownFunctionToPrintExplanationOf404HandlingOnCMSIfDieIsCalled();
         $this->expectException(SiteNotFoundException::class);
@@ -338,7 +338,7 @@ class PageIndexerTest extends IntegrationTest
      */
     protected function registerShutdownFunctionToPrintExplanationOf404HandlingOnCMSIfDieIsCalled()
     {
-        register_shutdown_function(function() {
+        register_shutdown_function(function () {
             // prompt only after phpProcessDoesNotDieIfPageIsNotAvailable() test case
             if ($this->getName() !== 'phpProcessDoesNotDieIfPageIsNotAvailable') {
                 return;
@@ -367,7 +367,7 @@ class PageIndexerTest extends IntegrationTest
      */
     protected function executePageIndexer(int $pageId = 1, string $MP = '', int $languageId = 0)
     {
-        $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TT'] = $this->createMock(TimeTracker::class);
 
         unset($GLOBALS['TSFE']);
 

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\AdditionalPageIndexer;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 
-class TestAdditionalPageIndexer implements AdditionalPageIndexer {
-
+class TestAdditionalPageIndexer implements AdditionalPageIndexer
+{
 
     /**
      * Provides additional documents that should be indexed together with a page.

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestPostProcessor.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestPostProcessor.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\PageDocumentPostProcessor;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
-class TestPostProcessor implements PageDocumentPostProcessor{
+class TestPostProcessor implements PageDocumentPostProcessor
+{
 
     /**
      * Allows Modification of the PageDocument
@@ -13,10 +15,9 @@ class TestPostProcessor implements PageDocumentPostProcessor{
      *
      * @param Document $pageDocument the generated page document
      * @param TypoScriptFrontendController $page the page object with information about page id or language
-     * @return void
      */
     public function postProcessPageDocument(Document $pageDocument, TypoScriptFrontendController $page)
     {
-        $pageDocument->addField('postProcessorField_stringS','postprocessed');
+        $pageDocument->addField('postProcessorField_stringS', 'postprocessed');
     }
 }

--- a/Tests/Integration/IndexQueue/Helpers/DummyAdditionalIndexQueueItemIndexer.php
+++ b/Tests/Integration/IndexQueue/Helpers/DummyAdditionalIndexQueueItemIndexer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers;
 
 /***************************************************************
@@ -43,7 +44,8 @@ class DummyAdditionalIndexQueueItemIndexer implements AdditionalIndexQueueItemIn
      *
      * @return Document[] An array of additional Apache Solr Document objects
      */
-    public function getAdditionalItemDocuments(Item $item, $language, Document $itemDocument) {
+    public function getAdditionalItemDocuments(Item $item, $language, Document $itemDocument)
+    {
         return [];
     }
 }

--- a/Tests/Integration/IndexQueue/Helpers/DummyIndexer.php
+++ b/Tests/Integration/IndexQueue/Helpers/DummyIndexer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers;
 
 /***************************************************************
@@ -23,7 +24,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-
 
 /**
  * Class DummyIndexer for testing purpose

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
 
 /***************************************************************
@@ -30,17 +31,17 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
-use ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers\DummyIndexer;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers\DummyAdditionalIndexQueueItemIndexer;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Helpers\DummyIndexer;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use Doctrine\DBAL\DBALException;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Middleware\NormalizedParamsAttribute;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
 
 /**
@@ -63,12 +64,11 @@ class IndexerTest extends IntegrationTest
     protected $indexer;
 
     /**
-     * @return void
      * @throws TestingFrameworkCoreException
      * @throws DBALException
      * @throws NoSuchCacheException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -85,12 +85,12 @@ class IndexerTest extends IntegrationTest
 
         $_SERVER['HTTP_HOST'] = 'test.local.typo3.org';
         $request = ServerRequestFactory::fromGlobals();
-        $handlerMock = $this->getMockBuilder( RequestHandlerInterface::class)->getMock();
+        $handlerMock = $this->createMock(RequestHandlerInterface::class);
         $normalizer = new NormalizedParamsAttribute();
         $normalizer->process($request, $handlerMock);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -114,15 +114,15 @@ class IndexerTest extends IntegrationTest
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
 
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"category_stringM":["the tag"]', $solrContent, 'Did not find MM related tag');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"category_stringM":["the tag"]', $solrContent, 'Did not find MM related tag');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -134,7 +134,7 @@ class IndexerTest extends IntegrationTest
         return [
             'with_l_paramater' => ['can_index_custom_translated_record_with_l_param.xml'],
             'without_l_paramater' => ['can_index_custom_translated_record_without_l_param.xml'],
-            'without_l_paramater_and_content_fallback' => ['can_index_custom_translated_record_without_l_param_and_content_fallback.xml']
+            'without_l_paramater_and_content_fallback' => ['can_index_custom_translated_record_without_l_param_and_content_fallback.xml'],
         ];
     }
 
@@ -154,32 +154,32 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture($fixture);
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 777);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr('core_en');
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"original"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"original2"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"url":"http://testone.site/en/?tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
-        $this->assertStringContainsString('"url":"http://testone.site/en/?tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"original"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"original2"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"url":"http://testone.site/en/?tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
+        self::assertStringContainsString('"url":"http://testone.site/en/?tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
 
         $this->waitToBeVisibleInSolr('core_de');
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Could not find translated record in solr document into solr');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Could not find translated record in solr document into solr');
         if ($fixture === 'can_index_custom_translated_record_without_l_param_and_content_fallback.xml') {
-            $this->assertStringContainsString('"title":"original"', $solrContent, 'Could not index  translated document into solr');
-            $this->assertStringContainsString('"title":"original2"', $solrContent, 'Could not index  translated document into solr');
+            self::assertStringContainsString('"title":"original"', $solrContent, 'Could not index  translated document into solr');
+            self::assertStringContainsString('"title":"original2"', $solrContent, 'Could not index  translated document into solr');
         } else {
-            $this->assertStringContainsString('"title":"translation"', $solrContent, 'Could not index  translated document into solr');
-            $this->assertStringContainsString('"title":"translation2"', $solrContent, 'Could not index  translated document into solr');
+            self::assertStringContainsString('"title":"translation"', $solrContent, 'Could not index  translated document into solr');
+            self::assertStringContainsString('"title":"translation2"', $solrContent, 'Could not index  translated document into solr');
         }
-        $this->assertStringContainsString('"url":"http://testone.site/de/?tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
-        $this->assertStringContainsString('"url":"http://testone.site/de/?tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
+        self::assertStringContainsString('"url":"http://testone.site/de/?tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
+        self::assertStringContainsString('"url":"http://testone.site/de/?tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
@@ -202,7 +202,7 @@ class IndexerTest extends IntegrationTest
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
 
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the values from the mm relation?
         $this->waitToBeVisibleInSolr();
@@ -210,20 +210,19 @@ class IndexerTest extends IntegrationTest
         $solrContent = json_decode($solrContentJson, true);
         $solrContentResponse = $solrContent['response'];
 
-        $this->assertArrayHasKey('docs', $solrContentResponse, 'Did not find docs in solr response');
+        self::assertArrayHasKey('docs', $solrContentResponse, 'Did not find docs in solr response');
 
         $solrDocs = $solrContentResponse['docs'];
 
-        $this->assertCount(1, $solrDocs, 'Could not found index document into solr');
-        $this->assertIsArray($solrDocs[0]);
-        $this->assertEquals('testnews', (string)$solrDocs[0]['title'], 'Title of Solr document is not as expected.');
-        $this->assertArrayHasKey('category_stringM', $solrDocs[0], 'Did not find MM related tags.');
-        $this->assertCount(2, $solrDocs[0]['category_stringM'], 'Did not find all MM related tags.');
-        $this->assertSame(['the tag', 'another tag'], $solrDocs[0]['category_stringM']);
+        self::assertCount(1, $solrDocs, 'Could not found index document into solr');
+        self::assertIsArray($solrDocs[0]);
+        self::assertEquals('testnews', (string)$solrDocs[0]['title'], 'Title of Solr document is not as expected.');
+        self::assertArrayHasKey('category_stringM', $solrDocs[0], 'Did not find MM related tags.');
+        self::assertCount(2, $solrDocs[0]['category_stringM'], 'Did not find all MM related tags.');
+        self::assertSame(['the tag', 'another tag'], $solrDocs[0]['category_stringM']);
 
         $this->cleanUpSolrServerAndAssertEmpty();
     }
-
 
     /**
      * This testcase should check if we can queue an custom record with MM relations.
@@ -242,19 +241,19 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_translated_record_with_mm_relation.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr('core_de');
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
 
-        $this->assertStringContainsString('"category_stringM":["translated tag"]', $solrContent, 'Did not find MM related tag');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"translation"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"category_stringM":["translated tag"]', $solrContent, 'Did not find MM related tag');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"translation"', $solrContent, 'Could not index document into solr');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
-     }
+    }
 
     /**
      * This testcase should check if we can queue an custom record with multiple MM relations.
@@ -274,7 +273,7 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_multiple_mm_relations.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr('core_en');
@@ -284,9 +283,9 @@ class IndexerTest extends IntegrationTest
         // @extensionScannerIgnoreLine
         $tags = $decodedSolrContent->response->docs[0]->tags_stringM;
 
-        $this->assertSame(['the tag', 'another tag'], $tags, $solrContent, 'Did not find MM related tags');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertSame(['the tag', 'another tag'], $tags, $solrContent, 'Did not find MM related tags');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
     }
@@ -307,15 +306,15 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_mm_relationAndAdditionalWhere.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"category_stringM":["another tag"]', $solrContent, 'Did not find MM related tag');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"category_stringM":["another tag"]', $solrContent, 'Did not find MM related tag');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -329,14 +328,13 @@ class IndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
 
-
         // create fake extension database table and TCA
         $this->importExtTablesDefinition('fake_extension2_table.sql');
         $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('fake_extension2_bar_tca.php'));
         $this->importDataSetFromFixture('can_index_custom_translated_record_with_mm_relation_to_a_page.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 88);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr('core_en');
@@ -345,8 +343,8 @@ class IndexerTest extends IntegrationTest
         $solrContentEn = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         $solrContentDe = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
 
-        $this->assertStringContainsString('"relatedPageTitles_stringM":["Related page"]', $solrContentEn, 'Can not find related page title');
-        $this->assertStringContainsString('"relatedPageTitles_stringM":["Translated related page"]', $solrContentDe, 'Can not find translated related page title');
+        self::assertStringContainsString('"relatedPageTitles_stringM":["Related page"]', $solrContentEn, 'Can not find related page title');
+        self::assertStringContainsString('"relatedPageTitles_stringM":["Translated related page"]', $solrContentDe, 'Can not find translated related page title');
 
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
         $this->cleanUpSolrServerAndAssertEmpty('core_de');
@@ -368,18 +366,18 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relation.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"category_stringM":["the category"]', $solrContent, 'Did not find direct related category');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"sysCategoryId_stringM":["1"]', $solrContent, 'Uid of related sys_category couldn\'t be resolved by using "foreignLabelField"');
-        $this->assertStringContainsString('"sysCategory_stringM":["sys_category"]', $solrContent, 'Label of related sys_category couldn\'t be resolved by using "foreignLabelField" and "enableRecursiveValueResolution"');
-        $this->assertStringContainsString('"sysCategoryDescription_stringM":["sys_category description"]', $solrContent, 'Description of related sys_category couldn\'t be resolved by using "foreignLabelField" and "enableRecursiveValueResolution"');
+        self::assertStringContainsString('"category_stringM":["the category"]', $solrContent, 'Did not find direct related category');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"sysCategoryId_stringM":["1"]', $solrContent, 'Uid of related sys_category couldn\'t be resolved by using "foreignLabelField"');
+        self::assertStringContainsString('"sysCategory_stringM":["sys_category"]', $solrContent, 'Label of related sys_category couldn\'t be resolved by using "foreignLabelField" and "enableRecursiveValueResolution"');
+        self::assertStringContainsString('"sysCategoryDescription_stringM":["sys_category description"]', $solrContent, 'Description of related sys_category couldn\'t be resolved by using "foreignLabelField" and "enableRecursiveValueResolution"');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -399,28 +397,28 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_multiple_direct_relations.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         $decodedSolrContent = json_decode($solrContent);
 
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
 
         // @extensionScannerIgnoreLine
         $category_stringM = $decodedSolrContent->response->docs[0]->category_stringM;
-        $this->assertSame(['the category','the second category'], $category_stringM, 'Unexpected category_stringM value');
+        self::assertSame(['the category', 'the second category'], $category_stringM, 'Unexpected category_stringM value');
         // @extensionScannerIgnoreLine
         $sysCategoryId_stringM = $decodedSolrContent->response->docs[0]->sysCategoryId_stringM;
-        $this->assertSame(['1','2'], $sysCategoryId_stringM, 'Unexpected sysCategoryId_stringM value');
+        self::assertSame(['1', '2'], $sysCategoryId_stringM, 'Unexpected sysCategoryId_stringM value');
         // @extensionScannerIgnoreLine
         $sysCategory_stringM = $decodedSolrContent->response->docs[0]->sysCategory_stringM;
-        $this->assertSame(['sys_category','sys_category 2'], $sysCategory_stringM, 'Unexpected sysCategory_stringM value');
+        self::assertSame(['sys_category', 'sys_category 2'], $sysCategory_stringM, 'Unexpected sysCategory_stringM value');
         // @extensionScannerIgnoreLine
         $sysCategoryDescription_stringM = $decodedSolrContent->response->docs[0]->sysCategoryDescription_stringM;
-        $this->assertSame(['sys_category description','second sys_category description'], $sysCategoryDescription_stringM, 'Unexpected sysCategoryDescription_stringM value');
+        self::assertSame(['sys_category description', 'second sys_category description'], $sysCategoryDescription_stringM, 'Unexpected sysCategoryDescription_stringM value');
 
         $this->cleanUpSolrServerAndAssertEmpty();
     }
@@ -442,15 +440,15 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_direct_relationAndAdditionalWhere.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"category_stringM":["another category"]', $solrContent, 'Did not find direct related category');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"category_stringM":["another category"]', $solrContent, 'Did not find direct related category');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -468,15 +466,15 @@ class IndexerTest extends IntegrationTest
         $this->importDataSetFromFixture('can_index_custom_record_with_configuration_in_rootline.xml');
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"fieldFromRootLine_stringS":"TESTNEWS"', $solrContent, 'Did not find field configured in rootline');
-        $this->assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"fieldFromRootLine_stringS":"TESTNEWS"', $solrContent, 'Did not find field configured in rootline');
+        self::assertStringContainsString('"title":"testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -487,7 +485,7 @@ class IndexerTest extends IntegrationTest
     {
         $this->expectException(\InvalidArgumentException::class);
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'][] = AdditionalIndexQueueItemIndexer::class;
-        $document = new Document;
+        $document = new Document();
         $metaData = ['item_type' => 'pages'];
         $record = [];
         $item = GeneralUtility::makeInstance(Item::class, $metaData, $record);
@@ -501,7 +499,7 @@ class IndexerTest extends IntegrationTest
     {
         $this->expectException(\UnexpectedValueException::class);
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'][] = DummyIndexer::class;
-        $document = new Document;
+        $document = new Document();
         $metaData = ['item_type' => 'pages'];
         $record = [];
         $item = GeneralUtility::makeInstance(Item::class, $metaData, $record);
@@ -515,7 +513,7 @@ class IndexerTest extends IntegrationTest
     {
         $this->expectException(\InvalidArgumentException::class);
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'][] = 'NonExistingClass';
-        $document = new Document;
+        $document = new Document();
         $metaData = ['item_type' => 'pages'];
         $record = [];
         $item = GeneralUtility::makeInstance(Item::class, $metaData, $record);
@@ -529,13 +527,13 @@ class IndexerTest extends IntegrationTest
     public function canGetAdditionalDocuments()
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['indexItemAddDocuments'][] = DummyAdditionalIndexQueueItemIndexer::class;
-        $document = new Document;
+        $document = new Document();
         $metaData = ['item_type' => 'pages'];
         $record = [];
         $item = GeneralUtility::makeInstance(Item::class, $metaData, $record);
 
         $result = $this->callInaccessibleMethod($this->indexer, 'getAdditionalDocuments', $item, 0, $document);
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
     }
 
     /**
@@ -553,14 +551,14 @@ class IndexerTest extends IntegrationTest
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 111);
 
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
 
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"external testnews"', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"external testnews"', $solrContent, 'Could not index document into solr');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -579,16 +577,16 @@ class IndexerTest extends IntegrationTest
 
         $result = $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_bar', 1);
 
-        $this->assertTrue($result, 'Indexing was not indicated to be successful');
+        self::assertTrue($result, 'Indexing was not indicated to be successful');
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
-        $this->assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":2', $solrContent, 'Could not index document into solr');
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*&fq=site:testone.site');
-        $this->assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
-        $this->assertStringContainsString('"url":"http://testone.site/en/"', $solrContent, 'Item was indexed with false site UID');
+        self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
+        self::assertStringContainsString('"url":"http://testone.site/en/"', $solrContent, 'Item was indexed with false site UID');
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
@@ -624,15 +622,15 @@ class IndexerTest extends IntegrationTest
             'item_type' => 'pages',
             'item_uid' => 1,
             'indexing_configuration' => '',
-            'has_indexing_properties' => false
+            'has_indexing_properties' => false,
         ];
         $item = new Item($itemMetaData);
 
         $result = $this->callInaccessibleMethod($this->indexer, 'getSolrConnectionsByItem', $item);
 
-        $this->assertInstanceOf(SolrConnection::class, $result[1], "Expect SolrConnection object in connection array item with key 1.");
-        $this->assertCount(1, $result, "Expect only one SOLR connection.");
-        $this->assertArrayNotHasKey(0, $result, "Expect, that there is no solr connection returned for default language,");
+        self::assertInstanceOf(SolrConnection::class, $result[1], 'Expect SolrConnection object in connection array item with key 1.');
+        self::assertCount(1, $result, 'Expect only one SOLR connection.');
+        self::assertArrayNotHasKey(0, $result, 'Expect, that there is no solr connection returned for default language,');
     }
 
     /**
@@ -648,16 +646,16 @@ class IndexerTest extends IntegrationTest
             'item_type' => 'pages',
             'item_uid' => 1,
             'indexing_configuration' => '',
-            'has_indexing_properties' => false
+            'has_indexing_properties' => false,
         ];
         $item = new Item($itemMetaData);
 
         $result = $this->callInaccessibleMethod($this->indexer, 'getSolrConnectionsByItem', $item);
 
-        $this->assertEmpty($result[0], 'Connection for default language was expected to be empty');
-        $this->assertInstanceOf(SolrConnection::class, $result[1], "Expect SolrConnection object in connection array item with key 1.");
-        $this->assertCount(1, $result, "Expect only one SOLR connection.");
-        $this->assertArrayNotHasKey(0, $result, "Expect, that there is no solr connection returned for default language,");
+        self::assertEmpty($result[0], 'Connection for default language was expected to be empty');
+        self::assertInstanceOf(SolrConnection::class, $result[1], 'Expect SolrConnection object in connection array item with key 1.');
+        self::assertCount(1, $result, 'Expect only one SOLR connection.');
+        self::assertArrayNotHasKey(0, $result, 'Expect, that there is no solr connection returned for default language,');
     }
 
     /**

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\Initializer;
 
 /***************************************************************
@@ -48,10 +49,7 @@ class PageTest extends IntegrationTest
      */
     protected $indexQueue;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBackendUserFromFixture(1);
@@ -68,12 +66,11 @@ class PageTest extends IntegrationTest
     protected function assertItemsInQueue($expectedAmount)
     {
         $itemCount = $this->indexQueue->getAllItemsCount();
-        $this->assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: ' . $expectedAmount);
+        self::assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: ' . $expectedAmount);
     }
 
     /**
      * Custom assertion to expect an empty queue.
-     * @return void
      */
     protected function assertEmptyQueue()
     {
@@ -82,8 +79,6 @@ class PageTest extends IntegrationTest
 
     /**
      * Initialize page index queue
-     *
-     * @return void
      */
     protected function initializeAllPageIndexQueues()
     {
@@ -91,7 +86,7 @@ class PageTest extends IntegrationTest
         /* @var $siteRepository SiteRepository */
         $sites = $siteRepository->getAvailableSites();
 
-        foreach($sites as $site) {
+        foreach ($sites as $site) {
             $this->pageInitializer->setIndexingConfigurationName('pages');
             $this->pageInitializer->setIndexingConfiguration(
                 $site->getSolrConfiguration()->getIndexQueueConfigurationByName('pages')
@@ -101,8 +96,6 @@ class PageTest extends IntegrationTest
             $this->pageInitializer->initialize();
         }
     }
-
-
 
     /**
      * In this testcase we check if the pages queue will be initialized as expected
@@ -126,13 +119,13 @@ class PageTest extends IntegrationTest
 
         $this->assertItemsInQueue(5);
 
-            // @todo: verify, is this really as expected? since mount_pid_ol is not set
-            // in the case when mount_pid_ol is set 4 pages get added
-        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 10));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 20));
+        // @todo: verify, is this really as expected? since mount_pid_ol is not set
+        // in the case when mount_pid_ol is set 4 pages get added
+        self::assertTrue($this->indexQueue->containsItem('pages', 1));
+        self::assertTrue($this->indexQueue->containsItem('pages', 10));
+        self::assertTrue($this->indexQueue->containsItem('pages', 20));
 
-        $this->assertFalse($this->indexQueue->containsItem('pages', 2));
+        self::assertFalse($this->indexQueue->containsItem('pages', 2));
     }
 
     /**
@@ -158,13 +151,13 @@ class PageTest extends IntegrationTest
         $this->initializeAllPageIndexQueues();
         $this->assertItemsInQueue(3); // The root page of "testtwo.site aka integration_tree_two" is included.
 
-        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 24));
+        self::assertTrue($this->indexQueue->containsItem('pages', 1));
+        self::assertTrue($this->indexQueue->containsItem('pages', 24));
 
         $items = $this->indexQueue->getItems('pages', 24);
         $firstItem = $items[0];
 
-        $this->assertSame('24-14-1', $firstItem->getMountPointIdentifier());
+        self::assertSame('24-14-1', $firstItem->getMountPointIdentifier());
     }
 
     /**
@@ -190,16 +183,16 @@ class PageTest extends IntegrationTest
         $this->initializeAllPageIndexQueues();
         $this->assertItemsInQueue(3); // The root page of "testtwo.site aka integration_tree_two" is included.
 
-        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
+        self::assertTrue($this->indexQueue->containsItem('pages', 1));
         // the mountpoint MUST NOT be in the queue,
         // because the page "[14] Mount Point" is set to overlay the content from mount source page.
-        $this->assertFalse($this->indexQueue->containsItem('pages', 14));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 24));
+        self::assertFalse($this->indexQueue->containsItem('pages', 14));
+        self::assertTrue($this->indexQueue->containsItem('pages', 24));
 
         $items = $this->indexQueue->getItems('pages', 24);
         $firstItem = $items[0];
 
-        $this->assertSame('24-14-1', $firstItem->getMountPointIdentifier());
+        self::assertSame('24-14-1', $firstItem->getMountPointIdentifier());
     }
 
     /**
@@ -229,24 +222,24 @@ class PageTest extends IntegrationTest
         $this->initializeAllPageIndexQueues();
         $this->assertItemsInQueue(4);
 
-        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
+        self::assertTrue($this->indexQueue->containsItem('pages', 1));
         // the mountpoint MUST NOT be in the queue,
         // because the page "[14] Mount Point" is set to overlay the content from mount source page.
-        $this->assertFalse($this->indexQueue->containsItem('pages', 14));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 24));
+        self::assertFalse($this->indexQueue->containsItem('pages', 14));
+        self::assertTrue($this->indexQueue->containsItem('pages', 24));
 
-        $this->assertTrue($this->indexQueue->containsItem('pages', 111));
+        self::assertTrue($this->indexQueue->containsItem('pages', 111));
         // the mountpoint MUST NOT be in the queue,
         // because the page "[34] Mount Point" is set to overlay the content from mount source page.
-        $this->assertFalse($this->indexQueue->containsItem('pages', 34));
+        self::assertFalse($this->indexQueue->containsItem('pages', 34));
 
         $items = $this->indexQueue->getItems('pages', 24);
         $firstItem = $items[0];
 
-        $this->assertSame('24-14-1', $firstItem->getMountPointIdentifier());
+        self::assertSame('24-14-1', $firstItem->getMountPointIdentifier());
 
         $secondItem = $items[1];
-        $this->assertSame('24-34-1', $secondItem->getMountPointIdentifier());
+        self::assertSame('24-34-1', $secondItem->getMountPointIdentifier());
     }
 
     /**
@@ -266,7 +259,7 @@ class PageTest extends IntegrationTest
 
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
-        $this->assertEquals(2, count($flashMessageQueue->getAllMessages()));
+        self::assertEquals(2, count($flashMessageQueue->getAllMessages()));
     }
 
     /**
@@ -294,7 +287,7 @@ class PageTest extends IntegrationTest
 
         $this->assertItemsInQueue(3); // The root page of "testtwo.site aka integration_tree_two" is included.
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->indexQueue->containsItem('pages', 3),
             'The index queue does not contain the sub pages of restricted by additionalWhereClause page.' . PHP_EOL
             . 'The initializer MUST NOT ignore the sub pages of restricted pages.'

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
 
 /***************************************************************
@@ -24,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -48,10 +49,7 @@ class QueueTest extends IntegrationTest
      */
     protected $siteRepository;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -67,12 +65,11 @@ class QueueTest extends IntegrationTest
     protected function assertItemsInQueue($expectedAmount)
     {
         $itemCount = $this->indexQueue->getAllItemsCount();
-        $this->assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: ' . $expectedAmount);
+        self::assertSame($itemCount, $expectedAmount, 'Indexqueue contains unexpected amount of items. Expected amount: ' . $expectedAmount);
     }
 
     /**
      * Custom assertion to expect an empty queue.
-     * @return void
      */
     protected function assertEmptyQueue()
     {
@@ -88,16 +85,16 @@ class QueueTest extends IntegrationTest
         $itemCount = $this->indexQueue->getAllItemsCount();
 
         $this->assertItemsInQueue(1);
-        $this->assertFalse($this->indexQueue->containsItem('pages', 1));
-        $this->assertTrue($this->indexQueue->containsItem('pages', 4711));
+        self::assertFalse($this->indexQueue->containsItem('pages', 1));
+        self::assertTrue($this->indexQueue->containsItem('pages', 4711));
 
         // after initialize the prefilled queue item should be lost and the root page should be added again
         $site = $this->siteRepository->getFirstAvailableSite();
         $this->indexQueue->getInitializationService()->initializeBySiteAndIndexConfiguration($site, 'pages');
 
         $this->assertItemsInQueue(1);
-        $this->assertTrue($this->indexQueue->containsItem('pages', 1));
-        $this->assertFalse($this->indexQueue->containsItem('pages', 4711));
+        self::assertTrue($this->indexQueue->containsItem('pages', 1));
+        self::assertFalse($this->indexQueue->containsItem('pages', 4711));
     }
 
     /**
@@ -108,11 +105,11 @@ class QueueTest extends IntegrationTest
         $this->assertEmptyQueue();
 
         $updateCount = $this->indexQueue->updateItem('pages', 1);
-        $this->assertSame(1, $updateCount);
+        self::assertSame(1, $updateCount);
         $this->assertItemsInQueue(1);
 
         $updateCount = $this->indexQueue->updateItem('pages', 1);
-        $this->assertSame(0, $updateCount);
+        self::assertSame(0, $updateCount);
         $this->assertItemsInQueue(1);
     }
 
@@ -154,11 +151,11 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_not_add_unallowed_pagetype.xml');
         $this->assertEmptyQueue();
 
-            // record does not exist in fixture
+        // record does not exist in fixture
         $updateCount = $this->indexQueue->updateItem('pages', 22);
-        $this->assertSame(0, $updateCount, 'Expected that no record was updated');
+        self::assertSame(0, $updateCount, 'Expected that no record was updated');
 
-            // queue should still be empty
+        // queue should still be empty
         $this->assertEmptyQueue();
     }
 
@@ -176,7 +173,6 @@ class QueueTest extends IntegrationTest
 
         $this->indexQueue->getInitializationService()->initializeBySiteAndIndexConfiguration($site, 'pages');
         $this->assertItemsInQueue(4);
-
     }
 
     /**
@@ -212,7 +208,7 @@ class QueueTest extends IntegrationTest
         $this->assertItemsInQueue(1);
 
         $queueItem = $this->indexQueue->getItem(1);
-        $this->assertEquals(
+        self::assertEquals(
             'custom_page_type',
             $queueItem->getIndexingConfigurationName(),
             'Item was queued with unexpected configuration'
@@ -228,8 +224,8 @@ class QueueTest extends IntegrationTest
         $site = $this->siteRepository->getFirstAvailableSite();
         $itemCount = $this->indexQueue->getStatisticsBySite($site)->getTotalCount();
 
-            // there are two items in the queue but only one for the site
-        $this->assertSame(1, $itemCount, 'Unexpected item count for the first site');
+        // there are two items in the queue but only one for the site
+        self::assertSame(1, $itemCount, 'Unexpected item count for the first site');
     }
 
     /**
@@ -241,12 +237,12 @@ class QueueTest extends IntegrationTest
         $site = $this->siteRepository->getFirstAvailableSite();
 
         $itemCount = $this->indexQueue->getStatisticsBySite($site)->getPendingCount();
-        $this->assertSame(1, $itemCount, 'Unexpected remaining item count for the first site');
+        self::assertSame(1, $itemCount, 'Unexpected remaining item count for the first site');
 
-            // when we update the item, no remaining item should be left
+        // when we update the item, no remaining item should be left
         $this->indexQueue->updateItem('pages', 1);
         $itemCount = $this->indexQueue->getStatisticsBySite($site)->getPendingCount();
-        $this->assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
+        self::assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
     }
 
     /**
@@ -268,18 +264,17 @@ class QueueTest extends IntegrationTest
             }
         }
 
+        $firstRootPage = $this->indexQueue->getItems('pages', 1);
+        $secondRootPage = $this->indexQueue->getItems('pages', 111);
 
-        $firstRootPage = $this->indexQueue->getItems('pages',1);
-        $secondRootPage = $this->indexQueue->getItems('pages',111);
+        self::assertCount(1, $firstRootPage);
+        self::assertCount(1, $secondRootPage);
 
-        $this->assertCount(1, $firstRootPage);
-        $this->assertCount(1, $secondRootPage);
+        $firstSubPage = $this->indexQueue->getItems('pages', 10);
+        $secondSubPage = $this->indexQueue->getItems('pages', 1111);
 
-        $firstSubPage = $this->indexQueue->getItems('pages',10);
-        $secondSubPage = $this->indexQueue->getItems('pages',1111);
-
-        $this->assertCount(1, $firstSubPage);
-        $this->assertCount(1, $secondSubPage);
+        self::assertCount(1, $firstSubPage);
+        self::assertCount(1, $secondSubPage);
 
         $this->assertItemsInQueue(4);
     }
@@ -294,9 +289,9 @@ class QueueTest extends IntegrationTest
 
         $site = $this->siteRepository->getSiteByPageId(111);
         $statistics = $this->indexQueue->getStatisticsBySite($site);
-        $this->assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed items from queue');
-        $this->assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed items from queue');
-        $this->assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed items from queue');
+        self::assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed items from queue');
+        self::assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed items from queue');
+        self::assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed items from queue');
     }
 
     /**
@@ -310,14 +305,14 @@ class QueueTest extends IntegrationTest
         $site = $this->siteRepository->getSiteByPageId(111);
         $statistics = $this->indexQueue->getStatisticsBySite($site, 'customIndexingConfigurationName');
 
-        $this->assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed custom items from queue');
-        $this->assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed custom items from queue');
-        $this->assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed custom items from queue');
+        self::assertSame(1, $statistics->getSuccessCount(), 'Can not get successful processed custom items from queue');
+        self::assertSame(1, $statistics->getFailedCount(), 'Can not get failed processed custom items from queue');
+        self::assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed custom items from queue');
 
         $notExistingIndexingConfStatistic = $this->indexQueue->getStatisticsBySite($site, 'notExistingIndexingConfigurationName');
-        $this->assertSame(0, $notExistingIndexingConfStatistic->getSuccessCount(), 'Can not get successful processed items from queue for not existing indexing configuration');
-        $this->assertSame(0, $notExistingIndexingConfStatistic->getFailedCount(), 'Can not get failed processed items from queue for not existing indexing configuration');
-        $this->assertSame(0, $notExistingIndexingConfStatistic->getPendingCount(), 'Can not get pending processed items from queue for not existing indexing configuration');
+        self::assertSame(0, $notExistingIndexingConfStatistic->getSuccessCount(), 'Can not get successful processed items from queue for not existing indexing configuration');
+        self::assertSame(0, $notExistingIndexingConfStatistic->getFailedCount(), 'Can not get failed processed items from queue for not existing indexing configuration');
+        self::assertSame(0, $notExistingIndexingConfStatistic->getPendingCount(), 'Can not get pending processed items from queue for not existing indexing configuration');
     }
 
     /**
@@ -328,7 +323,7 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_get_last_index_time.xml');
         $this->assertItemsInQueue(3);
         $lastIndexTime = $this->indexQueue->getLastIndexTime(2);
-        $this->assertEquals($lastIndexTime, 0);
+        self::assertEquals($lastIndexTime, 0);
     }
 
     /**
@@ -339,7 +334,7 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_get_last_index_time.xml');
         $this->assertItemsInQueue(3);
         $lastIndexTime = $this->indexQueue->getLastIndexTime(1);
-        $this->assertEquals($lastIndexTime, 1489383800);
+        self::assertEquals($lastIndexTime, 1489383800);
     }
 
     /**
@@ -350,7 +345,7 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_get_last_indexed_item_id.xml');
         $this->assertItemsInQueue(3);
         $lastIndexedItemIdUid = $this->indexQueue->getLastIndexedItemId(2);
-        $this->assertEquals($lastIndexedItemIdUid, 0);
+        self::assertEquals($lastIndexedItemIdUid, 0);
     }
 
     /**
@@ -361,7 +356,7 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_get_last_indexed_item_id.xml');
         $this->assertItemsInQueue(3);
         $lastIndexedItemIdUid = $this->indexQueue->getLastIndexedItemId(1);
-        $this->assertEquals($lastIndexedItemIdUid, 4713);
+        self::assertEquals($lastIndexedItemIdUid, 4713);
     }
 
     /**
@@ -374,7 +369,7 @@ class QueueTest extends IntegrationTest
         $item = $this->indexQueue->getItem(4711);
         $this->indexQueue->markItemAsFailed($item);
         $processedItem = $this->indexQueue->getItem($item->getIndexQueueUid());
-        $this->assertEquals($processedItem->getErrors(), '1');
+        self::assertEquals($processedItem->getErrors(), '1');
     }
 
     /**
@@ -387,7 +382,7 @@ class QueueTest extends IntegrationTest
         $item = $this->indexQueue->getItem(4711);
         $this->indexQueue->markItemAsFailed($item, 'Error during indexing canMarkItemAsFailedWithItemAndMessage');
         $processedItem = $this->indexQueue->getItem($item->getIndexQueueUid());
-        $this->assertEquals($processedItem->getErrors(), 'Error during indexing canMarkItemAsFailedWithItemAndMessage');
+        self::assertEquals($processedItem->getErrors(), 'Error during indexing canMarkItemAsFailedWithItemAndMessage');
     }
 
     /**
@@ -399,7 +394,7 @@ class QueueTest extends IntegrationTest
         $this->assertItemsInQueue(3);
         $this->indexQueue->markItemAsFailed(4712);
         $item = $this->indexQueue->getItem(4712);
-        $this->assertEquals($item->getErrors(), '1');
+        self::assertEquals($item->getErrors(), '1');
     }
 
     /**
@@ -411,7 +406,7 @@ class QueueTest extends IntegrationTest
         $this->assertItemsInQueue(3);
         $this->indexQueue->markItemAsFailed(4712, 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
         $item = $this->indexQueue->getItem(4712);
-        $this->assertEquals($item->getErrors(), 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
+        self::assertEquals($item->getErrors(), 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
     }
 
     /**
@@ -423,7 +418,7 @@ class QueueTest extends IntegrationTest
         $this->assertItemsInQueue(3);
         $this->indexQueue->markItemAsFailed(42, 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
         $item = $this->indexQueue->getItem(42);
-        $this->assertEquals($item, null);
+        self::assertEquals($item, null);
     }
 
     /**
@@ -436,7 +431,7 @@ class QueueTest extends IntegrationTest
         $item = $this->indexQueue->getItem(42);
         $this->indexQueue->markItemAsFailed($item, 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
         $processedItem = $this->indexQueue->getItem(42);
-        $this->assertEquals($processedItem, null);
+        self::assertEquals($processedItem, null);
     }
 
     /**
@@ -447,7 +442,7 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_update_index_time_by_item.xml');
         $this->assertItemsInQueue(3);
         $item = $this->indexQueue->getItem(42);
-        $this->assertEquals($item, null);
+        self::assertEquals($item, null);
     }
 
     /**
@@ -458,10 +453,10 @@ class QueueTest extends IntegrationTest
         $this->importDataSetFromFixture('can_update_index_time_by_item.xml');
         $this->assertItemsInQueue(3);
         $lastestUpdatedItem = $this->indexQueue->getLastIndexedItemId(1);
-        $this->assertEquals($lastestUpdatedItem, 4713);
+        self::assertEquals($lastestUpdatedItem, 4713);
         $this->indexQueue->updateIndexTimeByItem($this->indexQueue->getItem(4711));
         $lastestUpdatedItem = $this->indexQueue->getLastIndexedItemId(1);
-        $this->assertEquals($lastestUpdatedItem, 4711);
+        self::assertEquals($lastestUpdatedItem, 4711);
     }
 
     /**
@@ -477,16 +472,16 @@ class QueueTest extends IntegrationTest
         $firstSite = $siteRepository->getFirstAvailableSite();
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
+        self::assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
 
         $this->indexQueue->resetAllErrors();
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(0, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after reset');
+        self::assertSame(0, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after reset');
 
         $secondSite = $siteRepository->getSiteByPageId(111);
         $errorsForSecondSite = $this->indexQueue->getErrorsBySite($secondSite);
-        $this->assertSame(0, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
+        self::assertSame(0, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
     }
 
     /**
@@ -502,22 +497,23 @@ class QueueTest extends IntegrationTest
         $firstSite = $siteRepository->getFirstAvailableSite();
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
+        self::assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
 
         $this->indexQueue->resetErrorsBySite($firstSite);
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(0, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after reset');
+        self::assertSame(0, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after reset');
 
         $secondSite = $siteRepository->getSiteByPageId(111);
         $errorsForSecondSite = $this->indexQueue->getErrorsBySite($secondSite);
-        $this->assertSame(1, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
+        self::assertSame(1, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
     }
 
     /**
      * @test
      */
-    public function canFlushErrorByItem() {
+    public function canFlushErrorByItem()
+    {
         $this->importDataSetFromFixture('can_flush_error_by_item.xml');
         $this->assertItemsInQueue(4);
 
@@ -526,12 +522,12 @@ class QueueTest extends IntegrationTest
         $firstSite = $siteRepository->getFirstAvailableSite();
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
+        self::assertSame(2, count($errorsForFirstSite), 'Unexpected amount of errors for the first site');
 
         $item = $this->indexQueue->getItem(4714);
         $this->indexQueue->resetErrorByItem($item);
 
         $errorsForFirstSite = $this->indexQueue->getErrorsBySite($firstSite);
-        $this->assertSame(1, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after resetting one item');
+        self::assertSame(1, count($errorsForFirstSite), 'Unexpected amount of errors for the first site after resetting one item');
     }
 }

--- a/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
+++ b/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -35,10 +36,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class AccessFilterPluginInstalledStatusTest extends IntegrationTest
 {
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -52,6 +50,6 @@ class AccessFilterPluginInstalledStatusTest extends IntegrationTest
         /** @var $accessFilterStatus  AccessFilterPluginInstalledStatus */
         $accessFilterStatus = GeneralUtility::makeInstance(AccessFilterPluginInstalledStatus::class);
         $violations = $accessFilterStatus->getStatus();
-        $this->assertEmpty($violations, 'We expect to get no violations against the test solr server ');
+        self::assertEmpty($violations, 'We expect to get no violations against the test solr server ');
     }
 }

--- a/Tests/Integration/Report/SchemaStatusTest.php
+++ b/Tests/Integration/Report/SchemaStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -36,10 +37,7 @@ use TYPO3\CMS\Reports\Status;
  */
 class SchemaStatusTest extends IntegrationTest
 {
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -54,6 +52,6 @@ class SchemaStatusTest extends IntegrationTest
         $schemaStatus = GeneralUtility::makeInstance(SchemaStatus::class);
         $violations = $schemaStatus->getStatus();
 
-        $this->assertEmpty($violations, 'We expect to get no violations against the test solr server');
+        self::assertEmpty($violations, 'We expect to get no violations against the test solr server');
     }
 }

--- a/Tests/Integration/Report/SiteHandlingStatusTest.php
+++ b/Tests/Integration/Report/SiteHandlingStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -32,7 +33,6 @@ use TYPO3\CMS\Reports\Status;
 
 /**
  * Integration test for the site handling status report
- *
  */
 class SiteHandlingStatusTest extends IntegrationTest
 {
@@ -48,9 +48,9 @@ class SiteHandlingStatusTest extends IntegrationTest
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::OK, $status->getSeverity(), 'Expected that all status checks for site handling configuration of first test site should be ok');
+            self::assertSame(Status::OK, $status->getSeverity(), 'Expected that all status checks for site handling configuration of first test site should be ok');
         }
     }
 
@@ -61,20 +61,20 @@ class SiteHandlingStatusTest extends IntegrationTest
     {
         $this->writeDefaultSolrTestSiteConfiguration();
         $this->mergeSiteConfiguration('integration_tree_one', [
-            'base' => 'authorityOnly.example.com'
+            'base' => 'authorityOnly.example.com',
         ]);
         $this->mergeSiteConfiguration('integration_tree_two', [
-            'base' => 'authorityOnly.two.example.com'
+            'base' => 'authorityOnly.two.example.com',
         ]);
 
         /** @var $siteHandlingStatus  SiteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if scheme in "Entry Point[base]" is not defined.');
-            $this->assertMatchesRegularExpression('~.*are empty or invalid\: &quot;scheme&quot;~', $status->getMessage());
+            self::assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if scheme in "Entry Point[base]" is not defined.');
+            self::assertMatchesRegularExpression('~.*are empty or invalid\: &quot;scheme&quot;~', $status->getMessage());
         }
     }
 
@@ -85,20 +85,20 @@ class SiteHandlingStatusTest extends IntegrationTest
     {
         $this->writeDefaultSolrTestSiteConfiguration();
         $this->mergeSiteConfiguration('integration_tree_one', [
-            'base' => '/'
+            'base' => '/',
         ]);
         $this->mergeSiteConfiguration('integration_tree_two', [
-            'base' => '/'
+            'base' => '/',
         ]);
 
         /** @var $siteHandlingStatus  SiteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
-            $this->assertMatchesRegularExpression('~.*are empty or invalid\: &quot;scheme, host&quot;~', $status->getMessage());
+            self::assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
+            self::assertMatchesRegularExpression('~.*are empty or invalid\: &quot;scheme, host&quot;~', $status->getMessage());
         }
     }
 
@@ -125,10 +125,10 @@ class SiteHandlingStatusTest extends IntegrationTest
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
-            $this->assertMatchesRegularExpression('~.*is not valid URL\. Following parts of defined URL are empty or invalid\: &quot;scheme&quot;~', $status->getMessage());
+            self::assertSame(Status::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
+            self::assertMatchesRegularExpression('~.*is not valid URL\. Following parts of defined URL are empty or invalid\: &quot;scheme&quot;~', $status->getMessage());
         }
     }
 }

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -35,10 +36,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrConfigStatusTest extends IntegrationTest
 {
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -53,6 +51,6 @@ class SolrConfigStatusTest extends IntegrationTest
         /** @var $schemaStatus  SolrConfigStatus */
         $schemaStatus = GeneralUtility::makeInstance(SolrConfigStatus::class);
         $violations = $schemaStatus->getStatus();
-        $this->assertEmpty($violations, 'We expect to get no violations against the test solr server');
+        self::assertEmpty($violations, 'We expect to get no violations against the test solr server');
     }
 }

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -42,10 +43,7 @@ class SolrConfigurationStatusTest extends IntegrationTest
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -58,10 +56,10 @@ class SolrConfigurationStatusTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_get_green_solr_configuration_status_report.xml');
 
-            /** @var $solrConfigurationStatus  SolrConfigurationStatus */
+        /** @var $solrConfigurationStatus  SolrConfigurationStatus */
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
-        $this->assertEmpty($violations, 'We did not get an empty response from the solr configuration status report! Something is wrong');
+        self::assertEmpty($violations, 'We did not get an empty response from the solr configuration status report! Something is wrong');
     }
 
     /**
@@ -75,10 +73,10 @@ class SolrConfigurationStatusTest extends IntegrationTest
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
 
-        $this->assertCount(1, $violations, 'Asserting to contain only one violation.');
+        self::assertCount(1, $violations, 'Asserting to contain only one violation.');
 
         $firstViolation = array_pop($violations);
-        $this->assertStringContainsString('No sites', $firstViolation->getValue(), 'Did not get a no sites found violation');
+        self::assertStringContainsString('No sites', $firstViolation->getValue(), 'Did not get a no sites found violation');
     }
 
     /**
@@ -92,9 +90,9 @@ class SolrConfigurationStatusTest extends IntegrationTest
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
 
-        $this->assertCount(1, $violations, 'Asserting to contain only one violation.');
+        self::assertCount(1, $violations, 'Asserting to contain only one violation.');
 
         $firstViolation = array_pop($violations);
-        $this->assertStringContainsString('Indexing is disabled', $firstViolation->getValue(), 'Did not get a no sites found violation');
+        self::assertStringContainsString('Indexing is disabled', $firstViolation->getValue(), 'Did not get a no sites found violation');
     }
 }

--- a/Tests/Integration/Report/SolrStatusTest.php
+++ b/Tests/Integration/Report/SolrStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -47,9 +48,9 @@ class SolrStatusTest extends IntegrationTest
         $solrStatus = GeneralUtility::makeInstance(SolrStatus::class);
         $statusCollection = $solrStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::OK, $status->getSeverity(), 'Expected that all status objects should be ok');
+            self::assertSame(Status::OK, $status->getSeverity(), 'Expected that all status objects should be ok');
         }
     }
 
@@ -58,15 +59,15 @@ class SolrStatusTest extends IntegrationTest
      */
     public function allStatusChecksShouldFailForInvalidSolrConnection()
     {
-        $this->writeDefaultSolrTestSiteConfigurationForHostAndPort(null,'invalid', 4711);
+        $this->writeDefaultSolrTestSiteConfigurationForHostAndPort(null, 'invalid', 4711);
 
         /** @var $solrStatus  SolrStatus */
         $solrStatus = GeneralUtility::makeInstance(SolrStatus::class);
         $statusCollection = $solrStatus->getStatus();
 
-        foreach($statusCollection as $status) {
+        foreach ($statusCollection as $status) {
             /** @var $status Status */
-            $this->assertSame(Status::ERROR, $status->getSeverity(), 'Expected that all status objects should indicate an error');
+            self::assertSame(Status::ERROR, $status->getSeverity(), 'Expected that all status objects should indicate an error');
         }
     }
 }

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 /***************************************************************
@@ -35,10 +36,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrVersionStatusTest extends IntegrationTest
 {
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -54,6 +52,6 @@ class SolrVersionStatusTest extends IntegrationTest
         /** @var $solrVersionStatus  SolrVersionStatus */
         $solrVersionStatus = GeneralUtility::makeInstance(SolrVersionStatus::class);
         $violations = $solrVersionStatus->getStatus();
-        $this->assertEmpty($violations, 'We expect to get no violations against the test solr server');
+        self::assertEmpty($violations, 'We expect to get no violations against the test solr server');
     }
 }

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 /***************************************************************
@@ -34,9 +35,9 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
+use Solarium\QueryType\Select\Query\Query;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Solarium\QueryType\Select\Query\Query;
 
 /**
  * Test class to perform a search on a real solr server
@@ -57,15 +58,14 @@ class SearchTest extends IntegrationTest
      */
     protected $queryBuilder;
 
-
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
         $this->queryBuilder = new QueryBuilder(new TypoScriptConfiguration([]));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -78,7 +78,7 @@ class SearchTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('can_search.xml');
 
-        $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TT'] = $this->createMock(TimeTracker::class);
         $fakeTSFE = $this->getConfiguredTSFE();
         $GLOBALS['TSFE'] = $fakeTSFE;
 
@@ -88,7 +88,7 @@ class SearchTest extends IntegrationTest
 
         $this->waitToBeVisibleInSolr();
 
-            /** @var $searchInstance \ApacheSolrForTypo3\Solr\Search */
+        /** @var $searchInstance \ApacheSolrForTypo3\Solr\Search */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->queryBuilder
@@ -98,8 +98,8 @@ class SearchTest extends IntegrationTest
 
         $searchResponse = $searchInstance->search($query);
         $rawResponse = $searchResponse->getRawResponse();
-        $this->assertStringContainsString('"numFound":1', $rawResponse, 'Could not index document into solr');
-        $this->assertStringContainsString('"title":"Hello Search Test"', $rawResponse, 'Could not index document into solr');
+        self::assertStringContainsString('"numFound":1', $rawResponse, 'Could not index document into solr');
+        self::assertStringContainsString('"title":"Hello Search Test"', $rawResponse, 'Could not index document into solr');
     }
 
     /**
@@ -120,9 +120,9 @@ class SearchTest extends IntegrationTest
         $parsedData = $searchResponse->getParsedData();
         // document with "Hello World for phrase serchin" is not on first place!
         // @extensionScannerIgnoreLine
-        $this->assertGreaterThan(0, $parsedData->response->numFound, 'Could not index document into solr');
+        self::assertGreaterThan(0, $parsedData->response->numFound, 'Could not index document into solr');
         // @extensionScannerIgnoreLine
-        $this->assertNotEquals('Hello World for phrase serching', $parsedData->response->docs[0]->getTitle(), 'Unexpected score calculation. Expected Document shouldn\'t be at first place.');
+        self::assertNotEquals('Hello World for phrase serching', $parsedData->response->docs[0]->getTitle(), 'Unexpected score calculation. Expected Document shouldn\'t be at first place.');
 
         // Boost the document with query to make it first.
         $query = $this->queryBuilder->startFrom($query)->usePhraseFields(PhraseFields::fromString('title^10.0'))->getQuery();
@@ -130,9 +130,9 @@ class SearchTest extends IntegrationTest
         $parsedData = $searchResponse->getParsedData();
 
         // @extensionScannerIgnoreLine
-        $this->assertGreaterThan(0, $parsedData->response->numFound, 'Could not index document into solr');
+        self::assertGreaterThan(0, $parsedData->response->numFound, 'Could not index document into solr');
         // @extensionScannerIgnoreLine
-        $this->assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Unexpected score calculation. Document');
+        self::assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Unexpected score calculation. Document');
     }
 
     /**
@@ -148,7 +148,6 @@ class SearchTest extends IntegrationTest
         $query = $this->queryBuilder
             ->newSearchQuery('Hello World')
             ->getQuery();
-
 
         // Boost the document with query to make it first.
         $query = $this->queryBuilder->startFrom($query)->usePhraseFields(PhraseFields::fromString('title^10.0'))->getQuery();
@@ -191,19 +190,18 @@ class SearchTest extends IntegrationTest
         // Note positons beginning by 0 = first
         // first position is the same for all three slop values
         // @extensionScannerIgnoreLine
-        $this->assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
+        self::assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
             // @extensionScannerIgnoreLine
-                && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid()
-        , 'Phrase search does not work properly. Solr should position the document independent from slop value at first position.');
+                && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid(), 'Phrase search does not work properly. Solr should position the document independent from slop value at first position.');
         // the slop value of 1 moves doc UID = 11 to the second position
         // @extensionScannerIgnoreLine
-        $this->assertSame(11, $parsedDatasByPhraseSlop[1]->response->docs[1]->getUid(), 'Phrase slop setting does not work as expected.');
+        self::assertSame(11, $parsedDatasByPhraseSlop[1]->response->docs[1]->getUid(), 'Phrase slop setting does not work as expected.');
         // the slop value of 2 moves doc UID = 3 to the fifth position
         // @extensionScannerIgnoreLine
-        $this->assertSame(3, $parsedDatasByPhraseSlop[2]->response->docs[4]->getUid(), 'Phrase slop setting does not work as expected. The Phrase Slop value of 2 has no influence on boosts.');
+        self::assertSame(3, $parsedDatasByPhraseSlop[2]->response->docs[4]->getUid(), 'Phrase slop setting does not work as expected. The Phrase Slop value of 2 has no influence on boosts.');
         // the slop value of 2 has an influence of positions up to 8
         // @extensionScannerIgnoreLine
-        $this->assertSame(2, $parsedDatasByPhraseSlop[2]->response->docs[7]->getUid(), 'Phrase slop setting does not work as expected.');
+        self::assertSame(2, $parsedDatasByPhraseSlop[2]->response->docs[7]->getUid(), 'Phrase slop setting does not work as expected.');
     }
 
     /**
@@ -222,7 +220,6 @@ class SearchTest extends IntegrationTest
 
         $query = $this->getSearchQueryForSolr();
         $this->queryBuilder->useQueryString('Bigram Phrase Search');
-
 
         // Boost the document with query to make it first.
         $this->queryBuilder->useBigramPhraseFields(BigramPhraseFields::fromString('title^100.0'));
@@ -265,17 +262,16 @@ class SearchTest extends IntegrationTest
         // Note positons beginning by 0 = first
         // first position is the same for all three slop values
         // @extensionScannerIgnoreLine
-        $this->assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
+        self::assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
             // @extensionScannerIgnoreLine
-            && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid()
-            , 'Bigram Phrase search does not work properly. Solr should position the documents independent from slop value at first position.');
+            && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid(), 'Bigram Phrase search does not work properly. Solr should position the documents independent from slop value at first position.');
 
         // slop = 1
         // the slop value of 1 moves doc UID = 4 to the fourth(key 3) position
         // @extensionScannerIgnoreLine
-        $this->assertSame(4, $parsedDatasByPhraseSlop[1]->response->docs[3]->getUid(), 'Bigram phrase slop setting does not work as expected. It does not boost "sloppy phrase" docs for slop=1.');
+        self::assertSame(4, $parsedDatasByPhraseSlop[1]->response->docs[3]->getUid(), 'Bigram phrase slop setting does not work as expected. It does not boost "sloppy phrase" docs for slop=1.');
         // the docuemnt on position 3 and 4 have same score
-        $this->assertTrue(
+        self::assertTrue(
         // @extensionScannerIgnoreLine
             $parsedDatasByPhraseSlop[1]->response->docs[3]->getScore() === $parsedDatasByPhraseSlop[1]->response->docs[4]->getScore(),
             'Bigram phrase slop setting does not work as expected. It does not boost all "sloppy phrase" docs for slop=1.'
@@ -284,9 +280,9 @@ class SearchTest extends IntegrationTest
         // slop = 2
         // the slop value of 2 moves doc UID = 6 to the sixth(key 5) position
         // @extensionScannerIgnoreLine
-        $this->assertSame(6, $parsedDatasByPhraseSlop[2]->response->docs[5]->getUid(), 'Trigram phrase slop setting does not work as expected. The Phrase Slop value of 2 has no influence on boosts.');
+        self::assertSame(6, $parsedDatasByPhraseSlop[2]->response->docs[5]->getUid(), 'Trigram phrase slop setting does not work as expected. The Phrase Slop value of 2 has no influence on boosts.');
         // the docuemnt on position 5 and 6 have same score
-        $this->assertTrue(
+        self::assertTrue(
         // @extensionScannerIgnoreLine
             $parsedDatasByPhraseSlop[2]->response->docs[5]->getScore() === $parsedDatasByPhraseSlop[2]->response->docs[6]->getScore(),
             'Bigram phrase slop setting does not work as expected. It does not boost all "sloppy phrase" docs for slop=2.'
@@ -350,10 +346,9 @@ class SearchTest extends IntegrationTest
         // Note positons beginning by 0 = first
         // first position is the same for all three slop values
         // @extensionScannerIgnoreLine
-        $this->assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
+        self::assertTrue($parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[1]->response->docs[0]->getUid()
             // @extensionScannerIgnoreLine
-            && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid()
-            , 'Trigram Phrase search does not work properly. Solr should position the documents independent from slop value at first position.');
+            && $parsedDatasByPhraseSlop[0]->response->docs[0]->getUid() === $parsedDatasByPhraseSlop[2]->response->docs[0]->getUid(), 'Trigram Phrase search does not work properly. Solr should position the documents independent from slop value at first position.');
 
         // slop = 1
         // the slop value of 1 moves doc UID = 4 to the fourth(key 3) position
@@ -361,7 +356,7 @@ class SearchTest extends IntegrationTest
         $slop0ResponseDocs = $parsedDatasByPhraseSlop[0]->response->docs;
         // @extensionScannerIgnoreLine
         $slop1ResponseDocs = $parsedDatasByPhraseSlop[1]->response->docs;
-        $this->assertTrue(
+        self::assertTrue(
             $slop0ResponseDocs[3]->getUid() === $slop1ResponseDocs[3]->getUid()
             && $slop0ResponseDocs[3]->getScore() < $slop1ResponseDocs[3]->getScore(),
             'Trigram phrase slop value = 1 does not boost docs with "sloppy phrases"'
@@ -369,7 +364,7 @@ class SearchTest extends IntegrationTest
 
         // @extensionScannerIgnoreLine
         $slop2ResponseDocs = $parsedDatasByPhraseSlop[2]->response->docs;
-        $this->assertTrue(
+        self::assertTrue(
             $slop1ResponseDocs[5]->getUid() === $slop2ResponseDocs[5]->getUid()
             && $slop0ResponseDocs[5]->getScore() < $slop1ResponseDocs[5]->getScore(),
             'Trigram phrase slop value = 2 does not boost docs with "sloppy phrases"'
@@ -393,9 +388,9 @@ class SearchTest extends IntegrationTest
 
         // document with "Hello World for phrase searching" is not on first place!
         // @extensionScannerIgnoreLine
-        $this->assertSame(1, $parsedData->response->numFound, 'Could not index documents into solr to test boosts on explicit phrase searches.');
+        self::assertSame(1, $parsedData->response->numFound, 'Could not index documents into solr to test boosts on explicit phrase searches.');
         // @extensionScannerIgnoreLine
-        $this->assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Document containing "Hello World for phrase searching" should be found on explicit(surrounded with double quotes) phrase searching.');
+        self::assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Document containing "Hello World for phrase searching" should be found on explicit(surrounded with double quotes) phrase searching.');
     }
 
     /**
@@ -416,9 +411,9 @@ class SearchTest extends IntegrationTest
 
         // document with "Hello World for phrase serchin" is not on first place!
         // @extensionScannerIgnoreLine
-        $this->assertSame(1, $parsedData->response->numFound, 'Could not index document into solr');
+        self::assertSame(1, $parsedData->response->numFound, 'Could not index document into solr');
         // @extensionScannerIgnoreLine
-        $this->assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Document containing "Hello World for phrase serching" should be found');
+        self::assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Document containing "Hello World for phrase serching" should be found');
 
         // simulate Lucenes "Hello World"~1
         $slops = new Slops();
@@ -427,7 +422,7 @@ class SearchTest extends IntegrationTest
         $searchResponse = $searchInstance->search($query);
         $parsedData = $searchResponse->getParsedData();
         // @extensionScannerIgnoreLine
-        $this->assertSame(3, $parsedData->response->numFound, 'Could not index document into solr');
+        self::assertSame(3, $parsedData->response->numFound, 'Could not index document into solr');
 
         // simulate Lucenes "Hello World"~2
         $slops->setQuerySlop(2);
@@ -436,7 +431,7 @@ class SearchTest extends IntegrationTest
         $searchResponse = $searchInstance->search($query);
         $parsedData = $searchResponse->getParsedData();
         // @extensionScannerIgnoreLine
-        $this->assertSame(7, $parsedData->response->numFound, 'Found wrong number of decuments by explicit phrase search query.');
+        self::assertSame(7, $parsedData->response->numFound, 'Found wrong number of decuments by explicit phrase search query.');
     }
 
     /**
@@ -446,7 +441,7 @@ class SearchTest extends IntegrationTest
     {
         $this->importDataSetFromFixture($fixture);
 
-        $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
+        $GLOBALS['TT'] = $this->createMock(TimeTracker::class);
         for ($i = 1; $i <= 15; $i++) {
             $fakeTSFE = $this->getConfiguredTSFE($i);
             $GLOBALS['TSFE'] = $fakeTSFE;
@@ -461,7 +456,7 @@ class SearchTest extends IntegrationTest
     /**
      * @return Query
      */
-    protected function getSearchQueryForSolr() : Query
+    protected function getSearchQueryForSolr(): Query
     {
         return $this->queryBuilder
             ->newSearchQuery('')
@@ -473,7 +468,8 @@ class SearchTest extends IntegrationTest
      * @param string $feature
      * @param int $state
      */
-    protected function switchPhraseSearchFeature(string $feature, int $state) {
+    protected function switchPhraseSearchFeature(string $feature, int $state)
+    {
         $overwriteConfiguration = [];
         $overwriteConfiguration['search.']['query.'][$feature] = $state;
 

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
 
 /***************************************************************
@@ -45,6 +46,6 @@ class ConfigurationPageResolverTest extends IntegrationTest
         $configurationPageIdResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
 
         $pageIdWithActiveTypoScriptConfiguration = $configurationPageIdResolver->getClosestPageIdWithActiveTemplate(4);
-        $this->assertSame(2, $pageIdWithActiveTypoScriptConfiguration, 'Could not resolve expected page id with active typoscript configuration');
+        self::assertSame(2, $pageIdWithActiveTypoScriptConfiguration, 'Could not resolve expected page id with active typoscript configuration');
     }
 }

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
 
 /***************************************************************
@@ -30,40 +31,36 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
- *
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class TypoScriptConfigurationTest extends IntegrationTest
 {
-
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->setMethods([])->disableOriginalConstructor()->getMock();
+        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->onlyMethods([])->disableOriginalConstructor()->getMock();
         $tsfe->cObjectDepthCounter = 50;
         $GLOBALS['TSFE'] = $tsfe;
         parent::setUp();
     }
 
-     /**
-     * @test
-     */
-    public function testCanUsePlainValuesFromConfiguration() {
+    /**
+    * @test
+    */
+    public function testCanUsePlainValuesFromConfiguration()
+    {
         $configuration = [
             'plugin.' => [
                 'tx_solr.' => [
                     'search.' =>[
-                        'sorting' => 1
-                    ]
-                ]
-            ]
+                        'sorting' => 1,
+                    ],
+                ],
+            ],
         ];
 
         /** @var $typoScriptConfiguration TypoScriptConfiguration */
         $typoScriptConfiguration = GeneralUtility::makeInstance(TypoScriptConfiguration::class, $configuration, 0);
         $sorting = $typoScriptConfiguration->getSearchSorting();
-        $this->assertTrue($sorting, 'Can not get sorting configuration from typoscript');
+        self::assertTrue($sorting, 'Can not get sorting configuration from typoscript');
     }
 }

--- a/Tests/Integration/System/Environment/CliEnvironmentTest.php
+++ b/Tests/Integration/System/Environment/CliEnvironmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Environment;
 
 /***************************************************************
@@ -42,13 +43,13 @@ class CliEnvironmentTest extends IntegrationTest
      */
     public function canInitialize()
     {
-        $this->assertFalse(defined('TYPO3_PATH_WEB'));
+        self::assertFalse(defined('TYPO3_PATH_WEB'));
 
         $cliEnvironment = new CliEnvironment();
         $cliEnvironment->initialize('/var/www');
 
-        $this->assertTrue(defined('TYPO3_PATH_WEB'));
-        $this->assertEquals('/var/www', TYPO3_PATH_WEB);
+        self::assertTrue(defined('TYPO3_PATH_WEB'));
+        self::assertEquals('/var/www', TYPO3_PATH_WEB);
 
         $cliEnvironment->restore();
     }
@@ -59,7 +60,7 @@ class CliEnvironmentTest extends IntegrationTest
     public function canNotInitializeTwiceWithTwoInstances()
     {
         $this->expectException(WebRootAllReadyDefinedException::class);
-        $this->assertFalse(defined('TYPO3_PATH_WEB'));
+        self::assertFalse(defined('TYPO3_PATH_WEB'));
 
         $cliEnvironment = new CliEnvironment();
         $cliEnvironment->initialize('/var/www');
@@ -81,7 +82,7 @@ class CliEnvironmentTest extends IntegrationTest
         // the second init should return false because an initialization was allready done before
         $secondInit = $cliEnvironment->initialize('/var/www2');
 
-        $this->assertTrue($firstInit);
-        $this->assertFalse($secondInit);
+        self::assertTrue($firstInit);
+        self::assertFalse($secondInit);
     }
 }

--- a/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
+++ b/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\Pages;
 
 /***************************************************************
@@ -40,7 +41,7 @@ class PagesRepositoryTest extends IntegrationTest
      */
     protected $repository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->repository = GeneralUtility::makeInstance(PagesRepository::class);
@@ -56,15 +57,15 @@ class PagesRepositoryTest extends IntegrationTest
         $expectedResult = [
             0 => [
                 'uid' => 1,
-                'title' => 'Products'
+                'title' => 'Products',
             ],
             1 => [
                 'uid' => 5,
-                'title' => 'Support'
-            ]
+                'title' => 'Support',
+            ],
         ];
         $result = $this->repository->findAllRootPages();
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -99,24 +100,23 @@ class PagesRepositoryTest extends IntegrationTest
                 'uid' => 14,
                 'mountPageDestination' => 14,
                 'mountPageSource' => 24,
-                'mountPageOverlayed' => 1
+                'mountPageOverlayed' => 1,
             ],
             [
                 'uid' => 34,
                 'mountPageDestination' => 34,
                 'mountPageSource' => 25,
-                'mountPageOverlayed' => 1
-            ]
+                'mountPageOverlayed' => 1,
+            ],
         ];
 
         $result = $this->repository->findMountPointPropertiesByPageIdOrByRootLineParentPageIds(24);
-        $this->assertSame([$expectedResult[0]], $result);
+        self::assertSame([$expectedResult[0]], $result);
 
-        $rootLine = [24,20];
+        $rootLine = [24, 20];
 
         // Page [14] has both pages [24] and [25], because mounting works recursive
         $result = $this->repository->findMountPointPropertiesByPageIdOrByRootLineParentPageIds(25, $rootLine);
-        $this->assertSame($expectedResult, $result);
-
+        self::assertSame($expectedResult, $result);
     }
 }

--- a/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemCategory;
 
 /***************************************************************
@@ -42,9 +43,9 @@ class SystemCategoryRepositoryTest extends IntegrationTest
     {
         $this->importDataSetFromFixture('sys_category.xml');
 
-            /** @var $repository SystemCategoryRepository */
+        /** @var $repository SystemCategoryRepository */
         $repository = GeneralUtility::makeInstance(SystemCategoryRepository::class);
         $category = $repository->findOneByUid(2);
-        $this->assertSame('child', $category['title'], 'Can not retrieve system category by uid');
+        self::assertSame('child', $category['title'], 'Can not retrieve system category by uid');
     }
 }

--- a/Tests/Integration/System/Records/SystemLanguage/SystemLanguageRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemLanguage/SystemLanguageRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemLanguage;
 
 /***************************************************************
@@ -31,7 +32,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * SystemLanguageRepository to encapsulate the database access for records used in solr.
- *
  */
 class SystemLanguageRepositoryTest extends IntegrationTest
 {
@@ -45,7 +45,7 @@ class SystemLanguageRepositoryTest extends IntegrationTest
         /* @var $repository SystemLanguageRepository */
         $repository = GeneralUtility::makeInstance(SystemLanguageRepository::class);
         $languageTitle = $repository->findOneLanguageTitleByLanguageId(1);
-        $this->assertEquals('English', $languageTitle);
+        self::assertEquals('English', $languageTitle);
     }
 
     /**
@@ -56,7 +56,7 @@ class SystemLanguageRepositoryTest extends IntegrationTest
         /* @var $repository SystemLanguageRepository */
         $repository = GeneralUtility::makeInstance(SystemLanguageRepository::class);
         $languageTitle = $repository->findOneLanguageTitleByLanguageId(0);
-        $this->assertEquals('default', $languageTitle);
+        self::assertEquals('default', $languageTitle);
     }
 
     /**
@@ -71,6 +71,6 @@ class SystemLanguageRepositoryTest extends IntegrationTest
         $systemLanguages = $repository->findSystemLanguages();
 
         $expectedLangueages = [0, 1, 2, 3];
-        $this->assertSame($expectedLangueages, $systemLanguages);
+        self::assertSame($expectedLangueages, $systemLanguages);
     }
 }

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemTemplate;
 
 /***************************************************************
@@ -47,12 +48,12 @@ class SystemTemplateRepositoryTest extends IntegrationTest
         $fakeRootLine = [
             ['uid' => 100],
             ['uid' => 33],
-            ['uid' => 8657]
+            ['uid' => 8657],
         ];
 
         /* @var $repository SystemTemplateRepository */
         $repository = GeneralUtility::makeInstance(SystemTemplateRepository::class);
         $closestPageIdWithActiveTemplate = $repository->findOneClosestPageIdWithActiveTemplateByRootLine($fakeRootLine);
-        $this->assertEquals(33, $closestPageIdWithActiveTemplate, 'Can not find closest page id with active template.');
+        self::assertEquals(33, $closestPageIdWithActiveTemplate, 'Can not find closest page id with active template.');
     }
 }

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Solr\Service;
 
 /***************************************************************
@@ -46,16 +47,13 @@ class SolrAdminServiceTest extends IntegrationTest
     protected $solrAdminService;
 
     /**
-     * @return void
      * @throws NoSuchCacheException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         /* @var EventDispatcher $eventDispatcher */
-        $eventDispatcher = $this->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock(EventDispatcher::class);
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(
             $adapter,
@@ -63,7 +61,7 @@ class SolrAdminServiceTest extends IntegrationTest
         );
         $client->clearEndpoints();
         $solrConnectionInfo = $this->getSolrConnectionInfo();
-        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_en', 'key' => 'admin'] , true);
+        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_en', 'key' => 'admin'], true);
 
         $this->solrAdminService = GeneralUtility::makeInstance(SolrAdminService::class, $client);
     }
@@ -98,20 +96,20 @@ class SolrAdminServiceTest extends IntegrationTest
         $this->solrAdminService->reloadCore();
 
         $synonymsBeforeAdd = $this->solrAdminService->getSynonyms($baseWord);
-        $this->assertEquals([], $synonymsBeforeAdd, 'Synonyms was not empty');
+        self::assertEquals([], $synonymsBeforeAdd, 'Synonyms was not empty');
 
         $this->solrAdminService->addSynonym($baseWord, $synonyms);
         $this->solrAdminService->reloadCore();
 
         $synonymsAfterAdd = $this->solrAdminService->getSynonyms($baseWord);
 
-        $this->assertEquals($synonyms, $synonymsAfterAdd, 'Could not retrieve synonym after adding');
+        self::assertEquals($synonyms, $synonymsAfterAdd, 'Could not retrieve synonym after adding');
 
         $this->solrAdminService->deleteSynonym($baseWord);
         $this->solrAdminService->reloadCore();
 
         $synonymsAfterRemove = $this->solrAdminService->getSynonyms($baseWord);
-        $this->assertEquals([], $synonymsAfterRemove, 'Synonym was not removed');
+        self::assertEquals([], $synonymsAfterRemove, 'Synonym was not removed');
     }
 
     /**
@@ -121,7 +119,7 @@ class SolrAdminServiceTest extends IntegrationTest
     {
         return [
             'normal' => ['stopword' => 'badword'],
-            'umlaut' => ['stopword' => 'frühaufsteher']
+            'umlaut' => ['stopword' => 'frühaufsteher'],
         ];
     }
 
@@ -133,20 +131,20 @@ class SolrAdminServiceTest extends IntegrationTest
     {
         $stopWords = $this->solrAdminService->getStopWords();
 
-        $this->assertNotContains($stopWord, $stopWords, 'Stopwords are not empty after initializing');
+        self::assertNotContains($stopWord, $stopWords, 'Stopwords are not empty after initializing');
 
         $this->solrAdminService->addStopWords($stopWord);
         $this->solrAdminService->reloadCore();
 
         $stopWordsAfterAdd = $this->solrAdminService->getStopWords();
 
-        $this->assertContains($stopWord, $stopWordsAfterAdd, 'Stopword was not added');
+        self::assertContains($stopWord, $stopWordsAfterAdd, 'Stopword was not added');
 
         $this->solrAdminService->deleteStopWord($stopWord);
         $this->solrAdminService->reloadCore();
 
         $stopWordsAfterDelete = $this->solrAdminService->getStopWords();
-        $this->assertNotContains($stopWord, $stopWordsAfterDelete, 'Stopwords are not empty after removing');
+        self::assertNotContains($stopWord, $stopWordsAfterDelete, 'Stopwords are not empty after removing');
     }
 
     /**
@@ -157,7 +155,7 @@ class SolrAdminServiceTest extends IntegrationTest
     public function containsDefaultStopWord()
     {
         $stopWordsInSolr = $this->solrAdminService->getStopWords();
-        $this->assertContains('and', $stopWordsInSolr, 'Default stopword and was not present');
+        self::assertContains('and', $stopWordsInSolr, 'Default stopword and was not present');
     }
 
     /**
@@ -166,7 +164,7 @@ class SolrAdminServiceTest extends IntegrationTest
     public function canGetSystemInformation()
     {
         $informationResponse = $this->solrAdminService->getSystemInformation();
-        $this->assertSame(200, $informationResponse->getHttpStatus(), 'Could not get information response from solr server');
+        self::assertSame(200, $informationResponse->getHttpStatus(), 'Could not get information response from solr server');
     }
 
     /**
@@ -175,8 +173,8 @@ class SolrAdminServiceTest extends IntegrationTest
     public function canGetPingRoundtrimRunTime()
     {
         $pingRuntime = $this->solrAdminService->getPingRoundTripRuntime();
-        $this->assertGreaterThan(0, $pingRuntime, 'Ping runtime should be larger then 0');
-        $this->assertTrue(is_double($pingRuntime),'Ping runtime should be an integer');
+        self::assertGreaterThan(0, $pingRuntime, 'Ping runtime should be larger then 0');
+        self::assertTrue(is_float($pingRuntime), 'Ping runtime should be an integer');
     }
 
     /**
@@ -186,7 +184,7 @@ class SolrAdminServiceTest extends IntegrationTest
     {
         $solrServerVersion = $this->solrAdminService->getSolrServerVersion();
         $isVersionHigherSix = version_compare('6.0.0', $solrServerVersion, '<');
-        $this->assertTrue($isVersionHigherSix, 'Expecting to run on version larger then 6.0.0');
+        self::assertTrue($isVersionHigherSix, 'Expecting to run on version larger then 6.0.0');
     }
 
     /**
@@ -195,7 +193,7 @@ class SolrAdminServiceTest extends IntegrationTest
     public function canReloadCore()
     {
         $result = $this->solrAdminService->reloadCore();
-        $this->assertSame(200, $result->getHttpStatus(), 'Reload core did not responde with a 200 ok status');
+        self::assertSame(200, $result->getHttpStatus(), 'Reload core did not responde with a 200 ok status');
     }
 
     /**
@@ -204,8 +202,8 @@ class SolrAdminServiceTest extends IntegrationTest
     public function canGetPluginsInformation()
     {
         $result = $this->solrAdminService->getPluginsInformation();
-        $this->assertSame(0, $result->responseHeader->status);
-        $this->assertSame(2, count($result));
+        self::assertSame(0, $result->responseHeader->status);
+        self::assertSame(2, count($result));
     }
 
     /**
@@ -214,9 +212,7 @@ class SolrAdminServiceTest extends IntegrationTest
     public function canParseLanguageFromSchema()
     {
         /* @var EventDispatcher $eventDispatcher */
-        $eventDispatcher = $this->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock(EventDispatcher::class);
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(
             $adapter,
@@ -224,9 +220,9 @@ class SolrAdminServiceTest extends IntegrationTest
         );
         $client->clearEndpoints();
         $solrConnectionInfo = $this->getSolrConnectionInfo();
-        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_de', 'key' => 'admin'] , true);
+        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_de', 'key' => 'admin'], true);
 
         $this->solrAdminService = GeneralUtility::makeInstance(SolrAdminService::class, $client);
-        $this->assertSame("core_de", $this->solrAdminService->getSchema()->getManagedResourceId(), "Could not get the id of managed resources from core.");
+        self::assertSame('core_de', $this->solrAdminService->getSchema()->getManagedResourceId(), 'Could not get the id of managed resources from core.');
     }
 }

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -44,10 +44,9 @@ class SolrWriteServiceTest extends IntegrationTest
     protected $solrWriteService;
 
     /**
-     * @return void
      * @throws NoSuchCacheException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -56,8 +55,7 @@ class SolrWriteServiceTest extends IntegrationTest
         $requestFactory = GeneralUtility::getContainer()->get(RequestFactoryInterface::class);
         $streamFactory = GeneralUtility::getContainer()->get(StreamFactoryInterface::class);
         /* @var EventDispatcher $eventDispatcher */
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
-            ->disableOriginalConstructor()->getMock();
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $adapter = new Psr18Adapter(
             $psr7Client,
             $requestFactory,
@@ -67,7 +65,7 @@ class SolrWriteServiceTest extends IntegrationTest
 
         $client->clearEndpoints();
         $solrConnectionInfo = $this->getSolrConnectionInfo();
-        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_en', 'key' => 'admin'] , true);
+        $client->createEndpoint(['host' => $solrConnectionInfo['host'], 'port' => $solrConnectionInfo['port'], 'path' => '/', 'core' => 'core_en', 'key' => 'admin'], true);
 
         $this->solrWriteService = GeneralUtility::makeInstance(SolrWriteService::class, $client);
     }
@@ -83,6 +81,6 @@ class SolrWriteServiceTest extends IntegrationTest
         $extractQuery = GeneralUtility::makeInstance(ExtractingQuery::class, $testFilePath);
         $extractQuery->setExtractOnly(true);
         $response = $this->solrWriteService->extractByQuery($extractQuery);
-        $this->assertStringContainsString('PDF Test', $response[0], 'Could not extract text');
+        self::assertStringContainsString('PDF Test', $response[0], 'Could not extract text');
     }
 }

--- a/Tests/Integration/System/Solr/SolrConnectionTest.php
+++ b/Tests/Integration/System/Solr/SolrConnectionTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrConnectionTest extends IntegrationTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -49,13 +49,12 @@ class SolrConnectionTest extends IntegrationTest
         );
         try {
             $solrConnection = $connectionManager->getConnectionByPageId($pageUid, 0);
-            $this->assertInstanceOf(SolrConnection::class, $solrConnection, $messageOnNoSolrConnectionFoundException);
+            self::assertInstanceOf(SolrConnection::class, $solrConnection, $messageOnNoSolrConnectionFoundException);
             return $solrConnection;
         } catch (NoSolrConnectionFoundException $exception) {
-            $this->fail($messageOnNoSolrConnectionFoundException);
+            self::fail($messageOnNoSolrConnectionFoundException);
         }
     }
-
 
     /**
      * @test
@@ -77,33 +76,33 @@ class SolrConnectionTest extends IntegrationTest
         $httpSettingsIgnoredMessage = 'The client for solarium does not get TYPO3 system configuration for HTTP. ' . PHP_EOL .
             'Please check why "%s" does not taken into account or are overridden.';
 
-        $this->assertEquals(
+        self::assertEquals(
             $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'],
             $guzzleConfig['connect_timeout'],
             vsprintf(
                 $httpSettingsIgnoredMessage,
                 [
-                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'connect_timeout\']'
+                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'connect_timeout\']',
                 ]
             )
         );
-        $this->assertEquals(
+        self::assertEquals(
             $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'],
             $guzzleConfig['timeout'],
             vsprintf(
                 $httpSettingsIgnoredMessage,
                 [
-                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'timeout\']'
+                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'timeout\']',
                 ]
             )
         );
-        $this->assertEquals(
+        self::assertEquals(
             $GLOBALS['TYPO3_CONF_VARS']['HTTP']['headers']['User-Agent'],
             $guzzleConfig['headers']['User-Agent'],
             vsprintf(
                 $httpSettingsIgnoredMessage,
                 [
-                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'headers\'][\'User-Agent\']'
+                    '$GLOBALS[\'TYPO3_CONF_VARS\'][\'HTTP\'][\'headers\'][\'User-Agent\']',
                 ]
             )
         );

--- a/Tests/Integration/TSFEBootstrapResult.php
+++ b/Tests/Integration/TSFEBootstrapResult.php
@@ -7,7 +7,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class TSFEBootstrapResult
- * @package ApacheSolrForTypo3\Solr\Tests\Integration
  */
 class TSFEBootstrapResult
 {

--- a/Tests/Integration/TSFETestBootstrapper.php
+++ b/Tests/Integration/TSFETestBootstrapper.php
@@ -2,13 +2,14 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Error\Http\InternalServerErrorException;
 use TYPO3\CMS\Core\Error\Http\ServiceUnavailableException;
-use TYPO3\CMS\Core\Http\ImmediateResponseException;
-use TYPO3\CMS\Core\Localization\Locales;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -16,11 +17,9 @@ use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Core\Http\ServerRequest;
 
 /**
  * Class TSFETestBootstrapper
- * @package ApacheSolrForTypo3\Solr\Tests\Integration
  */
 class TSFETestBootstrapper
 {

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -26,14 +26,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Scheduler\Scheduler;
-use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
-use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * Test case to check if the scheduler task EventQueueWorkerTask can process
@@ -48,7 +48,7 @@ class EventQueueWorkerTaskTest extends IntegrationTest
      */
     protected $coreExtensionsToLoad = [
         'extensionmanager',
-        'scheduler'
+        'scheduler',
     ];
 
     /**
@@ -61,7 +61,7 @@ class EventQueueWorkerTaskTest extends IntegrationTest
      */
     protected $indexQueue;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -73,7 +73,7 @@ class EventQueueWorkerTaskTest extends IntegrationTest
         $extConf->set('solr', ['monitoringType' => 1]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->indexQueue);
         unset($this->eventQueue);
@@ -96,8 +96,8 @@ class EventQueueWorkerTaskTest extends IntegrationTest
         $scheduler = GeneralUtility::makeInstance(Scheduler::class);
         $scheduler->executeTask($task);
 
-        $this->assertEquals(1, $this->indexQueue->getAllItemsCount());
-        $this->assertEmpty($this->eventQueue->getEventQueueItems(null, false));
+        self::assertEquals(1, $this->indexQueue->getAllItemsCount());
+        self::assertEmpty($this->eventQueue->getEventQueueItems(null, false));
     }
 
     /**
@@ -114,11 +114,11 @@ class EventQueueWorkerTaskTest extends IntegrationTest
         $scheduler = GeneralUtility::makeInstance(Scheduler::class);
         $scheduler->executeTask($task);
 
-        $this->assertEquals(0, $this->indexQueue->getAllItemsCount());
-        $this->assertEmpty($this->eventQueue->getEventQueueItems());
+        self::assertEquals(0, $this->indexQueue->getAllItemsCount());
+        self::assertEmpty($this->eventQueue->getEventQueueItems());
         $queueItems = $this->eventQueue->getEventQueueItems(null, false);
-        $this->assertEquals(1, count($queueItems));
-        $this->assertEquals(1, $queueItems[0]['error']);
-        $this->assertNotEmpty($queueItems[0]['error_message']);
+        self::assertEquals(1, count($queueItems));
+        self::assertEquals(1, $queueItems[0]['error']);
+        self::assertNotEmpty($queueItems[0]['error_message']);
     }
 }

--- a/Tests/Integration/Task/IndexQueueDependencyFaker.php
+++ b/Tests/Integration/Task/IndexQueueDependencyFaker.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
 
 /**

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -55,10 +55,10 @@ class IndexQueueWorkerTaskTest extends IntegrationTest
      * @var array
      */
     protected $coreExtensionsToLoad = [
-        'scheduler'
+        'scheduler',
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
@@ -81,7 +81,7 @@ class IndexQueueWorkerTaskTest extends IntegrationTest
 
         $additionalInformation = $indexQueueQueueWorkerTask->getAdditionalInformation();
 
-        $this->assertStringContainsString('Root Page ID: 1', $additionalInformation);
-        $this->assertStringContainsString('Site: page for testing', $additionalInformation);
+        self::assertStringContainsString('Root Page ID: 1', $additionalInformation);
+        self::assertStringContainsString('Site: page for testing', $additionalInformation);
     }
 }

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
 
 /***************************************************************
@@ -25,15 +26,15 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Task\ReIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use Exception;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * TestCase to check if the index queue can be initialized by the ReIndex Task
@@ -63,14 +64,13 @@ class ReIndexTaskTest extends IntegrationTest
      * @var array
      */
     protected $coreExtensionsToLoad = [
-        'scheduler'
+        'scheduler',
     ];
 
     /**
-     * @return void
      * @throws NoSuchCacheException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -86,21 +86,18 @@ class ReIndexTaskTest extends IntegrationTest
         $GLOBALS['LANG'] = $languageService;
     }
 
-    /**
-     * @return void
-     */
     protected function assertEmptyIndexQueue()
     {
-        $this->assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
+        self::assertEquals(0, $this->indexQueue->getAllItemsCount(), 'Index queue is not empty as expected');
     }
 
-    /**
-     * @return void
-     */
     protected function assertNotEmptyIndexQueue()
     {
-        $this->assertGreaterThan(0, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to be not empty.');
+        self::assertGreaterThan(
+            0,
+            $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to be not empty.'
+        );
     }
 
     /**
@@ -108,8 +105,11 @@ class ReIndexTaskTest extends IntegrationTest
      */
     protected function assertIndexQueryContainsItemAmount($amount)
     {
-        $this->assertEquals($amount, $this->indexQueue->getAllItemsCount(),
-            'Index queue is empty and was expected to contain ' . (int) $amount . ' items.');
+        self::assertEquals(
+            $amount,
+            $this->indexQueue->getAllItemsCount(),
+            'Index queue is empty and was expected to contain ' . (int)$amount . ' items.'
+        );
     }
 
     /**
@@ -145,8 +145,8 @@ class ReIndexTaskTest extends IntegrationTest
         $this->task->setIndexingConfigurationsToReIndex(['pages']);
         $additionalInformation = $this->task->getAdditionalInformation();
 
-        $this->assertStringContainsString('Indexing Configurations: pages', $additionalInformation);
-        $this->assertStringContainsString('Root Page ID: 1', $additionalInformation);
+        self::assertStringContainsString('Indexing Configurations: pages', $additionalInformation);
+        self::assertStringContainsString('Root Page ID: 1', $additionalInformation);
     }
 
     /**

--- a/Tests/Integration/TestGarbageCollectorPostProcessor.php
+++ b/Tests/Integration/TestGarbageCollectorPostProcessor.php
@@ -1,13 +1,12 @@
 <?php
-namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
+namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\GarbageCollectorPostProcessor;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
  * Class TestGarbageCollectorPostProcessor
- * @package ApacheSolrForTypo3\Solr\Tests\Integration
  */
 class TestGarbageCollectorPostProcessor implements SingletonInterface, GarbageCollectorPostProcessor
 {
@@ -30,11 +29,10 @@ class TestGarbageCollectorPostProcessor implements SingletonInterface, GarbageCo
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isHookWasCalled(): bool
     {
         return $this->hookWasCalled;
     }
 }
-

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -39,7 +40,7 @@ class AbstractIndexerTest extends UnitTest
      */
     public function testTypeIsNotAllowedOverride()
     {
-        $this->assertFalse(AbstractIndexer::isAllowedToOverrideField('type'), 'Type is allowed to override');
-        $this->assertTrue(AbstractIndexer::isAllowedToOverrideField('test_stringS'), 'New dynamic fields was not indicated to be overrideable');
+        self::assertFalse(AbstractIndexer::isAllowedToOverrideField('type'), 'Type is allowed to override');
+        self::assertTrue(AbstractIndexer::isAllowedToOverrideField('test_stringS'), 'New dynamic fields was not indicated to be overrideable');
     }
 }

--- a/Tests/Unit/Access/RootlineElementTest.php
+++ b/Tests/Unit/Access/RootlineElementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Access;
 
 /***************************************************************
@@ -45,71 +46,71 @@ class RootlineElementTest extends UnitTest
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
                 'expectedGroups' => [0],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:0'
+                'expectedToString' => 'c:0',
             ],
             'no_prefix' => [
                 'stringRepresentation' => '0',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
                 'expectedGroups' => [0],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:0'
+                'expectedToString' => 'c:0',
             ],
             'no_prefix_restricted' => [
                 'stringRepresentation' => '1',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
                 'expectedGroups' => [1],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:1'
+                'expectedToString' => 'c:1',
             ],
             'no_prefix_multiple' => [
                 'stringRepresentation' => '0,1,2',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
-                'expectedGroups' => [0,1,2],
+                'expectedGroups' => [0, 1, 2],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:0,1,2'
+                'expectedToString' => 'c:0,1,2',
             ],
             'simpleContent' => [
                 'stringRepresentation' => 'c:0',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
                 'expectedGroups' => [0],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:0'
+                'expectedToString' => 'c:0',
             ],
             'contentWithPermissionContent' => [
                 'stringRepresentation' => 'c:1,2',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
-                'expectedGroups' => [1,2],
+                'expectedGroups' => [1, 2],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:1,2'
+                'expectedToString' => 'c:1,2',
             ],
             'record' => [
                 'stringRepresentation' => 'r:1,2',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_RECORD,
-                'expectedGroups' => [1,2],
+                'expectedGroups' => [1, 2],
                 'expectedPageId' => null,
-                'expectedToString' => 'r:1,2'
+                'expectedToString' => 'r:1,2',
             ],
             'page' => [
                 'stringRepresentation' => '4711:0',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_PAGE,
                 'expectedGroups' => [0],
                 'expectedPageId' => 4711,
-                'expectedToString' => '4711:0'
+                'expectedToString' => '4711:0',
             ],
             'pageList' => [
                 'stringRepresentation' => '4711:1,2',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_PAGE,
-                'expectedGroups' => [1,2],
+                'expectedGroups' => [1, 2],
                 'expectedPageId' => 4711,
-                'expectedToString' => '4711:1,2'
+                'expectedToString' => '4711:1,2',
             ],
             'minusTwo' => [
                 'stringRepresentation' => 'c:-2',
                 'expectedType' => RootlineElement::ELEMENT_TYPE_CONTENT,
                 'expectedGroups' => [-2],
                 'expectedPageId' => null,
-                'expectedToString' => 'c:-2'
-            ]
+                'expectedToString' => 'c:-2',
+            ],
         ];
     }
 
@@ -127,11 +128,11 @@ class RootlineElementTest extends UnitTest
     {
         $rootLine = new RootlineElement($stringRepresentation);
 
-        $this->assertSame($expectedType, $rootLine->getType(), 'Unexpected type after parsing the RootlineElement');
-        $this->assertSame($expectedGroups, $rootLine->getGroups(), 'Unexpected groups after parsing the RootlineElement');
-        $this->assertSame($expectedPageId, $rootLine->getPageId(), 'Unexpected pageId after parsing the RootlineElement field');
+        self::assertSame($expectedType, $rootLine->getType(), 'Unexpected type after parsing the RootlineElement');
+        self::assertSame($expectedGroups, $rootLine->getGroups(), 'Unexpected groups after parsing the RootlineElement');
+        self::assertSame($expectedPageId, $rootLine->getPageId(), 'Unexpected pageId after parsing the RootlineElement field');
 
         // most of the times the to string value is the same
-        $this->assertSame($expectedToString, (string) $rootLine, 'Conversion to string is not returning expected result');
+        self::assertSame($expectedToString, (string)$rootLine, 'Conversion to string is not returning expected result');
     }
 }

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Access;
 
 /***************************************************************
@@ -43,7 +44,7 @@ class RootlineTest extends UnitTest
         return [
             'simple' => ['string' => 'c:0', 'expectedGroups' => [0]],
             'simpleOneGroup' => ['string' => 'c:1', 'expectedGroups' => [1]],
-            'mixed' => ['string' => '35:1/c:0', 'expectedGroups' => [0,1]]
+            'mixed' => ['string' => '35:1/c:0', 'expectedGroups' => [0, 1]],
         ];
     }
 
@@ -55,6 +56,6 @@ class RootlineTest extends UnitTest
     {
         $rootline = new Rootline($rootLineString);
         $groups = $rootline->getGroups();
-        $this->assertSame($expectedGroups, $groups);
+        self::assertSame($expectedGroups, $groups);
     }
 }

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -87,10 +88,8 @@ class ConnectionManagerTest extends UnitTest
 
     /**
      * Set up the connection manager test
-     *
-     * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $TSFE = $this->getDumbMock(TypoScriptFrontendController::class);
         $GLOBALS['TSFE'] = $TSFE;
@@ -116,10 +115,11 @@ class ConnectionManagerTest extends UnitTest
             ->setConstructorArgs([
                 $this->languageRepositoryMock,
                 $this->pageRepositoryMock,
-                $this->siteRepositoryMock
+                $this->siteRepositoryMock,
             ])
             ->onlyMethods(['getSolrConnectionForNodes'])
             ->getMock();
+        parent::setUp();
     }
 
     /**
@@ -131,7 +131,7 @@ class ConnectionManagerTest extends UnitTest
     {
         return [
             ['host' => 'localhost', 'port' => '', 'path' => '', 'scheme' => '', 'expectsException' => true, 'expectedConnectionString' => null],
-            ['host' => '127.0.0.1', 'port' => 8181, 'path' => '/solr/core_de/', 'scheme' => 'https', 'expectsException' => false, 'expectedConnectionString' => 'https://127.0.0.1:8181/solr/core_de/']
+            ['host' => '127.0.0.1', 'port' => 8181, 'path' => '/solr/core_de/', 'scheme' => 'https', 'expectsException' => false, 'expectedConnectionString' => 'https://127.0.0.1:8181/solr/core_de/'],
         ];
     }
 
@@ -147,14 +147,12 @@ class ConnectionManagerTest extends UnitTest
      * @param string $scheme
      * @param bool $expectsException
      * @param string $expectedConnectionString
-     * @return void
      */
     public function canConnect($host, $port, $path, $scheme, $expectsException, $expectedConnectionString)
     {
         $self = $this;
-        $this->connectionManager->expects($this->once())->method('getSolrConnectionForNodes')->will(
-            $this->returnCallback(function($readNode, $writeNode) use ($self) {
-
+        $this->connectionManager->expects(self::once())->method('getSolrConnectionForNodes')->willReturnCallback(
+            function ($readNode, $writeNode) use ($self) {
                 $readNode = Node::fromArray($readNode);
                 $writeNode = Node::fromArray($writeNode);
                 /* @var TypoScriptConfiguration $typoScriptConfigurationMock */
@@ -181,7 +179,7 @@ class ConnectionManagerTest extends UnitTest
                     $this->getDumbMock(StreamFactoryInterface::class),
                     $this->getDumbMock(EventDispatcherInterface::class)
                 );
-            })
+            }
         );
         $exceptionOccurred = false;
         try {
@@ -190,10 +188,10 @@ class ConnectionManagerTest extends UnitTest
             $configuration['write'] = $readNode;
 
             $solrService = $this->connectionManager->getConnectionFromConfiguration($configuration);
-            $this->assertEquals($expectedConnectionString, $solrService->getReadService()->__toString());
+            self::assertEquals($expectedConnectionString, $solrService->getReadService()->__toString());
         } catch (UnexpectedValueException $exception) {
             $exceptionOccurred = true;
         }
-        $this->assertEquals($expectsException, $exceptionOccurred);
+        self::assertEquals($expectsException, $exceptionOccurred);
     }
 }

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 /***************************************************************
@@ -55,18 +56,18 @@ class ClassificationTest extends UnitTest
             'classes.' => [
                 [
                     'patterns' => 'TYPO3, joomla, core media',
-                    'class' => 'cms'
+                    'class' => 'cms',
                 ],
                 [
                     'patterns' => 'php, java, go, groovy',
-                    'class' => 'programming_language'
-                ]
-            ]
+                    'class' => 'programming_language',
+                ],
+            ],
         ];
 
         $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
         $expected = serialize(['cms']);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -77,12 +78,12 @@ class ClassificationTest extends UnitTest
         return [
             'excludePatternShouldLeadToUnassignedClass' => [
                 'input' => 'from the beach i can see the waves',
-                'expectedOutput' => []
+                'expectedOutput' => [],
             ],
             'noMatchingExlucePatternLeadsToExpectedClass' => [
                 'input' => 'i saw a shark between the waves',
-                'expectedOutput' => ['ocean']
-            ]
+                'expectedOutput' => ['ocean'],
+            ],
         ];
     }
 
@@ -101,14 +102,14 @@ class ClassificationTest extends UnitTest
                 [
                     'matchPatterns' => 'waves',
                     'unmatchPatterns' => 'beach',
-                    'class' => 'ocean'
-                ]
-            ]
+                    'class' => 'ocean',
+                ],
+            ],
         ];
 
         $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
         $expected = serialize($expectedOutput);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     protected function setUp(): void
@@ -121,10 +122,12 @@ class ClassificationTest extends UnitTest
         $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
             ->onlyMethods(['getResourceFactory', 'getEnvironmentVariable', 'getRequest'])
             ->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
+        parent::setUp();
     }
 
     protected function tearDown(): void
     {
         unset($GLOBALS['TSFE']);
+        parent::tearDown();
     }
 }

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 /***************************************************************
@@ -57,11 +58,11 @@ class MultivalueTest extends UnitTest
             Multivalue::CONTENT_OBJECT_NAME,
             [
                 'field' => 'list',
-                'separator' => ','
+                'separator' => ',',
             ]
         );
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -78,11 +79,11 @@ class MultivalueTest extends UnitTest
             Multivalue::CONTENT_OBJECT_NAME,
             [
                 'value' => $list,
-                'separator' => ','
+                'separator' => ',',
             ]
         );
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     protected function setUp(): void
@@ -93,12 +94,14 @@ class MultivalueTest extends UnitTest
         $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);
 
         $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
-            ->setMethods(['getResourceFactory', 'getEnvironmentVariable', 'getRequest'])
+            ->onlyMethods(['getResourceFactory', 'getEnvironmentVariable', 'getRequest'])
             ->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
+        parent::setUp();
     }
 
     protected function tearDown(): void
     {
         unset($GLOBALS['TSFE']);
+        parent::tearDown();
     }
 }

--- a/Tests/Unit/Controller/Backend/Search/AbstractModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/AbstractModuleControllerTest.php
@@ -50,7 +50,6 @@ abstract class AbstractModuleControllerTest extends UnitTest
      *
      * @param string $concreteModuleControllerClass
      * @param array $mockMethods
-     * @return void
      */
     protected function setUpConcreteModuleController(
         string $concreteModuleControllerClass,
@@ -66,17 +65,17 @@ abstract class AbstractModuleControllerTest extends UnitTest
                     'siteFinder' => $this->getDumbMock(SiteFinder::class),
                     'solrConnectionManager' => $this->connectionManagerMock = $this->getDumbMock(ConnectionManager::class),
                     'indexQueue' => $this->getDumbMock(Queue::class),
-                ])
+                ]
+            )
             ->onlyMethods($mockMethods)
             ->getMock();
         $uriBuilderMock = $this->getMockBuilder(UriBuilder::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['uriFor'])->getMock();
-        $uriBuilderMock->expects($this->any())
+        $uriBuilderMock->expects(self::any())
             ->method('uriFor')
-            ->will($this->returnValue('index'));
+            ->willReturn('index');
         $this->controller->injectUriBuilder($uriBuilderMock);
         $this->controller->setSelectedSite($this->selectedSiteMock);
     }
-
 }

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
 
 /*
@@ -36,8 +37,8 @@ class IndexAdministrationModuleControllerTest extends AbstractModuleControllerTe
 
     protected function setUp(): void
     {
-        parent::setUp();
         parent::setUpConcreteModuleController(IndexAdministrationModuleController::class);
+        parent::setUp();
     }
 
     /**
@@ -46,18 +47,18 @@ class IndexAdministrationModuleControllerTest extends AbstractModuleControllerTe
     public function testReloadIndexConfigurationAction()
     {
         $responseMock = $this->getDumbMock(ResponseAdapter::class);
-        $responseMock->expects($this->once())->method('getHttpStatus')->willReturn(200);
+        $responseMock->expects(self::once())->method('getHttpStatus')->willReturn(200);
 
         $writeEndpointMock = $this->getDumbMock(Endpoint::class);
         $adminServiceMock = $this->getDumbMock(SolrAdminService::class);
-        $adminServiceMock->expects($this->once())->method('reloadCore')->willReturn($responseMock);
-        $adminServiceMock->expects($this->once())->method('getPrimaryEndpoint')->willReturn($writeEndpointMock);
+        $adminServiceMock->expects(self::once())->method('reloadCore')->willReturn($responseMock);
+        $adminServiceMock->expects(self::once())->method('getPrimaryEndpoint')->willReturn($writeEndpointMock);
 
         $solrConnection = $this->getDumbMock(SolrConnection::class);
-        $solrConnection->expects($this->once())->method('getAdminService')->willReturn($adminServiceMock);
+        $solrConnection->expects(self::once())->method('getAdminService')->willReturn($adminServiceMock);
 
         $fakeConnections = [$solrConnection];
-        $this->connectionManagerMock->expects($this->once())
+        $this->connectionManagerMock->expects(self::once())
             ->method('getConnectionsBySite')
             ->with($this->selectedSiteMock)
             ->willReturn($fakeConnections);

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
 
 /*
@@ -30,12 +31,8 @@ class IndexQueueModuleControllerTest extends AbstractModuleControllerTest
      */
     protected $indexQueueMock;
 
-    /**
-     *
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         parent::setUpConcreteModuleController(
             IndexQueueModuleController::class,
             ['addIndexQueueFlashMessage']
@@ -45,6 +42,7 @@ class IndexQueueModuleControllerTest extends AbstractModuleControllerTest
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller->setIndexQueue($this->indexQueueMock);
+        parent::setUp();
     }
 
     /**
@@ -53,7 +51,7 @@ class IndexQueueModuleControllerTest extends AbstractModuleControllerTest
      */
     protected function assertQueueUpdateIsTriggeredFor($type, $uid)
     {
-        $this->indexQueueMock->expects($this->once())->method('updateOrAddItemForAllRelatedRootPages')->with($type, $uid)->will($this->returnValue(1));
+        $this->indexQueueMock->expects(self::once())->method('updateOrAddItemForAllRelatedRootPages')->with($type, $uid)->willReturn(1);
     }
 
     /**
@@ -73,14 +71,14 @@ class IndexQueueModuleControllerTest extends AbstractModuleControllerTest
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'][] = IndexQueueTestUpdateHandler::class;
 
         $testHandlerMock = $this->getDumbMock(IndexQueueTestUpdateHandler::class);
-        $testHandlerMock->expects($this->once())->method('postProcessIndexQueueUpdateItem');
+        $testHandlerMock->expects(self::once())->method('postProcessIndexQueueUpdateItem');
 
-        $this->indexQueueMock->expects($this->once())->method('updateOrAddItemForAllRelatedRootPages')->willReturn(0);
-        $this->indexQueueMock->expects($this->once())->method('getHookImplementation')->with(IndexQueueTestUpdateHandler::class)->willReturn($testHandlerMock);
+        $this->indexQueueMock->expects(self::once())->method('updateOrAddItemForAllRelatedRootPages')->willReturn(0);
+        $this->indexQueueMock->expects(self::once())->method('getHookImplementation')->with(IndexQueueTestUpdateHandler::class)->willReturn($testHandlerMock);
 
         $this->assertQueueUpdateIsTriggeredFor('tx_solr_file', 88);
         $this->controller->requeueDocumentAction('tx_solr_file', 88, 1, 0);
 
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'] = array();
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'] = [];
     }
 }

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Classification;
 
 /***************************************************************
@@ -50,16 +51,16 @@ class ClassificationServiceTest extends UnitTest
 
         $service = new ClassificationService();
         $matches = $service->getMatchingClassNames('I have a smartphone in my hand.', [$mobilePhoneClassification, $watchClassification]);
-        $this->assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
+        self::assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
 
         $matches = $service->getMatchingClassNames('I have a smartphone in my hand and a watch on my arm.', [$mobilePhoneClassification, $watchClassification]);
-        $this->assertSame(['mobilephone', 'watch'], $matches, 'Unexpected matched classification');
+        self::assertSame(['mobilephone', 'watch'], $matches, 'Unexpected matched classification');
 
         $matches = $service->getMatchingClassNames('I have nothing on my arm and in my hand.', [$mobilePhoneClassification, $watchClassification]);
-        $this->assertSame([], $matches, 'Unexpected matched classification');
+        self::assertSame([], $matches, 'Unexpected matched classification');
 
         $matches = $service->getMatchingClassNames('I like my SMARTPHONE.', [$mobilePhoneClassification, $watchClassification]);
-        $this->assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
+        self::assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
     }
 
     /**
@@ -74,13 +75,13 @@ class ClassificationServiceTest extends UnitTest
 
         $service = new ClassificationService();
         $matches = $service->getMatchingClassNames('', [$mobilePhoneClassification]);
-        $this->assertSame([], $matches, 'Nothing should match');
+        self::assertSame([], $matches, 'Nothing should match');
 
         $matches = $service->getMatchingClassNames('I have a smartphone in my hand.', [$mobilePhoneClassification]);
-        $this->assertSame(['mobilephone'], $matches, 'Wildcard not detected');
+        self::assertSame(['mobilephone'], $matches, 'Wildcard not detected');
 
         $matches = $service->getMatchingClassNames('smarthome is the future.', [$mobilePhoneClassification]);
-        $this->assertSame([], $matches, 'Unmatch pattern should remove assigned class');
+        self::assertSame([], $matches, 'Unmatch pattern should remove assigned class');
 
         $matchPatterns = ['\sh.nd\s'];
         $unMatchPatterns = [];
@@ -88,10 +89,10 @@ class ClassificationServiceTest extends UnitTest
         $testClassification = new Classification($matchPatterns, $unMatchPatterns, $mappedClass);
 
         $matches = $service->getMatchingClassNames('ein hund spring', [$testClassification]);
-        $this->assertSame(['test'], $matches, 'test class should assign');
+        self::assertSame(['test'], $matches, 'test class should assign');
         $matches = $service->getMatchingClassNames('eine hand klatscht', [$testClassification]);
-        $this->assertSame(['test'], $matches, 'test class should assign');
+        self::assertSame(['test'], $matches, 'test class should assign');
         $matches = $service->getMatchingClassNames('die hunde bellen', [$testClassification]);
-        $this->assertSame([], $matches, 'test class should assign');
+        self::assertSame([], $matches, 'test class should assign');
     }
 }

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
 
 /***************************************************************
@@ -26,10 +27,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\IndexService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
-use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
@@ -61,14 +62,13 @@ class IndexServiceTest extends UnitTest
      */
     protected $logManagerMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         $this->siteMock = $this->getDumbMock(Site::class);
         $this->queueMock = $this->getDumbMock(Queue::class);
         $this->dispatcherMock = $this->getDumbMock(Dispatcher::class);
         $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
+        parent::setUp();
     }
 
     /**
@@ -77,7 +77,7 @@ class IndexServiceTest extends UnitTest
     public function signalsAreTriggered()
     {
         $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->siteMock->expects($this->once())->method('getSolrConfiguration')->will($this->returnValue($fakeConfiguration));
+        $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
 
         // we create an IndexeService where indexItem is mocked to avoid real indexing in the unit test
         $indexService = $this->getMockBuilder(IndexService::class)
@@ -91,7 +91,7 @@ class IndexServiceTest extends UnitTest
         $fakeItems = [$item1, $item2];
         $this->fakeQueueItemContent($fakeItems);
 
-            // we assert that 6 signals will be dispatched 1 at the beginning 1 before and after each items and 1 at the end.
+        // we assert that 6 signals will be dispatched 1 at the beginning 1 before and after each items and 1 at the end.
         $this->assertSignalsWillBeDispatched(6);
         $indexService->indexItems(2);
     }
@@ -101,19 +101,19 @@ class IndexServiceTest extends UnitTest
      */
     public function testConfigurationIsNotFetchedWhenProgressIsCaluclated()
     {
-        $this->siteMock->expects($this->never())->method('getSolrConfiguration');
+        $this->siteMock->expects(self::never())->method('getSolrConfiguration');
 
         $statisticMock = $this->getDumbMock(QueueStatistic::class);
-        $statisticMock->expects($this->once())->method('getSuccessPercentage')->will($this->returnValue(50.0));
-        $this->queueMock->expects($this->once())->method('getStatisticsBySite')->will($this->returnValue($statisticMock));
+        $statisticMock->expects(self::once())->method('getSuccessPercentage')->willReturn(50.0);
+        $this->queueMock->expects(self::once())->method('getStatisticsBySite')->willReturn($statisticMock);
 
         $indexService = $this->getMockBuilder(IndexService::class)
             ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock, $this->logManagerMock])
-            ->setMethods(['indexItem'])
+            ->onlyMethods(['indexItem'])
             ->getMock();
 
         $progress = $indexService->getProgress();
-        $this->assertEquals(50, $progress);
+        self::assertEquals(50, $progress);
     }
 
     /**
@@ -122,27 +122,26 @@ class IndexServiceTest extends UnitTest
     public function testServerHostIsRestoredInCaseOfAnException()
     {
         $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->siteMock->expects($this->once())->method('getSolrConfiguration')->will($this->returnValue($fakeConfiguration));
-        $this->siteMock->expects($this->once())->method('getDomain')->willReturn('www.indextest.local');
+        $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
+        $this->siteMock->expects(self::once())->method('getDomain')->willReturn('www.indextest.local');
 
         /** @var $indexService IndexService */
         $indexService = $this->getMockBuilder(IndexService::class)
             ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->dispatcherMock, $this->logManagerMock])
-            ->setMethods(['getIndexerByItem','restoreOriginalHttpHost'])
+            ->onlyMethods(['getIndexerByItem', 'restoreOriginalHttpHost'])
             ->getMock();
 
-        $indexService->expects($this->exactly(2))->method('restoreOriginalHttpHost');
-
+        $indexService->expects(self::exactly(2))->method('restoreOriginalHttpHost');
 
         $indexerMock = $this->getDumbMock(Indexer::class);
-        $indexerMock->expects($this->exactly(2))->method('index')->willReturnCallback(function() {
+        $indexerMock->expects(self::exactly(2))->method('index')->willReturnCallback(function () {
             throw new Exception('unknowen error occured');
         });
-        $indexService->expects($this->exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
+        $indexService->expects(self::exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
 
         // we fake an index queue with two items
         $item1 = $this->getDumbMock(Item::class);
-        $item1->expects($this->any())->method('getSite')->willReturn($this->siteMock);
+        $item1->expects(self::any())->method('getSite')->willReturn($this->siteMock);
         $item2 = $this->getDumbMock(Item::class);
 
         $fakeItems = [$item1, $item2];
@@ -157,8 +156,8 @@ class IndexServiceTest extends UnitTest
     public function testDomainIsUsedFromSiteObject()
     {
         $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->siteMock->expects($this->once())->method('getSolrConfiguration')->will($this->returnValue($fakeConfiguration));
-        $this->siteMock->expects($this->any())->method('getDomain')->willReturn('www.indextest.local');
+        $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
+        $this->siteMock->expects(self::any())->method('getDomain')->willReturn('www.indextest.local');
 
         /** @var $indexService IndexService */
         $indexService = $this->getMockBuilder(IndexService::class)
@@ -167,12 +166,12 @@ class IndexServiceTest extends UnitTest
             ->getMock();
 
         $indexerMock = $this->getDumbMock(Indexer::class);
-        $indexerMock->expects($this->exactly(2))->method('index')->willReturn(true);
-        $indexService->expects($this->exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
+        $indexerMock->expects(self::exactly(2))->method('index')->willReturn(true);
+        $indexService->expects(self::exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
 
         // we fake an index queue with two items
         $item1 = $this->getDumbMock(Item::class);
-        $item1->expects($this->any())->method('getSite')->willReturn($this->siteMock);
+        $item1->expects(self::any())->method('getSite')->willReturn($this->siteMock);
         $item2 = $this->getDumbMock(Item::class);
 
         $fakeItems = [$item1, $item2];
@@ -186,7 +185,7 @@ class IndexServiceTest extends UnitTest
      */
     protected function fakeQueueItemContent($fakeItems)
     {
-        $this->queueMock->expects($this->once())->method('getItemsToIndex')->will($this->returnValue($fakeItems));
+        $this->queueMock->expects(self::once())->method('getItemsToIndex')->willReturn($fakeItems);
     }
 
     /**
@@ -194,6 +193,6 @@ class IndexServiceTest extends UnitTest
      */
     protected function assertSignalsWillBeDispatched($amount = 0)
     {
-        $this->dispatcherMock->expects($this->exactly($amount))->method('dispatch');
+        $this->dispatcherMock->expects(self::exactly($amount))->method('dispatch');
     }
 }

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\Helper\UriBuilder\TYPO3SiteStrategy;
@@ -13,7 +14,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class SolrSiteStrategyTest
- * @package ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index
  */
 class TYPO3SiteStrategyTest extends UnitTest
 {
@@ -25,18 +25,17 @@ class TYPO3SiteStrategyTest extends UnitTest
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->getDumbMock(Item::class);
-        $itemMock->expects($this->any())->method('getRecord')->willReturn($pageRecord);
-        $itemMock->expects($this->any())->method('getRecordUid')->willReturn(55);
+        $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
+        $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
         /** @var $loggerMock SolrLogManager */
         $loggerMock = $this->getDumbMock(SolrLogManager::class);
 
-            /** @var TYPO3SiteStrategy $typo3SiteStrategy */
+        /** @var TYPO3SiteStrategy $typo3SiteStrategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo');
     }
-
 
     /**
      * @test
@@ -45,8 +44,8 @@ class TYPO3SiteStrategyTest extends UnitTest
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->getDumbMock(Item::class);
-        $itemMock->expects($this->any())->method('getRecord')->willReturn($pageRecord);
-        $itemMock->expects($this->any())->method('getRecordUid')->willReturn(55);
+        $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
+        $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
         /** @var $loggerMock SolrLogManager */
@@ -55,7 +54,7 @@ class TYPO3SiteStrategyTest extends UnitTest
         /** @var TYPO3SiteStrategy $strategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $uri = $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo', ['frontendDataHelper.' => ['host' => 'www.secondsite.de']]);
-        $this->assertSame('http://www.secondsite.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
+        self::assertSame('http://www.secondsite.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
     }
 
     /**
@@ -65,8 +64,8 @@ class TYPO3SiteStrategyTest extends UnitTest
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->getDumbMock(Item::class);
-        $itemMock->expects($this->any())->method('getRecord')->willReturn($pageRecord);
-        $itemMock->expects($this->any())->method('getRecordUid')->willReturn(55);
+        $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
+        $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
         /** @var $loggerMock SolrLogManager */
@@ -75,7 +74,7 @@ class TYPO3SiteStrategyTest extends UnitTest
         /** @var TYPO3SiteStrategy $strategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $uri = $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo', ['frontendDataHelper.' => ['scheme' => 'https']]);
-        $this->assertSame('https://www.site.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
+        self::assertSame('https://www.site.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
     }
 
     /**
@@ -84,18 +83,18 @@ class TYPO3SiteStrategyTest extends UnitTest
     protected function getSiteFinderMock($pageRecord = []): SiteFinder
     {
         $uriMock = $this->getDumbMock(UriInterface::class);
-        $uriMock->expects($this->any())->method('__toString')->willReturn('http://www.site.de/en/test');
+        $uriMock->expects(self::any())->method('__toString')->willReturn('http://www.site.de/en/test');
 
         $routerMock = $this->getDumbMock(RouterInterface::class);
-        $routerMock->expects($this->once())->method('generateUri')->with($pageRecord, ['_language' => 2, 'MP' => 'foo'])
+        $routerMock->expects(self::once())->method('generateUri')->with($pageRecord, ['_language' => 2, 'MP' => 'foo'])
             ->willReturn($uriMock);
 
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->once())->method('getRouter')->willReturn($routerMock);
+        $siteMock->expects(self::once())->method('getRouter')->willReturn($routerMock);
 
         /** @var SiteFinder $siteFinderMock */
         $siteFinderMock = $this->getDumbMock(SiteFinder::class);
-        $siteFinderMock->expects($this->once())->method('getSiteByPageId')->willReturn($siteMock);
+        $siteFinderMock->expects(self::once())->method('getSiteByPageId')->willReturn($siteMock);
         return $siteFinderMock;
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
 
 /***************************************************************
@@ -25,8 +26,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueInitializationService;
-use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -56,35 +57,35 @@ class QueueInitializerServiceTest extends UnitTest
                                 'initialization' => 'MyPagesInitializer',
                                 'table' => 'pages',
                                 'fields.' => [
-                                    'title' => 'title'
-                                ]
+                                    'title' => 'title',
+                                ],
                             ],
                             'my_news' => 1,
                             'my_news.' => [
                                 'initialization' => 'MyNewsInitializer',
                                 'table' => 'tx_news_domain_model_news',
                                 'fields.' => [
-                                    'title' => 'title'
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                                    'title' => 'title',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeTs);
 
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
+        $siteMock->expects(self::any())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
 
         $service
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('executeInitializer')
             ->withConsecutive(
-            [$siteMock, 'my_pages', 'MyPagesInitializer', 'pages', $fakeTs['plugin.']['tx_solr.']['index.']['queue.']['my_pages.']],
-            [$siteMock, 'my_news', 'MyNewsInitializer', 'tx_news_domain_model_news', $fakeTs['plugin.']['tx_solr.']['index.']['queue.']['my_news.']]
-        );
+                [$siteMock, 'my_pages', 'MyPagesInitializer', 'pages', $fakeTs['plugin.']['tx_solr.']['index.']['queue.']['my_pages.']],
+                [$siteMock, 'my_news', 'MyNewsInitializer', 'tx_news_domain_model_news', $fakeTs['plugin.']['tx_solr.']['index.']['queue.']['my_news.']]
+            );
         $service->initializeBySiteAndIndexConfiguration($siteMock, '*');
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\RecordMonitor\Helper;
 
 /***************************************************************
@@ -28,7 +29,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -50,9 +51,6 @@ class RootPageResolverTest extends UnitTest
      */
     protected $rootPageResolver;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->fakeDisabledCache();
@@ -64,7 +62,8 @@ class RootPageResolverTest extends UnitTest
         /** @var $rootPageResolver RootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
-            ->setMethods(['getIsRootPageId','getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid', 'getRecordPageId', 'getPageRecordByPageId'])->getMock();
+            ->onlyMethods(['getIsRootPageId', 'getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid', 'getRecordPageId', 'getPageRecordByPageId'])->getMock();
+        parent::setUp();
     }
 
     /**
@@ -72,16 +71,16 @@ class RootPageResolverTest extends UnitTest
      */
     public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences()
     {
-        $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('getRecordPageId')->will($this->returnValue(111));
+        $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
+        $this->rootPageResolver->expects(self::once())->method('getRecordPageId')->willReturn(111);
 
-        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(true));
-        $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
+        $this->rootPageResolver->expects(self::once())->method('getIsRootPageId')->willReturn(true);
+        $this->rootPageResolver->expects(self::once())->method('getAlternativeSiteRootPagesIds')->willReturn([333, 444]);
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
 
         $message = 'Root page resolver did not retrieve and merge root page ids from root line and typoscript references';
-        $this->assertEquals([222,333,444], $resolvedRootPages, $message);
+        self::assertEquals([222, 333, 444], $resolvedRootPages, $message);
     }
 
     /**
@@ -89,59 +88,61 @@ class RootPageResolverTest extends UnitTest
      */
     public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot()
     {
-        $this->rootPageResolver->expects($this->once())->method('getRootPageIdByTableAndUid')->will($this->returnValue(222));
-        $this->rootPageResolver->expects($this->once())->method('getRecordPageId')->will($this->returnValue(111));
+        $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
+        $this->rootPageResolver->expects(self::once())->method('getRecordPageId')->willReturn(111);
 
-        $this->rootPageResolver->expects($this->once())->method('getIsRootPageId')->will($this->returnValue(false));
-        $this->rootPageResolver->expects($this->once())->method('getAlternativeSiteRootPagesIds')->will($this->returnValue([333,444]));
+        $this->rootPageResolver->expects(self::once())->method('getIsRootPageId')->willReturn(false);
+        $this->rootPageResolver->expects(self::once())->method('getAlternativeSiteRootPagesIds')->willReturn([333, 444]);
 
         $resolvedRootPages = $this->rootPageResolver->getResponsibleRootPageIds('pages', 41);
 
         $message = 'Root page resolver should only return rootPageIds from references';
-        $this->assertEquals([333,444], $resolvedRootPages, $message);
+        self::assertEquals([333, 444], $resolvedRootPages, $message);
     }
 
     /**
      * @test
      */
-    public function getIsRootPageIdWithPageIdZero() {
-        /** @var $rootPageResolver RootPageResolver */
-        $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
-            ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])->getMock();
-        $rootPage = $this->rootPageResolver->getIsRootPageId(0);
-        $this->assertEquals(false, $rootPage);
-    }
-
-    /**
-     * @test
-     */
-    public function getIsRootPageWithPageIdMinusOne() {
-        $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
-            ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])->getMock();
-        $rootPage = $this->rootPageResolver->getIsRootPageId(-1);
-        $this->assertEquals(false, $rootPage);
-    }
-
-    /**
-     * @test
-     */
-    public function getIsRootPageIdWithUnknownPageId() {
+    public function getIsRootPageIdWithPageIdZero()
+    {
+        /* @var RootPageResolver|MockObject $rootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
-            ->setMethods(['getPageRecordByPageId'])->getMock();
-        $this->rootPageResolver->expects($this->once())->method('getPageRecordByPageId')->willReturn(null);
+            ->onlyMethods([])
+            ->getMock();
+        $rootPage = $this->rootPageResolver->getIsRootPageId(0);
+        self::assertFalse($rootPage);
+    }
+
+    /**
+     * @test
+     */
+    public function getIsRootPageWithPageIdMinusOne()
+    {
+        $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
+            ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
+            ->onlyMethods([])
+            ->getMock();
+        $rootPage = $this->rootPageResolver->getIsRootPageId(-1);
+        self::assertFalse($rootPage);
+    }
+
+    /**
+     * @test
+     */
+    public function getIsRootPageIdWithUnknownPageId()
+    {
+        $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
+            ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
+            ->onlyMethods(['getPageRecordByPageId'])->getMock();
+        $this->rootPageResolver->expects(self::once())->method('getPageRecordByPageId')->willReturn(null);
         $this->expectException(\InvalidArgumentException::class);
         $this->rootPageResolver->getIsRootPageId(42);
     }
 
-    /**
-     * @return void
-     */
     protected function fakeDisabledCache()
     {
         $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
-        $this->cacheMock->method('get')->will($this->returnValue(false));
+        $this->cacheMock->method('get')->willReturn(false);
     }
-
-
 }

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\Statistic;
 
 /***************************************************************
@@ -36,25 +37,26 @@ class QueueStatisticTest extends UnitTest
     /**
      * @test
      */
-    public function canGetFailedPercentage() {
-            /** @var $statistic QueueStatistic */
+    public function canGetFailedPercentage()
+    {
+        /** @var $statistic QueueStatistic */
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
         $statistic->setFailedCount(2);
         $statistic->setSuccessCount(1);
         $statistic->setPendingCount(1);
 
-        $this->assertSame(50.0, $statistic->getFailedPercentage(), 'Can not calculate failed percentage');
-        $this->assertSame(25.0, $statistic->getSuccessPercentage(), 'Can not calculate success percentage');
-        $this->assertSame(25.0, $statistic->getPendingPercentage(), 'Can not calculate pending percentage');
+        self::assertSame(50.0, $statistic->getFailedPercentage(), 'Can not calculate failed percentage');
+        self::assertSame(25.0, $statistic->getSuccessPercentage(), 'Can not calculate success percentage');
+        self::assertSame(25.0, $statistic->getPendingPercentage(), 'Can not calculate pending percentage');
     }
 
     /**
      * @test
      */
-    public function canGetZeroPercentagesWhenEmpty() {
+    public function canGetZeroPercentagesWhenEmpty()
+    {
         /** @var $statistic QueueStatistic */
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
-        $this->assertSame(0.0, $statistic->getFailedPercentage(), 'Can not zero percent for empty');
+        self::assertSame(0.0, $statistic->getFailedPercentage(), 'Can not zero percent for empty');
     }
-
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
 
 /***************************************************************
@@ -24,16 +25,16 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Database\QueryGenerator;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
 use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Database\QueryGenerator;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Abstract testcase for the update handlers
@@ -77,7 +78,7 @@ abstract class AbstractUpdateHandlerTest extends UnitTest
      */
     protected $pagesRepositoryMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->recordServiceMock = $this->createMock(ConfigurationAwareRecordService::class);
         $this->frontendEnvironmentMock = $this->createMock(FrontendEnvironment::class);
@@ -87,18 +88,20 @@ abstract class AbstractUpdateHandlerTest extends UnitTest
 
         $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
         $this->frontendEnvironmentMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSolrConfigurationFromPageId')
             ->willReturn($this->typoScriptConfigurationMock);
 
         $this->queryGeneratorMock = $this->createMock(QueryGenerator::class);
 
         GeneralUtility::addInstance(QueryGenerator::class, $this->queryGeneratorMock);
+        parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
         unset($GLOBALS['TCA']);
+        parent::tearDown();
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
 
 /***************************************************************
@@ -24,17 +25,17 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Context\Context;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the DataUpdateHandler class.
@@ -70,10 +71,9 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
      */
     protected $solrLogManagerMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
-
         $this->mountPagesUpdaterMock = $this->createMock(MountPagesUpdater::class);
         $this->rootPageResolverMock = $this->createMock(RootPageResolver::class);
         $this->dataHandlerMock = $this->createMock(DataHandler::class);
@@ -92,7 +92,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         );
 
         $this->dataHandlerMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getPID')
             ->willReturn(self::DUMMY_PAGE_ID);
     }
@@ -104,17 +104,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
     protected function initRootPageResolverforValidDummyRootPage(): void
     {
         $this->rootPageResolverMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getRootPageId')
             ->willReturn(self::DUMMY_PAGE_ID);
 
         $this->rootPageResolverMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getIsRootPageId')
             ->willReturn(true);
 
         $this->rootPageResolverMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getResponsibleRootPageIds')
             ->willReturn([self::DUMMY_PAGE_ID]);
     }
@@ -128,17 +128,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page on which dummy ce is placed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with(
                 'pages',
@@ -146,7 +146,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             );
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteItem')
             ->with(
                 'pages',
@@ -154,13 +154,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             );
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('pages')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -170,7 +170,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isLocalizedRecord')
             ->with(
                 'pages',
@@ -179,7 +179,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(false);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslationOriginalUidIfTranslated')
             ->with(
                 'pages',
@@ -189,7 +189,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord['uid']);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'pages',
@@ -210,13 +210,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'invalid page on which dummy ce is placed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('collectGarbage')
             ->with(
                 'pages',
@@ -225,12 +225,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('containsItem')
             ->with(
                 'pages',
@@ -239,13 +239,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('pages')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -265,11 +265,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
     {
         $this->initRootPageResolverforValidDummyRootPage();
         $contextMock = $this->createMock(Context::class);
-        $contextMock->expects($this->any())->method('getPropertyFromAspect')->willReturn(1641472388);
+        $contextMock->expects(self::any())->method('getPropertyFromAspect')->willReturn(1641472388);
         GeneralUtility::setSingletonInstance(Context::class, $contextMock);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with(
                 'pages',
@@ -290,18 +290,18 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->initBasicPageUpdateExpectations($dummyPageRecord);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with(
                 'pages',
@@ -321,7 +321,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
     {
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteItem')
             ->with(
                 'pages',
@@ -329,13 +329,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             );
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('pages')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -345,7 +345,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isLocalizedRecord')
             ->with(
                 'pages',
@@ -354,7 +354,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(false);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslationOriginalUidIfTranslated')
             ->with(
                 'pages',
@@ -364,7 +364,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord['uid']);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'pages',
@@ -383,42 +383,42 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
             'sys_language_uid' => 0,
-            'extendToSubpages' => 1
+            'extendToSubpages' => 1,
         ];
 
         $GLOBALS['TCA']['pages'] = ['columns' => []];
 
         $this->queryGeneratorMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getTreeList')
             ->willReturn($dummyPageRecord['uid'] . ',100,200');
 
         $this->pagesRepositoryMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getPage')
             ->willReturn($dummyPageRecord);
         $this->pagesRepositoryMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getBackendEnableFields')
             ->willReturn(' AND deleted=0');
         $this->inject($this->dataUpdateHandler, 'pagesRepository', $this->pagesRepositoryMock);
         $this->initBasicPageUpdateExpectations($dummyPageRecord);
 
         $this->indexQueueMock
-            ->expects($this->exactly(3))
+            ->expects(self::exactly(3))
             ->method('updateItem')
             ->withConsecutive(
                 [
                     'pages',
-                    $dummyPageRecord['uid']
+                    $dummyPageRecord['uid'],
                 ],
                 [
                     'pages',
-                    100
+                    100,
                 ],
                 [
                     'pages',
-                    200
+                    200,
                 ]
             );
 
@@ -436,11 +436,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->rootPageResolverMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getAlternativeSiteRootPagesIds')
             ->with(
                 'pages',
@@ -450,12 +450,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn([]);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->frontendEnvironmentMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('getSolrConfigurationFromPageId');
 
         $this->dataUpdateHandler->handlePageUpdate($dummyPageRecord['uid']);
@@ -470,17 +470,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->initSiteForDummyConfiguration(self::DUMMY_PAGE_ID);
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('tx_foo_bar')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'tx_foo_bar',
@@ -490,11 +490,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord);
 
         $this->indexQueueMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('deleteItem');
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isLocalizedRecord')
             ->with(
                 'tx_foo_bar',
@@ -503,7 +503,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(false);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslationOriginalUidIfTranslated')
             ->with(
                 'tx_foo_bar',
@@ -513,7 +513,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord['uid']);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'tx_foo_bar',
@@ -522,7 +522,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with(
                 'tx_foo_bar',
@@ -544,12 +544,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->initSiteForDummyConfiguration(self::DUMMY_PAGE_ID);
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('collectGarbage')
             ->with(
                 'tx_foo_bar',
@@ -558,13 +558,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('tx_foo_bar')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'tx_foo_bar',
@@ -574,7 +574,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('containsItem')
             ->with(
                 'tx_foo_bar',
@@ -592,13 +592,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
     {
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
         $this->initSiteForDummyConfiguration($dummyRecord['pid']);
         $this->initSiteForDummyConfiguration(20);
 
         $this->rootPageResolverMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getResponsibleRootPageIds')
             ->with(
                 'tx_foo_bar',
@@ -607,36 +607,36 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn([self::DUMMY_PAGE_ID, 20]);
 
         $this->typoScriptConfigurationMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('getIndexQueueIsMonitoredTable')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('getRecord')
             ->willReturn($dummyRecord);
 
         $this->indexQueueMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('deleteItem');
 
         $this->tcaServiceMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('isLocalizedRecord')
             ->willReturn(false);
 
         $this->tcaServiceMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('getTranslationOriginalUidIfTranslated')
             ->willReturn($dummyRecord['uid']);
 
         $this->tcaServiceMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('isEnabledRecord')
             ->willReturn(true);
 
         $this->indexQueueMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('updateItem');
 
         $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
@@ -651,11 +651,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -665,7 +665,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'pages',
@@ -674,12 +674,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('pages', $dummyPageRecord['uid']);
 
@@ -696,11 +696,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -710,7 +710,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'pages',
@@ -719,12 +719,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('pages', $dummyPageRecord['uid']);
 
@@ -740,11 +740,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'invalid dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -754,7 +754,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('containsItem')
             ->with(
                 'pages',
@@ -764,7 +764,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('collectGarbage')
             ->with(
                 'pages',
@@ -783,17 +783,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->initRootPageResolverforValidDummyRootPage();
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('tx_foo_bar')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'tx_foo_bar',
@@ -803,7 +803,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'tx_foo_bar',
@@ -812,7 +812,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslationOriginalUidIfTranslated')
             ->with(
                 'tx_foo_bar',
@@ -822,7 +822,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('tx_foo_bar', $dummyRecord['uid']);
 
@@ -837,17 +837,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->initRootPageResolverforValidDummyRootPage();
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('tx_foo_bar')
             ->willReturn(true);
 
         $this->recordServiceMock
-        ->expects($this->once())
+        ->expects(self::once())
         ->method('getRecord')
         ->with(
             'tx_foo_bar',
@@ -857,7 +857,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('containsItem')
             ->with(
                 'tx_foo_bar',
@@ -867,7 +867,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('collectGarbage')
             ->with(
                 'tx_foo_bar',
@@ -878,7 +878,6 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->dataUpdateHandler->handleVersionSwap($dummyRecord['uid'], 'tx_foo_bar');
     }
 
-
     /**
      * @test
      */
@@ -888,11 +887,11 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $dummyPageRecord = [
             'uid' => self::DUMMY_PAGE_ID,
             'title' => 'dummy page to be processed',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ];
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'pages',
@@ -902,7 +901,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyPageRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'pages',
@@ -911,12 +910,12 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->mountPagesUpdaterMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('pages', $dummyPageRecord['uid']);
 
@@ -931,17 +930,17 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
         $this->initRootPageResolverforValidDummyRootPage();
         $dummyRecord = [
             'uid' => 789,
-            'pid' => self::DUMMY_PAGE_ID
+            'pid' => self::DUMMY_PAGE_ID,
         ];
 
         $this->typoScriptConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
             ->with('tx_foo_bar')
             ->willReturn(true);
 
         $this->recordServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecord')
             ->with(
                 'tx_foo_bar',
@@ -951,7 +950,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnabledRecord')
             ->with(
                 'tx_foo_bar',
@@ -960,7 +959,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn(true);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslationOriginalUidIfTranslated')
             ->with(
                 'tx_foo_bar',
@@ -970,7 +969,7 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
             ->willReturn($dummyRecord['uid']);
 
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('tx_foo_bar', $dummyRecord['uid']);
 
@@ -987,13 +986,13 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
     {
         $siteMock = $this->createMock(Site::class);
         $siteMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSolrConfiguration')
             ->willReturn($this->typoScriptConfigurationMock);
 
         $siteRepositoryMock = $this->createMock(SiteRepository::class);
         $siteRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getSiteByPageId')
             ->with($pageId)
             ->willReturn($siteMock);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/AbstractEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/AbstractEventListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
 
 /***************************************************************
@@ -24,11 +25,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListe
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Psr\EventDispatcher\EventDispatcherInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -38,7 +39,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 abstract class AbstractEventListenerTest extends UnitTest
 {
-    private const MONITORING_TYPES_TO_TEST = [0,1,2,99];
+    private const MONITORING_TYPES_TO_TEST = [0, 1, 2, 99];
 
     /**
      * @var AbstractBaseEventListener
@@ -55,16 +56,18 @@ abstract class AbstractEventListenerTest extends UnitTest
      */
     protected $eventDispatcherMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
         $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $this->listener = $this->initListener();
+        parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
+        parent::tearDown();
     }
 
     /**
@@ -80,12 +83,12 @@ abstract class AbstractEventListenerTest extends UnitTest
     public function canIndicateActiveMonitoring(): void
     {
         $this->extensionConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMonitoringType')
             ->willReturn($this->getMonitoringType());
 
         $status = $this->callInaccessibleMethod($this->listener, 'isProcessingEnabled');
-        $this->assertTrue($status);
+        self::assertTrue($status);
     }
 
     /**
@@ -97,12 +100,12 @@ abstract class AbstractEventListenerTest extends UnitTest
     public function canIndicateInactiveMonitoring(int $currentType): void
     {
         $this->extensionConfigurationMock
-        ->expects($this->once())
+        ->expects(self::once())
         ->method('getMonitoringType')
         ->willReturn($currentType);
 
         $status = $this->callInaccessibleMethod($this->listener, 'isProcessingEnabled');
-        $this->assertFalse($status);
+        self::assertFalse($status);
     }
 
     /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
 
 /***************************************************************
@@ -24,12 +25,12 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListe
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\DelayedProcessingEventListener;
-use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\DelayedProcessingEventListener;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the DelayedProcessingEventListener
@@ -41,9 +42,10 @@ class DelayedProcessingEventListenerTest extends AbstractEventListenerTest
     /**
      * @test
      */
-    public function canHandleEvents(): void {
+    public function canHandleEvents(): void
+    {
         $this->extensionConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMonitoringType')
             ->willReturn(1);
 
@@ -51,30 +53,31 @@ class DelayedProcessingEventListenerTest extends AbstractEventListenerTest
 
         $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('addEventToQueue')
             ->with($event);
         GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch')
-            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+            ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
-            }));
+            });
 
         $this->listener->__invoke($event);
-        $this->assertTrue($dispatchedEvent instanceof DelayedProcessingQueuingFinishedEvent);
-        $this->assertEquals($event, $dispatchedEvent->getDataUpdateEvent());
+        self::assertTrue($dispatchedEvent instanceof DelayedProcessingQueuingFinishedEvent);
+        self::assertEquals($event, $dispatchedEvent->getDataUpdateEvent());
     }
 
     /**
      * @test
      */
-    public function canSkipEventHandlingIfDisabled(): void {
+    public function canSkipEventHandlingIfDisabled(): void
+    {
         $this->extensionConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMonitoringType')
             ->willReturn(2);
 
@@ -82,12 +85,12 @@ class DelayedProcessingEventListenerTest extends AbstractEventListenerTest
 
         $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
         $eventQueueItemRepositoryMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('addEventToQueue');
         GeneralUtility::setSingletonInstance(EventQueueItemRepository::class, $eventQueueItemRepositoryMock);
 
         $this->eventDispatcherMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('dispatch');
 
         $this->listener->__invoke($event);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/AbstractProcessingFinishedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
 
 /***************************************************************
@@ -24,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListe
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEventInterface;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Abstract testcase for the processing finished events
@@ -46,6 +47,6 @@ abstract class AbstractProcessingFinishedEventTest extends UnitTest
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass($processedEvent);
 
-        $this->assertEquals($processedEvent, $event->getDataUpdateEvent());
+        self::assertEquals($processedEvent, $event->getDataUpdateEvent());
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListener;
 
 /***************************************************************
@@ -24,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\EventListe
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
 
 /**
  * Testcase for the NoProcessingEventListener
@@ -38,29 +39,31 @@ class NoProcessingEventListenerTest extends AbstractEventListenerTest
     /**
      * @test
      */
-    public function canHandleEvents(): void {
+    public function canHandleEvents(): void
+    {
         $this->extensionConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMonitoringType')
             ->willReturn(2);
 
         $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
         $this->listener->__invoke($event);
-        $this->assertTrue($event->isPropagationStopped());
+        self::assertTrue($event->isPropagationStopped());
     }
 
     /**
      * @test
      */
-    public function canSkipEventHandlingIfDisabled(): void {
+    public function canSkipEventHandlingIfDisabled(): void
+    {
         $this->extensionConfigurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMonitoringType')
             ->willReturn(0);
 
         $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
         $this->listener->__invoke($event);
-        $this->assertFalse($event->isPropagationStopped());
+        self::assertFalse($event->isPropagationStopped());
     }
 
     /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/AbstractDataUpdateEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************
@@ -24,10 +25,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Abstract testcase for the data update events
@@ -47,13 +48,13 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, static::EVENT_TEST_TABLE);
 
-        $this->assertEquals(123, $event->getUid());
-        $this->assertEquals(static::EVENT_TEST_TABLE, $event->getTable());
+        self::assertEquals(123, $event->getUid());
+        self::assertEquals(static::EVENT_TEST_TABLE, $event->getTable());
 
         // initial values
-        $this->assertEmpty($event->getFields());
-        $this->assertFalse($event->isPropagationStopped());
-        $this->assertFalse($event->isImmediateProcessingForced());
+        self::assertEmpty($event->getFields());
+        self::assertFalse($event->isPropagationStopped());
+        self::assertFalse($event->isImmediateProcessingForced());
 
         return $event;
     }
@@ -67,7 +68,7 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, static::EVENT_TEST_TABLE, $fields = ['hidden' => 1]);
 
-        $this->assertEquals($fields, $event->getFields());
+        self::assertEquals($fields, $event->getFields());
     }
 
     /**
@@ -78,12 +79,12 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
-        $this->assertFalse($event->isPageUpdate());
+        self::assertFalse($event->isPageUpdate());
 
         /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'pages');
-        $this->assertTrue($event->isPageUpdate());
+        self::assertTrue($event->isPageUpdate());
     }
 
     /**
@@ -94,12 +95,12 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
-        $this->assertFalse($event->isContentElementUpdate());
+        self::assertFalse($event->isContentElementUpdate());
 
         /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tt_content');
-        $this->assertTrue($event->isContentElementUpdate());
+        self::assertTrue($event->isContentElementUpdate());
     }
 
     /**
@@ -111,11 +112,11 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
 
-        $this->assertFalse($event->isPropagationStopped());
+        self::assertFalse($event->isPropagationStopped());
         $event->setStopProcessing(true);
-        $this->assertTrue($event->isPropagationStopped());
+        self::assertTrue($event->isPropagationStopped());
         $event->setStopProcessing(false);
-        $this->assertFalse($event->isPropagationStopped());
+        self::assertFalse($event->isPropagationStopped());
     }
 
     /**
@@ -127,11 +128,11 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
 
-        $this->assertFalse($event->isImmediateProcessingForced());
+        self::assertFalse($event->isImmediateProcessingForced());
         $event->setForceImmediateProcessing(true);
-        $this->assertTrue($event->isImmediateProcessingForced());
+        self::assertTrue($event->isImmediateProcessingForced());
         $event->setForceImmediateProcessing(false);
-        $this->assertFalse($event->isImmediateProcessingForced());
+        self::assertFalse($event->isImmediateProcessingForced());
     }
 
     /**
@@ -143,7 +144,7 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
             'uid' => 123,
             'pid' => 10,
             'title' => 'dummy title',
-            'l10n_diffsource' => 'dummy l10n_diffsource'
+            'l10n_diffsource' => 'dummy l10n_diffsource',
         ];
 
         /** @var AbstractDataUpdateEvent $event */
@@ -151,12 +152,12 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
         $event = new $eventClass(123, 'pages', $fields);
 
         $properties = $event->__sleep();
-        $this->assertNotEmpty($properties);
+        self::assertNotEmpty($properties);
 
         /** @var AbstractDataUpdateEvent $processedEvent */
         $processedEvent = unserialize(serialize($event));
-        $this->assertIsObject($processedEvent);
-        $this->assertArrayNotHasKey('l10n_diffsource', $processedEvent->getFields());
+        self::assertIsObject($processedEvent);
+        self::assertArrayNotHasKey('l10n_diffsource', $processedEvent->getFields());
 
         if ($event->getFields() !== []) {
             $requiredUpdateFields = array_unique(array_merge(
@@ -165,16 +166,16 @@ abstract class AbstractDataUpdateEventTest extends UnitTest
             ));
 
             foreach ($requiredUpdateFields as $requiredUpdateField) {
-                $this->assertArrayHasKey($requiredUpdateField, $processedEvent->getFields());
+                self::assertArrayHasKey($requiredUpdateField, $processedEvent->getFields());
             }
 
             if ($event->getTable() === 'pages') {
                 $processedFields = $fields;
                 unset($processedFields['l10n_diffsource']);
-                $this->assertEquals($processedFields, $processedEvent->getFields());
+                self::assertEquals($processedFields, $processedEvent->getFields());
             }
 
-            $this->assertEquals(10, $processedEvent->getFields()['pid']);
+            self::assertEquals(10, $processedEvent->getFields()['pid']);
         }
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************
@@ -42,7 +43,7 @@ class ContentElementDeletedEventTest extends AbstractDataUpdateEventTest
     public function canInitAndReturnFields(): void
     {
         $event = new ContentElementDeletedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
-        $this->assertEmpty($event->getFields());
+        self::assertEmpty($event->getFields());
     }
 
     /**
@@ -51,7 +52,7 @@ class ContentElementDeletedEventTest extends AbstractDataUpdateEventTest
     public function canForceTable(): void
     {
         $event = new ContentElementDeletedEvent(123, 'tx_foo_bar');
-        $this->assertEquals('tt_content', $event->getTable());
+        self::assertEquals('tt_content', $event->getTable());
     }
 
     /**
@@ -60,7 +61,7 @@ class ContentElementDeletedEventTest extends AbstractDataUpdateEventTest
     public function canIndicatePageUpdate(): void
     {
         $event = new ContentElementDeletedEvent(123);
-        $this->assertFalse($event->isPageUpdate());
+        self::assertFalse($event->isPageUpdate());
     }
 
     /**
@@ -69,6 +70,6 @@ class ContentElementDeletedEventTest extends AbstractDataUpdateEventTest
     public function canIndicateContentElementUpdate(): void
     {
         $event = new ContentElementDeletedEvent(123);
-        $this->assertTrue($event->isContentElementUpdate());
+        self::assertTrue($event->isContentElementUpdate());
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************
@@ -42,7 +43,7 @@ class PageMovedEventTest extends AbstractDataUpdateEventTest
     public function canInitAndReturnFields(): void
     {
         $event = new PageMovedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
-        $this->assertEmpty($event->getFields());
+        self::assertEmpty($event->getFields());
     }
 
     /**
@@ -51,7 +52,7 @@ class PageMovedEventTest extends AbstractDataUpdateEventTest
     public function canForceTable(): void
     {
         $event = new PageMovedEvent(123, 'tx_foo_bar');
-        $this->assertEquals('pages', $event->getTable());
+        self::assertEquals('pages', $event->getTable());
     }
 
     /**
@@ -60,7 +61,7 @@ class PageMovedEventTest extends AbstractDataUpdateEventTest
     public function canIndicatePageUpdate(): void
     {
         $event = new PageMovedEvent(123);
-        $this->assertTrue($event->isPageUpdate());
+        self::assertTrue($event->isPageUpdate());
     }
 
     /**
@@ -69,6 +70,6 @@ class PageMovedEventTest extends AbstractDataUpdateEventTest
     public function canIndicateContentElementUpdate(): void
     {
         $event = new PageMovedEvent(123);
-        $this->assertFalse($event->isContentElementUpdate());
+        self::assertFalse($event->isContentElementUpdate());
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
 
 /**
  * Testcase for the RecordGarbageCheckEvent
@@ -44,11 +45,11 @@ class RecordGarbageCheckEventTest extends AbstractDataUpdateEventTest
      */
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
     {
-       /** @var RecordGarbageCheckEvent $event */
+        /** @var RecordGarbageCheckEvent $event */
         $event = parent::canInitAndReturnBasicProperties();
 
         // initial values
-        $this->assertFalse($event->frontendGroupsRemoved());
+        self::assertFalse($event->frontendGroupsRemoved());
 
         return $event;
     }
@@ -59,6 +60,6 @@ class RecordGarbageCheckEventTest extends AbstractDataUpdateEventTest
     public function canInitAndReturnFrontendGroupsRemovedFlag(): void
     {
         $event = new RecordGarbageCheckEvent(123, 'tx_foo_bar', [], true);
-        $this->assertTrue($event->frontendGroupsRemoved());
+        self::assertTrue($event->frontendGroupsRemoved());
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler\Events;
 
 /***************************************************************

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
 
 /***************************************************************
@@ -24,13 +25,13 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\UpdateHandler;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Doctrine\DBAL\Result;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\PageStrategy;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\RecordStrategy;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use Doctrine\DBAL\Result;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the GarbageHandler class.
@@ -44,7 +45,7 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
      */
     protected $garbageHandler;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->garbageHandler = new GarbageHandler(
@@ -86,7 +87,7 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
         GeneralUtility::addInstance($strategy, $strategyMock);
 
         $strategyMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('removeGarbageOf')
             ->with(
                 $table,
@@ -101,7 +102,7 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
     {
         $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
         $this->indexQueueMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateItem')
             ->with('pages', 123);
 
@@ -117,36 +118,36 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
             'uid' => 789,
             'pid' => 1,
             'title' => 'dummy record to collect garbage for',
-            'hidden' => 1
+            'hidden' => 1,
         ];
 
         $this->initGarbageCollectionExpectations(RecordStrategy::class, 'tx_foo_bar', $dummyRecord['uid']);
 
         $GLOBALS['TCA']['tx_foo_bar'] = ['columns' => []];
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getVisibilityAffectingFieldsByTable')
             ->with('tx_foo_bar')
             ->willReturn('hidden,fe_group');
 
         $this->pagesRepositoryMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getPage')
             ->willReturn(['uid' => 1]);
         $this->inject($this->garbageHandler, 'pagesRepository', $this->pagesRepositoryMock);
 
         $resultMock = $this->createMock(Result::class);
-        $resultMock->expects($this->once())->method('fetchAssociative')->willReturn($dummyRecord);
+        $resultMock->expects(self::once())->method('fetchAssociative')->willReturn($dummyRecord);
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
-        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
-        $queryBuilderMock->expects($this->once())->method('select')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('from')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('where')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('executeQuery')->willReturn($resultMock);
+        $queryBuilderMock->expects(self::once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects(self::once())->method('select')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('from')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('where')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('executeQuery')->willReturn($resultMock);
         $this->inject($this->garbageHandler, 'queryBuilders', ['tx_foo_bar' => $queryBuilderMock]);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('normalizeFrontendGroupField')
             ->with('tx_foo_bar', $dummyRecord)
             ->willReturn($dummyRecord);
@@ -164,7 +165,7 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
             'pid' => 1,
             'title' => 'dummy record to collect garbage for',
             'hidden' => 1,
-            'extendToSubpages' => 1
+            'extendToSubpages' => 1,
         ];
 
         $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 100);
@@ -173,35 +174,35 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
 
         $GLOBALS['TCA']['pages'] = ['columns' => []];
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getVisibilityAffectingFieldsByTable')
             ->with('pages')
             ->willReturn('hidden,fe_group');
 
         $this->pagesRepositoryMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getPage')
             ->willReturn($dummyPageRecord);
         $this->inject($this->garbageHandler, 'pagesRepository', $this->pagesRepositoryMock);
 
         $resultMock = $this->createMock(Result::class);
-        $resultMock->expects($this->once())->method('fetchAssociative')->willReturn($dummyPageRecord);
+        $resultMock->expects(self::once())->method('fetchAssociative')->willReturn($dummyPageRecord);
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
-        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
-        $queryBuilderMock->expects($this->once())->method('select')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('from')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('where')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('executeQuery')->willReturn($resultMock);
+        $queryBuilderMock->expects(self::once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects(self::once())->method('select')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('from')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('where')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('executeQuery')->willReturn($resultMock);
         $this->inject($this->garbageHandler, 'queryBuilders', ['pages' => $queryBuilderMock]);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('normalizeFrontendGroupField')
             ->with('pages', $dummyPageRecord)
             ->willReturn($dummyPageRecord);
 
         $this->queryGeneratorMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getTreeList')
             ->willReturn($dummyPageRecord['uid'] . ',100,200');
 
@@ -216,7 +217,7 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
         $GLOBALS['TCA']['tx_foo_bar'] = ['columns' => []];
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getVisibilityAffectingFieldsByTable')
             ->with('tx_foo_bar')
             ->willReturn('hidden,fe_group');
@@ -224,16 +225,16 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
         $dummyRecord = ['uid' => 123];
 
         $resultMock = $this->createMock(Result::class);
-        $resultMock->expects($this->once())->method('fetchAssociative')->willReturn($dummyRecord);
+        $resultMock->expects(self::once())->method('fetchAssociative')->willReturn($dummyRecord);
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
-        $queryBuilderMock->expects($this->once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
-        $queryBuilderMock->expects($this->once())->method('select')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('from')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('where')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('executeQuery')->willReturn($resultMock);
+        $queryBuilderMock->expects(self::once())->method('getRestrictions')->willReturn($this->createMock(QueryRestrictionContainerInterface::class));
+        $queryBuilderMock->expects(self::once())->method('select')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('from')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('where')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('executeQuery')->willReturn($resultMock);
         $this->inject($this->garbageHandler, 'queryBuilders', ['tx_foo_bar' => $queryBuilderMock]);
 
         $record = $this->garbageHandler->getRecordWithFieldRelevantForGarbageCollection('tx_foo_bar', 123);
-        $this->assertEquals($dummyRecord, $record);
+        self::assertEquals($dummyRecord, $record);
     }
 }

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ApacheSolrDocument;
 
 /***************************************************************
@@ -26,8 +27,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ApacheSolrDocument;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
-use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
@@ -45,11 +46,11 @@ class BuilderTest extends UnitTest
         'crdate' => 1635537721,
         'SYS_LASTCHANGED' => 1635537721,
         'endtime' => null,
-        'subtitle' => "fake page test",
+        'subtitle' => 'fake page test',
         'nav_title' => null,
         'author' => null,
         'description' => null,
-        'abstract' => null
+        'abstract' => null,
     ];
 
     /**
@@ -72,19 +73,21 @@ class BuilderTest extends UnitTest
      */
     protected $documentBuilder;
 
-    public function setUp(): void {
+    protected function setUp(): void
+    {
         /** @var $variantIdBuilderMock */
         $this->variantIdBuilderMock = $this->getDumbMock(IdBuilder::class);
         $this->siteMock = $this->getDumbMock(Site::class);
         $this->typo3PageExtractorMock = $this->getDumbMock(Typo3PageContentExtractor::class);
 
         /** @var $documentBuilder Builder */
-        $this->documentBuilder = $this->getMockBuilder(Builder::class)->setConstructorArgs([$this->variantIdBuilderMock ])->setMethods(
-            ['getExtractorForPageContent', 'getSiteByPageId','getPageDocumentId', 'getDocumentId']
+        $this->documentBuilder = $this->getMockBuilder(Builder::class)->setConstructorArgs([$this->variantIdBuilderMock ])->onlyMethods(
+            ['getExtractorForPageContent', 'getSiteByPageId', 'getPageDocumentId', 'getDocumentId']
         )->getMock();
 
-        $this->documentBuilder->expects($this->any())->method('getExtractorForPageContent')->will($this->returnValue($this->typo3PageExtractorMock));
-        $this->documentBuilder->expects($this->any())->method('getSiteByPageId')->will($this->returnValue($this->siteMock));
+        $this->documentBuilder->expects(self::any())->method('getExtractorForPageContent')->willReturn($this->typo3PageExtractorMock);
+        $this->documentBuilder->expects(self::any())->method('getSiteByPageId')->willReturn($this->siteMock);
+        parent::setUp();
     }
 
     /**
@@ -94,7 +97,7 @@ class BuilderTest extends UnitTest
     {
         $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
-        $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
+        $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
         $this->fakeTagContent([]);
@@ -102,8 +105,8 @@ class BuilderTest extends UnitTest
         $fakePage->page = self::FAKE_PAGE_RECORD;
         $document = $this->documentBuilder->fromPage($fakePage, 'http://www.typo3-solr.com', $fakeRootLine, '');
 
-        $this->assertInstanceOf(Document::class, $document, 'Expect to get an ' . Document::class .  ' back');
-        $this->assertSame('siteHash/pages/4711', $document['id'], 'Builder did not use documentId from mock');
+        self::assertInstanceOf(Document::class, $document, 'Expect to get an ' . Document::class . ' back');
+        self::assertSame('siteHash/pages/4711', $document['id'], 'Builder did not use documentId from mock');
     }
 
     /**
@@ -113,7 +116,7 @@ class BuilderTest extends UnitTest
     {
         $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
-        $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
+        $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
         $this->fakeTagContent([]);
@@ -121,7 +124,7 @@ class BuilderTest extends UnitTest
         $fakePage->page = array_merge(self::FAKE_PAGE_RECORD, ['keywords' => 'foo,bar']);
         $document = $this->documentBuilder->fromPage($fakePage, 'http://www.typo3-solr.com', $fakeRootLine, '');
 
-        $this->assertSame($document['keywords'], ['foo','bar'], 'Could not set keywords from page document');
+        self::assertSame($document['keywords'], ['foo', 'bar'], 'Could not set keywords from page document');
     }
 
     /**
@@ -131,7 +134,7 @@ class BuilderTest extends UnitTest
     {
         $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
-        $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
+        $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
         $this->fakeTagContent([]);
@@ -139,7 +142,7 @@ class BuilderTest extends UnitTest
         $fakePage->page = array_merge(self::FAKE_PAGE_RECORD, ['endtime' => 1234]);
         $document = $this->documentBuilder->fromPage($fakePage, 'http://www.typo3-solr.com', $fakeRootLine, '');
 
-        $this->assertSame($document['endtime'], 1234, 'Could not set endtime from page document');
+        self::assertSame($document['endtime'], 1234, 'Could not set endtime from page document');
     }
 
     /**
@@ -149,7 +152,7 @@ class BuilderTest extends UnitTest
     {
         $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->getDumbMock(Rootline::class);
-        $fakeRootLine->expects($this->once())->method('getGroups')->will($this->returnValue([1]));
+        $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
         $this->fakeTagContent(['tagsH1' => 'Fake H1 content']);
@@ -157,7 +160,7 @@ class BuilderTest extends UnitTest
         $fakePage->page = self::FAKE_PAGE_RECORD;
         $document = $this->documentBuilder->fromPage($fakePage, 'http://www.typo3-solr.com', $fakeRootLine, '');
 
-        $this->assertSame($document['tagsH1'], 'Fake H1 content', 'Could not assign extracted h1 heading to solr document');
+        self::assertSame($document['tagsH1'], 'Fake H1 content', 'Could not assign extracted h1 heading to solr document');
     }
 
     /**
@@ -165,26 +168,26 @@ class BuilderTest extends UnitTest
      */
     public function canBuildFromRecord()
     {
-        $fakeRecord = ['uid' => 4711, 'pid' => 88,'type' => 'news'];
+        $fakeRecord = ['uid' => 4711, 'pid' => 88, 'type' => 'news'];
         $type = 'news';
         $this->fakeDocumentId('testSiteHash/news/4711');
 
-        $this->siteMock->expects($this->any())->method('getRootPageId')->willReturn(99);
-        $this->siteMock->expects($this->once())->method('getDomain')->willReturn('test.typo3.org');
-        $this->siteMock->expects($this->any())->method('getSiteHash')->willReturn('testSiteHash');
-        $this->variantIdBuilderMock->expects($this->once())->method('buildFromTypeAndUid')->with('news', 4711)->willReturn('testVariantId');
+        $this->siteMock->expects(self::any())->method('getRootPageId')->willReturn(99);
+        $this->siteMock->expects(self::once())->method('getDomain')->willReturn('test.typo3.org');
+        $this->siteMock->expects(self::any())->method('getSiteHash')->willReturn('testSiteHash');
+        $this->variantIdBuilderMock->expects(self::once())->method('buildFromTypeAndUid')->with('news', 4711)->willReturn('testVariantId');
 
         $document = $this->documentBuilder->fromRecord($fakeRecord, $type, 99, 'r:0');
 
-        $this->assertSame(4711, $document->uid, 'Uid field was not set as expected');
-        $this->assertSame(88, $document->pid, 'Pid field was not set as expected');
-        $this->assertSame('test.typo3.org', $document->site, 'Site field was not set as expected');
-        $this->assertSame('testSiteHash', $document->siteHash, 'SiteHash field was not set as expected');
-        $this->assertSame('testVariantId', $document->variantId, 'VariantId field was not set as expected');
-        $this->assertSame('r:0', $document->access, 'Access field was not set as expected');
-        $this->assertSame('testSiteHash/news/4711', $document->id, 'Id field was not set as expected');
-        $this->assertSame('news', $document->type, 'Type field was not set as expected');
-        $this->assertSame('EXT:solr', $document->appKey, 'appKey field was not set as expected');
+        self::assertSame(4711, $document->uid, 'Uid field was not set as expected');
+        self::assertSame(88, $document->pid, 'Pid field was not set as expected');
+        self::assertSame('test.typo3.org', $document->site, 'Site field was not set as expected');
+        self::assertSame('testSiteHash', $document->siteHash, 'SiteHash field was not set as expected');
+        self::assertSame('testVariantId', $document->variantId, 'VariantId field was not set as expected');
+        self::assertSame('r:0', $document->access, 'Access field was not set as expected');
+        self::assertSame('testSiteHash/news/4711', $document->id, 'Id field was not set as expected');
+        self::assertSame('news', $document->type, 'Type field was not set as expected');
+        self::assertSame('EXT:solr', $document->appKey, 'appKey field was not set as expected');
     }
 
     /**
@@ -192,7 +195,7 @@ class BuilderTest extends UnitTest
      */
     protected function fakePageDocumentId($documentId)
     {
-        $this->documentBuilder->expects($this->once())->method('getPageDocumentId')->will($this->returnValue($documentId));
+        $this->documentBuilder->expects(self::once())->method('getPageDocumentId')->willReturn($documentId);
     }
 
     /**
@@ -200,7 +203,7 @@ class BuilderTest extends UnitTest
      */
     protected function fakeDocumentId($documentId)
     {
-        $this->documentBuilder->expects($this->once())->method('getDocumentId')->will($this->returnValue($documentId));
+        $this->documentBuilder->expects(self::once())->method('getDocumentId')->willReturn($documentId);
     }
 
     /**
@@ -208,6 +211,6 @@ class BuilderTest extends UnitTest
      */
     protected function fakeTagContent($tagContent = [])
     {
-        $this->typo3PageExtractorMock->expects($this->once())->method('getTagContent')->will($this->returnValue($tagContent));
+        $this->typo3PageExtractorMock->expects(self::once())->method('getTagContent')->willReturn($tagContent);
     }
 }

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ApacheSolrDocument;
 
 /***************************************************************
@@ -26,11 +27,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ApacheSolrDocument;
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Repository;
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\Search;
-use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
@@ -67,12 +68,12 @@ class RepositoryTest extends UnitTest
         $apacheSolrDocumentCollection = [new Document(), new Document()];
         $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['findByPageIdAndByLanguageId']);
         $apacheSolrDocumentRepository
-            ->expects($this->exactly(1))
+            ->expects(self::exactly(1))
             ->method('findByPageIdAndByLanguageId')
-            ->will($this->returnValue($apacheSolrDocumentCollection));
+            ->willReturn($apacheSolrDocumentCollection);
 
         /* @var $apacheSolrDocumentRepository Repository */
-        $this->assertSame($apacheSolrDocumentCollection[0], $apacheSolrDocumentRepository->findOneByPageIdAndByLanguageId(0, 0));
+        self::assertSame($apacheSolrDocumentCollection[0], $apacheSolrDocumentRepository->findOneByPageIdAndByLanguageId(0, 0));
     }
 
     /**
@@ -80,7 +81,6 @@ class RepositoryTest extends UnitTest
      */
     public function findByPageIdAndByLanguageIdThrowsInvalidArgumentExceptionIfPageIdIsNotSet()
     {
-
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1487332926);
         /* @var $apacheSolrDocumentRepository Repository */
@@ -108,13 +108,12 @@ class RepositoryTest extends UnitTest
         /* @var $apacheSolrDocumentRepository Repository */
         $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['initializeSearch']);
         $apacheSolrDocumentRepository
-            ->expects($this->exactly(1))
+            ->expects(self::exactly(1))
             ->method('initializeSearch')
-            ->will($this->throwException(new NoSolrConnectionFoundException()));
+            ->will(self::throwException(new NoSolrConnectionFoundException()));
 
         $apacheSolrDocumentCollection = $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(777, 0);
-        $this->assertEmpty($apacheSolrDocumentCollection);
-
+        self::assertEmpty($apacheSolrDocumentCollection);
     }
 
     /**
@@ -122,10 +121,9 @@ class RepositoryTest extends UnitTest
      */
     public function findByPageIdAndByLanguageIdReturnsResultFromSearch()
     {
-
         $solrConnectionMock = $this->getDumbMock(SolrConnection::class);
         $solrConnectionManager = $this->getAccessibleMock(ConnectionManager::class, ['getConnectionByPageId'], [], '', false);
-        $solrConnectionManager->expects($this->any())->method('getConnectionByPageId')->will($this->returnValue($solrConnectionMock));
+        $solrConnectionManager->expects(self::any())->method('getConnectionByPageId')->willReturn($solrConnectionMock);
         $mockedSingletons = [ConnectionManager::class => $solrConnectionManager];
 
         $search = $this->getAccessibleMock(Search::class, ['search', 'getResultDocumentsEscaped'], [], '', false);
@@ -140,19 +138,18 @@ class RepositoryTest extends UnitTest
         // @extensionScannerIgnoreLine
         $parsedData->response->docs = $testDocuments;
         $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
-        $fakeResponse->expects($this->once())->method('getParsedData')->will($this->returnValue($parsedData));
-        $search->expects($this->any())->method('search')->willReturn($fakeResponse);
+        $fakeResponse->expects(self::once())->method('getParsedData')->willReturn($parsedData);
+        $search->expects(self::any())->method('search')->willReturn($fakeResponse);
 
         $queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
 
         /* @var $apacheSolrDocumentRepository Repository */
-        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage', 'getSearch'],[null, null, $queryBuilderMock]);
-        $apacheSolrDocumentRepository->expects($this->once())->method('getSearch')->willReturn($search);
+        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage', 'getSearch'], [null, null, $queryBuilderMock]);
+        $apacheSolrDocumentRepository->expects(self::once())->method('getSearch')->willReturn($search);
         $queryMock = $this->getDumbMock(Query::class);
-        $queryBuilderMock->expects($this->any())->method('buildPageQuery')->willReturn($queryMock);
+        $queryBuilderMock->expects(self::any())->method('buildPageQuery')->willReturn($queryMock);
         $actualApacheSolrDocumentCollection = $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(777, 0);
 
-        $this->assertSame($testDocuments, $actualApacheSolrDocumentCollection);
+        self::assertSame($testDocuments, $actualApacheSolrDocumentCollection);
     }
-
 }

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\FrequentSearches;
 
 /***************************************************************
@@ -58,28 +59,20 @@ class FrequentSearchesServiceTest extends UnitTest
      */
     protected $statisticsRepositoryMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
         $this->tsfeMock->tmpl = new \stdClass();
         $this->tsfeMock->tmpl->rootLine = [
             0 => [
-                'uid' => 4711
-            ]
+                'uid' => 4711,
+            ],
         ];
-        $this->statisticsRepositoryMock = $this->getDumbMock(StatisticsRepository::class );
+        $this->statisticsRepositoryMock = $this->getDumbMock(StatisticsRepository::class);
         $this->cacheMock = $this->getDumbMock(AbstractFrontend::class);
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
 
-        $this->frequentSearchesService = new class (
-            $this->configurationMock,
-            $this->cacheMock,
-            $this->tsfeMock,
-            $this->statisticsRepositoryMock
-        ) extends FrequentSearchesService {
+        $this->frequentSearchesService = new class($this->configurationMock, $this->cacheMock, $this->tsfeMock, $this->statisticsRepositoryMock) extends FrequentSearchesService {
 //            protected function getCacheIdentifier(array $frequentSearchConfiguration) : string {
 //                $identifier = 'frequentSearchesTags';
 //                if (isset($frequentSearchConfiguration['select.']['checkRootPageId']) && $frequentSearchConfiguration['select.']['checkRootPageId']) {
@@ -93,6 +86,7 @@ class FrequentSearchesServiceTest extends UnitTest
 //                return $identifier;
 //            }
         };
+        parent::setUp();
     }
 
     /**
@@ -102,12 +96,12 @@ class FrequentSearchesServiceTest extends UnitTest
     {
         $fakeConfiguration = [];
         $expectedCacheIdentifier = 'frequentSearchesTags_' . md5(serialize($fakeConfiguration));
-        $this->configurationMock->expects($this->once())->method('getSearchFrequentSearchesConfiguration')->will($this->returnValue($fakeConfiguration));
+        $this->configurationMock->expects(self::once())->method('getSearchFrequentSearchesConfiguration')->willReturn($fakeConfiguration);
 
         $this->fakeCacheResult($expectedCacheIdentifier, ['term a']);
 
         $frequentTerms = $this->frequentSearchesService->getFrequentSearchTerms();
-        $this->assertSame('term a', $frequentTerms[0], 'Could not get frequent terms from service');
+        self::assertSame('term a', $frequentTerms[0], 'Could not get frequent terms from service');
     }
 
     /**
@@ -123,25 +117,25 @@ class FrequentSearchesServiceTest extends UnitTest
                 'FROM' => '',
                 'ADD_WHERE' => '',
                 'GROUP_BY' => '',
-                'ORDER_BY' => ''
+                'ORDER_BY' => '',
             ],
-            'limit'
+            'limit',
         ];
 
-        $this->configurationMock->expects($this->once())->method('getSearchFrequentSearchesConfiguration')->will($this->returnValue($fakeConfiguration));
+        $this->configurationMock->expects(self::once())->method('getSearchFrequentSearchesConfiguration')->willReturn($fakeConfiguration);
 
-        $this->statisticsRepositoryMock->expects($this->once())->method('getFrequentSearchTermsFromStatisticsByFrequentSearchConfiguration')->will($this->returnValue([
+        $this->statisticsRepositoryMock->expects(self::once())->method('getFrequentSearchTermsFromStatisticsByFrequentSearchConfiguration')->willReturn([
             [
                'search_term' => 'my search',
-                'hits' => 22
-            ]
-        ]));
+                'hits' => 22,
+            ],
+        ]);
 
-            //we fake that we have no frequent searches in the cache and therefore expect that the database will be queried
+        //we fake that we have no frequent searches in the cache and therefore expect that the database will be queried
         $this->fakeIdentifierNotInCache();
         $frequentTerms = $this->frequentSearchesService->getFrequentSearchTerms();
 
-        $this->assertSame($frequentTerms, ['my search' => 22], 'Could not retrieve frequent search terms');
+        self::assertSame($frequentTerms, ['my search' => 22], 'Could not retrieve frequent search terms');
     }
 
     /**
@@ -150,15 +144,12 @@ class FrequentSearchesServiceTest extends UnitTest
      */
     public function fakeCacheResult($identifier, $value)
     {
-        $this->cacheMock->expects($this->once())->method('has')->with($identifier)->will($this->returnValue(true));
-        $this->cacheMock->expects($this->once())->method('get')->will($this->returnValue($value));
+        $this->cacheMock->expects(self::once())->method('has')->with($identifier)->willReturn(true);
+        $this->cacheMock->expects(self::once())->method('get')->willReturn($value);
     }
 
-    /**
-     * @return void
-     */
     public function fakeIdentifierNotInCache()
     {
-        $this->cacheMock->expects($this->once())->method('has')->will($this->returnValue(false));
+        $this->cacheMock->expects(self::once())->method('has')->willReturn(false);
     }
 }

--- a/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
+++ b/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Highlight;
 
 /***************************************************************
@@ -32,7 +33,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SiteHighlighterUrlModifierTest extends UnitTest
 {
-
     public function canModifyDataProvider()
     {
         return [
@@ -41,31 +41,30 @@ class SiteHighlighterUrlModifierTest extends UnitTest
                 '',
                 false,
                 true,
-                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar'
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
             ],
             'cHashIsRemoved' => [
                 'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
                 'hello world',
                 true,
                 false,
-                'http://mywebsite.de/home/index.html?foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1'
+                'http://mywebsite.de/home/index.html?foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1',
             ],
             'cHashIsKept' => [
                 'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar',
                 'hello world',
                 true,
                 true,
-                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1'
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1',
             ],
             'fragmentIsKept' => [
                 'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar#test',
                 'hello world',
                 true,
                 true,
-                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1#test'
-            ]
+                'http://mywebsite.de/home/index.html?cHash=HHZUUUdfsdf&foo=bar&sword_list%5B0%5D=hello&sword_list%5B1%5D=world&no_cache=1#test',
+            ],
         ];
-
     }
 
     /**
@@ -76,6 +75,6 @@ class SiteHighlighterUrlModifierTest extends UnitTest
     {
         $siteHighlightingModifier = new SiteHighlighterUrlModifier();
         $result = $siteHighlightingModifier->modify($inputUrl, $keywords, $no_cache, $keepCHash);
-        $this->assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 }

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\LastSearches;
 
 /***************************************************************
@@ -34,9 +35,12 @@ class LastSearchesRepositoryTest extends UnitTest
      */
     protected $lastSearchesRepositoryMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $this->lastSearchesRepositoryMock = $this->getMockBuilder(LastSearchesRepository::class)->setMethods(['getLastSearchesResultSet'])->getMock();
+        $this->lastSearchesRepositoryMock = $this->getMockBuilder(LastSearchesRepository::class)
+            ->onlyMethods(['getLastSearchesResultSet'])
+            ->getMock();
+        parent::setUp();
     }
 
     /**
@@ -48,9 +52,9 @@ class LastSearchesRepositoryTest extends UnitTest
             ['keywords' => 'test'],
             ['keywords' => 'test 2'],
             ['keywords' => '&#34;test X&#34;'],
-            ['keywords' => '&#x0027;test Y&#x0027;']
+            ['keywords' => '&#x0027;test Y&#x0027;'],
         ];
-        $this->lastSearchesRepositoryMock->method('getLastSearchesResultSet')->will($this->returnValue($givenKeywords));
+        $this->lastSearchesRepositoryMock->method('getLastSearchesResultSet')->willReturn($givenKeywords);
 
         $lastSearches = $this->lastSearchesRepositoryMock->findAllKeywords();
 
@@ -58,9 +62,9 @@ class LastSearchesRepositoryTest extends UnitTest
             'test',
             'test 2',
             '"test X"',
-            '\'test Y\''
+            '\'test Y\'',
         ];
 
-        $this->assertSame($expectedDecotedLastSearches, $lastSearches);
+        self::assertSame($expectedDecotedLastSearches, $lastSearches);
     }
 }

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\LastSearches;
 
 /***************************************************************
@@ -29,7 +30,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class LastSearchesServiceTest extends UnitTest
 {
@@ -53,22 +53,23 @@ class LastSearchesServiceTest extends UnitTest
      */
     protected $lastSearchesRepositoryMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->sessionMock = $this->getDumbMock(FrontendUserSession::class);
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
 
         $this->lastSearchesRepositoryMock = $this->getMockBuilder(LastSearchesRepository::class)
-            ->setMethods(['getLastSearchesResultSet', 'findAllKeywords'])->getMock();
+            ->onlyMethods(['getLastSearchesResultSet', 'findAllKeywords'])
+            ->getMock();
 
         $this->lastSearchesService = $this->getMockBuilder(LastSearchesService::class)
-            ->setMethods(['getLastSearchesFromFrontendSession'])
-            ->setConstructorArgs([  $this->configurationMock,
+            ->onlyMethods([])
+            ->setConstructorArgs([
+                $this->configurationMock,
                 $this->sessionMock,
-                $this->lastSearchesRepositoryMock])->getMock();
+                $this->lastSearchesRepositoryMock,
+                ])->getMock();
+        parent::setUp();
     }
 
     /**
@@ -78,16 +79,16 @@ class LastSearchesServiceTest extends UnitTest
     {
         $fakedLastSearchesInSession = ['first search', 'second search'];
 
-        $this->sessionMock->expects($this->once())->method('getLastSearches')->will($this->returnValue(
+        $this->sessionMock->expects(self::once())->method('getLastSearches')->willReturn(
             $fakedLastSearchesInSession
-        ));
+        );
 
         $this->assertRepositoryWillNeverBeCalled();
         $this->fakeLastSearchMode('user');
         $this->fakeLastSearchLimit(10);
 
         $lastSearches = $this->lastSearchesService->getLastSearches();
-        $this->assertSame($fakedLastSearchesInSession, array_reverse($lastSearches), 'Did not get last searches from session in user mode');
+        self::assertSame($fakedLastSearchesInSession, array_reverse($lastSearches), 'Did not get last searches from session in user mode');
     }
 
     /**
@@ -97,18 +98,17 @@ class LastSearchesServiceTest extends UnitTest
     {
         $fakedLastSearchesFromRepository = [
             'test',
-            'test 2'
+            'test 2',
         ];
 
         $this->fakeLastSearchMode('global');
         $this->fakeLastSearchLimit(10);
-        $this->assertSessionWillNeverBeQueried();
 
-        $this->lastSearchesRepositoryMock->method('findAllKeywords')->will($this->returnValue($fakedLastSearchesFromRepository));
+        $this->lastSearchesRepositoryMock->method('findAllKeywords')->willReturn($fakedLastSearchesFromRepository);
 
         $lastSearches = $this->lastSearchesService->getLastSearches();
 
-        $this->assertSame($fakedLastSearchesFromRepository, $lastSearches, 'Did not get last searches from database');
+        self::assertSame($fakedLastSearchesFromRepository, $lastSearches, 'Did not get last searches from database');
     }
 
     /**
@@ -116,7 +116,7 @@ class LastSearchesServiceTest extends UnitTest
      */
     protected function fakeLastSearchMode($mode)
     {
-        $this->configurationMock->expects($this->once())->method('getSearchLastSearchesMode')->will($this->returnValue($mode));
+        $this->configurationMock->expects(self::once())->method('getSearchLastSearchesMode')->willReturn($mode);
     }
 
     /**
@@ -124,22 +124,11 @@ class LastSearchesServiceTest extends UnitTest
      */
     protected function fakeLastSearchLimit($limit)
     {
-        $this->configurationMock->expects($this->once())->method('getSearchLastSearchesLimit')->will($this->returnValue($limit));
+        $this->configurationMock->expects(self::once())->method('getSearchLastSearchesLimit')->willReturn($limit);
     }
 
-    /**
-     * @return void
-     */
     protected function assertRepositoryWillNeverBeCalled()
     {
-        $this->lastSearchesRepositoryMock->expects($this->never())->method('findAllKeywords');
-    }
-
-    /**
-     * @return void
-     */
-    protected function assertSessionWillNeverBeQueried()
-    {
-        $this->lastSearchesService->expects($this->never())->method('getLastSearchesFromFrontendSession');
+        $this->lastSearchesRepositoryMock->expects(self::never())->method('findAllKeywords');
     }
 }

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Helper;
 
 /***************************************************************
@@ -57,7 +58,7 @@ class EscapeHelperTest extends UnitTest
             'numeric is kept' => ['input' => 42, 'expectedOutput' => 42],
             'combined quoted phrase' => ['input' => '"hello world" or planet', 'expectedOutput' => '"hello world" or planet'],
             'two combined quoted phrases' => ['input' => '"hello world" or "hello planet"', 'expectedOutput' => '"hello world" or "hello planet"'],
-            'combined quoted phrase mixed with escape character' => ['input' => '"hello world" or (planet)', 'expectedOutput' => '"hello world" or \(planet\)']
+            'combined quoted phrase mixed with escape character' => ['input' => '"hello world" or (planet)', 'expectedOutput' => '"hello world" or \(planet\)'],
         ];
     }
 
@@ -69,7 +70,6 @@ class EscapeHelperTest extends UnitTest
     {
         $escapeHelper = new EscapeService();
         $output = $escapeHelper::escape($input);
-        $this->assertSame($expectedOutput, $output, 'Query was not escaped as expected');
+        self::assertSame($expectedOutput, $output, 'Query was not escaped as expected');
     }
-
 }

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Parameter;
 
 /***************************************************************
@@ -38,6 +39,6 @@ class BigramPhraseFieldsTest extends UnitTest
     public function buildFromEmptyStringCreatesEmptyArrayOnBuild()
     {
         $bigramPhraseFields = BigramPhraseFields::fromString('');
-        $this->assertSame('', $bigramPhraseFields->toString());
+        self::assertSame('', $bigramPhraseFields->toString());
     }
 }

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilder;
 
 /***************************************************************
@@ -45,15 +46,14 @@ class GroupingTest extends UnitTest
                         'search.' => [
                             'grouping' => 1,
                             'grouping.' => [
-                                'sortBy' => 'title desc'
-                            ]
-                        ]
-                    ]
-                ]
+                                'sortBy' => 'title desc',
+                            ],
+                        ],
+                    ],
+                ],
             ]
         );
         $grouping = Grouping::fromTypoScriptConfiguration($typoScriptConfiguration);
-        $this->assertSame(['title desc'], $grouping->getSortings(), 'Could not set sortings from TypoScriptConfiguration');
+        self::assertSame(['title desc'], $grouping->getSortings(), 'Could not set sortings from TypoScriptConfiguration');
     }
-
 }

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Parameter;
 
 /***************************************************************
@@ -41,7 +42,6 @@ class QueryFieldsTest extends UnitTest
         $queryFields = QueryFields::fromString($input, ',');
         $output = $queryFields->toString(',');
 
-        $this->assertSame($input, $output, 'Parsing QueryFields from and to string did not produce the same result');
+        self::assertSame($input, $output, 'Parsing QueryFields from and to string did not produce the same result');
     }
-
 }

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query;
 
 /***************************************************************
@@ -37,8 +38,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\ReturnFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Sorting;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Spellchecking;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\TrigramPhraseFields;
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -74,12 +75,13 @@ class QueryBuilderTest extends UnitTest
      */
     protected $builder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->loggerMock = $this->getDumbMock(SolrLogManager::class);
         $this->siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
         $this->builder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
+        parent::setUp();
     }
 
     /**
@@ -110,7 +112,7 @@ class QueryBuilderTest extends UnitTest
     public function buildSearchQueryPassesQueryString()
     {
         $query = $this->builder->buildSearchQuery('one');
-        $this->assertSame('one', (string)$query, 'Query has unexpected value, when casted to string');
+        self::assertSame('one', (string)$query, 'Query has unexpected value, when casted to string');
     }
 
     /**
@@ -119,8 +121,7 @@ class QueryBuilderTest extends UnitTest
     public function buildSearchQueryPassesDefaultPerPage()
     {
         $query = $this->builder->buildSearchQuery('one');
-        $this->assertSame(10, $query->getRows(), 'Query was not created with default perPage value');
-
+        self::assertSame(10, $query->getRows(), 'Query was not created with default perPage value');
     }
 
     /**
@@ -129,7 +130,7 @@ class QueryBuilderTest extends UnitTest
     public function buildSearchQueryPassesCustomPerPage()
     {
         $query = $this->builder->buildSearchQuery('one', 22);
-        $this->assertSame(22, $query->getRows(), 'Query was not created with default perPage value');
+        self::assertSame(22, $query->getRows(), 'Query was not created with default perPage value');
     }
 
     /**
@@ -137,9 +138,9 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchQueryInitializesQueryFieldsFromConfiguration()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
         $query = $this->builder->buildSearchQuery('foo');
-        $this->assertSame('title^10.0 content^123.0', $this->getAllQueryParameters($query)['qf'], 'The queryFields have not been initialized as expected');
+        self::assertSame('title^10.0 content^123.0', $this->getAllQueryParameters($query)['qf'], 'The queryFields have not been initialized as expected');
     }
 
     /**
@@ -147,11 +148,11 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchQueryInitializesTrigramPhraseFields()
     {
-        $this->configurationMock->expects($this->once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);
+        $this->configurationMock->expects(self::once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);
 
-        $this->configurationMock->expects($this->once())->method('getSearchQueryTrigramPhraseFields')->willReturn('content^10.0, title^10.0');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryTrigramPhraseFields')->willReturn('content^10.0, title^10.0');
         $query = $this->builder->buildSearchQuery('trigram');
-        $this->assertSame('content^10.0 title^10.0', $this->getAllQueryParameters($query)['pf3'], 'The trigramPhraseFields have not been initialized as expected');
+        self::assertSame('content^10.0 title^10.0', $this->getAllQueryParameters($query)['pf3'], 'The trigramPhraseFields have not been initialized as expected');
     }
 
     /**
@@ -159,9 +160,9 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchIsSettingWildCardQueryOnInitializeWithEmptyQuery()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchInitializeWithEmptyQuery')->willReturn(true);
+        $this->configurationMock->expects(self::once())->method('getSearchInitializeWithEmptyQuery')->willReturn(true);
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
-        $this->assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
+        self::assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
     }
 
     /**
@@ -169,9 +170,9 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchIsSettingWildCardQueryOnInitializeWithAllowEmptyQuery()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchQueryAllowEmptyQuery')->willReturn(true);
+        $this->configurationMock->expects(self::once())->method('getSearchQueryAllowEmptyQuery')->willReturn(true);
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
-        $this->assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
+        self::assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
     }
 
     /**
@@ -179,9 +180,9 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchIsSettingQuerystringForConfiguredInitialQuery()
     {
-        $this->configurationMock->expects($this->exactly(2))->method('getSearchInitializeWithQuery')->willReturn('myinitialsearch');
+        $this->configurationMock->expects(self::exactly(2))->method('getSearchInitializeWithQuery')->willReturn('myinitialsearch');
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
-        $this->assertSame('myinitialsearch', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized from a configured initial query');
+        self::assertSame('myinitialsearch', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized from a configured initial query');
     }
 
     /**
@@ -189,13 +190,13 @@ class QueryBuilderTest extends UnitTest
      */
     public function buildSearchIsSettingConfiguredAdditionalFilters()
     {
-        $this->configurationMock->expects($this->any())->method('getSearchQueryFilterConfiguration')->willReturn(['noPage' => '-type:pages']);
+        $this->configurationMock->expects(self::any())->method('getSearchQueryFilterConfiguration')->willReturn(['noPage' => '-type:pages']);
         $query = $this->builder->buildSearchQuery('applies configured filters');
         $filterValue = $this->getAllQueryParameters($query)['fq'];
-        $filterArray = explode(" ", $filterValue);
+        $filterArray = explode(' ', $filterValue);
 
-        $this->assertCount(1, $filterArray, 'Unpexcted amount of filters for query');
-        $this->assertSame('-type:pages', $filterValue, 'First filter has unexpected value');
+        self::assertCount(1, $filterArray, 'Unpexcted amount of filters for query');
+        self::assertSame('-type:pages', $filterValue, 'First filter has unexpected value');
     }
 
     /**
@@ -204,7 +205,7 @@ class QueryBuilderTest extends UnitTest
     public function buildSearchIsSettingNoAlternativeQueryByDefault()
     {
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
-        $this->assertArrayNotHasKey('q.alt', $this->getAllQueryParameters($query), 'The alterativeQuery is not null when nothing was set');
+        self::assertArrayNotHasKey('q.alt', $this->getAllQueryParameters($query), 'The alterativeQuery is not null when nothing was set');
     }
 
     /**
@@ -219,8 +220,8 @@ class QueryBuilderTest extends UnitTest
 
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        $this->assertSame(200, $queryParameters['hl.fragsize'], 'hl.fragsize was not set to the default value of 200');
+        self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
+        self::assertSame(200, $queryParameters['hl.fragsize'], 'hl.fragsize was not set to the default value of 200');
     }
 
     /**
@@ -235,13 +236,13 @@ class QueryBuilderTest extends UnitTest
 
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
+        self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
 
         $highlighting->setIsEnabled(false);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('hl', $queryParameters, 'Could not disable highlighting');
+        self::assertArrayNotHasKey('hl', $queryParameters, 'Could not disable highlighting');
     }
 
     /**
@@ -261,8 +262,8 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        $this->assertSame('title', $queryParameters['hl.fl'], 'Can set highlighting field list');
+        self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
+        self::assertSame('title', $queryParameters['hl.fl'], 'Can set highlighting field list');
     }
 
     /**
@@ -280,10 +281,10 @@ class QueryBuilderTest extends UnitTest
         $highlighting->setIsEnabled(true);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('[A]', $queryParameters['hl.tag.pre'], 'Can set highlighting hl.tag.pre');
-        $this->assertSame('[B]', $queryParameters['hl.tag.post'], 'Can set highlighting hl.tag.post');
-        $this->assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.tag.pre');
-        $this->assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
+        self::assertSame('[A]', $queryParameters['hl.tag.pre'], 'Can set highlighting hl.tag.pre');
+        self::assertSame('[B]', $queryParameters['hl.tag.post'], 'Can set highlighting hl.tag.post');
+        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.tag.pre');
+        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
     }
 
     /**
@@ -305,10 +306,10 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting field list');
-        $this->assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting field list');
-        $this->assertEmpty($queryParameters['hl.tag.pre'], 'When the highlighting fragment size is to small hl.tag.pre should not be used because FastVectoreHighlighter will not be used');
-        $this->assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
+        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting field list');
+        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting field list');
+        self::assertEmpty($queryParameters['hl.tag.pre'], 'When the highlighting fragment size is to small hl.tag.pre should not be used because FastVectoreHighlighter will not be used');
+        self::assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
     }
 
     /**
@@ -327,8 +328,8 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        $this->assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
+        self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
+        self::assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
     }
 
     /**
@@ -347,8 +348,8 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        $this->assertSame('false',$queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
+        self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
+        self::assertSame('false', $queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
     }
 
     /**
@@ -357,7 +358,7 @@ class QueryBuilderTest extends UnitTest
     public function canSetQueryString()
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');
-        $this->assertSame('i like solr', $query->getQuery(), 'Can not set and get query string');
+        self::assertSame('i like solr', $query->getQuery(), 'Can not set and get query string');
     }
 
     /**
@@ -368,7 +369,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('i like solr');
         $query->setStart(10);
 
-        $this->assertSame(10, $query->getStart(), 'Can not set and get page');
+        self::assertSame(10, $query->getStart(), 'Can not set and get page');
     }
 
     /**
@@ -378,7 +379,7 @@ class QueryBuilderTest extends UnitTest
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('fq', $queryParameters, 'Query already contains filters after intialization.');
+        self::assertArrayNotHasKey('fq', $queryParameters, 'Query already contains filters after intialization.');
     }
 
     /**
@@ -390,7 +391,7 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([-1, 0]);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('{!typo3access}-1,0', $queryParameters['fq'], 'Accessfilter was not applied');
+        self::assertSame('{!typo3access}-1,0', $queryParameters['fq'], 'Accessfilter was not applied');
     }
 
     /**
@@ -402,7 +403,7 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([]);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('{!typo3access}0', $queryParameters['fq'], 'Changed accessfilter was not applied');
+        self::assertSame('{!typo3access}0', $queryParameters['fq'], 'Changed accessfilter was not applied');
     }
 
     /**
@@ -414,7 +415,7 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([5]);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('{!typo3access}0,5', $queryParameters['fq'], 'Access filter was not applied as expected');
+        self::assertSame('{!typo3access}0,5', $queryParameters['fq'], 'Access filter was not applied as expected');
     }
 
     /**
@@ -426,7 +427,7 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([1, 1]);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('{!typo3access}0,1', $queryParameters['fq'], 'Access filter was not applied as expected');
+        self::assertSame('{!typo3access}0,1', $queryParameters['fq'], 'Access filter was not applied as expected');
     }
 
     /**
@@ -439,7 +440,7 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder->startFrom($query)->useUserAccessGroups([1])->useUserAccessGroups([2]);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('{!typo3access}0,2', $queryParameters['fq'], 'Unexpected filter query');
+        self::assertSame('{!typo3access}0,2', $queryParameters['fq'], 'Unexpected filter query');
     }
 
     // TODO if user is in group -2 (logged in), disallow access to group -1
@@ -455,7 +456,7 @@ class QueryBuilderTest extends UnitTest
 
         $queryParameters = $query->getQueryParameters();
         foreach ($queryParameters as $queryParameter => $value) {
-            $this->assertTrue(
+            self::assertTrue(
                 !str_starts_with($queryParameter, 'group'),
                 'Query already contains grouping parameter "' . $queryParameter . '"'
             );
@@ -473,14 +474,14 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useGrouping($grouping)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayHasKey('group', $queryParameters);
-        $this->assertEquals('true', $queryParameters['group']);
+        self::assertArrayHasKey('group', $queryParameters);
+        self::assertEquals('true', $queryParameters['group']);
 
-        $this->assertArrayHasKey('group.format', $queryParameters);
-        $this->assertEquals('grouped', $queryParameters['group.format']);
+        self::assertArrayHasKey('group.format', $queryParameters);
+        self::assertEquals('grouped', $queryParameters['group.format']);
 
-        $this->assertArrayHasKey('group.ngroups', $queryParameters);
-        $this->assertEquals('true', $queryParameters['group.ngroups']);
+        self::assertArrayHasKey('group.ngroups', $queryParameters);
+        self::assertEquals('true', $queryParameters['group.ngroups']);
 
         return $query;
     }
@@ -495,7 +496,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->builder->startFrom($query)->useGrouping($grouping)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
         foreach ($queryParameters as $queryParameter => $value) {
-            $this->assertTrue(
+            self::assertTrue(
                 !str_starts_with($queryParameter, 'group'),
                 'Query contains grouping parameter "' . $queryParameter . '"'
             );
@@ -509,7 +510,7 @@ class QueryBuilderTest extends UnitTest
     {
         $query = $this->getInitializedTestSearchQuery('test');
         $query->getGrouping()->setNumberOfGroups(true);
-        $this->assertSame(true, $query->getGrouping()->getNumberOfGroups(), 'Could not set and get number of groups');
+        self::assertTrue($query->getGrouping()->getNumberOfGroups(), 'Could not set and get number of groups');
     }
 
     /**
@@ -518,9 +519,9 @@ class QueryBuilderTest extends UnitTest
     public function canAddGroupField()
     {
         $query = $this->getInitializedTestSearchQuery('test');
-        $this->assertSame([], $query->getGrouping()->getFields(), 'Unexpected default state of groupFields');
+        self::assertSame([], $query->getGrouping()->getFields(), 'Unexpected default state of groupFields');
         $query->getGrouping()->addField('category_s');
-        $this->assertSame(['category_s'], $query->getGrouping()->getFields(), 'groupFields has unexpected state after adding a group field');
+        self::assertSame(['category_s'], $query->getGrouping()->getFields(), 'groupFields has unexpected state after adding a group field');
     }
 
     /**
@@ -529,13 +530,13 @@ class QueryBuilderTest extends UnitTest
     public function canGetGroupSorting()
     {
         $query = $this->getInitializedTestSearchQuery('test');
-        $this->assertNull($query->getGrouping()->getSort(), 'By default getGroupSortings should return an empty array');
+        self::assertNull($query->getGrouping()->getSort(), 'By default getGroupSortings should return an empty array');
         $grouping = new Grouping(true);
         $grouping->addSorting('price_f');
         $grouping->addSorting('author_s');
         $query = $this->builder->startFrom($query)->useGrouping($grouping)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('price_f author_s', $queryParameters['group.sort'], 'Can not get groupSortings after adding');
+        self::assertSame('price_f author_s', $queryParameters['group.sort'], 'Can not get groupSortings after adding');
     }
 
     /**
@@ -547,11 +548,11 @@ class QueryBuilderTest extends UnitTest
         $grouping = new Grouping(true);
         $grouping->addSorting('price_f');
         $grouping->addSorting('author_s');
-        $this->assertSame(1, $grouping->getResultsPerGroup());
+        self::assertSame(1, $grouping->getResultsPerGroup());
         $grouping->setResultsPerGroup(22);
         $query = $this->builder->startFrom($query)->useGrouping($grouping)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame(22, $queryParameters['group.limit'], 'Can not set number of results per group');
+        self::assertSame(22, $queryParameters['group.limit'], 'Can not set number of results per group');
     }
 
     /**
@@ -561,9 +562,9 @@ class QueryBuilderTest extends UnitTest
     {
         $query = $this->getInitializedTestSearchQuery('group test');
         $initialGroupQueries = $query->getGrouping()->getQueries();
-        $this->assertSame([], $initialGroupQueries, 'Group queries should be an empty array at the beginning');
+        self::assertSame([], $initialGroupQueries, 'Group queries should be an empty array at the beginning');
         $query->getGrouping()->addQuery('price:[* TO 500]');
-        $this->assertSame(['price:[* TO 500]'], $query->getGrouping()->getQueries(), 'Could not retrieve group queries after adding one');
+        self::assertSame(['price:[* TO 500]'], $query->getGrouping()->getQueries(), 'Could not retrieve group queries after adding one');
     }
 
     /**
@@ -579,7 +580,7 @@ class QueryBuilderTest extends UnitTest
         $queryParameters = $this->getAllQueryParameters($query);
         $expectedOutput = 'content^10.0 title^5.0';
         $output = $queryParameters['qf'];
-        $this->assertSame($output, $expectedOutput, 'Passed and retrieved query fields are not the same');
+        self::assertSame($output, $expectedOutput, 'Passed and retrieved query fields are not the same');
     }
 
     /**
@@ -594,7 +595,7 @@ class QueryBuilderTest extends UnitTest
         $queryParameters = $this->getAllQueryParameters($query);
         $expectedOutput = '';
         $output = $queryParameters['qf'];
-        $this->assertSame($output, $expectedOutput, 'Unexpected output from getQueryFieldsAsString when no configuration was passed');
+        self::assertSame($output, $expectedOutput, 'Unexpected output from getQueryFieldsAsString when no configuration was passed');
     }
 
     /**
@@ -605,15 +606,15 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('mm', $queryParameters);
+        self::assertArrayNotHasKey('mm', $queryParameters);
 
         $query = $this->builder->startFrom($query)->useMinimumMatch('2<-35%')->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('2<-35%', $queryParameters['mm']);
+        self::assertSame('2<-35%', $queryParameters['mm']);
 
         $query = $this->builder->startFrom($query)->removeMinimumMatch()->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertEmpty($queryParameters['mm']);
+        self::assertEmpty($queryParameters['mm']);
     }
 
     /**
@@ -623,18 +624,18 @@ class QueryBuilderTest extends UnitTest
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('bf', $queryParameters);
+        self::assertArrayNotHasKey('bf', $queryParameters);
 
         $testBoostFunction = 'recip(ms(NOW,created),3.16e-11,1,1)';
         $query = $this->builder->startFrom($query)->useBoostFunction($testBoostFunction)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame($testBoostFunction, $queryParameters['bf'], 'bf queryParameter was not present after setting a boostFunction');
+        self::assertSame($testBoostFunction, $queryParameters['bf'], 'bf queryParameter was not present after setting a boostFunction');
 
         $query = $this->builder->startFrom($query)->removeAllBoostFunctions()->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertEmpty($queryParameters['bf'], 'bf parameter should be null after reset');
+        self::assertEmpty($queryParameters['bf'], 'bf parameter should be null after reset');
     }
 
     /**
@@ -644,14 +645,14 @@ class QueryBuilderTest extends UnitTest
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('bq', $queryParameters);
+        self::assertArrayNotHasKey('bq', $queryParameters);
         $testBoostQuery = '(type:tt_news)^10';
         $query = $this->builder->startFrom($query)->useBoostQueries($testBoostQuery)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame($testBoostQuery, $queryParameters['bq'], 'bq queryParameter was not present after setting a boostQuery');
+        self::assertSame($testBoostQuery, $queryParameters['bq'], 'bq queryParameter was not present after setting a boostQuery');
         $query = $this->builder->startFrom($query)->removeAllBoostQueries()->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('bq', $queryParameters, 'bq parameter should be null after reset');
+        self::assertArrayNotHasKey('bq', $queryParameters, 'bq parameter should be null after reset');
     }
 
     /**
@@ -665,7 +666,7 @@ class QueryBuilderTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('abstract,price', $queryParameters['fl'], 'Did not parse returnsFields as expected');
+        self::assertSame('abstract,price', $queryParameters['fl'], 'Did not parse returnsFields as expected');
     }
 
     /**
@@ -677,7 +678,7 @@ class QueryBuilderTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('*,score', $queryParameters['fl'], 'Did not parse returnsFields as expected');
+        self::assertSame('*,score', $queryParameters['fl'], 'Did not parse returnsFields as expected');
     }
 
     /**
@@ -692,7 +693,7 @@ class QueryBuilderTest extends UnitTest
         $returnFields->add('title');
         $this->builder->startFrom($query)->useReturnFields($returnFields);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('url,title', $queryParameters['fl'], 'Added return field was not in the list of valid fields');
+        self::assertSame('url,title', $queryParameters['fl'], 'Added return field was not in the list of valid fields');
     }
 
     /**
@@ -702,13 +703,13 @@ class QueryBuilderTest extends UnitTest
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $initialReturnFieldList = ['title','content','url'];
+        $initialReturnFieldList = ['title', 'content', 'url'];
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $returnFields = ReturnFields::fromArray($initialReturnFieldList);
         $returnFields->remove('content');
         $this->builder->startFrom($query)->useReturnFields($returnFields);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('title,url', $queryParameters['fl'], 'content was not remove from the fieldList');
+        self::assertSame('title,url', $queryParameters['fl'], 'content was not remove from the fieldList');
     }
 
     /**
@@ -721,7 +722,7 @@ class QueryBuilderTest extends UnitTest
         $faceting = new Faceting(true);
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['facet'], 'Enable faceting did not set the "facet" query parameter');
+        self::assertSame('true', $queryParameters['facet'], 'Enable faceting did not set the "facet" query parameter');
     }
 
     /**
@@ -737,16 +738,16 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['facet'], 'Enable faceting did not set the "facet" query parameter');
-        $this->assertSame('lex', $queryParameters['f.title.facet.sort'], 'Facet sorting parameter should be lex');
+        self::assertSame('true', $queryParameters['facet'], 'Enable faceting did not set the "facet" query parameter');
+        self::assertSame('lex', $queryParameters['f.title.facet.sort'], 'Facet sorting parameter should be lex');
 
         $faceting = new Faceting(false);
         $faceting->addAdditionalParameter('f.title.facet.sort', 'lex');
         $this->builder->startFrom($query)->useFaceting($faceting);
 
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('facet', $queryParameters, 'Facet argument should be null after reset');
-        $this->assertArrayNotHasKey('f.title.facet.sort', $queryParameters, 'Facet sorting parameter should also be removed after reset');
+        self::assertArrayNotHasKey('facet', $queryParameters, 'Facet argument should be null after reset');
+        self::assertArrayNotHasKey('f.title.facet.sort', $queryParameters, 'Facet sorting parameter should also be removed after reset');
     }
 
     /**
@@ -758,7 +759,7 @@ class QueryBuilderTest extends UnitTest
 
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $query->getQueryParameters();
-        $this->assertArrayNotHasKey('facet.field', $queryParameters, 'facet.field query parameter was expected to be null after init.');
+        self::assertArrayNotHasKey('facet.field', $queryParameters, 'facet.field query parameter was expected to be null after init.');
 
         $faceting = Faceting::fromTypoScriptConfiguration($fakeConfiguration);
         // after adding a few facet fields we should be able to retrieve them
@@ -768,7 +769,7 @@ class QueryBuilderTest extends UnitTest
 
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame(['color_s', 'price_f'], $queryParameters['facet.field'], 'facet.field should not be empty after adding a few fields.');
+        self::assertSame(['color_s', 'price_f'], $queryParameters['facet.field'], 'facet.field should not be empty after adding a few fields.');
     }
 
     /**
@@ -788,7 +789,7 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame(['lastname_s', 'role_s'], $queryParameters['facet.field'], 'Could not use setFields to pass facet fields');
+        self::assertSame(['lastname_s', 'role_s'], $queryParameters['facet.field'], 'Could not use setFields to pass facet fields');
     }
 
     /**
@@ -807,7 +808,7 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame(10, $queryParameters['facet.mincount'], 'Can not use facet.minimumCount from configuration');
+        self::assertSame(10, $queryParameters['facet.mincount'], 'Can not use facet.minimumCount from configuration');
     }
 
     /**
@@ -826,7 +827,7 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useFaceting($faceting);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('index', $queryParameters['facet.sort'], 'Can not use facet.sort from configuration');
+        self::assertSame('index', $queryParameters['facet.sort'], 'Can not use facet.sort from configuration');
     }
 
     /**
@@ -842,15 +843,15 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useSpellchecking($spellchecking);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['spellcheck'], 'Enable spellchecking did not set the "spellcheck" query parameter');
+        self::assertSame('true', $queryParameters['spellcheck'], 'Enable spellchecking did not set the "spellcheck" query parameter');
 
         // can we unset it again?
         $spellchecking->setIsEnabled(false);
         $this->builder->startFrom($query)->useSpellchecking($spellchecking);
 
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('spellcheck', $queryParameters, 'Disable spellchecking did not unset the "spellcheck" query parameter');
-        $this->assertArrayNotHasKey('spellcheck.maxCollationTries', $queryParameters, 'spellcheck.maxCollationTries was not unsetted');
+        self::assertArrayNotHasKey('spellcheck', $queryParameters, 'Disable spellchecking did not unset the "spellcheck" query parameter');
+        self::assertArrayNotHasKey('spellcheck.maxCollationTries', $queryParameters, 'spellcheck.maxCollationTries was not unsetted');
     }
 
     /**
@@ -860,8 +861,8 @@ class QueryBuilderTest extends UnitTest
     {
         /** @var $query \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery */
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => '*']);
-        $this->siteHashServiceMock->expects($this->once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('*');
+        $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => '*']);
+        $this->siteHashServiceMock->expects(self::once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('*');
 
         $builder = new QueryBuilder($configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $query = $builder->buildSearchQuery('');
@@ -869,7 +870,7 @@ class QueryBuilderTest extends UnitTest
         $query = $builder->startFrom($query)->useSiteHashFromTypoScript(4711)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('fq', $queryParameters, 'The filters should be empty when a wildcard sitehash was passed');
+        self::assertArrayNotHasKey('fq', $queryParameters, 'The filters should be empty when a wildcard sitehash was passed');
     }
 
     /**
@@ -879,10 +880,10 @@ class QueryBuilderTest extends UnitTest
     {
         /** @var $query \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery */
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => 'site1.local']);
+        $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => 'site1.local']);
 
-        $this->siteHashServiceMock->expects($this->once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('site1.local');
-        $this->siteHashServiceMock->expects($this->once())->method('getSiteHashForDomain')->willReturn('dsada43242342342');
+        $this->siteHashServiceMock->expects(self::once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('site1.local');
+        $this->siteHashServiceMock->expects(self::once())->method('getSiteHashForDomain')->willReturn('dsada43242342342');
 
         $builder = new QueryBuilder($configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $query = $builder->buildSearchQuery('');
@@ -890,7 +891,7 @@ class QueryBuilderTest extends UnitTest
         $query = $builder->startFrom($query)->useSiteHashFromTypoScript(4711)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertEquals('siteHash:"dsada43242342342"', $queryParameters['fq'], 'Unexpected siteHashFilter was added to the query');
+        self::assertEquals('siteHash:"dsada43242342342"', $queryParameters['fq'], 'Unexpected siteHashFilter was added to the query');
     }
 
     /**
@@ -910,9 +911,8 @@ class QueryBuilderTest extends UnitTest
         $builder->startFrom($query)->useSpellcheckingFromTypoScript();
 
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame($input, $queryParameters['spellcheck.maxCollationTries'], 'Could not set spellcheck.maxCollationTries as expected');
+        self::assertSame($input, $queryParameters['spellcheck.maxCollationTries'], 'Could not set spellcheck.maxCollationTries as expected');
     }
-
 
     /**
      * @test
@@ -921,13 +921,13 @@ class QueryBuilderTest extends UnitTest
     {
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
-            'variantField' => 'myField'
+            'variantField' => 'myField',
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('{!collapse field=myField}', $queryParameters['fq'], 'Collapse filter query was not created');
+        self::assertSame('{!collapse field=myField}', $queryParameters['fq'], 'Collapse filter query was not created');
     }
 
     /**
@@ -939,14 +939,14 @@ class QueryBuilderTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
             'variantField' => 'variants',
             'expand' => true,
-            'limit' => 10
+            'limit' => 10,
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['expand'], 'Expand argument of query was not set to true with configured expand');
-        $this->assertSame(10, $queryParameters['expand.rows'], 'Expand.rows argument of query was not set to true with configured expand.rows');
+        self::assertSame('true', $queryParameters['expand'], 'Expand argument of query was not set to true with configured expand');
+        self::assertSame(10, $queryParameters['expand.rows'], 'Expand.rows argument of query was not set to true with configured expand.rows');
     }
 
     /**
@@ -958,12 +958,12 @@ class QueryBuilderTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
             'variantField' => 'variants',
             'expand' => false,
-            'limit' => 10
+            'limit' => 10,
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('expand.rows', $queryParameters, 'Expand.rows should not be set when expand is set to false');
+        self::assertArrayNotHasKey('expand.rows', $queryParameters, 'Expand.rows should not be set when expand is set to false');
     }
 
     /**
@@ -974,7 +974,7 @@ class QueryBuilderTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('fq', $queryParameters, 'No filter query should be generated when field collapsing is disbled');
+        self::assertArrayNotHasKey('fq', $queryParameters, 'No filter query should be generated when field collapsing is disbled');
     }
 
     /**
@@ -985,8 +985,8 @@ class QueryBuilderTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
 
-        $queryToString = (string) $query;
-        $this->assertSame('test', $queryToString, 'Could not convert query to string');
+        $queryToString = (string)$query;
+        self::assertSame('test', $queryToString, 'Could not convert query to string');
     }
 
     /**
@@ -1001,27 +1001,27 @@ class QueryBuilderTest extends UnitTest
 
         $this->builder->startFrom($query)->useFilter('foo:bar');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('foo:bar', $parameters['fq'], 'Could not get filters from query object');
+        self::assertSame('foo:bar', $parameters['fq'], 'Could not get filters from query object');
 
         // can we remove the filter after adding?
         $this->builder->startFrom($query)->removeFilterByFieldName('foo');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('fq', $parameters, 'Could not remove filters from query object');
+        self::assertArrayNotHasKey('fq', $parameters, 'Could not remove filters from query object');
 
         // can we add a new filter
         $this->builder->startFrom($query)->useFilter('title:test');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('title:test', $parameters['fq'], 'Could not get filters from query object');
+        self::assertSame('title:test', $parameters['fq'], 'Could not get filters from query object');
         $this->builder->startFrom($query)->removeFilterByFieldName('title');
 
         // can we remove the filter by name?
         $this->builder->startFrom($query)->useFilter('siteHash:xyz', 'siteHashFilter');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('siteHash:xyz', $parameters['fq'], 'Could not get filters from query object');
+        self::assertSame('siteHash:xyz', $parameters['fq'], 'Could not get filters from query object');
         $this->builder->startFrom($query)->removeFilterByName('siteHashFilter');
 
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('fq', $parameters, 'Could not remove filters from query object by filter key');
+        self::assertArrayNotHasKey('fq', $parameters, 'Could not remove filters from query object by filter key');
     }
 
     /**
@@ -1035,11 +1035,11 @@ class QueryBuilderTest extends UnitTest
         // can we add a filter?
         $this->builder->startFrom($query)->useFilter('foo:bar');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('foo:bar', $parameters['fq'], 'Could not get filters from query object');
+        self::assertSame('foo:bar', $parameters['fq'], 'Could not get filters from query object');
 
         $this->builder->startFrom($query)->removeFilterByValue('foo:bar');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('fq', $parameters, 'Filters are not empty after removing the last one');
+        self::assertArrayNotHasKey('fq', $parameters, 'Filters are not empty after removing the last one');
     }
 
     /**
@@ -1053,7 +1053,7 @@ class QueryBuilderTest extends UnitTest
         // we add a filter with the same key twice and expect that only the first one is kept and not overwritten
         $this->builder->startFrom($query)->useFilter('foo:bar', 'test')->useFilter('foo:bla', 'test');
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('foo:bar', $parameters['fq'], 'Unexpected filter query was added');
+        self::assertSame('foo:bar', $parameters['fq'], 'Unexpected filter query was added');
     }
 
     /**
@@ -1064,16 +1064,16 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('qt', $queryParameters, 'The qt parameter was expected to be null');
+        self::assertArrayNotHasKey('qt', $queryParameters, 'The qt parameter was expected to be null');
 
         $this->builder->startFrom($query)->useQueryType('dismax');
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('dismax', $queryParameters['qt'], 'The qt parameter was expected to be dismax');
+        self::assertSame('dismax', $queryParameters['qt'], 'The qt parameter was expected to be dismax');
 
         //passing false as parameter should reset the query type
         $this->builder->startFrom($query)->removeQueryType();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('qt', $queryParameters, 'The qt parameter was expected to be null after reset');
+        self::assertArrayNotHasKey('qt', $queryParameters, 'The qt parameter was expected to be null after reset');
     }
 
     /**
@@ -1084,19 +1084,19 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('test');
 
         $queryParameters = $query->getQueryParameters();
-        $this->assertArrayNotHasKey('q.op', $queryParameters, 'The queryParameter q.op should be null because no operator was passed');
+        self::assertArrayNotHasKey('q.op', $queryParameters, 'The queryParameter q.op should be null because no operator was passed');
 
         $this->builder->startFrom($query)->useOperator(Operator::getOr());
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertEquals(Operator::OPERATOR_OR, $queryParameters['q.op'], 'The queryParameter q.op should be OR');
+        self::assertEquals(Operator::OPERATOR_OR, $queryParameters['q.op'], 'The queryParameter q.op should be OR');
 
         $this->builder->startFrom($query)->useOperator(Operator::getAnd());
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertEquals(Operator::OPERATOR_AND, $queryParameters['q.op'], 'The queryParameter q.op should be AND');
+        self::assertEquals(Operator::OPERATOR_AND, $queryParameters['q.op'], 'The queryParameter q.op should be AND');
 
         $this->builder->startFrom($query)->removeOperator();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertEmpty($queryParameters['q.op'], 'The queryParameter q.op should be null because operator was resetted');
+        self::assertEmpty($queryParameters['q.op'], 'The queryParameter q.op should be null because operator was resetted');
     }
 
     /**
@@ -1108,18 +1108,17 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('q.alt', $queryParameters, 'We expected that alternative query is initially null');
+        self::assertArrayNotHasKey('q.alt', $queryParameters, 'We expected that alternative query is initially null');
 
         // can we set it?
         $this->builder->startFrom($query)->useAlternativeQuery('alt query');
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertEquals('alt query', $queryParameters['q.alt'], 'Could not get passed alternative query');
-
+        self::assertEquals('alt query', $queryParameters['q.alt'], 'Could not get passed alternative query');
 
         // can we reset it?
         $this->builder->startFrom($query)->removeAlternativeQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('q.alt', $queryParameters, 'We expect alternative query is null after reset');
+        self::assertArrayNotHasKey('q.alt', $queryParameters, 'We expect alternative query is null after reset');
     }
 
     /**
@@ -1130,17 +1129,17 @@ class QueryBuilderTest extends UnitTest
         // check initial value
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $query->getQueryParameters();
-        $this->assertArrayNotHasKey('omitHeader', $queryParameters, 'The queryParameter omitHeader should be null because it was not');
+        self::assertArrayNotHasKey('omitHeader', $queryParameters, 'The queryParameter omitHeader should be null because it was not');
 
         $this->builder->startFrom($query)->useOmitHeader();
 
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['omitHeader'], 'The queryParameter omitHeader should be "true" because it was enabled');
+        self::assertSame('true', $queryParameters['omitHeader'], 'The queryParameter omitHeader should be "true" because it was enabled');
 
         $this->builder->startFrom($query)->useOmitHeader(false);
 
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('false',$queryParameters['omitHeader'], 'The queryParameter omitHeader should be null because it was resetted');
+        self::assertSame('false', $queryParameters['omitHeader'], 'The queryParameter omitHeader should be null because it was resetted');
     }
 
     /**
@@ -1151,17 +1150,17 @@ class QueryBuilderTest extends UnitTest
         // check initial value
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('*,score', $queryParameters['fl'], 'FieldList initially contained unexpected values');
+        self::assertSame('*,score', $queryParameters['fl'], 'FieldList initially contained unexpected values');
 
         // set from string
         $this->builder->startFrom($query)->useReturnFields(ReturnFields::fromString('content, title'));
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content,title', $queryParameters['fl'], 'Can not set fieldList from string');
+        self::assertSame('content,title', $queryParameters['fl'], 'Can not set fieldList from string');
 
         // set from array
         $this->builder->startFrom($query)->useReturnFields(ReturnFields::fromArray(['content', 'title']));
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content,title', $queryParameters['fl'], 'Can not set fieldList from array');
+        self::assertSame('content,title', $queryParameters['fl'], 'Can not set fieldList from array');
     }
 
     /**
@@ -1172,23 +1171,23 @@ class QueryBuilderTest extends UnitTest
         // check initial value
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null at the beginning');
+        self::assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null at the beginning');
 
         // can set a field and direction combination
         $this->builder->startFrom($query)->useSorting(Sorting::fromString('title desc'));
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('title desc', $queryParameters['sort'], 'Could not set sorting');
+        self::assertSame('title desc', $queryParameters['sort'], 'Could not set sorting');
 
         // can reset
         $this->builder->startFrom($query)->removeAllSortings();
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null after reset');
+        self::assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null after reset');
 
         // when relevance is getting passed it is the same as we have no
         // sorting because this is a "virtual" value
         $this->builder->startFrom($query)->useSorting(Sorting::fromString('relevance desc'));
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null after reset');
+        self::assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null after reset');
     }
 
     /**
@@ -1199,27 +1198,27 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('enableElevation', $queryParameters);
-        $this->assertArrayNotHasKey('forceElevation', $queryParameters);
-        $this->assertStringNotContainsString('isElevated:[elevated]', $queryParameters['fl']);
+        self::assertArrayNotHasKey('enableElevation', $queryParameters);
+        self::assertArrayNotHasKey('forceElevation', $queryParameters);
+        self::assertStringNotContainsString('isElevated:[elevated]', $queryParameters['fl']);
 
         // do we get the expected default values, when calling setQueryElevantion with no arguments?
 
         $elevation = new Elevation(true);
         $this->builder->startFrom($query)->useElevation($elevation);
         $queryParameters = $this->getAllQueryParameters($query);
-        $this->assertSame('true', $queryParameters['enableElevation'], 'enabledElevation was not set after enabling elevation');
-        $this->assertSame('true', $queryParameters['forceElevation'], 'forceElevation was not set after enabling elevation');
-        $this->assertStringContainsString('isElevated:[elevated]', $queryParameters['fl'], 'isElevated should be in the list of return fields');
+        self::assertSame('true', $queryParameters['enableElevation'], 'enabledElevation was not set after enabling elevation');
+        self::assertSame('true', $queryParameters['forceElevation'], 'forceElevation was not set after enabling elevation');
+        self::assertStringContainsString('isElevated:[elevated]', $queryParameters['fl'], 'isElevated should be in the list of return fields');
 
         // can we reset the elevantion?
         $elevation->setIsEnabled(false);
         $this->builder->startFrom($query)->useElevation($elevation);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('enableElevation', $queryParameters);
-        $this->assertArrayNotHasKey('forceElevation', $queryParameters);
-        $this->assertSame('*,score', $queryParameters['fl']);
+        self::assertArrayNotHasKey('enableElevation', $queryParameters);
+        self::assertArrayNotHasKey('forceElevation', $queryParameters);
+        self::assertSame('*,score', $queryParameters['fl']);
     }
 
     /**
@@ -1230,8 +1229,8 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('test');
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('enableElevation', $queryParameters);
-        $this->assertArrayNotHasKey('forceElevation', $queryParameters);
+        self::assertArrayNotHasKey('enableElevation', $queryParameters);
+        self::assertArrayNotHasKey('forceElevation', $queryParameters);
 
         $elevation = new Elevation();
         $elevation->setIsEnabled(true);
@@ -1240,15 +1239,15 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useElevation($elevation);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $queryParameters['enableElevation'], 'enabledElevation was not set after enabling elevation');
-        $this->assertSame('false', $queryParameters['forceElevation'], 'forceElevation was not false after forcing');
+        self::assertSame('true', $queryParameters['enableElevation'], 'enabledElevation was not set after enabling elevation');
+        self::assertSame('false', $queryParameters['forceElevation'], 'forceElevation was not false after forcing');
 
         $elevation->setIsEnabled(false);
         $this->builder->startFrom($query)->useElevation($elevation);
         $queryParameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('enableElevation', $queryParameters);
-        $this->assertArrayNotHasKey('forceElevation', $queryParameters);
+        self::assertArrayNotHasKey('enableElevation', $queryParameters);
+        self::assertArrayNotHasKey('forceElevation', $queryParameters);
     }
 
     /**
@@ -1269,26 +1268,26 @@ class QueryBuilderTest extends UnitTest
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
         $query = $queryBuilder->newSearchQuery('hello world')
             ->useFilter('color:red')
-            ->useUserAccessGroups([1,2,3])
+            ->useUserAccessGroups([1, 2, 3])
             ->useFaceting($faceting)
             ->useReturnFields($returnFields)
             ->useFieldCollapsing($fieldCollapsing)
             ->getQuery();
 
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('title', $parameters['fl']);
+        self::assertSame('title', $parameters['fl']);
 
         $filterQueries = $parameters['fq'];
-        $this->assertCount(3, $filterQueries, 'Unexpected amount of filter queries created');
-        $this->assertSame('color:red', $parameters['fq'][0]);
-        $this->assertSame('{!typo3access}0,1,2,3', $parameters['fq'][1]);
-        $this->assertSame('{!collapse field=variantId}', $parameters['fq'][2]);
+        self::assertCount(3, $filterQueries, 'Unexpected amount of filter queries created');
+        self::assertSame('color:red', $parameters['fq'][0]);
+        self::assertSame('{!typo3access}0,1,2,3', $parameters['fq'][1]);
+        self::assertSame('{!collapse field=variantId}', $parameters['fq'][2]);
 
-        $this->assertSame('content', $parameters['facet.field'][0]);
-        $this->assertSame('type', $parameters['facet.field'][1]);
-        $this->assertSame('color', $parameters['facet.field'][2]);
+        self::assertSame('content', $parameters['facet.field'][0]);
+        self::assertSame('type', $parameters['facet.field'][1]);
+        self::assertSame('color', $parameters['facet.field'][2]);
 
-        $this->assertArrayNotHasKey('qf', $parameters, 'No query fields have been set');
+        self::assertArrayNotHasKey('qf', $parameters, 'No query fields have been set');
     }
 
     /**
@@ -1302,7 +1301,7 @@ class QueryBuilderTest extends UnitTest
 
         $parameters = $this->getAllQueryParameters($query);
         // the , delimiter is removed
-        $this->assertSame('content^100.0 title^10.0', $parameters['qf'], 'Can not set and get query fields');
+        self::assertSame('content^100.0 title^10.0', $parameters['qf'], 'Can not set and get query fields');
     }
 
     /**
@@ -1313,7 +1312,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('foo bar');
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertEmpty($parameters['qf'], 'QueryFields are not empty by default');
+        self::assertEmpty($parameters['qf'], 'QueryFields are not empty by default');
 
         $queryFields = new QueryFields([]);
         $queryFields->set('content', 10);
@@ -1321,13 +1320,13 @@ class QueryBuilderTest extends UnitTest
 
         $this->builder->startFrom($query)->useQueryFields($queryFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^11.0', $parameters['qf']);
+        self::assertSame('content^10.0 title^11.0', $parameters['qf']);
 
         // overwrite the boost of title
         $queryFields->set('title', 9);
         $this->builder->startFrom($query)->useQueryFields($queryFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^9.0', $parameters['qf'], 'qf parameter not set in QueryParameters');
+        self::assertSame('content^10.0 title^9.0', $parameters['qf'], 'qf parameter not set in QueryParameters');
     }
 
     /**
@@ -1339,7 +1338,7 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->usePhraseFields(PhraseFields::fromString('content^100.0, title^10.0'));
         $parameters = $this->getAllQueryParameters($query);
         // the , delimiter is removed
-        $this->assertSame('content^100.0 title^10.0', $parameters['pf'], 'Can not set and get phrase fields');
+        self::assertSame('content^100.0 title^10.0', $parameters['pf'], 'Can not set and get phrase fields');
     }
 
     /**
@@ -1350,7 +1349,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('foo bar');
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('pf', $parameters, 'Phrase Fields must be empty by default');
+        self::assertArrayNotHasKey('pf', $parameters, 'Phrase Fields must be empty by default');
 
         $phraseFields = new PhraseFields(true);
         $phraseFields->add('content', 10);
@@ -1358,14 +1357,14 @@ class QueryBuilderTest extends UnitTest
 
         $this->builder->startFrom($query)->usePhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^11.0', $parameters['pf']);
+        self::assertSame('content^10.0 title^11.0', $parameters['pf']);
 
         // overwrite the boost of title
         $phraseFields->add('title', 9);
         $this->builder->startFrom($query)->usePhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame('content^10.0 title^9.0', $parameters['pf']);
+        self::assertSame('content^10.0 title^9.0', $parameters['pf']);
     }
 
     /**
@@ -1380,7 +1379,7 @@ class QueryBuilderTest extends UnitTest
         $phraseFields->add('title', 11);
         $this->builder->startFrom($query)->usePhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('pf', $parameters, 'pf parameter must be empty(not set) if phrase search is disabled');
+        self::assertArrayNotHasKey('pf', $parameters, 'pf parameter must be empty(not set) if phrase search is disabled');
     }
 
     /**
@@ -1398,7 +1397,7 @@ class QueryBuilderTest extends UnitTest
         $phraseFields->add('title', 11);
         $this->builder->startFrom($query)->usePhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
+        self::assertSame('content^10.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
     }
 
     /**
@@ -1414,7 +1413,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('foo bar', $fakeConfiguration);
 
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^22.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
+        self::assertSame('content^22.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
     }
 
     /**
@@ -1428,7 +1427,7 @@ class QueryBuilderTest extends UnitTest
         $phraseFields->add('title', 11);
         $this->builder->startFrom($query)->useBigramPhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('pf2', $parameters, 'pf2 parameter must be empty(not set) if phrase search is disabled');
+        self::assertArrayNotHasKey('pf2', $parameters, 'pf2 parameter must be empty(not set) if phrase search is disabled');
     }
 
     /**
@@ -1446,7 +1445,7 @@ class QueryBuilderTest extends UnitTest
         $phraseFields->add('title', 11);
         $this->builder->startFrom($query)->useBigramPhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^11.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
+        self::assertSame('content^10.0 title^11.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
     }
 
     /**
@@ -1462,7 +1461,7 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery('foo bar', $fakeConfiguration);
 
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^12.0 title^14.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
+        self::assertSame('content^12.0 title^14.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
     }
 
     /**
@@ -1476,7 +1475,7 @@ class QueryBuilderTest extends UnitTest
         $phraseFields->add('title', 11);
         $this->builder->startFrom($query)->useTrigramPhraseFields($phraseFields);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('pf3', $parameters, 'pf3 parameter must be empty(not set) if phrase search is disabled');
+        self::assertArrayNotHasKey('pf3', $parameters, 'pf3 parameter must be empty(not set) if phrase search is disabled');
     }
 
     /**
@@ -1493,7 +1492,7 @@ class QueryBuilderTest extends UnitTest
         $trigram->add('title', 11);
         $this->builder->startFrom($query)->useTrigramPhraseFields($trigram);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^10.0 title^11.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
+        self::assertSame('content^10.0 title^11.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
     }
 
     /**
@@ -1507,7 +1506,7 @@ class QueryBuilderTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $query = $this->getInitializedTestSearchQuery('foo bar', $fakeConfiguration);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('content^12.0 title^14.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
+        self::assertSame('content^12.0 title^14.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
     }
 
     /**
@@ -1518,19 +1517,19 @@ class QueryBuilderTest extends UnitTest
         $query = $this->getInitializedTestSearchQuery();
 
         $parameter = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('debugQuery', $parameter, 'Debug query should be disabled by default');
-        $this->assertArrayNotHasKey('echoParams', $parameter, 'Debug query should be disabled by default');
+        self::assertArrayNotHasKey('debugQuery', $parameter, 'Debug query should be disabled by default');
+        self::assertArrayNotHasKey('echoParams', $parameter, 'Debug query should be disabled by default');
 
         $this->builder->startFrom($query)->useDebug(true);
         $parameter = $this->getAllQueryParameters($query);
 
-        $this->assertSame('true', $parameter['debugQuery'], 'Debug query should be disabled by default');
-        $this->assertSame('all', $parameter['echoParams'], 'Debug query should be disabled by default');
+        self::assertSame('true', $parameter['debugQuery'], 'Debug query should be disabled by default');
+        self::assertSame('all', $parameter['echoParams'], 'Debug query should be disabled by default');
 
         $this->builder->startFrom($query)->useDebug(false);
         $parameter = $this->getAllQueryParameters($query);
-        $this->assertArrayNotHasKey('debugQuery', $parameter, 'Can not unset debug mode');
-        $this->assertArrayNotHasKey('echoParams', $parameter, 'Can not unset debug mode');
+        self::assertArrayNotHasKey('debugQuery', $parameter, 'Can not unset debug mode');
+        self::assertArrayNotHasKey('echoParams', $parameter, 'Can not unset debug mode');
     }
 
     /**
@@ -1545,7 +1544,7 @@ class QueryBuilderTest extends UnitTest
         $grouping->addQuery('someField:someValue');
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame(['price:[* TO 500]', 'someField:someValue'], $parameters['group.query'], 'Could not add group queries properly');
+        self::assertSame(['price:[* TO 500]', 'someField:someValue'], $parameters['group.query'], 'Could not add group queries properly');
     }
 
     /**
@@ -1559,7 +1558,7 @@ class QueryBuilderTest extends UnitTest
         $grouping->addSorting('title desc');
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame('price_f title desc', $parameters['group.sort'], 'Could not add group sortings properly');
+        self::assertSame('price_f title desc', $parameters['group.sort'], 'Could not add group sortings properly');
     }
 
     /**
@@ -1573,7 +1572,7 @@ class QueryBuilderTest extends UnitTest
         $grouping->addField('category_s');
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
-        $this->assertSame(['price_f', 'category_s'], $parameters['group.field'], 'Could not add group fields properly');
+        self::assertSame(['price_f', 'category_s'], $parameters['group.field'], 'Could not add group fields properly');
     }
 
     /**
@@ -1587,26 +1586,26 @@ class QueryBuilderTest extends UnitTest
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame($parameters['group'], 'true');
-        $this->assertSame($parameters['group.format'], 'grouped');
-        $this->assertSame($parameters['group.ngroups'], 'true');
+        self::assertSame($parameters['group'], 'true');
+        self::assertSame($parameters['group.format'], 'grouped');
+        self::assertSame($parameters['group.ngroups'], 'true');
 
         $grouping->addSorting('title desc');
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertSame($parameters['group.sort'], 'title desc', 'Group sorting was not added');
-        $this->assertArrayNotHasKey('group.field', $parameters, 'No field was passed, so it should not be set');
-        $this->assertArrayNotHasKey('group.query', $parameters, 'No query was passed, so it should not be set');
+        self::assertSame($parameters['group.sort'], 'title desc', 'Group sorting was not added');
+        self::assertArrayNotHasKey('group.field', $parameters, 'No field was passed, so it should not be set');
+        self::assertArrayNotHasKey('group.query', $parameters, 'No query was passed, so it should not be set');
 
         $grouping->setIsEnabled(false);
         $this->builder->startFrom($query)->useGrouping($grouping);
         $parameters = $this->getAllQueryParameters($query);
 
-        $this->assertArrayNotHasKey('group.sort', $parameters, 'Grouping parameters should be removed');
-        $this->assertArrayNotHasKey('group', $parameters, 'Grouping parameters should be removed');
-        $this->assertArrayNotHasKey('group.format', $parameters, 'Grouping parameters should be removed');
-        $this->assertArrayNotHasKey('group.ngroups', $parameters, 'Grouping parameters should be removed');
+        self::assertArrayNotHasKey('group.sort', $parameters, 'Grouping parameters should be removed');
+        self::assertArrayNotHasKey('group', $parameters, 'Grouping parameters should be removed');
+        self::assertArrayNotHasKey('group.format', $parameters, 'Grouping parameters should be removed');
+        self::assertArrayNotHasKey('group.ngroups', $parameters, 'Grouping parameters should be removed');
     }
 
     /**
@@ -1615,20 +1614,20 @@ class QueryBuilderTest extends UnitTest
     public function canBuildSuggestQuery()
     {
         $this->configurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getObjectByPathOrDefault')
             ->willReturn([
                 'suggestField' => 'spell',
-                'numberOfSuggestions' => 10
+                'numberOfSuggestions' => 10,
             ]);
         $this->builder = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->configurationMock, $this->loggerMock])
-            ->setMethods(['useSiteHashFromTypoScript'])
+            ->onlyMethods(['useSiteHashFromTypoScript'])
             ->getMock();
 
         $suggestQuery = $this->builder->buildSuggestQuery('foo', [], 3232, '');
         $queryParameters = $this->getAllQueryParameters($suggestQuery);
-        $this->assertSame('foo', $queryParameters['facet.prefix'], 'Passed query string is not used as facet.prefix argument');
+        self::assertSame('foo', $queryParameters['facet.prefix'], 'Passed query string is not used as facet.prefix argument');
     }
 
     /**
@@ -1637,11 +1636,11 @@ class QueryBuilderTest extends UnitTest
     public function alternativeQueryIsWildCardQueryForSuggestQuery()
     {
         $this->configurationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getObjectByPathOrDefault')
             ->willReturn([
                 'suggestField' => 'spell',
-                'numberOfSuggestions' => 10
+                'numberOfSuggestions' => 10,
             ]);
         $this->builder = $this->getMockBuilder(QueryBuilder::class)
                                 ->setConstructorArgs([$this->configurationMock, $this->loggerMock])
@@ -1650,6 +1649,6 @@ class QueryBuilderTest extends UnitTest
 
         $suggestQuery = $this->builder->buildSuggestQuery('bar', [], 3232, '');
         $queryParameters = $this->getAllQueryParameters($suggestQuery);
-        $this->assertSame('*:*', $queryParameters['q.alt'], 'Alterntive query is not set to wildcard query by default');
+        self::assertSame('*:*', $queryParameters['q.alt'], 'Alterntive query is not set to wildcard query by default');
     }
 }

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query;
 
 /***************************************************************
@@ -24,12 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
@@ -46,14 +44,14 @@ class SuggestQueryTest extends UnitTest
     {
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
-            'variantField' => 'myField'
+            'variantField' => 'myField',
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $queryBuilder = new QueryBuilder($fakeConfiguration);
         $suggestQuery = $queryBuilder->newSuggestQuery('type')->getQuery();
 
-        $this->assertNull($suggestQuery->getFilterQuery('fieldCollapsing'), 'Collapsing should never be active for a suggest query, even when active');
+        self::assertNull($suggestQuery->getFilterQuery('fieldCollapsing'), 'Collapsing should never be active for a suggest query, even when active');
     }
 
     /**
@@ -67,6 +65,6 @@ class SuggestQueryTest extends UnitTest
         $queryBuilder = new QueryBuilder($fakeConfiguration);
         $queryBuilder->startFrom($suggestQuery)->useFilter('+type:pages');
         $queryParameters = $suggestQuery->getRequestBuilder()->build($suggestQuery)->getParams();
-        $this->assertSame('+type:pages', $queryParameters['fq'], 'Filter was not added to the suggest query parameters');
+        self::assertSame('+type:pages', $queryParameters['fq'], 'Filter was not added to the suggest query parameters');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/AbstractFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/AbstractFacetParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -16,15 +17,15 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Faceting;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
-use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
+use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -45,13 +46,12 @@ abstract class AbstractFacetParserTest extends UnitTest
     {
         $fakeResponseJson = $this->getFixtureContentByName($fixtureFile);
 
-        $facetingMock = $this->getMockBuilder(Faceting::class)->setMethods(['getSorting'])->disableOriginalConstructor()->getMock();
-        $facetingMock->expects($this->any())->method('getSorting')->will($this->returnValue(''));
-        $usedQueryMock = $this->getMockBuilder(Query::class)->setMethods(['getFaceting'])->disableOriginalConstructor()->getMock();
-        $usedQueryMock->expects($this->any())->method('getFaceting')->will($this->returnValue($facetingMock));
+        $facetingMock = $this->getMockBuilder(Faceting::class)->onlyMethods(['getSorting'])->disableOriginalConstructor()->getMock();
+        $facetingMock->expects(self::any())->method('getSorting')->willReturn('');
+        $usedQueryMock = $this->getMockBuilder(Query::class)->onlyMethods([])->disableOriginalConstructor()->getMock();
 
         $searchRequestMock = $this->getMockBuilder(SearchRequest::class)
-            ->setMethods(['getActiveFacetNames', 'getContextTypoScriptConfiguration', 'getActiveFacets', 'getActiveFacetValuesByName'])
+            ->onlyMethods(['getActiveFacetNames', 'getContextTypoScriptConfiguration', 'getActiveFacets', 'getActiveFacetValuesByName'])
             ->getMock();
 
         $fakeResponse = new ResponseAdapter($fakeResponseJson, 200);
@@ -67,26 +67,26 @@ abstract class AbstractFacetParserTest extends UnitTest
         $configuration = [];
         $configuration['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = $facetConfiguration;
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchRequestMock->expects($this->any())
+        $searchRequestMock->expects(self::any())
             ->method('getContextTypoScriptConfiguration')
-            ->will($this->returnValue($typoScriptConfiguration));
+            ->willReturn($typoScriptConfiguration);
 
         // Replace calls with own data bag
-        $searchRequestMock->expects($this->any())
+        $searchRequestMock->expects(self::any())
             ->method('getActiveFacetNames')
-            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+            ->willReturnCallback(function () use ($activeUrlFacets) {
                 return $activeUrlFacets->getActiveFacetNames();
-            }));
-        $searchRequestMock->expects($this->any())
+            });
+        $searchRequestMock->expects(self::any())
             ->method('getActiveFacets')
-            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+            ->willReturnCallback(function () use ($activeUrlFacets) {
                 return $activeUrlFacets->getActiveFacets();
-            }));
-        $searchRequestMock->expects($this->any())
+            });
+        $searchRequestMock->expects(self::any())
             ->method('getActiveFacetValuesByName')
-            ->will($this->returnCallback(function(string $facetName) use ($activeUrlFacets) {
+            ->willReturnCallback(function (string $facetName) use ($activeUrlFacets) {
                 return $activeUrlFacets->getActiveFacetValuesByName($facetName);
-            }));
+            });
 
         return $searchResultSet;
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -51,14 +52,13 @@ class DefaultFacetQueryBuilderTest extends UnitTest
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $defaultQueryBuilder = new DefaultFacetQueryBuilder();
         $result = $defaultQueryBuilder->build('color', $fakeConfiguration);
 
-        $this->assertStringNotContainsString('{!ex', $result['facet.field'][0]);
+        self::assertStringNotContainsString('{!ex', $result['facet.field'][0]);
     }
-
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -33,6 +34,6 @@ class DefaultUrlDecoderTest extends UnitTest
         $value = 'a + b';
         $encoder = new DefaultUrlDecoder();
         $encodedValue = $encoder->decode($value);
-        $this->assertSame('"a + b"', $encodedValue, 'Encode and decode does not produce initial value');
+        self::assertSame('"a + b"', $encodedValue, 'Encode and decode does not produce initial value');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -14,10 +15,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Class FacetCollectionTest
@@ -40,8 +41,8 @@ class FacetCollectionTest extends UnitTest
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 
-        $this->assertEquals($colorFacet, $facetCollection['color']);
-        $this->assertEquals($brandFacet, $facetCollection['brand']);
+        self::assertEquals($colorFacet, $facetCollection['color']);
+        self::assertEquals($brandFacet, $facetCollection['brand']);
     }
 
     /**
@@ -57,8 +58,8 @@ class FacetCollectionTest extends UnitTest
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 
-        $this->assertEquals($colorFacet, $facetCollection->getByPosition(0));
-        $this->assertEquals($brandFacet, $facetCollection->getByPosition(1));
+        self::assertEquals($colorFacet, $facetCollection->getByPosition(0));
+        self::assertEquals($brandFacet, $facetCollection->getByPosition(1));
     }
 
     /**
@@ -75,8 +76,8 @@ class FacetCollectionTest extends UnitTest
         $facetCollection->addFacet($brandFacet);
 
         $leftFacetCollection = $facetCollection->getByGroupName('left');
-        $this->assertEquals(1, $leftFacetCollection->count());
-        $this->assertEquals($brandFacet, $leftFacetCollection['brand']);
+        self::assertEquals(1, $leftFacetCollection->count());
+        self::assertEquals($brandFacet, $leftFacetCollection['brand']);
     }
 
     /**
@@ -93,7 +94,7 @@ class FacetCollectionTest extends UnitTest
         $facetCollection->addFacet($brandFacet);
 
         $leftFacetCollection = $facetCollection->getByGroupName('left');
-        $this->assertEquals(1, $leftFacetCollection->count());
-        $this->assertEquals($brandFacet, $leftFacetCollection->getByPosition(0));
+        self::assertEquals(1, $leftFacetCollection->count());
+        self::assertEquals($brandFacet, $leftFacetCollection->getByPosition(0));
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -14,10 +15,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsPackage;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage\TestPackage;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -36,12 +37,10 @@ class FacetRegistryTest extends UnitTest
      */
     protected $objectManagerMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void {
+    protected function setUp(): void
+    {
+        $this->objectManagerMock = $this->createMock(ObjectManager::class);
         parent::setUp();
-        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
     }
 
     /**
@@ -61,9 +60,9 @@ class FacetRegistryTest extends UnitTest
         $facetRegistry->injectObjectManager($this->objectManagerMock);
 
         if (!empty($createsPackageInstances)) {
-            $facetRegistry->expects($this->any())
+            $facetRegistry->expects(self::any())
                 ->method('createInstance')
-                ->will($this->returnValueMap($createsPackageInstances));
+                ->willReturnMap($createsPackageInstances);
         }
 
         return $facetRegistry;
@@ -81,7 +80,7 @@ class FacetRegistryTest extends UnitTest
         $facetRegistry = $this->getTestFacetPackageRegistry([[$packageClass, $packageObject]]);
         $facetRegistry->registerPackage($packageClass, $facetType);
 
-        $this->assertEquals($packageObject, $facetRegistry->getPackage($facetType));
+        self::assertEquals($packageObject, $facetRegistry->getPackage($facetType));
     }
 
     /**
@@ -114,7 +113,7 @@ class FacetRegistryTest extends UnitTest
     {
         $optionsFacetPackage = new OptionsPackage();
         $facetParserRegistry = $this->getTestFacetPackageRegistry([[OptionsPackage::class, $optionsFacetPackage]]);
-        $this->assertEquals($optionsFacetPackage, $facetParserRegistry->getPackage('unknownType'));
+        self::assertEquals($optionsFacetPackage, $facetParserRegistry->getPackage('unknownType'));
     }
 
     /**
@@ -128,6 +127,6 @@ class FacetRegistryTest extends UnitTest
         $facetParserRegistry = $this->getTestFacetPackageRegistry([[$packageClass, $packageObject]]);
         $facetParserRegistry->setDefaultPackage($packageClass);
 
-        $this->assertEquals($packageObject, $facetParserRegistry->getPackage('unknownType'));
+        self::assertEquals($packageObject, $facetParserRegistry->getPackage('unknownType'));
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy;
 
 /*
@@ -14,9 +15,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacetParser;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\AbstractFacetParserTest;
 
 /**
@@ -38,7 +39,7 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
                 'type' => 'hierarchy',
                 'label' => 'Rootline',
                 'field' => 'rootline',
-            ]
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -49,15 +50,15 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
         /** @var $parser HierarchyFacetParser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
-        $this->assertInstanceOf(HierarchyFacet::class, $facet);
+        self::assertInstanceOf(HierarchyFacet::class, $facet);
 
         // on the rootlevel there should only be one childNode
-        $this->assertSame(1, $facet->getChildNodes()->getCount());
-        $this->assertSame(8, $facet->getChildNodes()->getByPosition(0)->getChildNodes()->getCount());
+        self::assertSame(1, $facet->getChildNodes()->getCount());
+        self::assertSame(8, $facet->getChildNodes()->getByPosition(0)->getChildNodes()->getCount());
 
         $firstNode = $facet->getChildNodes()->getByPosition(0)->getChildNodes()->getByPosition(0);
-        $this->assertSame('/1/14/', $firstNode->getValue());
-        $this->assertSame('14', $firstNode->getKey());
+        self::assertSame('/1/14/', $firstNode->getValue());
+        self::assertSame('14', $firstNode->getKey());
     }
 
     /**
@@ -72,10 +73,10 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
                         'type' => 'hierarchy',
                         'label' => 'Rootline',
                         'field' => 'rootline',
-                        'sortBy' => 'count'
-                    ]
+                        'sortBy' => 'count',
+                    ],
                 ],
-                'fake_solr_response_with_deep_more_then_10_hierarchy_facet_sorted_by_count.json'
+                'fake_solr_response_with_deep_more_then_10_hierarchy_facet_sorted_by_count.json',
             ],
             'sortByIndex' => [
                 [
@@ -83,11 +84,11 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
                         'type' => 'hierarchy',
                         'label' => 'Rootline',
                         'field' => 'rootline',
-                        'sortBy' => 'index'
-                    ]
+                        'sortBy' => 'index',
+                    ],
                 ],
-                'fake_solr_response_with_deep_more_then_10_hierarchy_facet_sorted_by_index.json'
-            ]
+                'fake_solr_response_with_deep_more_then_10_hierarchy_facet_sorted_by_index.json',
+            ],
         ];
     }
 
@@ -106,9 +107,9 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
 
-        $this->assertInstanceOf(HierarchyFacet::class, $facet);
+        self::assertInstanceOf(HierarchyFacet::class, $facet);
 
-        $this->assertSame(1, $facet->getChildNodes()->getCount(), 'The hierarchy facet is broken. Expected that no node has more than one child node.');
+        self::assertSame(1, $facet->getChildNodes()->getCount(), 'The hierarchy facet is broken. Expected that no node has more than one child node.');
         $this->assertNoNodeHasMoreThanOneChildInTheHierarchy($facet->getChildNodes()->getByPosition(0));
     }
 
@@ -119,7 +120,7 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
      */
     protected function assertNoNodeHasMoreThanOneChildInTheHierarchy(Node $node)
     {
-        $this->assertLessThanOrEqual(1, $node->getChildNodes()->getCount(), 'The hierarchy facet is broken. Expected that no node has more than one child node.');
+        self::assertLessThanOrEqual(1, $node->getChildNodes()->getCount(), 'The hierarchy facet is broken. Expected that no node has more than one child node.');
         if ($node->getChildNodes()->getCount() === 0) {
             return;
         }
@@ -129,25 +130,26 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
     /**
      * @test
      */
-    public function selectedOptionWithSlashInTitleOnHierarchicalFacetDoesNotBreakTheFacet() {
+    public function selectedOptionWithSlashInTitleOnHierarchicalFacetDoesNotBreakTheFacet()
+    {
         $facetConfiguration = [
             'type' => 'hierarchy',
             'label' => 'Category Hierarch By Title',
             'field' => 'categoryHierarchyByTitle_stringM',
             'sortBy' => 'alpha',
-            'keepAllOptionsOnSelection' => 1
+            'keepAllOptionsOnSelection' => 1,
         ];
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
             'fake_solr_response_with_hierachy_facet_with_slash_in_title.json',
-            $facetConfiguration
-            , ['categoryHierarchyByTitle:/folder2\/level1\//folder2\/level2\//']
+            $facetConfiguration,
+            ['categoryHierarchyByTitle:/folder2\/level1\//folder2\/level2\//']
         );
 
         /** @var $parser HierarchyFacetParser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'categoryHierarchyByTitle', $facetConfiguration);
         // HierarchyFacetParser::getActiveFacetValuesFromRequest() must be aware about slashes in path segments
-        $this->assertSame(5, $facet->getAllFacetItems()->count(), 'Selected facet option is wrong parsed. The slash in Title leads to new facet option.');
+        self::assertSame(5, $facet->getAllFacetItems()->count(), 'Selected facet option is wrong parsed. The slash in Title leads to new facet option.');
 
         // each node has only one child node in fake response, parsing must be synchron with data.
         $this->assertNoNodeHasMoreThanOneChildInTheHierarchy($facet->getChildNodes()->getByPosition(0));
@@ -156,12 +158,12 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
         $optionValue = '/folder2\/level1\//folder2\/level2\//folder2\/level3/';
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
             'fake_solr_response_with_hierachy_facet_with_slash_in_title.json',
-            $facetConfiguration
-            , ['categoryHierarchyByTitle:' . $optionValue]
+            $facetConfiguration,
+            ['categoryHierarchyByTitle:' . $optionValue]
         );
         $facet = $parser->parse($searchResultSet, 'categoryHierarchyByTitle', $facetConfiguration);
 
-        $this->assertSame(1, $facet->getAllFacetItems()->getByValue($optionValue)->getChildNodes()->count(), 'Selected facet-option with slash in title/name breaks the Hierarchical facets.');
+        self::assertSame(1, $facet->getAllFacetItems()->getByValue($optionValue)->getChildNodes()->count(), 'Selected facet-option with slash in title/name breaks the Hierarchical facets.');
     }
 
     /**
@@ -174,7 +176,7 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
                 'type' => 'hierarchy',
                 'label' => 'Rootline',
                 'field' => 'rootline',
-            ]
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -182,10 +184,10 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
             $facetConfiguration
         );
 
-            /** @var $parser HierarchyFacetParser */
+        /** @var $parser HierarchyFacetParser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
-        $this->assertFalse($facet->getIsUsed());
+        self::assertFalse($facet->getIsUsed());
     }
 
     /**
@@ -198,7 +200,7 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
                 'type' => 'hierarchy',
                 'label' => 'Rootline',
                 'field' => 'rootline',
-            ]
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -212,12 +214,12 @@ class HierarchyFacetParserTest extends AbstractFacetParserTest
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
 
         $selectedFacetByUrl = $facet->getChildNodes()->getByPosition(0)->getChildNodes()->getByPosition(0);
-        $this->assertTrue($facet->getIsUsed());
+        self::assertTrue($facet->getIsUsed());
 
         $valueSelectedItem = $selectedFacetByUrl->getLabel();
-        $this->assertSame('14', $valueSelectedItem, 'Unexpected value for selected item');
+        self::assertSame('14', $valueSelectedItem, 'Unexpected value for selected item');
 
         $subItemCountOfSelectedFacet = $selectedFacetByUrl->getChildNodes()->count();
-        $this->assertSame(15, $subItemCountOfSelectedFacet, 'Expected to have 15 sub items below path /1/14/');
+        self::assertSame(15, $subItemCountOfSelectedFacet, 'Expected to have 15 sub items below path /1/14/');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy;
 
 /***************************************************************
@@ -30,7 +31,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- *
  * Testcase for query parser range
  * @author Markus Goldbach
  */
@@ -41,9 +41,10 @@ class HierarchyUrlEncoderTest extends UnitTest
      */
     protected $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parser = GeneralUtility::makeInstance(HierarchyUrlDecoder::class);
+        parent::setUp();
     }
 
     /**
@@ -54,7 +55,7 @@ class HierarchyUrlEncoderTest extends UnitTest
         $expected = '"2-sport/skateboarding/street/"';
         $actual = $this->parser->decode('/sport/skateboarding/street/');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -65,7 +66,7 @@ class HierarchyUrlEncoderTest extends UnitTest
         $expected = '"2-sport/skateboarding\\\\/snowboarding/street/"';
         $actual = $this->parser->decode('/sport/skateboarding\/snowboarding/street/');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -76,7 +77,7 @@ class HierarchyUrlEncoderTest extends UnitTest
         $expected = '"1-sport/skateboarding/"';
         $actual = $this->parser->decode('/sport/skateboarding/');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -87,6 +88,6 @@ class HierarchyUrlEncoderTest extends UnitTest
         $expected = '"0-sport/"';
         $actual = $this->parser->decode('/sport/');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy;
 
 /*
@@ -14,9 +15,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Testcase to test the Node class
@@ -33,13 +34,13 @@ class NodeTest extends UnitTest
     {
         $facetMock = $this->getDumbMock(HierarchyFacet::class);
         $node = new Node($facetMock);
-        $this->assertFalse($node->getHasParentNode(), 'Node with unassigned parent node should not indicate that a parent node was assigned');
+        self::assertFalse($node->getHasParentNode(), 'Node with unassigned parent node should not indicate that a parent node was assigned');
 
         $facetMock = $this->getDumbMock(HierarchyFacet::class);
         $parentNode = new Node($facetMock);
         $node = new Node($facetMock, $parentNode);
-        $this->assertTrue($node->getHasParentNode(), 'Node with assigned parent node should indicate that');
-        $this->assertSame($parentNode, $node->getParentNode(), 'Node did not return assigend parent node');
+        self::assertTrue($node->getHasParentNode(), 'Node with assigned parent node should indicate that');
+        self::assertSame($parentNode, $node->getParentNode(), 'Node did not return assigend parent node');
     }
 
     /**
@@ -50,7 +51,7 @@ class NodeTest extends UnitTest
         $facetMock = $this->getDumbMock(HierarchyFacet::class);
         $node = new Node($facetMock);
 
-        $this->assertFalse($node->getHasChildNodeSelected(), 'Node without childnodes should not indicate that it as a selected child node');
+        self::assertFalse($node->getHasChildNodeSelected(), 'Node without childnodes should not indicate that it as a selected child node');
     }
 
     /**
@@ -64,7 +65,7 @@ class NodeTest extends UnitTest
         $childNode = new Node($facetMock, $node);
         $node->addChildNode($childNode);
 
-        $this->assertFalse($node->getHasChildNodeSelected(), 'Node with only unselected childnodes should not indicate that it has a selected child node');
+        self::assertFalse($node->getHasChildNodeSelected(), 'Node with only unselected childnodes should not indicate that it has a selected child node');
     }
 
     /**
@@ -78,6 +79,6 @@ class NodeTest extends UnitTest
         $selectedChildNode = new Node($facetMock, $node, '', '', '', 0, true);
         $node->addChildNode($selectedChildNode);
 
-        $this->assertTrue($node->getHasChildNodeSelected(), 'Node with selected child node should indicate that it has a selected child node');
+        self::assertTrue($node->getHasChildNodeSelected(), 'Node with selected child node should indicate that it has a selected child node');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Options;
 
 /***************************************************************
@@ -24,11 +25,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test for the OptionsFacet
@@ -56,9 +56,9 @@ class OptionCollectionTest extends UnitTest
         // @extensionScannerIgnoreLine
         $sortedOptions = $facet->getOptions()->getManualSortedCopy(['yellow', 'blue']);
 
-        $this->assertSame($yellow, $sortedOptions->getByPosition(0), 'First sorted item was not yellow');
-        $this->assertSame($blue, $sortedOptions->getByPosition(1), 'First sorted item was not blue');
-        $this->assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
+        self::assertSame($yellow, $sortedOptions->getByPosition(0), 'First sorted item was not yellow');
+        self::assertSame($blue, $sortedOptions->getByPosition(1), 'First sorted item was not blue');
+        self::assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
     }
 
     /**
@@ -83,7 +83,7 @@ class OptionCollectionTest extends UnitTest
 
         // @extensionScannerIgnoreLine
         $labelPrefixes = $facet->getOptions()->getLowercaseLabelPrefixes(1);
-        $this->assertSame(['r','p','l'], $labelPrefixes, 'Can not get expected label prefixes');
+        self::assertSame(['r', 'p', 'l'], $labelPrefixes, 'Can not get expected label prefixes');
     }
 
     /**
@@ -108,11 +108,11 @@ class OptionCollectionTest extends UnitTest
 
         // @extensionScannerIgnoreLine
         $optionsStartingWithL = $facet->getOptions()->getByLowercaseLabelPrefix('l');
-        $this->assertCount(1, $optionsStartingWithL, 'Unexpected amount of options starting with l');
+        self::assertCount(1, $optionsStartingWithL, 'Unexpected amount of options starting with l');
 
         // @extensionScannerIgnoreLine
         $optionsStartingWithR = $facet->getOptions()->getByLowercaseLabelPrefix('r');
-        $this->assertCount(3, $optionsStartingWithR, 'Unexpected amount of options starting with r');
+        self::assertCount(3, $optionsStartingWithR, 'Unexpected amount of options starting with r');
     }
 
     /**
@@ -131,7 +131,7 @@ class OptionCollectionTest extends UnitTest
 
         // @extensionScannerIgnoreLine
         $optionsStartingWithO = $facet->getOptions()->getByLowercaseLabelPrefix('ø');
-        $this->assertCount(1, $optionsStartingWithO, 'Unexpected amount of options starting with ø');
+        self::assertCount(1, $optionsStartingWithO, 'Unexpected amount of options starting with ø');
     }
 
     /**
@@ -151,22 +151,21 @@ class OptionCollectionTest extends UnitTest
         $facet->addOption($yellow);
 
         // @extensionScannerIgnoreLine
-        $this->assertSame($yellow, $facet->getOptions()->getByValue('yellow'), 'Can not get option by value');
+        self::assertSame($yellow, $facet->getOptions()->getByValue('yellow'), 'Can not get option by value');
         // @extensionScannerIgnoreLine
-        $this->assertSame($blue, $facet->getOptions()->getByValue('blue'), 'Can not get option by value');
+        self::assertSame($blue, $facet->getOptions()->getByValue('blue'), 'Can not get option by value');
         // @extensionScannerIgnoreLine
-        $this->assertSame($red, $facet->getOptions()->getByValue('red'), 'Can not get option by value');
+        self::assertSame($red, $facet->getOptions()->getByValue('red'), 'Can not get option by value');
 
         // @extensionScannerIgnoreLine
         $sortedOptions = $facet->getOptions()->getManualSortedCopy(['yellow', 'blue']);
 
-        $this->assertSame($yellow, $sortedOptions->getByValue('yellow'), 'Can not get option by value');
-        $this->assertSame($blue, $sortedOptions->getByValue('blue'), 'Can not get option by value');
-        $this->assertSame($red, $sortedOptions->getByValue('red'), 'Can not get option by value');
+        self::assertSame($yellow, $sortedOptions->getByValue('yellow'), 'Can not get option by value');
+        self::assertSame($blue, $sortedOptions->getByValue('blue'), 'Can not get option by value');
+        self::assertSame($red, $sortedOptions->getByValue('red'), 'Can not get option by value');
 
-        $this->assertSame($yellow, $sortedOptions->getByPosition(0), 'First sorted item was not yellow');
-        $this->assertSame($blue, $sortedOptions->getByPosition(1), 'First sorted item was not blue');
-        $this->assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
+        self::assertSame($yellow, $sortedOptions->getByPosition(0), 'First sorted item was not yellow');
+        self::assertSame($blue, $sortedOptions->getByPosition(1), 'First sorted item was not blue');
+        self::assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
     }
 }
-

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBase\Options;
 
 /***************************************************************
@@ -52,14 +53,14 @@ class OptionsFacetQueryBuilderTest extends UnitTest
             'sortDirection' => 'desc',
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->with(100)->will(
-            $this->returnValue(100)
+        $configurationMock->expects(self::any())->method('getSearchFacetingFacetLimit')->with(100)->willReturn(
+            100
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->with(1)->will(
-            $this->returnValue(1)
+        $configurationMock->expects(self::any())->method('getSearchFacetingMinimumCount')->with(1)->willReturn(
+            1
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -73,12 +74,11 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'mincount' => 1,
                     'sort' => 'index desc',
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
-
 
     /**
      * @test
@@ -93,11 +93,11 @@ class OptionsFacetQueryBuilderTest extends UnitTest
             'facetLimit' => 20,
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->with(1)->will(
-            $this->returnValue(1)
+        $configurationMock->expects(self::any())->method('getSearchFacetingMinimumCount')->with(1)->willReturn(
+            1
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -110,10 +110,10 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'limit' => 20,
                     'mincount' => 1,
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
     /**
@@ -125,18 +125,18 @@ class OptionsFacetQueryBuilderTest extends UnitTest
          * limit
          */
         $fakeFacetConfiguration = [
-            'field' => 'category'
+            'field' => 'category',
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
 
-        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->will(
-            $this->returnValue(15)
+        $configurationMock->expects(self::any())->method('getSearchFacetingFacetLimit')->willReturn(
+            15
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->with(1)->will(
-            $this->returnValue(1)
+        $configurationMock->expects(self::any())->method('getSearchFacetingMinimumCount')->with(1)->willReturn(
+            1
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -149,10 +149,10 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'limit' => 15,
                     'mincount' => 1,
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
     /**
@@ -168,11 +168,11 @@ class OptionsFacetQueryBuilderTest extends UnitTest
             'minimumCount' => 2,
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->with(100)->will(
-            $this->returnValue(100)
+        $configurationMock->expects(self::any())->method('getSearchFacetingFacetLimit')->with(100)->willReturn(
+            100
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -185,10 +185,10 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'limit' => 100,
                     'mincount' => 2,
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
     /**
@@ -214,18 +214,18 @@ class OptionsFacetQueryBuilderTest extends UnitTest
          * mincount = 2
          */
         $fakeFacetConfiguration = [
-            'field' => 'category'
+            'field' => 'category',
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
 
-        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->will(
-            $this->returnValue($expectedMinimumCount)
+        $configurationMock->expects(self::any())->method('getSearchFacetingMinimumCount')->willReturn(
+            $expectedMinimumCount
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->with(100)->will(
-            $this->returnValue(100)
+        $configurationMock->expects(self::any())->method('getSearchFacetingFacetLimit')->with(100)->willReturn(
+            100
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -238,10 +238,10 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                     'limit' => 100,
                     'mincount' => $expectedMinimumCount,
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
     /**
@@ -261,14 +261,14 @@ class OptionsFacetQueryBuilderTest extends UnitTest
             ],
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('category')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
+            $fakeFacetConfiguration
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingFacetLimit')->with(100)->will(
-            $this->returnValue(100)
+        $configurationMock->expects(self::any())->method('getSearchFacetingFacetLimit')->with(100)->willReturn(
+            100
         );
-        $configurationMock->expects($this->any())->method('getSearchFacetingMinimumCount')->with(1)->will(
-            $this->returnValue(1)
+        $configurationMock->expects(self::any())->method('getSearchFacetingMinimumCount')->with(1)->willReturn(
+            1
         );
 
         $builder = new OptionsFacetQueryBuilder();
@@ -284,9 +284,9 @@ class OptionsFacetQueryBuilderTest extends UnitTest
                         'metrics_downloads' => 'sum(downloads_intS)',
                     ],
                 ],
-            ]
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Options;
 
 /*
@@ -14,11 +15,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test for the OptionsFacet
@@ -36,7 +36,7 @@ class OptionsFacetTest extends UnitTest
     {
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $optionsFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
-        $this->assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from options facet');
+        self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from options facet');
     }
 
     /**
@@ -48,14 +48,14 @@ class OptionsFacetTest extends UnitTest
         $optionsFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         $option = new Option($optionsFacet);
 
-            // before adding there should not be any facet present
+        // before adding there should not be any facet present
         // @extensionScannerIgnoreLine
-        $this->assertEquals(0, $optionsFacet->getOptions()->getCount());
+        self::assertEquals(0, $optionsFacet->getOptions()->getCount());
         $optionsFacet->addOption($option);
 
-            // now we should have 1 option present
+        // now we should have 1 option present
         // @extensionScannerIgnoreLine
-        $this->assertEquals(1, $optionsFacet->getOptions()->getCount());
+        self::assertEquals(1, $optionsFacet->getOptions()->getCount());
     }
 
     /**
@@ -66,7 +66,7 @@ class OptionsFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $queryGroupFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
 
-        $this->assertEquals('Options', $queryGroupFacet->getPartialName());
+        self::assertEquals('Options', $queryGroupFacet->getPartialName());
     }
 
     /**
@@ -77,7 +77,7 @@ class OptionsFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $queryGroupFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
-        $this->assertEquals('MyPartial', $queryGroupFacet->getPartialName());
+        self::assertEquals('MyPartial', $queryGroupFacet->getPartialName());
     }
 
     /**
@@ -88,7 +88,7 @@ class OptionsFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $myFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
-        $this->assertEquals('options', $myFacet->getType());
+        self::assertEquals('options', $myFacet->getType());
     }
 
     /**
@@ -101,7 +101,7 @@ class OptionsFacetTest extends UnitTest
             'zero' => [0, false],
             'one' => [1, true],
             '1' => ['1', true],
-            '0' => ['0', false]
+            '0' => ['0', false],
         ];
     }
 
@@ -116,6 +116,6 @@ class OptionsFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $myFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['includeInAvailableFacets' => $includeInAvailableFacetsConfiguration]);
 
-        $this->assertSame($myFacet->getIncludeInAvailableFacets(), $expectedResult, 'Method getIncludeInAvailableFacets returns unexpected result');
+        self::assertSame($myFacet->getIncludeInAvailableFacets(), $expectedResult, 'Method getIncludeInAvailableFacets returns unexpected result');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup;
 
 /*
@@ -14,10 +15,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test for the QueryGroupFacet options collection
@@ -46,8 +47,8 @@ class OptionCollectionTest extends UnitTest
         // @extensionScannerIgnoreLine
         $sortedOptions = $facet->getOptions()->getManualSortedCopy(['1year', '1month']);
 
-        $this->assertSame($year, $sortedOptions->getByPosition(0), 'First sorted item was not 1year');
-        $this->assertSame($month, $sortedOptions->getByPosition(1), 'Second item was not 1month');
-        $this->assertSame($week, $sortedOptions->getByPosition(2), 'Third item was not 1week');
+        self::assertSame($year, $sortedOptions->getByPosition(0), 'First sorted item was not 1year');
+        self::assertSame($month, $sortedOptions->getByPosition(1), 'Second item was not 1month');
+        self::assertSame($week, $sortedOptions->getByPosition(2), 'Third item was not 1week');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup;
 
 /*
@@ -14,16 +15,15 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacetParser;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\AbstractFacetParserTest;
 
 /**
@@ -53,25 +53,25 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
         $configuration = [];
         $configuration['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = $facetConfiguration;
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchRequestMock->expects($this->any())
+        $searchRequestMock->expects(self::any())
             ->method('getContextTypoScriptConfiguration')
-            ->will($this->returnValue($typoScriptConfiguration));
+            ->willReturn($typoScriptConfiguration);
 
         $activeUrlFacets = new UrlFacetContainer(
             new ArrayAccessor([ 'tx_solr' => ['filter' => $activeFilters] ])
         );
 
-        $searchRequestMock->expects($this->any())
+        $searchRequestMock->expects(self::any())
             ->method('getActiveFacetNames')
-            ->will($this->returnCallback(function() use ($activeUrlFacets) {
+            ->willReturnCallback(function () use ($activeUrlFacets) {
                 return $activeUrlFacets->getActiveFacetNames();
-            }));
+            });
 
-        $searchRequestMock->expects($this->any())
+        $searchRequestMock->expects(self::any())
             ->method('getHasFacetValue')
-            ->will($this->returnCallback(function(string $facetName, $facetValue) use ($activeUrlFacets) {
+            ->willReturnCallback(function (string $facetName, $facetValue) use ($activeUrlFacets) {
                 return $activeUrlFacets->hasFacetValue($facetName, $facetValue);
-            }));
+            });
 
         return $searchResultSet;
     }
@@ -91,9 +91,9 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
                     'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                     'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                     'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                ]
-            ]
+                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                ],
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -104,7 +104,7 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
-        $this->assertInstanceOf(QueryGroupFacet::class, $facet);
+        self::assertInstanceOf(QueryGroupFacet::class, $facet);
     }
 
     /**
@@ -122,9 +122,9 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
                     'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                     'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                     'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                ]
-            ]
+                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                ],
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -132,11 +132,11 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
             $facetConfiguration
         );
 
-         /** @var $parser QueryGroupFacetParser */
+        /** @var $parser QueryGroupFacetParser */
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
-        $this->assertFalse($facet->getIsUsed());
+        self::assertFalse($facet->getIsUsed());
     }
 
     /**
@@ -154,9 +154,9 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
                     'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                     'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                     'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                ]
-            ]
+                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                ],
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -168,7 +168,7 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
-        $this->assertTrue($facet->getIsUsed());
+        self::assertTrue($facet->getIsUsed());
     }
 
     /**
@@ -186,9 +186,9 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
                     'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                     'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                     'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                ]
-            ]
+                    'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                ],
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -204,9 +204,9 @@ class QueryGroupFacetParserTest extends AbstractFacetParserTest
         /** @var Option $option */ // @extensionScannerIgnoreLine
         foreach ($facet->getOptions() as $option) {
             if ($option->getValue() === 'week') {
-                $this->assertTrue($option->getSelected(), 'Option ' . $option->getValue() . ' isn\'t active');
+                self::assertTrue($option->getSelected(), 'Option ' . $option->getValue() . ' isn\'t active');
             } else {
-                $this->assertFalse((bool)$option->getSelected(), 'Option ' . $option->getValue() . ' is active but was not expected to be');
+                self::assertFalse((bool)$option->getSelected(), 'Option ' . $option->getValue() . ' is active but was not expected to be');
             }
         }
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
 
 /***************************************************************
@@ -27,7 +28,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacetQueryBuilder;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
@@ -62,12 +62,12 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
             'keepAllOptionsOnSelection' => 1,
             'queryGroup.' => [
                 'week.' => ['query' => '[NOW/DAY-7DAYS TO *]'],
-                'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]']
-            ]
+                'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
+            ],
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('testFacet')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
+            $fakeFacetConfiguration
         );
 
         $builder = new QueryGroupFacetQueryBuilder();
@@ -75,13 +75,12 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
         $expectedFacetParameters = [
             'facet.query' => [
                 '{!ex=created}created:[NOW/DAY-7DAYS TO *]',
-                '{!ex=created}created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'
-            ]
+                '{!ex=created}created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]',
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
-
 
     /**
      * @test
@@ -114,11 +113,11 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
                     'field' => 'created',
                     'queryGroup.' => [
                         'week.' => ['query' => '[NOW/DAY-7DAYS TO *]'],
-                        'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]']
-                    ]
-                ]
+                        'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
+                    ],
+                ],
 
-            ]
+            ],
         ];
 
         $fakeConfiguration['plugin.']['tx_solr.']['search.']['faceting.'] = $fakeFacetConfiguration;
@@ -129,11 +128,11 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
         $expectedFacetParameters = [
             'facet.query' => [
                 '{!ex=type,created}created:[NOW/DAY-7DAYS TO *]',
-                '{!ex=type,created}created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'
-            ]
+                '{!ex=type,created}created:[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]',
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
     /**
@@ -157,12 +156,12 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
             'field' => 'created',
             'queryGroup.' => [
                 'week.' => ['query' => '[NOW/DAY-14DAYS TO *]'],
-                'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-14DAYS]']
-            ]
+                'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-14DAYS]'],
+            ],
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('testFacet')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
+            $fakeFacetConfiguration
         );
 
         $builder = new QueryGroupFacetQueryBuilder();
@@ -170,10 +169,10 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
         $expectedFacetParameters = [
             'facet.query' => [
                 'created:[NOW/DAY-14DAYS TO *]',
-                'created:[NOW/DAY-1MONTH TO NOW/DAY-14DAYS]'
-            ]
+                'created:[NOW/DAY-1MONTH TO NOW/DAY-14DAYS]',
+            ],
         ];
 
-        $this->assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
+        self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup;
 
 /*
@@ -14,10 +15,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test for the QueryGroupFacet
@@ -35,7 +36,7 @@ class QueryGroupFacetTest extends UnitTest
     {
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $optionsFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
-        $this->assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from queryGroup facet');
+        self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from queryGroup facet');
     }
 
     /**
@@ -47,14 +48,14 @@ class QueryGroupFacetTest extends UnitTest
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         $option = new Option($queryGroupFacet);
 
-            // before adding there should not be any facet present
+        // before adding there should not be any facet present
         // @extensionScannerIgnoreLine
-        $this->assertEquals(0, $queryGroupFacet->getOptions()->getCount());
+        self::assertEquals(0, $queryGroupFacet->getOptions()->getCount());
         $queryGroupFacet->addOption($option);
 
-            // now we should have 1 option present
+        // now we should have 1 option present
         // @extensionScannerIgnoreLine
-        $this->assertEquals(1, $queryGroupFacet->getOptions()->getCount());
+        self::assertEquals(1, $queryGroupFacet->getOptions()->getCount());
     }
 
     /**
@@ -65,7 +66,7 @@ class QueryGroupFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
 
-        $this->assertEquals('Options', $queryGroupFacet->getPartialName());
+        self::assertEquals('Options', $queryGroupFacet->getPartialName());
     }
 
     /**
@@ -76,6 +77,6 @@ class QueryGroupFacetTest extends UnitTest
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
-        $this->assertEquals('MyPartial', $queryGroupFacet->getPartialName());
+        self::assertEquals('MyPartial', $queryGroupFacet->getPartialName());
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
 
 /*
@@ -35,7 +36,7 @@ class DateRangeFacetParserTest extends AbstractFacetParserTest
                 'type' => 'dateRange',
                 'label' => 'Created',
                 'field' => 'created',
-            ]
+            ],
         ];
 
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -48,15 +49,15 @@ class DateRangeFacetParserTest extends AbstractFacetParserTest
         $parser = $this->getInitializedParser(DateRangeFacetParser::class);
 
         $facet = $parser->parse($searchResultSet, 'myCreated', $facetConfiguration['myCreated.']);
-        $this->assertInstanceOf(DateRangeFacet::class, $facet);
-        $this->assertSame($facet->getConfiguration(), $facetConfiguration['myCreated.'], 'Configuration was not passed to new facets');
-        $this->assertTrue($facet->getIsUsed());
+        self::assertInstanceOf(DateRangeFacet::class, $facet);
+        self::assertSame($facet->getConfiguration(), $facetConfiguration['myCreated.'], 'Configuration was not passed to new facets');
+        self::assertTrue($facet->getIsUsed());
 
-        $this->assertEquals('201506020000-201706020000', $facet->getRange()->getLabel());
-        $this->assertEquals(32, $facet->getRange()->getDocumentCount());
-        $this->assertCount(3, $facet->getRange()->getRangeCounts(), 'We expected that there are three count items attached');
+        self::assertEquals('201506020000-201706020000', $facet->getRange()->getLabel());
+        self::assertEquals(32, $facet->getRange()->getDocumentCount());
+        self::assertCount(3, $facet->getRange()->getRangeCounts(), 'We expected that there are three count items attached');
 
-        $this->assertSame($facet->getRange()->getEndInResponse()->format('Ymd'), '20170602');
-        $this->assertSame($facet->getRange()->getStartInResponse()->format('Ymd'), '20150602');
+        self::assertSame($facet->getRange()->getEndInResponse()->format('Ymd'), '20170602');
+        self::assertSame($facet->getRange()->getStartInResponse()->format('Ymd'), '20150602');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
 
 /***************************************************************
@@ -46,19 +47,19 @@ class DateRangeFacetQueryBuilderTest extends UnitTest
         $fakeFacetConfiguration = [
             'field' => 'created',
             'keepAllOptionsOnSelection' => 1,
-            'dateRange.' => ['start' => 'NOW/DAY-2YEAR', 'end' => 'NOW/DAY+2YEAR', 'gap' => '+1DAY']
+            'dateRange.' => ['start' => 'NOW/DAY-2YEAR', 'end' => 'NOW/DAY+2YEAR', 'gap' => '+1DAY'],
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('testFacet')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
+            $fakeFacetConfiguration
         );
 
         $builder = new DateRangeFacetQueryBuilder();
         $facetParameters = $builder->build('testFacet', $configurationMock);
 
-        $this->assertSame($facetParameters['facet.range'][0], '{!ex=created}created', 'Could not apply keepAllOptionsOnSelection');
-        $this->assertSame($facetParameters['f.created.facet.range.start'], 'NOW/DAY-2YEAR', 'Could not build range.start as expected');
-        $this->assertSame($facetParameters['f.created.facet.range.end'], 'NOW/DAY+2YEAR', 'Could not build range.end as expected');
-        $this->assertSame($facetParameters['f.created.facet.range.gap'], '+1DAY', 'Could not build range.gap as epxected');
+        self::assertSame($facetParameters['facet.range'][0], '{!ex=created}created', 'Could not apply keepAllOptionsOnSelection');
+        self::assertSame($facetParameters['f.created.facet.range.start'], 'NOW/DAY-2YEAR', 'Could not build range.start as expected');
+        self::assertSame($facetParameters['f.created.facet.range.end'], 'NOW/DAY+2YEAR', 'Could not build range.end as expected');
+        self::assertSame($facetParameters['f.created.facet.range.gap'], '+1DAY', 'Could not build range.gap as epxected');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\DateRange;
 
 /*
@@ -26,7 +27,6 @@ class DateRangeTest extends UnitTest
 {
     /**
      * @test
-     * @noinspection PhpUndefinedVariableInspection
      */
     public function canHandleHalfOpenDateRanges()
     {
@@ -57,15 +57,13 @@ class DateRangeTest extends UnitTest
         try {
             $dateRangeCollectionKeyOpenStart = $dateRangeOpenStart->getCollectionKey();
             $dateRangeCollectionKeyOpenEnd = $dateRangeOpenEnd->getCollectionKey();
-
         } catch (\Error $error) {
-            $this->fail(
+            self::fail(
                 'Can\'t handle half open date ranges. Please see: https://github.com/TYPO3-Solr/ext-solr/issues/2942 and error: ' . PHP_EOL .
                 $error->getMessage() . ' in ' . $error->getFile() . ':' . $error->getLine()
             );
         }
-        $this->assertEquals('-202107200000', $dateRangeCollectionKeyOpenStart);
-        $this->assertEquals('202107200000-', $dateRangeCollectionKeyOpenEnd);
+        self::assertEquals('-202107200000', $dateRangeCollectionKeyOpenStart);
+        self::assertEquals('202107200000-', $dateRangeCollectionKeyOpenEnd);
     }
-
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\FilterEncoder;
 
 /***************************************************************
@@ -42,9 +43,10 @@ class DateRangeUrlEncoderTest extends UnitTest
      */
     protected $rangeParser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->rangeParser = GeneralUtility::makeInstance(DateRangeUrlDecoder::class);
+        parent::setUp();
     }
 
     /**
@@ -54,7 +56,7 @@ class DateRangeUrlEncoderTest extends UnitTest
     {
         $expected = '[2010-01-01T00:00:00Z TO 2010-01-31T23:59:59Z]';
         $actual = $this->rangeParser->decode('201001010000-201001312359');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -64,7 +66,7 @@ class DateRangeUrlEncoderTest extends UnitTest
     {
         $expected = '[* TO 2010-01-31T23:59:59Z]';
         $actual = $this->rangeParser->decode('-201001312359');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -74,6 +76,6 @@ class DateRangeUrlEncoderTest extends UnitTest
     {
         $expected = '[2010-01-01T00:00:00Z TO *]';
         $actual = $this->rangeParser->decode('201001010000-');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\NumericRange;
 
 /*
@@ -14,7 +15,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
  * The TYPO3 project - inspiring people to share!
  */
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRange;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\AbstractFacetParserTest;
@@ -42,12 +42,12 @@ class NumericRangeFacetParserTest extends AbstractFacetParserTest
                 'label' => 'Pids',
                 'field' => 'pid',
                 'numericRange.' => [
-                    'start' => (int) $start,
-                    'end' => (int) $end,
-                    'gap' => (int) $gap
+                    'start' => (int)$start,
+                    'end' => (int)$end,
+                    'gap' => (int)$gap,
 
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -81,19 +81,19 @@ class NumericRangeFacetParserTest extends AbstractFacetParserTest
         $facetConfiguration = $this->getPageIdFacetConfiguration();
         $facet = $this->getNumericRangeFacet($facetConfiguration, ['myPids:10-98'], 'myPids');
 
-        $this->assertInstanceOf(NumericRangeFacet::class, $facet);
-        $this->assertSame($facet->getConfiguration(), $facetConfiguration['myPids.'], 'Configuration was not passed to new facets');
-        $this->assertTrue($facet->getIsUsed());
+        self::assertInstanceOf(NumericRangeFacet::class, $facet);
+        self::assertSame($facet->getConfiguration(), $facetConfiguration['myPids.'], 'Configuration was not passed to new facets');
+        self::assertTrue($facet->getIsUsed());
 
-        $this->assertEquals('10-98', $facet->getRange()->getLabel());
-        $this->assertEquals(25, $facet->getRange()->getDocumentCount());
-        $this->assertCount(4, $facet->getRange()->getRangeCounts(), 'We expected that there are four count items attached');
+        self::assertEquals('10-98', $facet->getRange()->getLabel());
+        self::assertEquals(25, $facet->getRange()->getDocumentCount());
+        self::assertCount(4, $facet->getRange()->getRangeCounts(), 'We expected that there are four count items attached');
 
-        $this->assertSame($facet->getRange()->getEndInResponse(), 100);
-        $this->assertSame($facet->getRange()->getStartInResponse(), -100);
-        $this->assertSame($facet->getRange()->getGap(), 2);
-        $this->assertSame((int) $facet->getRange()->getStartRequested(), 10);
-        $this->assertSame((int) $facet->getRange()->getEndRequested(), 98);
+        self::assertSame($facet->getRange()->getEndInResponse(), 100);
+        self::assertSame($facet->getRange()->getStartInResponse(), -100);
+        self::assertSame($facet->getRange()->getGap(), 2);
+        self::assertSame((int)$facet->getRange()->getStartRequested(), 10);
+        self::assertSame((int)$facet->getRange()->getEndRequested(), 98);
     }
 
     /**
@@ -109,8 +109,8 @@ class NumericRangeFacetParserTest extends AbstractFacetParserTest
         $facetConfiguration = $this->getPageIdFacetConfiguration();
         $facet = $this->getNumericRangeFacet($facetConfiguration, ['myPids:' . $startRequested . '-' . $endRequested], 'myPids');
 
-        $this->assertSame((int) $facet->getRange()->getStartRequested(), $startRequested);
-        $this->assertSame((int) $facet->getRange()->getEndRequested(), $endRequested);
+        self::assertSame((int)$facet->getRange()->getStartRequested(), $startRequested);
+        self::assertSame((int)$facet->getRange()->getEndRequested(), $endRequested);
     }
 
     /**
@@ -123,16 +123,16 @@ class NumericRangeFacetParserTest extends AbstractFacetParserTest
         return [
             [
                 'startRequested' => 10,
-                'endRequested' => 98
+                'endRequested' => 98,
             ],
             [
                 'startRequested' => -10,
-                'endRequested' => 98
+                'endRequested' => 98,
             ],
             [
                 'startRequested' => -50,
-                'endRequested' => -1
-            ]
+                'endRequested' => -1,
+            ],
         ];
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\NumericRange;
 
 /***************************************************************
@@ -46,19 +47,19 @@ class NumericRangeFacetQueryBuilderTest extends UnitTest
         $fakeFacetConfiguration = [
             'field' => 'price',
             'keepAllOptionsOnSelection' => 1,
-            'numericRange.' => ['start' => 1, 'end' => 100, 'gap' => 5]
+            'numericRange.' => ['start' => 1, 'end' => 100, 'gap' => 5],
         ];
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetByName')->with('testFacet')->will(
-            $this->returnValue($fakeFacetConfiguration)
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
+            $fakeFacetConfiguration
         );
 
         $builder = new NumericRangeFacetQueryBuilder();
         $facetParameters = $builder->build('testFacet', $configurationMock);
 
-        $this->assertSame($facetParameters['facet.range'][0], '{!ex=price}price', 'Could not apply keepAllOptionsOnSelection');
-        $this->assertSame($facetParameters['f.price.facet.range.start'], 1, 'Could not build range.start as expected');
-        $this->assertSame($facetParameters['f.price.facet.range.end'], 100, 'Could not build range.end as expected');
-        $this->assertSame($facetParameters['f.price.facet.range.gap'], 5, 'Could not build range.gap as epxected');
+        self::assertSame($facetParameters['facet.range'][0], '{!ex=price}price', 'Could not apply keepAllOptionsOnSelection');
+        self::assertSame($facetParameters['f.price.facet.range.start'], 1, 'Could not build range.start as expected');
+        self::assertSame($facetParameters['f.price.facet.range.end'], 100, 'Could not build range.end as expected');
+        self::assertSame($facetParameters['f.price.facet.range.gap'], 5, 'Could not build range.gap as epxected');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\NumericRange;
 
 /***************************************************************
@@ -47,9 +48,10 @@ class NumericRangeUrlEncoderTest extends UnitTest
      */
     protected $rangeParser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->rangeParser = GeneralUtility::makeInstance(NumericRangeUrlDecoder::class);
+        parent::setUp();
     }
 
     /**
@@ -62,7 +64,7 @@ class NumericRangeUrlEncoderTest extends UnitTest
         return [
             ['firstValue' => '50', 'secondValue' => '100', 'expected' => '[50 TO 100]'],
             ['firstValue' => '-10', 'secondValue' => '20', 'expected' => '[-10 TO 20]'],
-            ['firstValue' => '-10', 'secondValue' => '-5', 'expected' => '[-10 TO -5]']
+            ['firstValue' => '-10', 'secondValue' => '-5', 'expected' => '[-10 TO -5]'],
         ];
     }
 
@@ -75,20 +77,17 @@ class NumericRangeUrlEncoderTest extends UnitTest
      * @param string $firstValue
      * @param string $secondValue
      * @param string $expectedResult
-     * @return void
      */
     public function canParseRangeQuery(string $firstValue, string $secondValue, string $expectedResult)
     {
         $actual = $this->rangeParser->decode($firstValue . '-' . $secondValue);
-        $this->assertEquals($expectedResult, $actual);
+        self::assertEquals($expectedResult, $actual);
     }
 
     /**
      * Test the handling of invalid parameters
      *
      * @test
-     *
-     * @return void
      */
     public function canHandleInvalidParameters()
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RenderingInstructions;
 
 /***************************************************************
@@ -27,7 +28,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rend
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
-
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
@@ -41,7 +41,7 @@ class FormatDateTest extends UnitTest
     {
         $processingInstruction = new FormatDate();
         $result = $processingInstruction->format('2015-11-17T17:16:10Z', []);
-        $this->assertSame('17-11-15', $result, 'Could not format date with default format');
+        self::assertSame('17-11-15', $result, 'Could not format date with default format');
     }
 
     /**
@@ -51,7 +51,7 @@ class FormatDateTest extends UnitTest
     {
         $processingInstruction = new FormatDate();
         $result = $processingInstruction->format('2015-11-17T17:16:10Z', ['outputFormat' => 'd.m.Y']);
-        $this->assertSame('17.11.2015', $result, 'Could not format date with default format');
+        self::assertSame('17.11.2015', $result, 'Could not format date with default format');
     }
 
     /**
@@ -61,7 +61,7 @@ class FormatDateTest extends UnitTest
     {
         $processingInstruction = new FormatDate();
         $fiveDays = (60 * 60 * 24 * 5) - 1;
-        $result = $processingInstruction->format((string) $fiveDays, ['inputFormat' => 'U', 'outputFormat' => 'd.m.Y']);
-        $this->assertSame('05.01.1970', $result, 'Could not format date from timestamp');
+        $result = $processingInstruction->format((string)$fiveDays, ['inputFormat' => 'U', 'outputFormat' => 'd.m.Y']);
+        self::assertSame('05.01.1970', $result, 'Could not format date from timestamp');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -32,7 +33,7 @@ class RequirementsServiceTest extends UnitTest
     {
         $facet = $this->getDumbMock(OptionsFacet::class);
         $service = new RequirementsService();
-        $this->assertTrue($service->getAllRequirementsMet($facet), 'Facet without any requirements should met all requirements');
+        self::assertTrue($service->getAllRequirementsMet($facet), 'Facet without any requirements should met all requirements');
     }
 
     /**
@@ -49,14 +50,14 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red'
-                ]
-            ]
+                    'values' => 'red',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement is not met');
+        self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement is not met');
     }
 
     /**
@@ -78,14 +79,14 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red,green'
-                ]
-            ]
+                    'values' => 'red,green',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color option is present, but is indicated to not be met');
+        self::assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color option is present, but is indicated to not be met');
     }
 
     /**
@@ -110,19 +111,19 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red,green'
+                    'values' => 'red,green',
                 ],
                 'matchesSize' => [
                     'facet' => 'mysize',
-                    'values' => 'xl'
+                    'values' => 'xl',
                 ],
 
-            ]
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color and size option is present, but is indicated to not be met');
+        self::assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color and size option is present, but is indicated to not be met');
     }
 
     /**
@@ -144,19 +145,19 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red,green'
+                    'values' => 'red,green',
                 ],
                 'matchesSize' => [
                     'facet' => 'mysize',
-                    'values' => 'xl'
+                    'values' => 'xl',
                 ],
 
-            ]
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met since the matchesSize requirement is not met.');
+        self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met since the matchesSize requirement is not met.');
     }
 
     /**
@@ -177,14 +178,14 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'blue,green'
-                ]
-            ]
+                    'values' => 'blue,green',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the facet has not the require value');
+        self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the facet has not the require value');
     }
 
     /**
@@ -205,14 +206,14 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red,blue,green'
-                ]
-            ]
+                    'values' => 'red,blue,green',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the required option is not selected');
+        self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the required option is not selected');
     }
 
     /**
@@ -228,9 +229,9 @@ class RequirementsServiceTest extends UnitTest
             'requirements.' => [
                 'matchesColor' => [
                     'facet' => 'mycolor',
-                    'values' => 'red,green'
-                ]
-            ]
+                    'values' => 'red,green',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
@@ -257,14 +258,13 @@ class RequirementsServiceTest extends UnitTest
                 'matchesColor' => [
                     'facet' => 'mycolor',
                     'values' => 'blue,green',
-                    'negate' => '1'
-                ]
-            ]
+                    'negate' => '1',
+                ],
+            ],
         ];
         $categoryFacet = new OptionsFacet($resultSet, 'mycategory', 'category_stringM', 'Category', $categoryConfig);
         $resultSet->addFacet($categoryFacet);
         $service = new RequirementsService();
-        $this->assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met because of negate but is not met');
+        self::assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met because of negate but is not met');
     }
-
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /***************************************************************
@@ -85,7 +86,7 @@ class SortingExpressionTest extends UnitTest
     /**
      * @param string $sorting
      * @param string $direction
-     * @param boolean $isJson
+     * @param bool $isJson
      * @param string $expectedResult
      * @dataProvider canBuildSortExpressionDataProvider
      * @test
@@ -98,6 +99,6 @@ class SortingExpressionTest extends UnitTest
         } else {
             $result = $expression->getForFacet($sorting);
         }
-        $this->assertSame($expectedResult, $result, 'Unexpected expression for solr server');
+        self::assertSame($expectedResult, $result, 'Unexpected expression for solr server');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 
-class TestFacet extends AbstractFacet  {
+class TestFacet extends AbstractFacet
+{
 
     /**
      * The implementation of this method should return a "flatten" collection of all items.

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetPackage;
 
-class TestPackage extends AbstractFacetPackage {
+class TestPackage extends AbstractFacetPackage
+{
 
     /**
      * @return string

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
-class TestParser extends AbstractFacetParser  {
+class TestParser extends AbstractFacetParser
+{
 
     /**
      * @param SearchResultSet $resultSet

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 /*
@@ -36,9 +37,9 @@ class UrlFacetContainerTest extends UnitTest
                 'type:pages',
                 'type:example',
                 'type:news',
-                'created:12345'
-            ]
-        ]
+                'created:12345',
+            ],
+        ],
     ];
     /**
      * Test data for assoc based url parameters
@@ -51,9 +52,9 @@ class UrlFacetContainerTest extends UnitTest
                 'type:pages' => 1,
                 'type:example' => 1,
                 'type:news' => 1,
-                'created:12345' => 1
-            ]
-        ]
+                'created:12345' => 1,
+            ],
+        ],
     ];
 
     /**
@@ -63,7 +64,7 @@ class UrlFacetContainerTest extends UnitTest
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
         $urlFacetBack->enableSort();
-        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+        self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
     /**
@@ -76,7 +77,7 @@ class UrlFacetContainerTest extends UnitTest
             'tx_solr',
             'assoc'
         );
-        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+        self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
     /**
@@ -85,9 +86,9 @@ class UrlFacetContainerTest extends UnitTest
     public function canRemoveAllIndexFacetsParameter()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
-        $this->assertEquals(4, $urlFacetBack->count());
+        self::assertEquals(4, $urlFacetBack->count());
         $urlFacetBack->removeAllFacets();
-        $this->assertEquals(0, $urlFacetBack->count());
+        self::assertEquals(0, $urlFacetBack->count());
     }
 
     /**
@@ -100,9 +101,9 @@ class UrlFacetContainerTest extends UnitTest
             'tx_solr',
             'assoc'
         );
-        $this->assertEquals(4, $urlFacetBack->count());
+        self::assertEquals(4, $urlFacetBack->count());
         $urlFacetBack->removeAllFacets();
-        $this->assertEquals(0, $urlFacetBack->count());
+        self::assertEquals(0, $urlFacetBack->count());
     }
 
     /**
@@ -111,9 +112,9 @@ class UrlFacetContainerTest extends UnitTest
     public function canRemoveAllFacetsParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
-        $this->assertEquals(4, $urlFacetBack->count());
+        self::assertEquals(4, $urlFacetBack->count());
         $urlFacetBack->removeAllFacetValuesByName('type');
-        $this->assertEquals(1, $urlFacetBack->count());
+        self::assertEquals(1, $urlFacetBack->count());
     }
 
     /**
@@ -126,9 +127,9 @@ class UrlFacetContainerTest extends UnitTest
             'tx_solr',
             'assoc'
         );
-        $this->assertEquals(4, $urlFacetBack->count());
+        self::assertEquals(4, $urlFacetBack->count());
         $urlFacetBack->removeAllFacetValuesByName('type');
-        $this->assertEquals(1, $urlFacetBack->count());
+        self::assertEquals(1, $urlFacetBack->count());
     }
 
     /**
@@ -137,9 +138,9 @@ class UrlFacetContainerTest extends UnitTest
     public function canRemoveASingleFacetParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
-        $this->assertEquals(4, $urlFacetBack->count());
+        self::assertEquals(4, $urlFacetBack->count());
         $urlFacetBack->removeFacetValue('type', 'example');
-        $this->assertEquals(3, $urlFacetBack->count());
+        self::assertEquals(3, $urlFacetBack->count());
     }
 
     /**
@@ -153,7 +154,7 @@ class UrlFacetContainerTest extends UnitTest
             'assoc'
         );
         $urlFacetBack->removeFacetValue('type', 'example');
-        $this->assertEquals(3, $urlFacetBack->count());
+        self::assertEquals(3, $urlFacetBack->count());
     }
 
     /**
@@ -162,7 +163,7 @@ class UrlFacetContainerTest extends UnitTest
     public function keepOrderingOfIndexParameters()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
-        $this->assertEquals(['pages', 'example', 'news'], $urlFacetBack->getActiveFacetValuesByName('type'));
+        self::assertEquals(['pages', 'example', 'news'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
     /**
@@ -172,7 +173,7 @@ class UrlFacetContainerTest extends UnitTest
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
         $urlFacetBack->enableSort();
-        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+        self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
     /**
@@ -185,7 +186,7 @@ class UrlFacetContainerTest extends UnitTest
             'tx_solr',
             'assoc'
         );
-        $this->assertNotEquals(
+        self::assertNotEquals(
             ['pages', 'example', 'news'],
             $urlFacetBack->getActiveFacetValuesByName('type')
         );
@@ -201,6 +202,6 @@ class UrlFacetContainerTest extends UnitTest
             'tx_solr',
             'assoc'
         );
-        $this->assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
+        self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Grouping;
 
 /***************************************************************
@@ -50,9 +51,8 @@ class GroupCollectionTest extends UnitTest
         $groupCollection[] = $groupB;
         $groupCollection[] = $groupC;
 
-        $this->assertSame($groupB, $groupCollection->getByName('color'), 'Could not get groupByName');
-        $this->assertNull($groupCollection->getByName('unexisting'), 'Could not get groupByName');
-
+        self::assertSame($groupB, $groupCollection->getByName('color'), 'Could not get groupByName');
+        self::assertNull($groupCollection->getByName('unexisting'), 'Could not get groupByName');
     }
 
     /**
@@ -69,7 +69,7 @@ class GroupCollectionTest extends UnitTest
         $groupCollection[] = $groupB;
         $groupCollection[] = $groupC;
 
-        $this->assertSame(['type','color','price'], $groupCollection->getGroupNames(), 'Could not get groupNames');
+        self::assertSame(['type', 'color', 'price'], $groupCollection->getGroupNames(), 'Could not get groupNames');
     }
 
     /**
@@ -81,8 +81,7 @@ class GroupCollectionTest extends UnitTest
         $groupCollection = new GroupCollection();
         $groupCollection[] = $groupA;
 
-        $this->assertTrue($groupCollection->getHasWithName('price'), 'Item that should be in GroupCollection does not occure in GroupCollection');
-        $this->assertFalse($groupCollection->getHasWithName('nonexisting'), 'Unexisting GroupCollection item was indicated to exist in the collection');
+        self::assertTrue($groupCollection->getHasWithName('price'), 'Item that should be in GroupCollection does not occure in GroupCollection');
+        self::assertFalse($groupCollection->getHasWithName('nonexisting'), 'Unexisting GroupCollection item was indicated to exist in the collection');
     }
-
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Grouping;
 
 /***************************************************************
@@ -47,13 +48,11 @@ class GroupItemTest extends UnitTest
      */
     protected $parentGroup;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parentGroup = new Group('typeGroup');
         $this->groupItem = new GroupItem($this->parentGroup, 'pages', 12, 1, 99);
+        parent::setUp();
     }
 
     /**
@@ -61,7 +60,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetMaximumScore()
     {
-        $this->assertSame(99, $this->groupItem->getMaximumScore(), 'Unexpected maximumScore');
+        self::assertSame(99, $this->groupItem->getMaximumScore(), 'Unexpected maximumScore');
     }
 
     /**
@@ -69,7 +68,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetStart()
     {
-        $this->assertSame(1, $this->groupItem->getStart(), 'Unexpected start');
+        self::assertSame(1, $this->groupItem->getStart(), 'Unexpected start');
     }
 
     /**
@@ -77,7 +76,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetNumFound()
     {
-        $this->assertSame(12, $this->groupItem->getAllResultCount(), 'Unexpected numFound');
+        self::assertSame(12, $this->groupItem->getAllResultCount(), 'Unexpected numFound');
     }
 
     /**
@@ -85,7 +84,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetGroupValue()
     {
-        $this->assertSame('pages', $this->groupItem->getGroupValue(), 'Unexpected groupValue');
+        self::assertSame('pages', $this->groupItem->getGroupValue(), 'Unexpected groupValue');
     }
 
     /**
@@ -93,7 +92,7 @@ class GroupItemTest extends UnitTest
      */
     public function canGetGroup()
     {
-        $this->assertSame($this->parentGroup, $this->groupItem->getGroup(), 'Unexpected parentGroup');
+        self::assertSame($this->parentGroup, $this->groupItem->getGroup(), 'Unexpected parentGroup');
     }
 
     /**
@@ -101,11 +100,11 @@ class GroupItemTest extends UnitTest
      */
     public function canGetSearchResults()
     {
-        $this->assertSame(0, $this->groupItem->getSearchResults()->getCount());
+        self::assertSame(0, $this->groupItem->getSearchResults()->getCount());
 
         $searchResult = $this->getDumbMock(SearchResult::class);
         $this->groupItem->addSearchResult($searchResult);
 
-        $this->assertSame(1, $this->groupItem->getSearchResults()->getCount());
+        self::assertSame(1, $this->groupItem->getSearchResults()->getCount());
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Grouping;
 
 /***************************************************************
@@ -43,11 +44,10 @@ class GroupTest extends UnitTest
     public function testCanGroupName()
     {
         $group = new Group('typeGroup');
-        $this->assertSame('typeGroup', $group->getGroupName(), 'Can not getGroupName from group');
+        self::assertSame('typeGroup', $group->getGroupName(), 'Can not getGroupName from group');
 
         $group->setGroupName('changedTypeGroup');
-        $this->assertSame('changedTypeGroup', $group->getGroupName(), 'Can not getGroupName from group');
-
+        self::assertSame('changedTypeGroup', $group->getGroupName(), 'Can not getGroupName from group');
     }
 
     /**
@@ -56,7 +56,7 @@ class GroupTest extends UnitTest
     public function canGetGroupItemsReturnEmptyCollection()
     {
         $group = new Group('typeGroup');
-        $this->assertSame(0, $group->getGroupItems()->getCount(), 'Can not get empty groupItem collection');
+        self::assertSame(0, $group->getGroupItems()->getCount(), 'Can not get empty groupItem collection');
     }
 
     /**
@@ -65,10 +65,10 @@ class GroupTest extends UnitTest
     public function canGetResultsPerPage()
     {
         $group = new Group('typeGroup', 22);
-        $this->assertSame(22, $group->getResultsPerPage(), 'Can not get results per page');
+        self::assertSame(22, $group->getResultsPerPage(), 'Can not get results per page');
 
         $group->setResultsPerPage(11);
-        $this->assertSame(11, $group->getResultsPerPage(), 'Can not get results per page');
+        self::assertSame(11, $group->getResultsPerPage(), 'Can not get results per page');
     }
 
     /**
@@ -83,7 +83,7 @@ class GroupTest extends UnitTest
 
         $group->setGroupItems($groupItems);
 
-        $this->assertSame($groupItems, $group->getGroupItems(), 'Can not get group items from group');
+        self::assertSame($groupItems, $group->getGroupItems(), 'Can not get group items from group');
     }
 
     /**
@@ -93,10 +93,10 @@ class GroupTest extends UnitTest
     {
         $group = new Group('typeGroup', 10);
 
-        $this->assertCount(0, $group->getGroupItems(), 'GroupItems are not empty from the beginning');
+        self::assertCount(0, $group->getGroupItems(), 'GroupItems are not empty from the beginning');
         $groupItem = new GroupItem($group, 'test', 12, 0, 22.0);
         $group->addGroupItem($groupItem);
 
-        $this->assertCount(1, $group->getGroupItems(), 'Unexpected group item count after adding a group');
+        self::assertCount(1, $group->getGroupItems(), 'Unexpected group item count after adding a group');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser;
 
 /***************************************************************
@@ -48,10 +49,11 @@ class DefaultParserTest extends UnitTest
      */
     protected $parser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->parser = new DefaultResultParser();
+        parent::setUp();
     }
 
     /**
@@ -59,14 +61,14 @@ class DefaultParserTest extends UnitTest
      */
     public function parseWillCreateResultCollectionFromSolrResponse()
     {
-        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
         $fakedSolrResponse = $this->getFixtureContentByName('fakeResponse.json');
         $fakeResponse = new ResponseAdapter($fakedSolrResponse);
 
-        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $fakeResultSet->expects(self::once())->method('getResponse')->willReturn($fakeResponse);
         $parsedResultSet = $this->parser->parse($fakeResultSet, true);
-        $this->assertCount(3, $parsedResultSet->getSearchResults());
+        self::assertCount(3, $parsedResultSet->getSearchResults());
     }
 
     /**
@@ -74,14 +76,14 @@ class DefaultParserTest extends UnitTest
      */
     public function returnsResultSetWithResultCount()
     {
-        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
         $fakedSolrResponse = $this->getFixtureContentByName('fake_solr_response_with_query_fields_facets.json');
         $fakeResponse = new ResponseAdapter($fakedSolrResponse);
 
-        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $fakeResultSet->expects(self::once())->method('getResponse')->willReturn($fakeResponse);
         $parsedResultSet = $this->parser->parse($fakeResultSet, true);
-        $this->assertSame(10, $parsedResultSet->getAllResultCount());
+        self::assertSame(10, $parsedResultSet->getAllResultCount());
     }
 
     /**
@@ -89,14 +91,14 @@ class DefaultParserTest extends UnitTest
      */
     public function parseWillSetMaximumScore()
     {
-        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->setMethods(['getResponse'])->getMock();
+        $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
         $fakedSolrResponse = $this->getFixtureContentByName('fakeResponse.json');
         $fakeResponse = new ResponseAdapter($fakedSolrResponse);
 
-        $fakeResultSet->expects($this->once())->method('getResponse')->will($this->returnValue($fakeResponse));
+        $fakeResultSet->expects(self::once())->method('getResponse')->willReturn($fakeResponse);
         $parsedResultSet = $this->parser->parse($fakeResultSet, true);
-        $this->assertSame(3.1, $parsedResultSet->getMaximumScore());
+        self::assertSame(3.1, $parsedResultSet->getMaximumScore());
     }
 
     /**
@@ -105,12 +107,12 @@ class DefaultParserTest extends UnitTest
     public function canParseReturnsFalseWhenGroupingIsEnabled()
     {
         $requestMock = $this->getDumbMock(SearchRequest::class);
-        $requestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($this->configurationMock));
+        $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);
         $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
-        $fakeResultSet->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue($requestMock));
+        $fakeResultSet->expects(self::any())->method('getUsedSearchRequest')->willReturn($requestMock);
 
-        $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(true));
-        $this->assertFalse($this->parser->canParse($fakeResultSet));
+        $this->configurationMock->expects(self::once())->method('getSearchGrouping')->willReturn(true);
+        self::assertFalse($this->parser->canParse($fakeResultSet));
     }
 
     /**
@@ -119,13 +121,11 @@ class DefaultParserTest extends UnitTest
     public function canParseReturnsTrueWhenGroupingIsDisabled()
     {
         $requestMock = $this->getDumbMock(SearchRequest::class);
-        $requestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($this->configurationMock));
+        $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);
         $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
-        $fakeResultSet->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue($requestMock));
+        $fakeResultSet->expects(self::any())->method('getUsedSearchRequest')->willReturn($requestMock);
 
-        $this->configurationMock->expects($this->once())->method('getSearchGrouping')->will($this->returnValue(false));
-        $this->assertTrue($this->parser->canParse($fakeResultSet));
+        $this->configurationMock->expects(self::once())->method('getSearchGrouping')->willReturn(false);
+        self::assertTrue($this->parser->canParse($fakeResultSet));
     }
-
-
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser;
 
 /***************************************************************
@@ -26,8 +27,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Pars
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\ResultParserRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser\TestResultParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
@@ -43,18 +42,10 @@ class ResultParserRegistryTest extends UnitTest
      */
     protected $registry;
 
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->registry = new ResultParserRegistry($this->configurationMock);
+        $this->registry = new ResultParserRegistry();
+        parent::setUp();
     }
 
     /**
@@ -65,7 +56,7 @@ class ResultParserRegistryTest extends UnitTest
         $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
         $this->registry->registerParser(TestResultParser::class, 200);
         $retrievedParser = $this->registry->getParser($fakeResultSet);
-        $this->assertInstanceOf(TestResultParser::class, $retrievedParser, 'Did not retrieve register custom parser with higher priority');
+        self::assertInstanceOf(TestResultParser::class, $retrievedParser, 'Did not retrieve register custom parser with higher priority');
     }
 
     /**
@@ -74,7 +65,7 @@ class ResultParserRegistryTest extends UnitTest
     public function hasParser()
     {
         $this->registry->registerParser(TestResultParser::class, 200);
-        $this->assertTrue($this->registry->hasParser(TestResultParser::class, 200), 'hasParser returned unexpected result for a parser that should exist');
-        $this->assertFalse($this->registry->hasParser('Fooo', 100), 'hasParser returned unexpected result for a parser that not should exist');
+        self::assertTrue($this->registry->hasParser(TestResultParser::class, 200), 'hasParser returned unexpected result for a parser that should exist');
+        self::assertFalse($this->registry->hasParser('Fooo', 100), 'hasParser returned unexpected result for a parser that not should exist');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Parser;
 
 /***************************************************************
@@ -25,7 +26,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Pars
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\AbstractResultParser;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\DefaultResultParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result;
 
 /***************************************************************
@@ -40,14 +41,12 @@ class SearchResultCollectionTest extends UnitTest
     /**
      * @var SearchResultCollection
      */
-    protected $searchResultCollection = null;
+    protected $searchResultCollection;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->searchResultCollection = new SearchResultCollection();
+        parent::setUp();
     }
 
     /**
@@ -55,7 +54,7 @@ class SearchResultCollectionTest extends UnitTest
      */
     public function getHasGroupsReturnsFalseByDefault()
     {
-        $this->assertFalse($this->searchResultCollection->getHasGroups());
+        self::assertFalse($this->searchResultCollection->getHasGroups());
     }
 
     /**
@@ -65,7 +64,7 @@ class SearchResultCollectionTest extends UnitTest
     {
         $groupA = new Group('foo');
         $this->searchResultCollection->getGroups()->add($groupA);
-        $this->assertTrue($this->searchResultCollection->getHasGroups());
+        self::assertTrue($this->searchResultCollection->getHasGroups());
     }
 
     /**
@@ -75,6 +74,6 @@ class SearchResultCollectionTest extends UnitTest
     {
         $groupCollection = new GroupCollection();
         $this->searchResultCollection->setGroups($groupCollection);
-        $this->assertSame($groupCollection, $this->searchResultCollection->getGroups());
+        self::assertSame($groupCollection, $this->searchResultCollection->getGroups());
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test case for the SearchResult.
@@ -39,7 +40,7 @@ class SearchResultTest extends UnitTest
      */
     protected $searchResult;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $fields = [
             'id' => 4711,
@@ -48,9 +49,10 @@ class SearchResultTest extends UnitTest
             'content' => 'foobar',
             'isElevated' => true,
             'url' => '://mytestdomain.com/test',
-            'type' => 'pages'
+            'type' => 'pages',
         ];
         $this->searchResult = new SearchResult($fields);
+        parent::setUp();
     }
 
     /**
@@ -58,7 +60,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetId()
     {
-        $this->assertSame(4711, $this->searchResult->getId(), 'Could not get id from searchResult');
+        self::assertSame(4711, $this->searchResult->getId(), 'Could not get id from searchResult');
     }
 
     /**
@@ -66,7 +68,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetScore()
     {
-        $this->assertSame(0.55, $this->searchResult->getScore(), 'Could not get score from searchResult');
+        self::assertSame(0.55, $this->searchResult->getScore(), 'Could not get score from searchResult');
     }
 
     /**
@@ -74,7 +76,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetContent()
     {
-        $this->assertSame('foobar', $this->searchResult->getContent(), 'Could not get content from searchResult');
+        self::assertSame('foobar', $this->searchResult->getContent(), 'Could not get content from searchResult');
     }
 
     /**
@@ -82,7 +84,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetType()
     {
-        $this->assertSame('pages', $this->searchResult->getType(), 'Could not get type from searchResult');
+        self::assertSame('pages', $this->searchResult->getType(), 'Could not get type from searchResult');
     }
 
     /**
@@ -90,7 +92,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetTitle()
     {
-        $this->assertSame('The title', $this->searchResult->getTitle(), 'Could not get title from searchResult');
+        self::assertSame('The title', $this->searchResult->getTitle(), 'Could not get title from searchResult');
     }
 
     /**
@@ -98,7 +100,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetUrl()
     {
-        $this->assertSame('://mytestdomain.com/test', $this->searchResult->getUrl(), 'Could not get url from searchResult');
+        self::assertSame('://mytestdomain.com/test', $this->searchResult->getUrl(), 'Could not get url from searchResult');
     }
 
     /**
@@ -106,7 +108,7 @@ class SearchResultTest extends UnitTest
      */
     public function canGetIsElevated()
     {
-        $this->assertSame(true, $this->searchResult->getIsElevated(), 'Could not get isElevated from searchResult');
+        self::assertTrue($this->searchResult->getIsElevated(), 'Could not get isElevated from searchResult');
     }
 
     /**
@@ -114,6 +116,6 @@ class SearchResultTest extends UnitTest
      */
     public function getOnUnexistingFieldReturnsNull()
     {
-        $this->assertNull($this->searchResult->getUnexistingField(), 'Calling getter for unexisting field does not return null');
+        self::assertNull($this->searchResult->getUnexistingField(), 'Calling getter for unexisting field does not return null');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -15,16 +15,16 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\ResultSetReconstitutionProcessor;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
@@ -61,14 +61,13 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no spelling suggestions
         // are present
-        $this->assertFalse($searchResultSet->getHasSpellCheckingSuggestions());
-
+        self::assertFalse($searchResultSet->getHasSpellCheckingSuggestions());
 
         $processor = new ResultSetReconstitutionProcessor();
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be present
-        $this->assertTrue($searchResultSet->getHasSpellCheckingSuggestions());
+        self::assertTrue($searchResultSet->getHasSpellCheckingSuggestions());
     }
 
     /**
@@ -80,7 +79,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -88,17 +87,16 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type',
-                ]
-             ]
+                ],
+             ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
         // after the reconstitution they should be 1 facet present
-        $this->assertCount(1, $searchResultSet->getFacets());
+        self::assertCount(1, $searchResultSet->getFacets());
     }
-
 
     /**
      * @test
@@ -109,16 +107,16 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
             'facets.' => [
                 'type.' => [
                     'label' => 'My Type',
-                    'field' => 'type'
-                ]
-            ]
+                    'field' => 'type',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -126,14 +124,14 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be 1 facet present
-        $this->assertCount(1, $searchResultSet->getFacets());
+        self::assertCount(1, $searchResultSet->getFacets());
 
         /** @var $optionFacet OptionsFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
         // @extensionScannerIgnoreLine
-        $this->assertSame('tx_myext_domain_model_mytype', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Custom type facet not found');
+        self::assertSame('tx_myext_domain_model_mytype', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Custom type facet not found');
         // @extensionScannerIgnoreLine
-        $this->assertSame(19, $optionFacet->getOptions()->getByPosition(0)->getDocumentCount(), 'Custom type facet count not correct');
+        self::assertSame(19, $optionFacet->getOptions()->getByPosition(0)->getDocumentCount(), 'Custom type facet count not correct');
     }
 
     /**
@@ -145,7 +143,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -157,8 +155,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'category.' => [
                     'label' => 'My Category',
                     'field' => 'category_stringM',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -166,7 +164,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be 2 facets present
-        $this->assertCount(2, $searchResultSet->getFacets());
+        self::assertCount(2, $searchResultSet->getFacets());
     }
 
     /**
@@ -178,7 +176,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -186,25 +184,24 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type_stringS',
-                    'excludeValues' => 'somethingelse, page, whatever'
-                ]
-            ]
+                    'excludeValues' => 'somethingelse, page, whatever',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        $this->assertCount(1, $searchResultSet->getFacets());
+        self::assertCount(1, $searchResultSet->getFacets());
 
-            /** @var $optionFacet OptionsFacet */
+        /** @var $optionFacet OptionsFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
         // @extensionScannerIgnoreLine
-        $this->assertCount(1, $optionFacet->getOptions());
+        self::assertCount(1, $optionFacet->getOptions());
         // @extensionScannerIgnoreLine
-        $this->assertSame('event', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Skipping configured value not working as expected');
+        self::assertSame('event', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Skipping configured value not working as expected');
     }
-
 
     /**
      * @test
@@ -215,7 +212,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -226,15 +223,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                     'requirements.' => [
                         'categoryIsInternal.' => [
                             'facet' => 'myCategory',
-                            'values' => 'internal'
-                        ]
-                    ]
+                            'values' => 'internal',
+                        ],
+                    ],
                 ],
                 'myCategory.' => [
                     'label' => 'My Category',
                     'field' => 'category_stringM',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -242,13 +239,12 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be 1 facet present
-        $this->assertCount(2, $searchResultSet->getFacets());
+        self::assertCount(2, $searchResultSet->getFacets());
 
         $firstFacet = $searchResultSet->getFacets()->getByPosition(0);
-        $this->assertSame('myType', $firstFacet->getName(), 'Unexpected facet name for first facet');
-        $this->assertFalse($firstFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
+        self::assertSame('myType', $firstFacet->getName(), 'Unexpected facet name for first facet');
+        self::assertFalse($firstFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
     }
-
 
     /**
      * @test
@@ -256,15 +252,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function canSetRequirementsMetToTrueOnFacetThatFullFillsARequirement()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 return $name == 'myType' ? ['pages'] : [];
-            })
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -279,11 +275,11 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                     'requirements.' => [
                         'typeIsPage.' => [
                             'facet' => 'myType',
-                            'values' => 'pages'
-                        ]
-                    ]
-                ]
-            ]
+                            'values' => 'pages',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -291,11 +287,11 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be 1 facet present
-        $this->assertCount(2, $searchResultSet->getFacets());
+        self::assertCount(2, $searchResultSet->getFacets());
 
         $secondFacet = $searchResultSet->getFacets()->getByPosition(1);
-        $this->assertSame('myCategory', $secondFacet->getName(), 'Unexpected facet name for first facet');
-        $this->assertTrue($secondFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
+        self::assertSame('myCategory', $secondFacet->getName(), 'Unexpected facet name for first facet');
+        self::assertTrue($secondFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
     }
 
     /**
@@ -307,15 +303,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type_stringS',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -327,11 +323,11 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $option1 Option */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
-        $this->assertSame('page', $option1->getValue());
+        self::assertSame('page', $option1->getValue());
 
         /** @var $option2 Option */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
-        $this->assertSame('event', $option2->getValue());
+        self::assertSame('event', $option2->getValue());
     }
 
     /**
@@ -343,7 +339,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -351,8 +347,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                     'reverseOrder' => 1,
                     'label' => 'My Type',
                     'field' => 'type_stringS',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -364,13 +360,12 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $option1 Option */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
-        $this->assertSame('event', $option1->getValue());
+        self::assertSame('event', $option1->getValue());
 
         /** @var $option2 Option */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
-        $this->assertSame('page', $option2->getValue());
+        self::assertSame('page', $option2->getValue());
     }
-
 
     /**
      * @test
@@ -381,7 +376,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -389,8 +384,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                     'manualSortOrder' => 'event,page',
                     'label' => 'My Type',
                     'field' => 'type_stringS',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -402,11 +397,11 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $option1 Option */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
-        $this->assertSame('event', $option1->getValue());
+        self::assertSame('event', $option1->getValue());
 
         /** @var $option2 Option */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
-        $this->assertSame('page', $option2->getValue());
+        self::assertSame('page', $option2->getValue());
     }
 
     /**
@@ -418,7 +413,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -429,13 +424,13 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 ],
                 'category.' => [
                     'label' => 'My Category',
-                    'field' => 'category_stringM'
+                    'field' => 'category_stringM',
                 ],
                 'category2.' => [
                     'label' => 'My Category again',
-                    'field' => 'category_stringM'
-                ]
-            ]
+                    'field' => 'category_stringM',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -443,13 +438,12 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be 1 facet present
-        $this->assertCount(3, $searchResultSet->getFacets());
+        self::assertCount(3, $searchResultSet->getFacets());
 
         /** @var OptionsFacet $facet */
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(2, $facets->getByPosition(0)->getOptions());
+        self::assertCount(2, $facets->getByPosition(0)->getOptions());
     }
-
 
     /**
      * @test
@@ -457,16 +451,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function canReconstituteUsedFacet()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
-
-            })
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -477,9 +470,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 ],
                 'category.' => [
                     'label' => 'My Category',
-                    'field' => 'category'
-                ]
-            ]
+                    'field' => 'category',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -487,19 +480,19 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         // after the reconstitution we should have two facets present
-        $this->assertCount(2, $searchResultSet->getFacets());
+        self::assertCount(2, $searchResultSet->getFacets());
 
         $facets = $searchResultSet->getFacets();
 
         /** @var OptionsFacet $facet1 */
         $facet1 = $facets->getByPosition(0);
-        $this->assertEquals('My Type', $facet1->getLabel());
-        $this->assertTrue($facet1->getIsUsed());
+        self::assertEquals('My Type', $facet1->getLabel());
+        self::assertTrue($facet1->getIsUsed());
 
         /** @var OptionsFacet $facet2 */
         $facet2 = $facets->getByPosition(1);
-        $this->assertEquals('My Category', $facet2->getLabel());
-        $this->assertFalse($facet2->getIsUsed());
+        self::assertEquals('My Category', $facet2->getLabel());
+        self::assertFalse($facet2->getIsUsed());
     }
 
     /**
@@ -508,16 +501,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function canMarkUsedOptionAsSelected()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
-
-            })
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -529,9 +521,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                  // category is configured but not available
                 'category.' => [
                     'label' => 'My Category',
-                    'field' => 'category'
-                ]
-            ]
+                    'field' => 'category',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -540,9 +532,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         $facets = $searchResultSet->getFacets();
 
-        $this->assertCount(2, $facets, 'we have two facets at all');
-        $this->assertCount(1, $facets->getAvailable(), 'but only "type" is available');
-        $this->assertCount(1, $facets->getUsed(), 'and also "type" is the only used facet');
+        self::assertCount(2, $facets, 'we have two facets at all');
+        self::assertCount(1, $facets->getAvailable(), 'but only "type" is available');
+        self::assertCount(1, $facets->getUsed(), 'and also "type" is the only used facet');
     }
 
     /**
@@ -551,16 +543,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function includeIsUsedFacetsCanBeSetToFalse()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
-
-            })
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -568,9 +559,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type',
-                    'includeInUsedFacets' => '0'
-                ]
-            ]
+                    'includeInUsedFacets' => '0',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -579,8 +570,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         $facets = $searchResultSet->getFacets();
 
-        $this->assertCount(1, $facets, 'we have one facets at all');
-        $this->assertCount(0, $facets->getUsed(), 'we should have 0 used facets because type has configuration includeInUsedFacets=0');
+        self::assertCount(1, $facets, 'we have one facets at all');
+        self::assertCount(0, $facets->getUsed(), 'we should have 0 used facets because type has configuration includeInUsedFacets=0');
     }
 
     /**
@@ -589,16 +580,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function canGetConfiguredFacetNotInResponseAsUnavailableFacet()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 return $name == 'type' ? ['pages'] : [];
-
-            })
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -606,8 +596,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type',
-                ]
-            ]
+                ],
+            ],
 
         ];
 
@@ -622,8 +612,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $firstOption Option */ // @extensionScannerIgnoreLine
         $firstOption = $facet1->getOptions()->getByPosition(0);
-        $this->assertEquals('pages', $firstOption->getValue());
-        $this->assertEquals(5, $firstOption->getDocumentCount());
+        self::assertEquals('pages', $firstOption->getValue());
+        self::assertEquals(5, $firstOption->getDocumentCount());
         $this->asserttrue($firstOption->getSelected());
     }
 
@@ -633,20 +623,18 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     public function canGetTwoUsedFacetOptions()
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_two_used_facets.json');
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetValuesByName')->will(
-            $this->returnCallback(function ($name) {
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+            function ($name) {
                 if ($name == 'mytitle') {
                     return ['jpeg', 'kasper"s'];
-                } else {
-                    return [];
                 }
-
-            })
+                return [];
+            }
         );
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 1,
@@ -654,8 +642,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'mytitle.' => [
                     'label' => 'My Title',
                     'field' => 'title',
-                ]
-            ]
+                ],
+            ],
 
         ];
 
@@ -670,9 +658,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $firstOption Option */ // @extensionScannerIgnoreLine
         $firstOption = $facet1->getOptions()->getByPosition(0);
-        $this->assertEquals('jpeg', $firstOption->getValue());
-        $this->assertEquals(1, $firstOption->getDocumentCount());
-        $this->assertTrue($firstOption->getSelected());
+        self::assertEquals('jpeg', $firstOption->getValue());
+        self::assertEquals(1, $firstOption->getDocumentCount());
+        self::assertTrue($firstOption->getSelected());
     }
 
     /**
@@ -684,7 +672,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'showEmptyFacets' => 0,
@@ -696,9 +684,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 // category is configured but not available
                 'category.' => [
                     'label' => 'My Category',
-                    'field' => 'category'
-                ]
-            ]
+                    'field' => 'category',
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -706,7 +694,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(1, $facets, 'we have two facets at all');
+        self::assertCount(1, $facets, 'we have two facets at all');
     }
 
     /**
@@ -718,7 +706,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -730,9 +718,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'category.' => [
                     'label' => 'My Category',
                     'field' => 'category',
-                    'showEvenWhenEmpty' => 1
-                ]
-            ]
+                    'showEvenWhenEmpty' => 1,
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -740,7 +728,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(2, $facets, 'we have two facets at all');
+        self::assertCount(2, $facets, 'we have two facets at all');
     }
 
     /**
@@ -752,16 +740,16 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type',
-                    'includeInAvailableFacets' => 0
-                ]
-            ]
+                    'includeInAvailableFacets' => 0,
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -769,8 +757,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(1, $facets, 'we have one facets at all');
-        $this->assertCount(0, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
+        self::assertCount(1, $facets, 'we have one facets at all');
+        self::assertCount(0, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
     }
 
     /**
@@ -782,16 +770,16 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type',
-                    'includeInAvailableFacets' => 1
-                ]
-            ]
+                    'includeInAvailableFacets' => 1,
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -799,8 +787,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(1, $facets, 'we have one facets at all');
-        $this->assertCount(1, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
+        self::assertCount(1, $facets, 'we have one facets at all');
+        self::assertCount(1, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
     }
 
     /**
@@ -812,15 +800,15 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
                 'type.' => [
                     'label' => 'My Type with special rendering',
                     'field' => 'type_stringS',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -829,7 +817,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         /** @var $facet OptionsFacet */
         $facet = $searchResultSet->getFacets()->getByPosition(0);
-        $this->assertSame('My Type with special rendering', $facet->getLabel(), 'Could not get label for facet');
+        self::assertSame('My Type with special rendering', $facet->getLabel(), 'Could not get label for facet');
     }
 
     /**
@@ -841,7 +829,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -854,10 +842,10 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                         'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                         'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                         'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                    ]
-                ]
-            ]
+                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -865,14 +853,14 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $processor->process($searchResultSet);
 
         $facets = $searchResultSet->getFacets();
-        $this->assertCount(1, $facets, 'Facet not created');
+        self::assertCount(1, $facets, 'Facet not created');
 
         /** @var QueryGroupFacet $facet */
         $facet = $facets->getByPosition(0);
-        $this->assertInstanceOf(QueryGroupFacet::class, $facet);
+        self::assertInstanceOf(QueryGroupFacet::class, $facet);
 
         // @extensionScannerIgnoreLine
-        $this->assertCount(3, $facet->getOptions());
+        self::assertCount(3, $facet->getOptions());
     }
 
     /**
@@ -884,7 +872,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -897,10 +885,10 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                         'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                         'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                         'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                    ]
-                ]
-            ]
+                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -917,9 +905,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         // @extensionScannerIgnoreLine
         $thirdValue = $facet->getOptions()->getByPosition(2)->getValue();
 
-        $this->assertSame('month', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('halfYear', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('month', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('halfYear', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
     /**
@@ -931,7 +919,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -945,10 +933,10 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                         'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                         'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                         'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                    ]
-                ]
-            ]
+                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -965,9 +953,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         // @extensionScannerIgnoreLine
         $thirdValue = $facet->getOptions()->getByPosition(2)->getValue();
 
-        $this->assertSame('halfYear', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('month', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('halfYear', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('month', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
     /**
@@ -979,7 +967,7 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
 
         // before the reconstitution of the domain object from the response we expect that no facets
         // are present
-        $this->assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
 
         $facetConfiguration = [
             'facets.' => [
@@ -993,10 +981,10 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                         'month' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
                         'halfYear' => ['query' => '[NOW/DAY-6MONTHS TO NOW/DAY-1MONTH]'],
                         'year' => ['query' => '[NOW/DAY-1YEAR TO NOW/DAY-6MONTHS]'],
-                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]']
-                    ]
-                ]
-            ]
+                        'old' => ['query' => '[* TO NOW/DAY-1YEAR]'],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
@@ -1013,9 +1001,9 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         // @extensionScannerIgnoreLine
         $thirdValue = $facet->getOptions()->getByPosition(2)->getValue();
 
-        $this->assertSame('old', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('halfYear', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
-        $this->assertSame('month', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('old', $firstValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('halfYear', $secondValue, 'Could not get values in expected order from QueryGroupFacet');
+        self::assertSame('month', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
     /**
@@ -1033,20 +1021,20 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'options.' => [
                     'relevance.' => [
                         'field' => 'relevance',
-                        'label' => 'Relevance'
-                    ]
-                ]
-            ]
+                        'label' => 'Relevance',
+                    ],
+                ],
+            ],
         ];
 
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getHasSorting')->will($this->returnValue(false));
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getHasSorting')->willReturn(false);
 
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        $this->assertEquals(1, $searchResultSet->getSortings()->getCount(), 'No sorting was created');
-        $this->assertEquals('relevance', $searchResultSet->getSortings()->getSelected()->getName());
-        $this->assertTrue($searchResultSet->getSortings()->getHasSelected(), 'The sorting by "relevance/score" is active but not marked as selected.');
+        self::assertEquals(1, $searchResultSet->getSortings()->getCount(), 'No sorting was created');
+        self::assertEquals('relevance', $searchResultSet->getSortings()->getSelected()->getName());
+        self::assertTrue($searchResultSet->getSortings()->getHasSelected(), 'The sorting by "relevance/score" is active but not marked as selected.');
     }
 
     /**
@@ -1064,27 +1052,27 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
                 'options.' => [
                     'relevance.' => [
                         'field' => 'relevance',
-                        'label' => 'Relevance'
+                        'label' => 'Relevance',
                     ],
                     'title.' => [
                         'field' => 'sortTitle',
-                        'label' => 'Title'
-                    ]
+                        'label' => 'Title',
+                    ],
 
-                ]
-            ]
+                ],
+            ],
         ];
 
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getHasSorting')->will($this->returnValue(true));
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getSortingName')->will($this->returnValue('title'));
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getSortingDirection')->will($this->returnValue('desc'));
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getHasSorting')->willReturn(true);
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getSortingName')->willReturn('title');
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getSortingDirection')->willReturn('desc');
 
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        $this->assertEquals(2, $searchResultSet->getSortings()->getCount(), 'Unexpected amount of sorting options have been created');
-        $this->assertTrue($searchResultSet->getSortings()->getHasSelected(), 'Expected that a selected sorting was present');
-        $this->assertSame('desc', $searchResultSet->getSortings()->getSelected()->getDirection(), 'Selected sorting as unexpected direction');
+        self::assertEquals(2, $searchResultSet->getSortings()->getCount(), 'Unexpected amount of sorting options have been created');
+        self::assertTrue($searchResultSet->getSortings()->getHasSelected(), 'Expected that a selected sorting was present');
+        self::assertSame('desc', $searchResultSet->getSortings()->getSelected()->getDirection(), 'Selected sorting as unexpected direction');
     }
 
     /**
@@ -1106,8 +1094,8 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
     protected function getConfiguredReconstitutionProcessor($configuration, $searchResultSet): ResultSetReconstitutionProcessor
     {
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfiguration));
-        $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue([]));
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetNames')->willReturn([]);
 
         $processor = new ResultSetReconstitutionProcessor();
 

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
 /***************************************************************
@@ -68,14 +69,14 @@ class SearchResultSetServiceTest extends UnitTest
     /**
      * @var ObjectManager
      */
-    protected $objectManagerMock = null;
+    protected $objectManagerMock;
 
     /**
      * @var QueryBuilder
      */
     protected $queryBuilderMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
@@ -83,8 +84,9 @@ class SearchResultSetServiceTest extends UnitTest
         $this->searchResultBuilderMock = $this->getDumbMock(SearchResultBuilder::class);
         $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
         $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock);
-        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $this->objectManagerMock = $this->createMock(ObjectManager::class);
         $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
+        parent::setUp();
     }
 
     /**
@@ -95,9 +97,9 @@ class SearchResultSetServiceTest extends UnitTest
         $searchRequest = new SearchRequest();
         $searchRequest->setRawQueryString(null);
         $this->assertAllInitialSearchesAreDisabled();
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($searchRequest);
-        $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
+        self::assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
 
     /**
@@ -106,21 +108,18 @@ class SearchResultSetServiceTest extends UnitTest
     public function searchIsNotTriggeredWhenEmptyQueryWasPassedAndEmptySearchWasDisabled()
     {
         $searchRequest = new SearchRequest();
-        $searchRequest->setRawQueryString("");
-        $this->configurationMock->expects($this->once())->method('getSearchQueryAllowEmptyQuery')->willReturn(false);
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $searchRequest->setRawQueryString('');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryAllowEmptyQuery')->willReturn(false);
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($searchRequest);
-        $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
+        self::assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
 
-    /**
-     * @return void
-     */
     protected function assertAllInitialSearchesAreDisabled()
     {
-        $this->configurationMock->expects($this->any())->method('getSearchInitializeWithEmptyQuery')->willReturn(false);
-        $this->configurationMock->expects($this->any())->method('getSearchShowResultsOfInitialEmptyQuery')->willReturn(false);
-        $this->configurationMock->expects($this->any())->method('getSearchInitializeWithQuery')->willReturn('');
-        $this->configurationMock->expects($this->any())->method('getSearchShowResultsOfInitialQuery')->willReturn(false);
+        $this->configurationMock->expects(self::any())->method('getSearchInitializeWithEmptyQuery')->willReturn(false);
+        $this->configurationMock->expects(self::any())->method('getSearchShowResultsOfInitialEmptyQuery')->willReturn(false);
+        $this->configurationMock->expects(self::any())->method('getSearchInitializeWithQuery')->willReturn('');
+        $this->configurationMock->expects(self::any())->method('getSearchShowResultsOfInitialQuery')->willReturn(false);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
 /***************************************************************
@@ -27,6 +28,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
@@ -37,8 +39,6 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
-
 
 /**
  * @author Timo Schmidt <timo.schmidt@dkd.de>
@@ -84,12 +84,9 @@ class SearchResultSetTest extends UnitTest
     /**
      * @var ObjectManager
      */
-    protected $objectManagerMock = null;
+    protected $objectManagerMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->searchMock = $this->getDumbMock(Search::class);
@@ -97,14 +94,15 @@ class SearchResultSetTest extends UnitTest
 
         $this->siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
         $this->escapeServiceMock = $this->getDumbMock(EscapeService::class);
-        $this->escapeServiceMock->expects($this->any())->method('escape')->will($this->returnArgument(0));
+        $this->escapeServiceMock->expects(self::any())->method('escape')->willReturnArgument(0);
 
         $this->searchResultSetService = $this->getMockBuilder(SearchResultSetService::class)
-            ->setMethods(['getRegisteredSearchComponents'])
+            ->onlyMethods(['getRegisteredSearchComponents'])
             ->setConstructorArgs([$this->configurationMock, $this->searchMock, $this->solrLogManagerMock])
             ->getMock();
-        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $this->objectManagerMock = $this->createMock(ObjectManager::class);
         $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
+        parent::setUp();
     }
 
     /**
@@ -112,8 +110,8 @@ class SearchResultSetTest extends UnitTest
      */
     protected function fakeRegisteredSearchComponents(array $fakedRegisteredComponents)
     {
-        $this->searchResultSetService->expects($this->once())->method('getRegisteredSearchComponents')->will(
-            $this->returnValue($fakedRegisteredComponents)
+        $this->searchResultSetService->expects(self::once())->method('getRegisteredSearchComponents')->willReturn(
+            $fakedRegisteredComponents
         );
     }
 
@@ -124,41 +122,40 @@ class SearchResultSetTest extends UnitTest
     {
         $this->fakeRegisteredSearchComponents([]);
 
-            // we expect the the ->search method on the Search object will be called once
-            // and we pass the response that should be returned when it was call to compare
-            // later if we retrieve the expected result
+        // we expect the the ->search method on the Search object will be called once
+        // and we pass the response that should be returned when it was call to compare
+        // later if we retrieve the expected result
         $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my search', 0, $fakeResponse);
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
-
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my search']]);
         $fakeRequest->setResultsPerPage(10);
 
         $this->objectManagerMock
-            ->expects($this->once())->method('get')->with(SearchResultSet::class)
+            ->expects(self::once())->method('get')->with(SearchResultSet::class)
             ->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
-        $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
+        self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
-     /**
-     * @test
-     */
+    /**
+    * @test
+    */
     public function testOffsetIsPassedAsExpectedWhenSearchWasPaginated()
     {
         $this->fakeRegisteredSearchComponents([]);
 
         $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 2. search', 50, $fakeResponse);
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
-        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 2. search','page' => 3]]);
+        $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 2. search', 'page' => 3]]);
         $fakeRequest->setResultsPerPage(25);
 
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
-        $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
+        self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
     /**
@@ -166,13 +163,13 @@ class SearchResultSetTest extends UnitTest
      */
     public function testQueryAwareComponentGetsInitialized()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchConfiguration')->will($this->returnValue([]));
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+        $this->configurationMock->expects(self::once())->method('getSearchConfiguration')->willReturn([]);
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
-            // we expect that the initialize method of our component will be called
+        // we expect that the initialize method of our component will be called
         $fakeQueryAwareSpellChecker = $this->getDumbMock(SpellcheckingComponent::class);
-        $fakeQueryAwareSpellChecker->expects($this->once())->method('initializeSearchComponent');
-        $fakeQueryAwareSpellChecker->expects($this->once())->method('setQuery');
+        $fakeQueryAwareSpellChecker->expects(self::once())->method('initializeSearchComponent');
+        $fakeQueryAwareSpellChecker->expects(self::once())->method('setQuery');
 
         $this->fakeRegisteredSearchComponents([$fakeQueryAwareSpellChecker]);
         $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
@@ -181,9 +178,9 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 3. search']]);
         $fakeRequest->setResultsPerPage(10);
 
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
-        $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
+        self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
     /**
@@ -191,7 +188,7 @@ class SearchResultSetTest extends UnitTest
      */
     public function canRegisterSearchResultSetProcessor()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         $processSearchResponseBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch'] ?? null;
 
@@ -207,12 +204,12 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest->setResultsPerPage(10);
 
         $this->objectManagerMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('get')
             ->withConsecutive(
                 [SearchResultSet::class],
                 [$testProcessor]
-            )->will($this->onConsecutiveCalls(
+            )->will(self::onConsecutiveCalls(
                 new SearchResultSet(),
                 new TestSearchResultSetProcessor()
             ));
@@ -221,13 +218,12 @@ class SearchResultSetTest extends UnitTest
 
         $documents  = $resultSet->getSearchResults();
 
-        $this->assertSame(3, count($documents), 'Did not get 3 documents from fake response');
+        self::assertSame(3, count($documents), 'Did not get 3 documents from fake response');
         $firstResult = $documents[0];
-        $this->assertSame('PAGES', $firstResult->getType(), 'Could not get modified type from result');
+        self::assertSame('PAGES', $firstResult->getType(), 'Could not get modified type from result');
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch'] = $processSearchResponseBackup;
     }
-
 
     /**
      * @test
@@ -239,20 +235,20 @@ class SearchResultSetTest extends UnitTest
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
 
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
-        $this->configurationMock->expects($this->any())->method('getSearchQueryFilterConfiguration')->will(
-            $this->returnValue(['type:pages'])
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+        $this->configurationMock->expects(self::any())->method('getSearchQueryFilterConfiguration')->willReturn(
+            ['type:pages']
         );
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'test']]);
         $fakeRequest->setResultsPerPage(10);
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
 
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
 
-        $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
-        $this->assertSame(count($resultSet->getUsedQuery()->getFilterQueries()), 1, 'There should be one registered filter in the query');
+        self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
+        self::assertSame(count($resultSet->getUsedQuery()->getFilterQueries()), 1, 'There should be one registered filter in the query');
     }
 
     /**
@@ -261,12 +257,12 @@ class SearchResultSetTest extends UnitTest
     public function testExpandedDocumentsGetAddedWhenVariantsAreConfigured()
     {
         // we fake that collapsing is enabled
-        $this->configurationMock->expects($this->atLeastOnce())->method('getSearchVariants')->will($this->returnValue(true));
+        $this->configurationMock->expects(self::atLeastOnce())->method('getSearchVariants')->willReturn(true);
 
-            // in this case we collapse on the type field
-        $this->configurationMock->expects($this->atLeastOnce())->method('getSearchVariantsField')->will($this->returnValue('type'));
+        // in this case we collapse on the type field
+        $this->configurationMock->expects(self::atLeastOnce())->method('getSearchVariantsField')->willReturn('type');
 
-        $this->configurationMock->expects($this->once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
+        $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         $this->fakeRegisteredSearchComponents([]);
         $fakedSolrResponse = $this->getFixtureContentByName('fakeCollapsedResponse.json');
@@ -276,13 +272,13 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'variantsSearch']]);
         $fakeRequest->setResultsPerPage(10);
 
-        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects(self::once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
-        $this->assertSame(1, count($resultSet->getSearchResults()), 'Unexpected amount of document');
+        self::assertSame(1, count($resultSet->getSearchResults()), 'Unexpected amount of document');
 
-            /** @var  $fistResult SearchResult */
+        /** @var  $fistResult SearchResult */
         $fistResult = $resultSet->getSearchResults()[0];
-        $this->assertSame(5, count($fistResult->getVariants()), 'Unexpected amount of expanded result');
+        self::assertSame(5, count($fistResult->getVariants()), 'Unexpected amount of expanded result');
     }
 
     /**
@@ -292,16 +288,12 @@ class SearchResultSetTest extends UnitTest
      */
     public function assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse($expextedQueryString, $expectedOffset, ResponseAdapter $fakeResponse)
     {
-        $this->searchMock->expects($this->once())->method('search')->will(
-            $this->returnCallback(
-                function(Query $query, $offset) use($expextedQueryString, $expectedOffset, $fakeResponse) {
-
-                    $this->assertSame($expextedQueryString, $query->getQuery() , "Search was not triggered with an expected queryString");
-                    $this->assertSame($expectedOffset, $offset);
-                    return $fakeResponse;
-                }
-
-            )
+        $this->searchMock->expects(self::once())->method('search')->willReturnCallback(
+            function (Query $query, $offset) use ($expextedQueryString, $expectedOffset, $fakeResponse) {
+                $this->assertSame($expextedQueryString, $query->getQuery(), 'Search was not triggered with an expected queryString');
+                $this->assertSame($expectedOffset, $offset);
+                return $fakeResponse;
+            }
         );
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Sorting;
 
 /***************************************************************
@@ -41,17 +42,17 @@ class SortingHelperTest extends UnitTest
         $sortConfiguration = [
             'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
             'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
-            'type.' => ['field' => 'type', 'label' => 'Type']
+            'type.' => ['field' => 'type', 'label' => 'Type'],
         ];
         $sorting = new SortingHelper($sortConfiguration);
         $sortField = $sorting->getSortFieldFromUrlParameter('title asc');
-        $this->assertSame('sortTitle asc', $sortField);
+        self::assertSame('sortTitle asc', $sortField);
 
         $sortField = $sorting->getSortFieldFromUrlParameter('title desc');
-        $this->assertSame('sortTitle desc', $sortField);
+        self::assertSame('sortTitle desc', $sortField);
 
         $sortField = $sorting->getSortFieldFromUrlParameter('title desc,type asc');
-        $this->assertSame('sortTitle desc, type asc', $sortField);
+        self::assertSame('sortTitle desc, type asc', $sortField);
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Sorting;
 
 /***************************************************************
@@ -24,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Sorting;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\Sorting;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
@@ -45,10 +46,7 @@ class SortingTest extends UnitTest
      */
     protected $resultSetMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resultSetMock = $this->getDumbMock(SearchResultSet::class);
 
@@ -59,6 +57,7 @@ class SortingTest extends UnitTest
         $selected = false;
         $isResetOption = false;
         $this->sorting = new Sorting($this->resultSetMock, $name, $field, $direction, $label, $selected, $isResetOption);
+        parent::setUp();
     }
 
     /**
@@ -75,7 +74,7 @@ class SortingTest extends UnitTest
      */
     public function canGetName()
     {
-        $this->assertSame('Price', $this->sorting->getName(), 'Could not get name from sorting');
+        self::assertSame('Price', $this->sorting->getName(), 'Could not get name from sorting');
     }
 
     /**
@@ -83,7 +82,7 @@ class SortingTest extends UnitTest
      */
     public function canGetLabel()
     {
-        $this->assertSame('the príce', $this->sorting->getLabel(), 'Could not get label from sorting');
+        self::assertSame('the príce', $this->sorting->getLabel(), 'Could not get label from sorting');
     }
 
     /**
@@ -91,7 +90,7 @@ class SortingTest extends UnitTest
      */
     public function canGetField()
     {
-        $this->assertSame('price_f', $this->sorting->getField(), 'Could not get field from sorting');
+        self::assertSame('price_f', $this->sorting->getField(), 'Could not get field from sorting');
     }
 
     /**
@@ -99,7 +98,7 @@ class SortingTest extends UnitTest
      */
     public function canGetDirection()
     {
-        $this->assertSame('asc', $this->sorting->getDirection(), 'Could not get direction');
+        self::assertSame('asc', $this->sorting->getDirection(), 'Could not get direction');
     }
 
     /**
@@ -107,10 +106,10 @@ class SortingTest extends UnitTest
      */
     public function canGetOppositeDirection()
     {
-        $this->assertSame('desc', $this->sorting->getOppositeDirection(), 'Could not get opposite direction');
+        self::assertSame('desc', $this->sorting->getOppositeDirection(), 'Could not get opposite direction');
 
         $descSorting = new Sorting($this->resultSetMock, 'Color', 'color_s', Sorting::DIRECTION_DESC, 'the color', false, false);
-        $this->assertSame('asc', $descSorting->getOppositeDirection(), 'Could not get opposite direction');
+        self::assertSame('asc', $descSorting->getOppositeDirection(), 'Could not get opposite direction');
     }
 
     /**
@@ -118,7 +117,7 @@ class SortingTest extends UnitTest
      */
     public function getGetIsAsDirection()
     {
-        $this->assertTrue($this->sorting->getIsAscDirection(), 'Sorting direction was not handled as ascending');
+        self::assertTrue($this->sorting->getIsAscDirection(), 'Sorting direction was not handled as ascending');
     }
 
     /**
@@ -126,7 +125,7 @@ class SortingTest extends UnitTest
      */
     public function getGetIsDescDirection()
     {
-        $this->assertFalse($this->sorting->getIsDescDirection(), 'Sorting should be indicated to not be descending');
+        self::assertFalse($this->sorting->getIsDescDirection(), 'Sorting should be indicated to not be descending');
     }
 
     /**
@@ -134,6 +133,6 @@ class SortingTest extends UnitTest
      */
     public function canGetIsResetOption()
     {
-        $this->assertFalse($this->sorting->getIsResetOption(), 'Sorting options should not be a reset option');
+        self::assertFalse($this->sorting->getIsResetOption(), 'Sorting options should not be a reset option');
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/TestSearchResultSetProcessor.php
+++ b/Tests/Unit/Domain/Search/ResultSet/TestSearchResultSetProcessor.php
@@ -11,7 +11,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 class TestSearchResultSetProcessor implements SearchResultSetProcessor
 {
 
-
     /**
      * @param SearchResultSet $resultSet
      * @return SearchResultSet

--- a/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
+++ b/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Score;
 
 /***************************************************************
@@ -38,12 +39,10 @@ class ScoreCalculationServiceTest extends UnitTest
      */
     protected ScoreCalculationService $scoreCalculationService;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->scoreCalculationService = new ScoreCalculationService();
+        parent::setUp();
     }
 
     /**
@@ -56,12 +55,12 @@ class ScoreCalculationServiceTest extends UnitTest
 
         $scoreAnalysis = $this->scoreCalculationService->getRenderedScores($fakeDebugData, $fakeQueryFields);
 
-        $this->assertStringContainsString('<td>+     98.444336</td', $scoreAnalysis);
-        $this->assertStringContainsString('<td>content</td>', $scoreAnalysis);
-        $this->assertStringContainsString('<td>40.0</td></tr>', $scoreAnalysis);
+        self::assertStringContainsString('<td>+     98.444336</td', $scoreAnalysis);
+        self::assertStringContainsString('<td>content</td>', $scoreAnalysis);
+        self::assertStringContainsString('<td>40.0</td></tr>', $scoreAnalysis);
 
-        $this->assertStringContainsString('<td>+     6.2762194</td>', $scoreAnalysis);
-        $this->assertStringContainsString('<td>tagsH2H3</td>', $scoreAnalysis);
-        $this->assertStringContainsString('<td>3.0</td></tr>', $scoreAnalysis);
+        self::assertStringContainsString('<td>+     6.2762194</td>', $scoreAnalysis);
+        self::assertStringContainsString('<td>tagsH2H3</td>', $scoreAnalysis);
+        self::assertStringContainsString('<td>3.0</td></tr>', $scoreAnalysis);
     }
 }

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
 
 /***************************************************************
@@ -39,12 +40,10 @@ class SearchRequestTest extends UnitTest
      */
     protected $searchRequest;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->searchRequest = new SearchRequest();
+        parent::setUp();
     }
 
     /**
@@ -52,7 +51,7 @@ class SearchRequestTest extends UnitTest
      */
     public function testGetPageIsNullWhenNothingWasPassed()
     {
-        $this->assertNull($this->searchRequest->getPage(), 'Page was expected to be null');
+        self::assertNull($this->searchRequest->getPage(), 'Page was expected to be null');
     }
 
     /**
@@ -61,10 +60,10 @@ class SearchRequestTest extends UnitTest
     public function testCanMerge()
     {
         $this->searchRequest = new SearchRequest(['tx_solr' => ['page' => 2]]);
-        $this->assertSame(2, $this->searchRequest->getPage(), 'Retrieved unexpected page');
+        self::assertSame(2, $this->searchRequest->getPage(), 'Retrieved unexpected page');
 
         $this->searchRequest->mergeArguments(['tx_solr' => ['page' => 8]]);
-        $this->assertSame(8, $this->searchRequest->getPage(), 'Page was not properly merged');
+        self::assertSame(8, $this->searchRequest->getPage(), 'Page was not properly merged');
     }
 
     /**
@@ -74,7 +73,7 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertEquals(['type'], $request->getActiveFacetNames());
+        self::assertEquals(['type'], $request->getActiveFacetNames());
     }
 
     /**
@@ -84,7 +83,7 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertEquals('typo3', $request->getRawUserQuery());
+        self::assertEquals('typo3', $request->getRawUserQuery());
     }
 
     /**
@@ -94,7 +93,7 @@ class SearchRequestTest extends UnitTest
     {
         $request = $this->getSearchRequestFromQueryString('');
         $data  = $request->setRawQueryString('foobar')->getAsArray();
-        $this->assertEquals(['tx_solr' => ['q' => 'foobar']], $data, 'The argument container did not contain the expected argument');
+        self::assertEquals(['tx_solr' => ['q' => 'foobar']], $data, 'The argument container did not contain the expected argument');
     }
 
     /**
@@ -106,7 +105,7 @@ class SearchRequestTest extends UnitTest
         $arguments  = $request->addFacetValue('foo', 'bar')->getAsArray();
         $expectedArguments = [];
         $expectedArguments['tx_solr']['filter'][0] = 'foo:bar';
-        $this->assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
+        self::assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
     }
 
     /**
@@ -120,7 +119,7 @@ class SearchRequestTest extends UnitTest
         $expectedArguments['tx_solr']['filter'][0] = 'type:pages';
         $expectedArguments['tx_solr']['filter'][1] = 'type:tt_content';
 
-        $this->assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
+        self::assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
     }
 
     /**
@@ -135,7 +134,7 @@ class SearchRequestTest extends UnitTest
         $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
-        $this->assertSame($arguments, $expectedArguments, 'Could not set a query and add a facet at the same time');
+        self::assertSame($arguments, $expectedArguments, 'Could not set a query and add a facet at the same time');
     }
 
     /**
@@ -146,7 +145,7 @@ class SearchRequestTest extends UnitTest
         $request = $this->getSearchRequestFromQueryString('');
         $arguments  = $request->setRawQueryString('mysearch')->addFacetValue('type', 'tt_content')->reset()->getAsArray();
         $expectedArguments = [];
-        $this->assertSame($arguments, $expectedArguments, 'Could not reset arguments');
+        self::assertSame($arguments, $expectedArguments, 'Could not reset arguments');
     }
 
     /**
@@ -166,7 +165,7 @@ class SearchRequestTest extends UnitTest
         $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
-        $this->assertSame($arguments, $expectedArguments, 'Could not reset arguments');
+        self::assertSame($arguments, $expectedArguments, 'Could not reset arguments');
     }
 
     /**
@@ -186,7 +185,7 @@ class SearchRequestTest extends UnitTest
         $expectedArguments['tx_solr']['q'] = 'mysearch';
         $expectedArguments['tx_solr']['filter'][0] = 'type:tt_content';
 
-        $this->assertSame($arguments, $expectedArguments);
+        self::assertSame($arguments, $expectedArguments);
     }
 
     /**
@@ -195,7 +194,7 @@ class SearchRequestTest extends UnitTest
     public function canGetContextSystemLanguageUidPassedOnCreation()
     {
         $request = new SearchRequest([], 111, 4711);
-        $this->assertSame($request->getContextSystemLanguageUid(), 4711, 'Can get initial passed sys_language_uid');
+        self::assertSame($request->getContextSystemLanguageUid(), 4711, 'Can get initial passed sys_language_uid');
     }
 
     /**
@@ -204,7 +203,7 @@ class SearchRequestTest extends UnitTest
     public function canGetContextPageUidPassedOnCreation()
     {
         $request = new SearchRequest([], 111, 4711);
-        $this->assertSame($request->getContextPageUid(), 111, 'Can get initial passed page_uid');
+        self::assertSame($request->getContextPageUid(), 111, 'Can get initial passed page_uid');
     }
 
     /**
@@ -215,9 +214,9 @@ class SearchRequestTest extends UnitTest
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
         $request = $this->getSearchRequestFromQueryString($query);
 
-        $this->assertTrue($request->getHasFacetValue('type', 'pages'), 'Facet was not present');
+        self::assertTrue($request->getHasFacetValue('type', 'pages'), 'Facet was not present');
         $request->removeFacetValue('type', 'pages');
-        $this->assertFalse($request->getHasFacetValue('type', 'pages'), 'Could not remove facet value');
+        self::assertFalse($request->getHasFacetValue('type', 'pages'), 'Could not remove facet value');
     }
 
     /**
@@ -227,7 +226,7 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Anews';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertEquals(['pages', 'news'], $request->getActiveFacetValuesByName('type'));
+        self::assertEquals(['pages', 'news'], $request->getActiveFacetValuesByName('type'));
     }
 
     /**
@@ -237,9 +236,9 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertSame(2, $request->getActiveFacetCount(), 'Expected to have two active facets');
+        self::assertSame(2, $request->getActiveFacetCount(), 'Expected to have two active facets');
         $request->removeAllFacets();
-        $this->assertSame(0, $request->getActiveFacetCount(), 'Expected to have no active facets');
+        self::assertSame(0, $request->getActiveFacetCount(), 'Expected to have no active facets');
     }
 
     /**
@@ -249,9 +248,9 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents&tx_solr%5Bfilter%5D%5B2%5D=created%253A1-4';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertSame(3, $request->getActiveFacetCount(), 'Expected to have two active facets');
+        self::assertSame(3, $request->getActiveFacetCount(), 'Expected to have two active facets');
         $request->removeAllFacetValuesByName('type');
-        $this->assertSame(1, $request->getActiveFacetCount(), 'Only 1 facet should remain active');
+        self::assertSame(1, $request->getActiveFacetCount(), 'Only 1 facet should remain active');
     }
 
     /**
@@ -261,9 +260,9 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
-        $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
-        $this->assertSame('asc', $request->getSortingDirection(), 'Expected sorting direction was asc');
+        self::assertTrue($request->getHasSorting(), 'Passed query has no sorting');
+        self::assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
+        self::assertSame('asc', $request->getSortingDirection(), 'Expected sorting direction was asc');
     }
 
     /**
@@ -273,16 +272,16 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
-        $this->assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
+        self::assertTrue($request->getHasSorting(), 'Passed query has no sorting');
+        self::assertSame('title', $request->getSortingName(), 'Expected sorting name was title');
         $requestAsArray = $request->getAsArray();
-        $this->assertTrue(isset($requestAsArray['tx_solr']['sort']), 'Sorting was not set but was expected to be set');
+        self::assertTrue(isset($requestAsArray['tx_solr']['sort']), 'Sorting was not set but was expected to be set');
 
         $request->removeSorting();
-        $this->assertFalse($request->getHasSorting(), 'Expected that sorting was removed, but is still present');
+        self::assertFalse($request->getHasSorting(), 'Expected that sorting was removed, but is still present');
 
         $requestAsArray = $request->getAsArray();
-        $this->assertFalse(isset($requestAsArray['tx_solr']['sort']), 'Sorting was set but was not expected to be set');
+        self::assertFalse(isset($requestAsArray['tx_solr']['sort']), 'Sorting was set but was not expected to be set');
     }
 
     /**
@@ -292,10 +291,10 @@ class SearchRequestTest extends UnitTest
     {
         $query = 'tx_solr%5Bq%5D=typo3';
         $request = $this->getSearchRequestFromQueryString($query);
-        $this->assertFalse($request->getHasSorting(), 'Passed query has no sorting');
+        self::assertFalse($request->getHasSorting(), 'Passed query has no sorting');
 
         $request->setSorting('auther', 'desc');
-        $this->assertTrue($request->getHasSorting(), 'Passed query has no sorting');
+        self::assertTrue($request->getHasSorting(), 'Passed query has no sorting');
     }
 
     /**
@@ -304,7 +303,7 @@ class SearchRequestTest extends UnitTest
     public function canGetHighestGroupItemPageWhenNoPageWasPassed()
     {
         $request = $this->getSearchRequestFromQueryString('');
-        $this->assertSame(1, $request->getHighestGroupPage(), 'Can not get highest group item page when no group page was passed');
+        self::assertSame(1, $request->getHighestGroupPage(), 'Can not get highest group item page when no group page was passed');
     }
 
     /**
@@ -313,7 +312,7 @@ class SearchRequestTest extends UnitTest
     public function canGetInitialGroupItemPage()
     {
         $request = $this->getSearchRequestFromQueryString('');
-        $this->assertSame(1, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not get initial group item page');
+        self::assertSame(1, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not get initial group item page');
     }
 
     /**
@@ -325,7 +324,7 @@ class SearchRequestTest extends UnitTest
         $request = $this->getSearchRequestFromQueryString($query);
         $request->setGroupItemPage('typeGroup', 'pages', 2);
 
-        $this->assertSame(2, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not set and get groupItemPage');
+        self::assertSame(2, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not set and get groupItemPage');
     }
 
     /**
@@ -337,7 +336,7 @@ class SearchRequestTest extends UnitTest
         $request = $this->getSearchRequestFromQueryString($query);
         $request->setGroupItemPage('pidGroup', 'pid:[0 to 5]', 3);
 
-        $this->assertSame(3, $request->getGroupItemPage('pidGroup', 'pid:[0 to 5]'), 'Can not set and get groupItemPage for a query');
+        self::assertSame(3, $request->getGroupItemPage('pidGroup', 'pid:[0 to 5]'), 'Can not set and get groupItemPage for a query');
     }
 
     /**
@@ -351,11 +350,11 @@ class SearchRequestTest extends UnitTest
         $request->setGroupItemPage('colorGroup', 'colors', 4);
 
         $requestArguments = $request->getAsArray();
-        $this->assertCount(2, $requestArguments['tx_solr']['groupPage'], 'Expected to have two group pages registered');
+        self::assertCount(2, $requestArguments['tx_solr']['groupPage'], 'Expected to have two group pages registered');
 
         $request->removeAllGroupItemPages();
         $requestArguments = $request->getAsArray();
-        $this->assertArrayNotHasKey('groupPage', $requestArguments['tx_solr'], 'Expected to have two group pages registered');
+        self::assertArrayNotHasKey('groupPage', $requestArguments['tx_solr'], 'Expected to have two group pages registered');
     }
 
     /**
@@ -364,7 +363,7 @@ class SearchRequestTest extends UnitTest
     public function twoDifferentRequestsHaveADifferentId()
     {
         $newSearchRequest = new SearchRequest();
-        $this->assertNotEquals($newSearchRequest->getId(), $this->searchRequest->getId(), 'Two different requests seem to have the same id');
+        self::assertNotEquals($newSearchRequest->getId(), $this->searchRequest->getId(), 'Two different requests seem to have the same id');
     }
 
     /**
@@ -372,9 +371,9 @@ class SearchRequestTest extends UnitTest
      */
     public function setPerPageWillMarkedTheRequestAsChanged()
     {
-        $this->assertFalse($this->searchRequest->getStateChanged());
+        self::assertFalse($this->searchRequest->getStateChanged());
         $this->searchRequest->setResultsPerPage(10);
-        $this->assertTrue($this->searchRequest->getStateChanged());
+        self::assertTrue($this->searchRequest->getStateChanged());
     }
 
     /**
@@ -397,6 +396,6 @@ class SearchRequestTest extends UnitTest
         $typoScriptConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
         $request = new SearchRequest([], 111, 4711, $typoScriptConfiguration);
 
-        $this->assertSame($request->getContextTypoScriptConfiguration(), $typoScriptConfiguration, 'Can get initial passed TypoScriptConfiguration');
+        self::assertSame($request->getContextTypoScriptConfiguration(), $typoScriptConfiguration, 'Can get initial passed TypoScriptConfiguration');
     }
 }

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Statistics;
 
 /***************************************************************
@@ -29,8 +30,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsWriterProcessor;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -73,16 +74,16 @@ class StatisticsWriterProcessorTest extends UnitTest
      */
     protected $queryMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
-        $this->statisticsRepositoryMock = $this->getMockBuilder(StatisticsRepository::class)->setMethods(['saveStatisticsRecord'])->getMock();
+        $this->statisticsRepositoryMock = $this->getMockBuilder(StatisticsRepository::class)->onlyMethods(['saveStatisticsRecord'])->getMock();
 
         $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
-        $this->processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setConstructorArgs([$this->statisticsRepositoryMock, $this->siteRepositoryMock])->setMethods(['getTSFE', 'getTime', 'getUserIp'])->getMock();
+        $this->processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setConstructorArgs([$this->statisticsRepositoryMock, $this->siteRepositoryMock])->onlyMethods(['getTSFE', 'getTime', 'getUserIp'])->getMock();
         $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
         $this->queryMock = $this->getDumbMock(Query::class);
+        parent::setUp();
     }
 
     /**
@@ -97,29 +98,28 @@ class StatisticsWriterProcessorTest extends UnitTest
         $fakeIP = '192.168.2.22';
 
         $fakeSite = $this->getDumbMock(Site::class);
-        $fakeSite->expects($this->once())->method('getRootPageId')->willReturn(4711);
-        $this->siteRepositoryMock->expects($this->once())->method('getSiteByPageId')->with(888)->willReturn($fakeSite);
+        $fakeSite->expects(self::once())->method('getRootPageId')->willReturn(4711);
+        $this->siteRepositoryMock->expects(self::once())->method('getSiteByPageId')->with(888)->willReturn($fakeSite);
 
-        $this->processor->expects($this->once())->method('getTSFE')->will($this->returnValue($fakeTSFE));
-        $this->processor->expects($this->once())->method('getUserIp')->will($this->returnValue($fakeIP));
-        $this->processor->expects($this->once())->method('getTime')->will($this->returnValue($fakeTime));
-        $this->typoScriptConfigurationMock->expects($this->once())->method('getStatisticsAnonymizeIP')->will($this->returnValue(0));
-        $this->searchRequestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->will($this->returnValue($this->typoScriptConfigurationMock));
+        $this->processor->expects(self::once())->method('getTSFE')->willReturn($fakeTSFE);
+        $this->processor->expects(self::once())->method('getUserIp')->willReturn($fakeIP);
+        $this->processor->expects(self::once())->method('getTime')->willReturn($fakeTime);
+        $this->typoScriptConfigurationMock->expects(self::once())->method('getStatisticsAnonymizeIP')->willReturn(0);
+        $this->searchRequestMock->expects(self::once())->method('getContextTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
 
-        $this->queryMock->expects($this->once())->method('getQuery')->willReturn('my search');
+        $this->queryMock->expects(self::once())->method('getQuery')->willReturn('my search');
 
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $resultSetMock->expects($this->once())->method('getUsedQuery')->will($this->returnValue($this->queryMock));
-        $resultSetMock->expects($this->once())->method('getUsedSearchRequest')->will($this->returnValue($this->searchRequestMock));
+        $resultSetMock->expects(self::once())->method('getUsedQuery')->willReturn($this->queryMock);
+        $resultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($this->searchRequestMock);
 
         $self = $this;
-        $this->statisticsRepositoryMock->expects($this->any())->method('saveStatisticsRecord')->will($this->returnCallback(function($statisticData) use ($self) {
+        $this->statisticsRepositoryMock->expects(self::any())->method('saveStatisticsRecord')->willReturnCallback(function ($statisticData) use ($self) {
             $this->assertSame('my search', $statisticData['keywords'], 'Unexpected keywords given');
             $this->assertSame('192.168.2.22', $statisticData['ip'], 'Unexpected ip given');
             $this->assertSame(4711, $statisticData['root_pid'], 'Unexpected root pid given');
-        }));
+        });
 
         $this->processor->process($resultSetMock);
     }
-
 }

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
 
 /***************************************************************
@@ -79,10 +80,7 @@ class SuggestServiceTest extends UnitTest
      */
     protected $suggestQueryMock;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
         $this->searchResultSetServiceMock = $this->getDumbMock(SearchResultSetService::class);
@@ -90,12 +88,13 @@ class SuggestServiceTest extends UnitTest
         $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
 
         $this->suggestQueryMock = $this->getDumbMock(SuggestQuery::class);
-        $this->queryBuilderMock->expects($this->once())->method('buildSuggestQuery')->willReturn($this->suggestQueryMock);
+        $this->queryBuilderMock->expects(self::once())->method('buildSuggestQuery')->willReturn($this->suggestQueryMock);
 
         $this->suggestService = $this->getMockBuilder(SuggestService::class)
-            ->setMethods(['getSolrSuggestions'])
+            ->onlyMethods(['getSolrSuggestions'])
             ->setConstructorArgs([$this->tsfeMock, $this->searchResultSetServiceMock, $this->configurationMock, $this->queryBuilderMock])
             ->getMock();
+        parent::setUp();
     }
 
     /**
@@ -103,7 +102,7 @@ class SuggestServiceTest extends UnitTest
      */
     protected function assertSuggestQueryWithQueryStringCreated($queryString)
     {
-        $this->suggestQueryMock->expects($this->any())->method('getQuery')->willReturn($queryString);
+        $this->suggestQueryMock->expects(self::any())->method('getQuery')->willReturn($queryString);
     }
 
     /**
@@ -115,14 +114,14 @@ class SuggestServiceTest extends UnitTest
         $this->assertSuggestQueryWithQueryStringCreated('');
         $fakeRequest = $this->getFakedSearchRequest('ty');
 
-        $this->configurationMock->expects($this->once())->method('getSuggestShowTopResults')->will($this->returnValue(false));
+        $this->configurationMock->expects(self::once())->method('getSuggestShowTopResults')->willReturn(false);
 
         $this->assertNoSearchWillBeTriggered();
 
-        $this->suggestService->expects($this->once())->method('getSolrSuggestions')->will($this->returnValue([
+        $this->suggestService->expects(self::once())->method('getSolrSuggestions')->willReturn([
             'type',
-            'typo'
-        ]));
+            'typo',
+        ]);
 
         $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
@@ -130,10 +129,10 @@ class SuggestServiceTest extends UnitTest
             'suggestions' => ['type', 'typo'],
             'suggestion' => 'ty',
             'documents' => [],
-            'didSecondSearch' => false
+            'didSecondSearch' => false,
         ];
 
-        $this->assertSame($expectedSuggestions, $suggestions, 'Suggest response did not contain expected content');
+        self::assertSame($expectedSuggestions, $suggestions, 'Suggest response did not contain expected content');
     }
 
     /**
@@ -146,7 +145,7 @@ class SuggestServiceTest extends UnitTest
 
         $solrConnectionMock = $this->getDumbMock(SolrConnection::class);
         $connectionManagerMock = $this->getAccessibleMock(ConnectionManager::class, ['getConnectionByPageId'], [], '', false);
-        $connectionManagerMock->expects($this->any())->method('getConnectionByPageId')->will($this->returnValue($solrConnectionMock));
+        $connectionManagerMock->expects(self::any())->method('getConnectionByPageId')->willReturn($solrConnectionMock);
         GeneralUtility::setSingletonInstance(ConnectionManager::class, $connectionManagerMock);
 
         $searchStub = new class($this->getDumbMock(SolrConnection::class)) extends Search implements SingletonInterface {
@@ -154,13 +153,13 @@ class SuggestServiceTest extends UnitTest
             public function search(Query $query, $offset = 0, $limit = 10)
             {
                 return self::$suggestServiceTest->getMockBuilder(ResponseAdapter::class)
-                    ->setMethods([])->disableOriginalConstructor()->getMock();
+                    ->onlyMethods([])->disableOriginalConstructor()->getMock();
             }
         };
         $searchStub::$suggestServiceTest = $this;
         GeneralUtility::setSingletonInstance(Search::class, $searchStub);
 
-        $this->tsfeMock->expects($this->any())->method('getRequestedId')->will($this->returnValue(7411));
+        $this->tsfeMock->expects(self::any())->method('getRequestedId')->willReturn(7411);
         $suggestService = new SuggestService(
             $this->tsfeMock,
             $this->searchResultSetServiceMock,
@@ -171,7 +170,7 @@ class SuggestServiceTest extends UnitTest
         try {
             $suggestions = $suggestService->getSuggestions($fakeRequest);
         } catch (\Error $error) {
-            $this->fail(
+            self::fail(
                 'The method \ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService::getSolrSuggestions() ' .
                 'can not handle Apache Solr syntax errors. The method is failing with exception from below:' . PHP_EOL . PHP_EOL .
                 $error->getMessage() . ' in ' . $error->getFile() . ':' . $error->getLine()
@@ -179,7 +178,7 @@ class SuggestServiceTest extends UnitTest
         }
 
         $expectedSuggestions = ['status' => false];
-        $this->assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
+        self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
     }
 
     /**
@@ -187,16 +186,16 @@ class SuggestServiceTest extends UnitTest
      */
     public function emptyJsonIsReturnedWhenSolrHasNoSuggestions()
     {
-        $this->configurationMock->expects($this->never())->method('getSuggestShowTopResults');
+        $this->configurationMock->expects(self::never())->method('getSuggestShowTopResults');
         $this->assertNoSearchWillBeTriggered();
 
         $fakeRequest = $this->getFakedSearchRequest('ty');
 
-        $this->suggestService->expects($this->once())->method('getSolrSuggestions')->will($this->returnValue([]));
+        $this->suggestService->expects(self::once())->method('getSolrSuggestions')->willReturn([]);
         $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
         $expectedSuggestions = ['status' => false];
-        $this->assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
+        self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
     }
 
     /**
@@ -204,39 +203,36 @@ class SuggestServiceTest extends UnitTest
      */
     public function canGetSuggestionsWithTopResults()
     {
-        $this->configurationMock->expects($this->once())->method('getSuggestShowTopResults')->will($this->returnValue(true));
-        $this->configurationMock->expects($this->once())->method('getSuggestNumberOfTopResults')->will($this->returnValue(2));
-        $this->configurationMock->expects($this->once())->method('getSuggestAdditionalTopResultsFields')->will($this->returnValue([]));
+        $this->configurationMock->expects(self::once())->method('getSuggestShowTopResults')->willReturn(true);
+        $this->configurationMock->expects(self::once())->method('getSuggestNumberOfTopResults')->willReturn(2);
+        $this->configurationMock->expects(self::once())->method('getSuggestAdditionalTopResultsFields')->willReturn([]);
 
         $this->assertSuggestQueryWithQueryStringCreated('');
         $fakeRequest = $this->getFakedSearchRequest('type');
-        $fakeRequest->expects($this->any())->method('getCopyForSubRequest')->will($this->returnValue($fakeRequest));
+        $fakeRequest->expects(self::any())->method('getCopyForSubRequest')->willReturn($fakeRequest);
 
-        $this->suggestService->expects($this->once())->method('getSolrSuggestions')->will($this->returnValue([
+        $this->suggestService->expects(self::once())->method('getSolrSuggestions')->willReturn([
             'type',
-            'typo'
-        ]));
+            'typo',
+        ]);
 
         $fakeTopResults = $this->getDumbMock(SearchResultSet::class);
         $fakeResultDocuments = new SearchResultCollection(
             [
-                $this->getFakedSearchResult('http://www.typo3-solr.com/a','pages','hello solr','my suggestions'),
-                $this->getFakedSearchResult('http://www.typo3-solr.com/b','news','what new in solr','new autosuggest'),
+                $this->getFakedSearchResult('http://www.typo3-solr.com/a', 'pages', 'hello solr', 'my suggestions'),
+                $this->getFakedSearchResult('http://www.typo3-solr.com/b', 'news', 'what new in solr', 'new autosuggest'),
             ]
         );
 
-        $fakeTopResults->expects($this->once())->method('getSearchResults')->will($this->returnValue($fakeResultDocuments));
-        $this->searchResultSetServiceMock->expects($this->once())->method('search')->will($this->returnValue($fakeTopResults));
-
+        $fakeTopResults->expects(self::once())->method('getSearchResults')->willReturn($fakeResultDocuments);
+        $this->searchResultSetServiceMock->expects(self::once())->method('search')->willReturn($fakeTopResults);
 
         $suggestions = $this->suggestService->getSuggestions($fakeRequest, []);
 
-        $this->assertCount(2, $suggestions['documents'], 'Expected to have two top results');
-        $this->assertSame('pages', $suggestions['documents'][0]['type'],'The first top result has an unexpected type');
-        $this->assertSame('news', $suggestions['documents'][1]['type'],'The second top result has an unexpected type');
+        self::assertCount(2, $suggestions['documents'], 'Expected to have two top results');
+        self::assertSame('pages', $suggestions['documents'][0]['type'], 'The first top result has an unexpected type');
+        self::assertSame('news', $suggestions['documents'][1]['type'], 'The second top result has an unexpected type');
     }
-
-
 
     /**
      * Builds a faked SearchResult object.
@@ -250,20 +246,17 @@ class SuggestServiceTest extends UnitTest
     protected function getFakedSearchResult($url, $type, $title, $content)
     {
         $result = $this->getDumbMock(SearchResult::class);
-        $result->expects($this->once())->method('getUrl')->will($this->returnValue($url));
-        $result->expects($this->once())->method('getType')->will($this->returnValue($type));
-        $result->expects($this->once())->method('getTitle')->will($this->returnValue($title));
-        $result->expects($this->once())->method('getContent')->will($this->returnValue($content));
+        $result->expects(self::once())->method('getUrl')->willReturn($url);
+        $result->expects(self::once())->method('getType')->willReturn($type);
+        $result->expects(self::once())->method('getTitle')->willReturn($title);
+        $result->expects(self::once())->method('getContent')->willReturn($content);
 
         return $result;
     }
 
-    /**
-     * @return void
-     */
     protected function assertNoSearchWillBeTriggered()
     {
-        $this->searchResultSetServiceMock->expects($this->never())->method('search');
+        $this->searchResultSetServiceMock->expects(self::never())->method('search');
     }
 
     /**
@@ -272,7 +265,7 @@ class SuggestServiceTest extends UnitTest
     protected function getFakedSearchRequest($queryString)
     {
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->atLeastOnce())->method('getRawUserQuery')->will($this->returnValue($queryString));
+        $fakeRequest->expects(self::atLeastOnce())->method('getRawUserQuery')->willReturn($queryString);
         return $fakeRequest;
     }
 }

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Uri;
 
 /*
@@ -17,11 +18,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Uri;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\Group;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
-use ApacheSolrForTypo3\Solr\Util;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -48,20 +48,18 @@ class SearchUriBuilderTest extends UnitTest
      */
     protected $routingServiceMock;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->extBaseUriBuilderMock = $this->getDumbMock(UriBuilder::class);
         $this->routingServiceMock = $this->getDumbMock(RoutingService::class);
         $eventDispatcherMock = $this->getDumbMock(EventDispatcher::class);
-        $eventDispatcherMock->expects($this->any())->method('dispatch')->willReturnArgument(0);
+        $eventDispatcherMock->expects(self::any())->method('dispatch')->willReturnArgument(0);
         $this->searchUrlBuilder = new SearchUriBuilder();
         $this->searchUrlBuilder->injectUriBuilder($this->extBaseUriBuilderMock);
         $this->searchUrlBuilder->injectRoutingService($this->routingServiceMock);
         $this->searchUrlBuilder->injectEventDispatcher($eventDispatcherMock);
         $this->searchUrlBuilder->flushInMemoryCache();
+        parent::setUp();
     }
 
     /**
@@ -70,13 +68,13 @@ class SearchUriBuilderTest extends UnitTest
     public function addFacetLinkIsCalledWithSubstitutedArguments()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->willReturn([]);
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0:foo###']]];
 
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'foo', 'bar');
@@ -88,28 +86,28 @@ class SearchUriBuilderTest extends UnitTest
     public function addFacetLinkWillAddAdditionalConfiguredArguments()
     {
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0:option###']], 'foo' => '###foo###'];
-        $linkBuilderResult = '/index.php?id=1&filter='.urlencode('###tx_solr:filter:0:option###').'&foo='.urlencode('###foo###');
+        $linkBuilderResult = '/index.php?id=1&filter=' . urlencode('###tx_solr:filter:0:option###') . '&foo=' . urlencode('###foo###');
 
-        $this->extBaseUriBuilderMock->expects($this->once())
+        $this->extBaseUriBuilderMock->expects(self::once())
             ->method('setArguments')
             ->with($expectedArguments)
-            ->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())
+            ->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())
             ->method('reset')
             ->with()
-            ->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())
+            ->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())
             ->method('build')
             ->with()
-            ->will($this->returnValue($linkBuilderResult));
+            ->willReturn($linkBuilderResult);
         /* @var $configurationMock TypoScriptConfiguration */
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())
+        $configurationMock->expects(self::any())
             ->method('getSearchPluginNamespace')
-            ->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())
+            ->willReturn('tx_solr');
+        $configurationMock->expects(self::once())
             ->method('getSearchFacetingFacetLinkUrlParametersAsArray')
-            ->will($this->returnValue(['foo' => 'bar']));
+            ->willReturn(['foo' => 'bar']);
         /*
          * Method 'reviseFilterVariables()' of class RoutingService used to remove the facet prefix within
          * the path segment
@@ -121,19 +119,19 @@ class SearchUriBuilderTest extends UnitTest
          *
          * @see \ApacheSolrForTypo3\Solr\Routing\RoutingService::reviseFilterVariables
          */
-        $this->routingServiceMock->expects($this->any())
+        $this->routingServiceMock->expects(self::any())
             ->method('reviseFilterVariables')
-            ->will($this->returnValue(['###tx_solr:filter:0:option###' => 'option%3Avalue', '###foo###' => 'bar']));
-        $configurationMock->expects($this->once())
+            ->willReturn(['###tx_solr:filter:0:option###' => 'option%3Avalue', '###foo###' => 'bar']);
+        $configurationMock->expects(self::once())
             ->method('getSearchTargetPage')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $previousRequest =  new SearchRequest([], 1, 0, $configurationMock);
 
         $linkBuilderResult = $this->searchUrlBuilder
             ->getAddFacetValueUri($previousRequest, 'option', 'value');
 
-        $this->assertEquals('/index.php?id=1&filter=option%3Avalue&foo=bar', $linkBuilderResult);
+        self::assertEquals('/index.php?id=1&filter=option%3Avalue&foo=bar', $linkBuilderResult);
     }
 
     /**
@@ -142,14 +140,14 @@ class SearchUriBuilderTest extends UnitTest
     public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
-        $configurationMock->expects($this->any())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->willReturn([]);
+        $configurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(1);
 
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0:color###']]];
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue(urlencode('/index.php?id=1&tx_solr[filter][0]=###tx_solr:filter:0###')));
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn(urlencode('/index.php?id=1&tx_solr[filter][0]=###tx_solr:filter:0###'));
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
         $previousRequest->removeAllFacets();
@@ -168,12 +166,12 @@ class SearchUriBuilderTest extends UnitTest
     public function targetPageUidIsPassedWhenSortingIsAdded()
     {
         $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
-        $linkBuilderResult = '/index.php?id=1&' . urlencode('tx_solr[sort]') . '='.urlencode('###tx_solr:sort###');
+        $linkBuilderResult = '/index.php?id=1&' . urlencode('tx_solr[sort]') . '=' . urlencode('###tx_solr:sort###');
 
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(4711));
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(4711);
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
         /*
          * Method 'reviseFilterVariables()' of class RoutingService used to remove the facet prefix within
@@ -186,46 +184,47 @@ class SearchUriBuilderTest extends UnitTest
          *
          * @see \ApacheSolrForTypo3\Solr\Routing\RoutingService::reviseFilterVariables
          */
-        $this->routingServiceMock->expects($this->any())
+        $this->routingServiceMock->expects(self::any())
             ->method('reviseFilterVariables')
-            ->will($this->returnValue(['###tx_solr:sort###' => 'title+desc']));
+            ->willReturn(['###tx_solr:sort###' => 'title+desc']);
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
 
-            // we expect that the page uid from the configruation will be used to build the url with the uri builder
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setTargetPageUid')->with(4711)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
+        // we expect that the page uid from the configruation will be used to build the url with the uri builder
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setTargetPageUid')->with(4711)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn($linkBuilderResult);
         $result = $this->searchUrlBuilder->getSetSortingUri($previousRequest, 'title', 'desc');
-        $this->assertEquals('/index.php?id=1&'  . urlencode('tx_solr[sort]') . '=' . urlencode('title desc'), $result);
+        self::assertEquals('/index.php?id=1&' . urlencode('tx_solr[sort]') . '=' . urlencode('title desc'), $result);
     }
 
-   /**
+    /**
      * @test
      */
     public function canGetRemoveFacetOptionUri()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
-        $previousRequest =  new SearchRequest([
+        $previousRequest =  new SearchRequest(
+            [
                     'tx_solr' => [
                         'filter' => [
-                            'type:pages'
-                        ]
-                    ]
+                            'type:pages',
+                        ],
+                    ],
                 ],
-                0,
-                0,
-                $configurationMock
+            0,
+            0,
+            $configurationMock
         );
 
         // we expect that the filters are empty after remove
         $expectedArguments = ['tx_solr' => ['filter' => []]];
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
         $this->searchUrlBuilder->getRemoveFacetValueUri($previousRequest, 'type', 'pages');
     }
 
@@ -235,26 +234,28 @@ class SearchUriBuilderTest extends UnitTest
     public function canGetRemoveFacetUri()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
-        $previousRequest =  new SearchRequest([
+        $previousRequest =  new SearchRequest(
+            [
                     'tx_solr' => [
                         'filter' => [
                             'type:pages',
                             'type:tt_news',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                0,
-                0,
-                $configurationMock);
+            0,
+            0,
+            $configurationMock
+        );
 
         // we expect that the filters are empty after remove
         //@todo we need to refactor the request in ext:solr to cleanup empty arguments completely to assert  $expectedArguments = []
         $expectedArguments = ['tx_solr' => ['filter' => []]];
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
         $this->searchUrlBuilder->getRemoveFacetUri($previousRequest, 'type');
     }
 
@@ -266,33 +267,37 @@ class SearchUriBuilderTest extends UnitTest
     public function addFacetUriRemovesPreviousGroupPage()
     {
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())
+        $configurationMock->expects(self::any())
             ->method('getSearchPluginNamespace')
-            ->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())
+            ->willReturn('tx_solr');
+        $configurationMock->expects(self::once())
             ->method('getSearchTargetPage')
-            ->will($this->returnValue(1));
-        $configurationMock->expects($this->any())
+            ->willReturn(1);
+        $configurationMock->expects(self::any())
             ->method('getSearchFacetingFacetLinkUrlParametersAsArray')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
-        $previousRequest =  new SearchRequest([
+        $previousRequest =  new SearchRequest(
+            [
                 'tx_solr' => [
                     'groupPage' => [
                         'typeGroup' => [
-                            'pages' => 4
-                        ]
-                    ]
-                ]
+                            'pages' => 4,
+                        ],
+                    ],
+                ],
             ],
-            0, 0, $configurationMock);
+            0,
+            0,
+            $configurationMock
+        );
 
-        $this->extBaseUriBuilderMock->expects($this->any())->method('setArguments')->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->any())->method('build')->will($this->returnValue('/index.php?id=1&tx_solr[filter][0]=type:pages'));
+        $this->extBaseUriBuilderMock->expects(self::any())->method('setArguments')->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::any())->method('build')->willReturn('/index.php?id=1&tx_solr[filter][0]=type:pages');
 
         $uri = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'type', 'pages');
-        $this->assertSame('/index.php?id=1&tx_solr[filter][0]=type:pages', urldecode($uri), 'Unexpected uri generated');
+        self::assertSame('/index.php?id=1&tx_solr[filter][0]=type:pages', urldecode($uri), 'Unexpected uri generated');
     }
 
     /**
@@ -304,36 +309,35 @@ class SearchUriBuilderTest extends UnitTest
             'tx_solr' => [
                 'groupPage' => [
                     'smallPidRange' => [
-                        'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###'
-                    ]
-                ]
-            ]
+                        'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###',
+                    ],
+                ],
+            ],
         ];
         $givenTemplate = [
             'id' => 1,
             'tx_solr' => [
                 'groupPage' => [
                     'smallPidRange' => [
-                        'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###'
-                    ]
+                        'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###',
+                    ],
                 ],
-            ]
+            ],
         ];
         $linkBuilderResult = '/index.php?' . http_build_query($givenTemplate);
 
-
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(1));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
 
         $group = new Group('smallPidRange', 5);
         $groupItem = new GroupItem($group, 'pid:[0 to 5]', 12, 0, 32);
 
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
+        $this->extBaseUriBuilderMock->expects(self::once())->method('setArguments')->with($expectedArguments)->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn($linkBuilderResult);
 
         /*
          * Method 'reviseFilterVariables()' of class RoutingService used to remove the facet prefix within
@@ -346,11 +350,11 @@ class SearchUriBuilderTest extends UnitTest
          *
          * @see \ApacheSolrForTypo3\Solr\Routing\RoutingService::reviseFilterVariables
          */
-        $this->routingServiceMock->expects($this->any())
+        $this->routingServiceMock->expects(self::any())
             ->method('reviseFilterVariables')
-            ->will($this->returnValue(['###tx_solr:groupPage:smallPidRange:pid0to5###' => '5']));
+            ->willReturn(['###tx_solr:groupPage:smallPidRange:pid0to5###' => '5']);
         $uri = $this->searchUrlBuilder->getResultGroupItemPageUri($previousRequest, $groupItem, 5);
-        $this->assertStringContainsString(urlencode('tx_solr[groupPage][smallPidRange][pid0to5]') . '=5', $uri, 'Uri did not contain link segment for query group');
+        self::assertStringContainsString(urlencode('tx_solr[groupPage][smallPidRange][pid0to5]') . '=5', $uri, 'Uri did not contain link segment for query group');
     }
 
     /*
@@ -364,9 +368,9 @@ class SearchUriBuilderTest extends UnitTest
     {
         $configuration = Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'));
         $routingServiceMock = $this->getDumbMock(RoutingService::class);
-        $routingServiceMock->expects($this->any())
+        $routingServiceMock->expects(self::any())
             ->method('fetchEnhancerByPageUid')
-            ->will($this->returnValue($configuration['routeEnhancers']['example']));
+            ->willReturn($configuration['routeEnhancers']['example']);
         $queryParameters = [
             'tx_solr' => [
                 'filter' => [
@@ -378,8 +382,8 @@ class SearchUriBuilderTest extends UnitTest
                     'taste:sour',
                     'product:candy',
                     'product:sweets',
-                ]
-            ]
+                ],
+            ],
         ];
         $expectedQueryParameters = [
             'tx_solr' => [
@@ -392,24 +396,24 @@ class SearchUriBuilderTest extends UnitTest
                     '###tx_solr:filter:5:taste###',
                     '###tx_solr:filter:6:product###',
                     '###tx_solr:filter:7:product###',
-                ]
-            ]
+                ],
+            ],
         ];
         $linkBuilderResult = '/index.php?id=42&color=' . urlencode('green,red,yellow') .
             '&taste=' . urlencode('matcha,sour') .
             '&product=' . urlencode('candy,sweets');
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(42));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(42);
 
         $previousRequest =  new SearchRequest($queryParameters, 42, 0, $configurationMock);
-        $this->extBaseUriBuilderMock->expects($this->any())->method('setArguments')->with($expectedQueryParameters)
-            ->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
+        $this->extBaseUriBuilderMock->expects(self::any())->method('setArguments')->with($expectedQueryParameters)
+            ->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn($linkBuilderResult);
         $this->searchUrlBuilder->injectRoutingService($routingServiceMock);
         $uri = $this->searchUrlBuilder->getResultPageUri($previousRequest, 0);
-        $this->assertEquals($linkBuilderResult, $uri);
+        self::assertEquals($linkBuilderResult, $uri);
     }
 
     /**
@@ -419,9 +423,9 @@ class SearchUriBuilderTest extends UnitTest
     {
         $configuration = Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'));
         $routingServiceMock = $this->getDumbMock(RoutingService::class);
-        $routingServiceMock->expects($this->any())
+        $routingServiceMock->expects(self::any())
             ->method('fetchEnhancerByPageUid')
-            ->will($this->returnValue($configuration['routeEnhancers']['example']));
+            ->willReturn($configuration['routeEnhancers']['example']);
         $queryParameters = [
             'tx_solr' => [
                 'filter' => [
@@ -433,9 +437,9 @@ class SearchUriBuilderTest extends UnitTest
                     'taste:sour',
                     'product:candy',
                     'product:sweets',
-                    'quantity:20'
-                ]
-            ]
+                    'quantity:20',
+                ],
+            ],
         ];
         $expectedQueryParameters = [
             'tx_solr' => [
@@ -449,24 +453,24 @@ class SearchUriBuilderTest extends UnitTest
                     '###tx_solr:filter:6:product###',
                     '###tx_solr:filter:7:product###',
                     '###tx_solr:filter:8:quantity###',
-                ]
-            ]
+                ],
+            ],
         ];
         $linkBuilderResult = '/index.php?id=42&color=' . urlencode('green,red,yellow') .
             '&taste=' . urlencode('matcha,sour') .
             '&product=' . urlencode('candy,sweets') .
-            '&' . urlencode('tx_solr[filter][0]') .'=' . urlencode('quantity:20');
+            '&' . urlencode('tx_solr[filter][0]') . '=' . urlencode('quantity:20');
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
-        $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(42));
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(42);
 
         $previousRequest =  new SearchRequest($queryParameters, 42, 0, $configurationMock);
-        $this->extBaseUriBuilderMock->expects($this->any())->method('setArguments')->with($expectedQueryParameters)
-            ->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('reset')->with()->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
+        $this->extBaseUriBuilderMock->expects(self::any())->method('setArguments')->with($expectedQueryParameters)
+            ->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn($linkBuilderResult);
         $this->searchUrlBuilder->injectRoutingService($routingServiceMock);
         $uri = $this->searchUrlBuilder->getResultPageUri($previousRequest, 0);
-        $this->assertEquals($linkBuilderResult, $uri);
+        self::assertEquals($linkBuilderResult, $uri);
     }
 }

--- a/Tests/Unit/Domain/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/SearchRequestBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
 
 /***************************************************************
@@ -51,14 +52,12 @@ class SearchRequestBuilderTest extends UnitTest
      */
     protected $searchRequestBuilder;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->sessionMock = $this->getDumbMock(FrontendUserSession::class);
         $this->searchRequestBuilder = new SearchRequestBuilder($this->configurationMock, $this->sessionMock);
+        parent::setUp();
     }
 
     /**
@@ -66,19 +65,19 @@ class SearchRequestBuilderTest extends UnitTest
      */
     public function testPageIsResettedWhenValidResultsPerPageValueWasPassed()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
-            ->will($this->returnValue([10, 25]));
-        $this->configurationMock->expects($this->any())->method('getSearchPluginNamespace')
-            ->will($this->returnValue(SearchRequest::DEFAULT_PLUGIN_NAMESPACE));
+        $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
+            ->willReturn([10, 25]);
+        $this->configurationMock->expects(self::any())->method('getSearchPluginNamespace')
+            ->willReturn(SearchRequest::DEFAULT_PLUGIN_NAMESPACE);
         $this->assertPerPageInSessionWillBeChanged();
 
         $requestArguments = [
             'q' => 'test',
             'resultsPerPage' => 25,
-            'page' => 5 // pagination page
+            'page' => 5, // pagination page
         ];
         $request = $this->searchRequestBuilder->buildForSearch($requestArguments, 0, 0);
-        $this->assertSame($request->getPage(), null, 'Page was not resetted.');
+        self::assertSame($request->getPage(), null, 'Page was not resetted.');
     }
 
     /**
@@ -86,27 +85,21 @@ class SearchRequestBuilderTest extends UnitTest
      */
     public function testPerPageValueIsNotSetInSession()
     {
-        $this->configurationMock->expects($this->once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
-            ->will($this->returnValue([10, 25]));
+        $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
+            ->willReturn([10, 25]);
         $this->assertPerPageInSessionWillNotBeChanged();
 
         $requestArguments = ['q' => 'test', 'page' => 3];
         $this->searchRequestBuilder->buildForSearch($requestArguments, 0, 0);
     }
 
-    /**
-     * @return void
-     */
     private function assertPerPageInSessionWillBeChanged()
     {
-        $this->sessionMock->expects($this->once())->method('setPerPage');
+        $this->sessionMock->expects(self::once())->method('setPerPage');
     }
 
-    /**
-     * @return void
-     */
     private function assertPerPageInSessionWillNotBeChanged()
     {
-        $this->sessionMock->expects($this->never())->method('setPerPage');
+        $this->sessionMock->expects(self::never())->method('setPerPage');
     }
 }

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
@@ -41,13 +42,14 @@ class SiteHashServiceTest extends UnitTest
     /**
      * @return array
      */
-    public function canResolveSiteHashAllowedSitesDataProvider() {
+    public function canResolveSiteHashAllowedSitesDataProvider()
+    {
         return [
             'siteHashDisabled' => ['*', '*'],
             'allSitesInSystem' => ['__all', 'solrtesta.local,solrtestb.local'],
             'currentSiteOnly' => ['__current_site', 'solrtesta.local'],
             'emptyIsFallingBackToCurrentSiteOnly' => ['', 'solrtesta.local'],
-            'nullIsFallingBackToCurrentSiteOnly' => [null, 'solrtesta.local']
+            'nullIsFallingBackToCurrentSiteOnly' => [null, 'solrtesta.local'],
         ];
     }
 
@@ -55,21 +57,21 @@ class SiteHashServiceTest extends UnitTest
      * @dataProvider canResolveSiteHashAllowedSitesDataProvider
      * @test
      */
-    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration , $expectedAllowedSites)
+    public function canResolveSiteHashAllowedSites($allowedSitesConfiguration, $expectedAllowedSites)
     {
         $siteA = $this->getDumbMock(Site::class);
-        $siteA->expects($this->any())->method('getDomain')->will($this->returnValue('solrtesta.local'));
+        $siteA->expects(self::any())->method('getDomain')->willReturn('solrtesta.local');
         $siteB = $this->getDumbMock(Site::class);
-        $siteB->expects($this->any())->method('getDomain')->will($this->returnValue('solrtestb.local'));
+        $siteB->expects(self::any())->method('getDomain')->willReturn('solrtestb.local');
         $allSites = [$siteA, $siteB];
 
-            /** @var $siteHashServiceMock SiteHashService */
-        $siteHashServiceMock = $this->getMockBuilder(SiteHashService::class)->setMethods(['getAvailableSites','getSiteByPageId'])->getMock();
-        $siteHashServiceMock->expects($this->any())->method('getAvailableSites')->will($this->returnValue($allSites));
-        $siteHashServiceMock->expects($this->any())->method('getSiteByPageId')->will($this->returnValue($siteA));
+        /** @var $siteHashServiceMock SiteHashService */
+        $siteHashServiceMock = $this->getMockBuilder(SiteHashService::class)->onlyMethods(['getAvailableSites', 'getSiteByPageId'])->getMock();
+        $siteHashServiceMock->expects(self::any())->method('getAvailableSites')->willReturn($allSites);
+        $siteHashServiceMock->expects(self::any())->method('getSiteByPageId')->willReturn($siteA);
 
         $allowedSites = $siteHashServiceMock->getAllowedSitesForPageIdAndAllowedSitesConfiguration(1, $allowedSitesConfiguration);
-        $this->assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
+        self::assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
     }
 
     /**
@@ -84,8 +86,8 @@ class SiteHashServiceTest extends UnitTest
         $hash1 = $service->getSiteHashForDomain('www.example.com');
         $hash2 = $service->getSiteHashForDomain('www.example.com');
 
-        $this->assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash1);
-        $this->assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash2);
+        self::assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash1);
+        self::assertEquals('3f91984c5c353933cc82d3659dbb08e392b7d541', $hash2);
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $oldKey;
     }
 }

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
 
 /***************************************************************
@@ -25,11 +26,12 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
-use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
 
@@ -68,7 +70,7 @@ class SiteRepositoryTest extends UnitTest
      */
     protected $siteFinderMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
@@ -79,8 +81,9 @@ class SiteRepositoryTest extends UnitTest
         // we mock buildSite to avoid the creation of real Site objects and pass all dependencies as mock
         $this->siteRepository = $this->getMockBuilder(SiteRepository::class)
             ->setConstructorArgs([$this->rootPageResolverMock, $this->cacheMock, $this->registryMock, $this->siteFinderMock])
-            ->setMethods(['buildSite','getSolrServersFromRegistry'])
+            ->onlyMethods(['buildSite'])
             ->getMock();
+        parent::setUp();
     }
 
     /**
@@ -94,7 +97,7 @@ class SiteRepositoryTest extends UnitTest
         $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getSiteByRootPageId(4711);
-        $this->assertInstanceOf(Site::class, $site);
+        self::assertInstanceOf(Site::class, $site);
     }
 
     /**
@@ -109,7 +112,7 @@ class SiteRepositoryTest extends UnitTest
         $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getSiteByPageId(222);
-        $this->assertInstanceOf(Site::class, $site);
+        self::assertInstanceOf(Site::class, $site);
     }
 
     /**
@@ -119,16 +122,16 @@ class SiteRepositoryTest extends UnitTest
     {
         $this->fakeEmptyCache();
 
-        $siteMock = $this->getSiteMock(333, [0,1,2]);
+        $siteMock = $this->getSiteMock(333, [0, 1, 2]);
         $this->fakeSitesInTYPO3Systems([$siteMock]);
 
         $this->assertThatSitesAreCreatedWithPageIds([333], [
-            0 => ['language' => 0]
+            0 => ['language' => 0],
         ]);
         $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getFirstAvailableSite();
-        $this->assertInstanceOf(Site::class, $site);
+        self::assertInstanceOf(Site::class, $site);
     }
 
     /**
@@ -137,15 +140,15 @@ class SiteRepositoryTest extends UnitTest
     public function canGetAvailableSites()
     {
         $this->fakeEmptyCache();
-        $siteMockA = $this->getSiteMock(123, [0,1]);
-        $siteMockB = $this->getSiteMock(234, [0,2]);
+        $siteMockA = $this->getSiteMock(123, [0, 1]);
+        $siteMockB = $this->getSiteMock(234, [0, 2]);
         $this->fakeSitesInTYPO3Systems([$siteMockA, $siteMockB]);
 
-        $this->assertThatSitesAreCreatedWithPageIds([123,234],[0 => ['language' => 0], 1 => ['language' => 1]]);
+        $this->assertThatSitesAreCreatedWithPageIds([123, 234], [0 => ['language' => 0], 1 => ['language' => 1]]);
         $this->assertCacheIsWritten();
 
         $sites = $this->siteRepository->getAvailableSites();
-        $this->assertCount(2, $sites, 'We expect to have two sites with two languages');
+        self::assertCount(2, $sites, 'We expect to have two sites with two languages');
     }
 
     /**
@@ -154,12 +157,12 @@ class SiteRepositoryTest extends UnitTest
     public function canGetAllLanguages()
     {
         $this->fakeEmptyCache();
-        $siteMockA = $this->getSiteMock(123, [0,2,5]);
+        $siteMockA = $this->getSiteMock(123, [0, 2, 5]);
         $siteMockB = $this->getSiteMock(234, [0]);
         $this->fakeSitesInTYPO3Systems([$siteMockA, $siteMockB]);
 
         $this->assertThatSitesAreCreatedWithPageIds(
-            [123,234],
+            [123, 234],
             [
                 0 => ['language' => 0],
                 2 => ['language' => 2],
@@ -169,23 +172,17 @@ class SiteRepositoryTest extends UnitTest
 
         $siteOne = $this->siteRepository->getFirstAvailableSite();
         $connections =$siteOne->getAllSolrConnectionConfigurations();
-        $this->assertEquals([0,2,5], array_keys($connections), 'Could not get languages for site');
+        self::assertEquals([0, 2, 5], array_keys($connections), 'Could not get languages for site');
     }
 
-    /**
-     * @return void
-     */
     protected function fakeEmptyCache()
     {
-        $this->cacheMock->expects($this->any())->method('get')->will($this->returnValue(null));
+        $this->cacheMock->expects(self::any())->method('get')->willReturn(null);
     }
 
-    /**
-     * @return void
-     */
     protected function assertCacheIsWritten()
     {
-        $this->cacheMock->expects($this->once())->method('set');
+        $this->cacheMock->expects(self::once())->method('set');
     }
 
     /**
@@ -194,12 +191,12 @@ class SiteRepositoryTest extends UnitTest
      */
     protected function assertThatSitesAreCreatedWithPageIds(array $pageIds, array $fakedConnectionConfiguration = [])
     {
-        $this->siteRepository->expects($this->any())->method('buildSite')->will(
-            $this->returnCallback(function($idToUse) use ($pageIds, $fakedConnectionConfiguration) {
-                if(in_array($idToUse, $pageIds)) {
+        $this->siteRepository->expects(self::any())->method('buildSite')->willReturnCallback(
+            function ($idToUse) use ($pageIds, $fakedConnectionConfiguration) {
+                if (in_array($idToUse, $pageIds)) {
                     $site = $this->getDumbMock(Site::class);
-                    $site->expects($this->any())->method('getRootPageId')->will(
-                        $this->returnValue($idToUse)
+                    $site->expects($this->any())->method('getRootPageId')->willReturn(
+                        $idToUse
                     );
                     $site->expects($this->any())->method('isEnabled')->willReturn(count($fakedConnectionConfiguration) > 0);
                     $site->expects($this->any())
@@ -207,52 +204,42 @@ class SiteRepositoryTest extends UnitTest
                         ->willReturn($fakedConnectionConfiguration);
                     return $site;
                 }
-            })
+            }
         );
     }
 
     /**
-     * @param integer $forPageId
-     * @param integer $rootPageId
+     * @param int $forPageId
+     * @param int $rootPageId
      */
     protected function fakeExistingRootPage($forPageId, $rootPageId)
     {
-        $this->rootPageResolverMock->expects($this->any())->method('getRootPageId')->with($forPageId)->will($this->returnValue($rootPageId));
+        $this->rootPageResolverMock->expects(self::any())->method('getRootPageId')->with($forPageId)->willReturn($rootPageId);
     }
 
     /**
      * @param int $rootPageUid
-     * @return \TYPO3\CMS\Core\Site\Entity\Site
+     * @return CoreSite
      */
     protected function getSiteMock(int $rootPageUid, array $languageUids)
     {
-            /** @var \TYPO3\CMS\Core\Site\Entity\Site $siteMock */
-        $siteMock = $this->getDumbMock( \TYPO3\CMS\Core\Site\Entity\Site::class);
-        $siteMock->expects($this->any())->method('getRootPageId')->willReturn($rootPageUid);
+        /** @var CoreSite $siteMock */
+        $siteMock = $this->getDumbMock(CoreSite::class);
+        $siteMock->expects(self::any())->method('getRootPageId')->willReturn($rootPageUid);
 
         $languageMocks = [];
         $defaultLanguage = null;
 
-        foreach($languageUids as $languageUid) {
+        foreach ($languageUids as $languageUid) {
             $languageMock = $this->getDumbMock(SiteLanguage::class);
-            $languageMock->expects($this->any())->method('getLanguageId')->willReturn($languageUid);
+            $languageMock->expects(self::any())->method('getLanguageId')->willReturn($languageUid);
             $languageMocks[] = $languageMock;
         }
 
-        $siteMock->expects($this->any())->method('getAllLanguages')->willReturn($languageMocks);
-        $siteMock->expects($this->any())->method('getDefaultLanguage')->willReturn(reset($languageMocks));
+        $siteMock->expects(self::any())->method('getAllLanguages')->willReturn($languageMocks);
+        $siteMock->expects(self::any())->method('getDefaultLanguage')->willReturn(reset($languageMocks));
 
         return $siteMock;
-    }
-
-    /**
-     * @param array $sitesInRegistry
-     */
-    protected function fakeSitesInRegistry(array $sitesInRegistry)
-    {
-        $this->siteRepository->expects($this->any())->method('getSolrServersFromRegistry')->will(
-            $this->returnValue($sitesInRegistry)
-        );
     }
 
     /**
@@ -260,8 +247,8 @@ class SiteRepositoryTest extends UnitTest
      */
     protected function fakeSitesInTYPO3Systems(array $sitesInTYPO3)
     {
-        $this->siteFinderMock->expects($this->any())->method('getAllSites')->will(
-            $this->returnValue($sitesInTYPO3)
+        $this->siteFinderMock->expects(self::any())->method('getAllSites')->willReturn(
+            $sitesInTYPO3
         );
     }
 }

--- a/Tests/Unit/Domain/Variants/CustomIdModifier.php
+++ b/Tests/Unit/Domain/Variants/CustomIdModifier.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Variants;
 
 /***************************************************************
@@ -26,13 +27,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Variants;
 
 use ApacheSolrForTypo3\Solr\Domain\Variants\IdModifier;
 
-class CustomIdModifier implements IdModifier {
+class CustomIdModifier implements IdModifier
+{
 
     /**
      * @param string $variantId
      * @param string $systemHash
      * @param string $type
-     * @param integer $uid
+     * @param int $uid
      * @return string
      */
     public function modifyVariantId($variantId, $systemHash, $type, $uid)

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Variants;
 
 /***************************************************************
@@ -40,14 +41,14 @@ class IdBuilderTest extends UnitTest
      */
     protected $oldEncryptionKey;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->oldEncryptionKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'testkey';
         parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $this->oldEncryptionKey;
         parent::tearDown();
@@ -60,7 +61,7 @@ class IdBuilderTest extends UnitTest
     {
         $build = new IdBuilder();
         $variantId = $build->buildFromTypeAndUid('pages', 4711);
-        $this->assertSame('e99b3552a0451f1a2e7aca4ac06ccaba063393de/pages/4711', $variantId);
+        self::assertSame('e99b3552a0451f1a2e7aca4ac06ccaba063393de/pages/4711', $variantId);
     }
 
     /**
@@ -74,7 +75,7 @@ class IdBuilderTest extends UnitTest
         $variantId = $build->buildFromTypeAndUid('pages', 4711);
 
         // the variantId should be overwritten by the custom modifier
-        $this->assertSame('mycustomid', $variantId);
+        self::assertSame('mycustomid', $variantId);
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['modifyVariantId'] = [];
     }

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
 
 /***************************************************************
@@ -35,12 +36,15 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 class PathToHierarchyTest extends UnitTest
 {
 
-    /** @var PathToHierarchy */
+    /**
+     * @var PathToHierarchy
+     */
     protected $processor;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->processor = new PathToHierarchy();
+        parent::setUp();
     }
 
     /**
@@ -48,25 +52,35 @@ class PathToHierarchyTest extends UnitTest
      */
     public function canBuildSolrHierarchyString()
     {
-        $this->assertEquals($this->processor->process(['sport/cricket']),
-            ['0-sport/', '1-sport/cricket/']);
-        $this->assertEquals($this->processor->process(['sport/skateboarding']),
-            ['0-sport/', '1-sport/skateboarding/']);
+        self::assertEquals(
+            $this->processor->process(['sport/cricket']),
+            ['0-sport/', '1-sport/cricket/']
+        );
+        self::assertEquals(
+            $this->processor->process(['sport/skateboarding']),
+            ['0-sport/', '1-sport/skateboarding/']
+        );
 
-        $this->assertEquals($this->processor->process(['sport/skateboarding \/ snowboarding']),
-            ['0-sport/', '1-sport/skateboarding \/ snowboarding/']);
+        self::assertEquals(
+            $this->processor->process(['sport/skateboarding \/ snowboarding']),
+            ['0-sport/', '1-sport/skateboarding \/ snowboarding/']
+        );
 
-        $this->assertEquals($this->processor->process(['sport/skateboarding/street']),
+        self::assertEquals(
+            $this->processor->process(['sport/skateboarding/street']),
             [
                 '0-sport/',
                 '1-sport/skateboarding/',
-                '2-sport/skateboarding/street/'
-            ]);
-        $this->assertEquals($this->processor->process(['/sport/skateboarding/street//']),
+                '2-sport/skateboarding/street/',
+            ]
+        );
+        self::assertEquals(
+            $this->processor->process(['/sport/skateboarding/street//']),
             [
                 '0-sport/',
                 '1-sport/skateboarding/',
-                '2-sport/skateboarding/street/'
-            ]);
+                '2-sport/skateboarding/street/',
+            ]
+        );
     }
 }

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
 
 /***************************************************************
@@ -48,11 +49,11 @@ class ServiceTest extends UnitTest
      */
     protected $service;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        date_default_timezone_set('Europe/Berlin');
         $this->documentMock = new Document();
         $this->service = new Service();
+        parent::setUp();
     }
 
     /**
@@ -64,7 +65,7 @@ class ServiceTest extends UnitTest
         $configuration = ['stringField' => 'uppercase'];
 
         $this->service->processDocument($this->documentMock, $configuration);
-        $this->assertEquals(
+        self::assertEquals(
             $this->documentMock['stringField'],
             'STRINGVALUE',
             'field was not processed with uppercase'
@@ -81,7 +82,7 @@ class ServiceTest extends UnitTest
         $configuration = ['stringField' => 'uppercase'];
 
         $this->service->processDocument($this->documentMock, $configuration);
-        $this->assertEquals(
+        self::assertEquals(
             $this->documentMock['stringField'],
             ['STRINGVALUE_1', 'STRINGVALUE_2'],
             'field was not processed with uppercase'
@@ -93,12 +94,14 @@ class ServiceTest extends UnitTest
      */
     public function transformsUnixTimestampToIsoDateOnSingleValuedField()
     {
-        $this->documentMock->setField('dateField',
-            '1262343600'); // 2010-01-01 12:00
+        $this->documentMock->setField(
+            'dateField',
+            '1262343600'
+        ); // 2010-01-01 12:00
         $configuration = ['dateField' => 'timestampToIsoDate'];
 
         $this->service->processDocument($this->documentMock, $configuration);
-        $this->assertEquals(
+        self::assertEquals(
             $this->documentMock['dateField'],
             '2010-01-01T12:00:00Z',
             'field was not processed with timestampToIsoDate'
@@ -110,14 +113,18 @@ class ServiceTest extends UnitTest
      */
     public function transformsUnixTimestampToIsoDateOnMultiValuedField()
     {
-        $this->documentMock->addField('dateField',
-            '1262343600'); // 2010-01-01 12:00
-        $this->documentMock->addField('dateField',
-            '1262343601'); // 2010-01-01 12:01
+        $this->documentMock->addField(
+            'dateField',
+            '1262343600'
+        ); // 2010-01-01 12:00
+        $this->documentMock->addField(
+            'dateField',
+            '1262343601'
+        ); // 2010-01-01 12:01
         $configuration = ['dateField' => 'timestampToIsoDate'];
 
         $this->service->processDocument($this->documentMock, $configuration);
-        $this->assertEquals(
+        self::assertEquals(
             $this->documentMock['dateField'],
             ['2010-01-01T12:00:00Z', '2010-01-01T12:00:01Z'],
             'field was not processed with timestampToIsoDate'

--- a/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
+++ b/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
@@ -38,23 +38,22 @@ class TypoScriptTest extends UnitTest
      */
     protected $typoScriptConfigurationDumpMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->typoScriptMock = $this->getMockBuilder(TypoScript::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'buildConfigurationArray',
                     'buildTypoScriptConfigurationFromArray',
-                    'getConfigurationPageIdToUse'
                 ]
             )->getMock();
 
         $this->typoScriptConfigurationDumpMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GeneralUtility::resetSingletonInstances([]);
         unset(
@@ -99,7 +98,7 @@ class TypoScriptTest extends UnitTest
             $language
         );
 
-        $this->assertInstanceOf(TypoScriptConfiguration::class, $newConfiguration);
+        self::assertInstanceOf(TypoScriptConfiguration::class, $newConfiguration);
 
         // prepare second/cached call
         // pageRepository->getRootLine should be called only once
@@ -110,9 +109,8 @@ class TypoScriptTest extends UnitTest
             $language
         );
 
-        $this->assertInstanceOf(TypoScriptConfiguration::class, $cachedConfiguration);
+        self::assertInstanceOf(TypoScriptConfiguration::class, $cachedConfiguration);
 
-        $this->assertSame($newConfiguration, $cachedConfiguration);
+        self::assertSame($newConfiguration, $cachedConfiguration);
     }
-
 }

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -24,18 +25,18 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Psr\EventDispatcher\EventDispatcherInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the GarbageCollector class.
@@ -64,7 +65,7 @@ class GarbageCollectorTest extends UnitTest
      */
     protected $garbageHandlerMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $this->tcaServiceMock = $this->createMock(TCAService::class);
@@ -75,9 +76,10 @@ class GarbageCollectorTest extends UnitTest
 
         $GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
         $GLOBALS['BE_USER']->workspace = 0;
+        parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($GLOBALS['BE_USER']);
         unset($GLOBALS['TCA']);
@@ -94,16 +96,16 @@ class GarbageCollectorTest extends UnitTest
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch')
-            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+            ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
-            }));
+            });
         $this->garbageCollector->processCmdmap_preProcess('delete', 'pages', 123, '', $dataHandlerMock);
 
-        $this->assertTrue($dispatchedEvent instanceof RecordDeletedEvent);
-        $this->assertEquals('pages', $dispatchedEvent->getTable());
-        $this->assertEquals(123, $dispatchedEvent->getUid());
+        self::assertTrue($dispatchedEvent instanceof RecordDeletedEvent);
+        self::assertEquals('pages', $dispatchedEvent->getTable());
+        self::assertEquals(123, $dispatchedEvent->getUid());
     }
 
     /**
@@ -115,7 +117,7 @@ class GarbageCollectorTest extends UnitTest
 
         $GLOBALS['BE_USER']->workspace = 1;
         $this->eventDispatcherMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('dispatch');
         $this->garbageCollector->processCmdmap_preProcess('delete', 'pages', 123, '', $dataHandlerMock);
     }
@@ -129,17 +131,17 @@ class GarbageCollectorTest extends UnitTest
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch')
-            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+            ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
-            }));
+            });
 
         $this->garbageCollector->processCmdmap_postProcess('move', 'pages', 1011, '', $dataHandlerMock);
 
-        $this->assertTrue($dispatchedEvent instanceof PageMovedEvent);
-        $this->assertEquals('pages', $dispatchedEvent->getTable());
-        $this->assertEquals(1011, $dispatchedEvent->getUid());
+        self::assertTrue($dispatchedEvent instanceof PageMovedEvent);
+        self::assertEquals('pages', $dispatchedEvent->getTable());
+        self::assertEquals(1011, $dispatchedEvent->getUid());
     }
 
     /**
@@ -151,7 +153,7 @@ class GarbageCollectorTest extends UnitTest
 
         $GLOBALS['BE_USER']->workspace = 1;
         $this->eventDispatcherMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('dispatch');
 
         $this->garbageCollector->processCmdmap_postProcess('move', 'pages', 1011, '', $dataHandlerMock);
@@ -167,11 +169,11 @@ class GarbageCollectorTest extends UnitTest
             'uid' => 123,
             'pid' => 1,
             'hidden' => 0,
-            'fe_group' => '1,2'
+            'fe_group' => '1,2',
         ];
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isEnableColumn')
             ->with(
                 'tx_foo_bar',
@@ -180,7 +182,7 @@ class GarbageCollectorTest extends UnitTest
             ->willReturn(true);
 
         $this->garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecordWithFieldRelevantForGarbageCollection')
             ->with(
                 'tx_foo_bar',
@@ -189,7 +191,7 @@ class GarbageCollectorTest extends UnitTest
             ->willReturn($dummyRecord);
 
         $this->tcaServiceMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('normalizeFrontendGroupField')
             ->with(
                 'tx_foo_bar',
@@ -204,7 +206,7 @@ class GarbageCollectorTest extends UnitTest
         $property->setAccessible(true);
         $trackedRecords = $property->getValue($this->garbageCollector);
 
-        $this->assertEquals($dummyRecord, $trackedRecords['tx_foo_bar'][123]);
+        self::assertEquals($dummyRecord, $trackedRecords['tx_foo_bar'][123]);
     }
 
     /**
@@ -218,18 +220,18 @@ class GarbageCollectorTest extends UnitTest
             'uid' => 123,
             'pid' => 1,
             'hidden' => 0,
-            'fe_group' => '1,2'
+            'fe_group' => '1,2',
         ];
         $trackedRecords = [
             'tx_foo_bar' => [
-                123 => $dummyRecord
-            ]
+                123 => $dummyRecord,
+            ],
         ];
         $this->inject($this->garbageCollector, 'trackedRecords', $trackedRecords);
         $dummyRecord['fe_group'] = '1';
 
         $this->garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRecordWithFieldRelevantForGarbageCollection')
             ->with(
                 'tx_foo_bar',
@@ -239,11 +241,11 @@ class GarbageCollectorTest extends UnitTest
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch')
-            ->will($this->returnCallback(function() use (&$dispatchedEvent) {
+            ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
-            }));
+            });
 
         $this->garbageCollector->processDatamap_afterDatabaseOperations(
             'update',
@@ -253,10 +255,10 @@ class GarbageCollectorTest extends UnitTest
             $dataHandlerMock
         );
 
-        $this->assertTrue($dispatchedEvent instanceof RecordGarbageCheckEvent);
-        $this->assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
-        $this->assertEquals(123, $dispatchedEvent->getUid());
-        $this->assertTrue($dispatchedEvent->frontendGroupsRemoved());
+        self::assertTrue($dispatchedEvent instanceof RecordGarbageCheckEvent);
+        self::assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
+        self::assertEquals(123, $dispatchedEvent->getUid());
+        self::assertTrue($dispatchedEvent->frontendGroupsRemoved());
     }
 
     /**
@@ -265,7 +267,7 @@ class GarbageCollectorTest extends UnitTest
     public function collectGarbageTriggersGarbageCollection(): void
     {
         $this->garbageHandlerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('collectGarbage')
             ->with(
                 'pages',

--- a/Tests/Unit/Helper/FakeObjectManager.php
+++ b/Tests/Unit/Helper/FakeObjectManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Helper;
 
 /***************************************************************
@@ -32,8 +33,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
  * This class is a light weight fake object manager that just dispatches the creation
  * of an object to GeneralUtitlity::makeInstance. When the object contains a method,
  * injectObjectManager it injects the object manager into the instance.
- *
- * @package ApacheSolrForTypo3\Solr\Tests\Unit\Helper
  */
 class FakeObjectManager implements ObjectManagerInterface
 {
@@ -46,7 +45,7 @@ class FakeObjectManager implements ObjectManagerInterface
      */
     public function isRegistered(string $objectName): bool
     {
-        throw new InvalidArgumentException("Not implemented in the FakeObjectManager");
+        throw new InvalidArgumentException('Not implemented in the FakeObjectManager');
     }
 
     /**
@@ -78,7 +77,7 @@ class FakeObjectManager implements ObjectManagerInterface
      */
     public function getEmptyObject(string $className): object
     {
-        throw new InvalidArgumentException("Not implemented in the FakeObjectManager");
+        throw new InvalidArgumentException('Not implemented in the FakeObjectManager');
     }
 
     /**
@@ -89,6 +88,6 @@ class FakeObjectManager implements ObjectManagerInterface
      */
     public function getScope(string $objectName): int
     {
-        throw new InvalidArgumentException("Not implemented in the FakeObjectManager");
+        throw new InvalidArgumentException('Not implemented in the FakeObjectManager');
     }
 }

--- a/Tests/Unit/HtmlContentExtractorTest.php
+++ b/Tests/Unit/HtmlContentExtractorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -44,10 +45,10 @@ class HtmlContentExtractorTest extends UnitTest
 
         $expectedTagContent = [
             'tagsH1' => 'Level 1 headline',
-            'tagsH2H3' => 'Level 2 headline Level 3 headline'
+            'tagsH2H3' => 'Level 2 headline Level 3 headline',
         ];
 
-        $this->assertSame($expectedTagContent, $tagContent, 'Extractor did not retrieve expected tag content');
+        self::assertSame($expectedTagContent, $tagContent, 'Extractor did not retrieve expected tag content');
     }
 
     public function getIndexableContentDataProvider()
@@ -55,28 +56,28 @@ class HtmlContentExtractorTest extends UnitTest
         return [
             'unifyWhitespaces' => [
                 'websiteContent' => $this->getFixtureContentByName('fixture2.html'),
-                'exptectedIndexableContent' => 'Title Level 1 headline Hello World Level 2 headline Level 3 headline'
+                'exptectedIndexableContent' => 'Title Level 1 headline Hello World Level 2 headline Level 3 headline',
             ],
             'unifyTabs' => [
                 'websiteContent' => "Test\t\tTest",
-                'exptectedIndexableContent' => 'Test Test'
+                'exptectedIndexableContent' => 'Test Test',
             ],
             'removeScriptTags' => [
                 'websiteContent' => '<script>foo</script>Test',
-                'exptectedIndexableContent' => 'Test'
+                'exptectedIndexableContent' => 'Test',
             ],
             'decodeEntities' => [
                 'websiteContent' => 'B&auml;hm',
-                'exptectedIndexableContent' => 'Bähm'
+                'exptectedIndexableContent' => 'Bähm',
             ],
             'decodeSpaceEntities' => [
                 'websiteContent' => 'B&auml;hm&nbsp; Bum',
-                'exptectedIndexableContent' => 'Bähm Bum'
+                'exptectedIndexableContent' => 'Bähm Bum',
             ],
             'decodeSpaceUtf8Nbsp' => [
                 'websiteContent' => 'test <br/>afterNBSP',
-                'exptectedIndexableContent' => 'test afterNBSP'
-            ]
+                'exptectedIndexableContent' => 'test afterNBSP',
+            ],
         ];
     }
 
@@ -87,6 +88,6 @@ class HtmlContentExtractorTest extends UnitTest
     public function canUnifyWhitespacesInIndexableContent($websiteContent, $expectedIndexableContent)
     {
         $extractor = new HtmlContentExtractor($websiteContent);
-        $this->assertSame($expectedIndexableContent, $extractor->getIndexableContent(), 'Unexpected indexable content');
+        self::assertSame($expectedIndexableContent, $extractor->getIndexableContent(), 'Unexpected indexable content');
     }
 }

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -33,10 +34,10 @@ use UnexpectedValueException;
  */
 class AbstractIndexerTest extends UnitTest
 {
-
-    public function setUp(): void
+    protected function setUp(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'] = [];
+        parent::setUp();
     }
 
     /**
@@ -48,19 +49,18 @@ class AbstractIndexerTest extends UnitTest
             'topic_stringM' => 'SOLR_CLASSIFICATION',
             'categories_stringM' => 'SOLR_RELATION',
             'categories_stringM.' => [
-                'multiValue' => true
+                'multiValue' => true,
             ],
             'csv_stringM' => 'SOLR_MULTIVALUE',
-            'category_stringM' => 'SOLR_RELATION'
+            'category_stringM' => 'SOLR_RELATION',
         ];
 
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Response of SOLR_CLASSIFICATION is expected to be serialized');
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Response of SOLR_CLASSIFICATION is expected to be serialized');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Response of SOLR_MULTIVALUE is expected to be serialized');
 
-
-        $this->assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM'), 'Non configured fields should allways be unserialized');
-        $this->assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM'), 'Non configured fields should allways be unserialized');
+        self::assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM'), 'Non configured fields should allways be unserialized');
+        self::assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM'), 'Non configured fields should allways be unserialized');
     }
 
     /**
@@ -74,7 +74,7 @@ class AbstractIndexerTest extends UnitTest
         $this->expectExceptionMessageMatches('/.*InvalidSerializedValueDetector must implement interface.*/');
 
         $indexingConfiguration = [
-            'topic_stringM' => 'SOLR_CLASSIFICATION'
+            'topic_stringM' => 'SOLR_CLASSIFICATION',
         ];
 
         // when an invalid detector is registered we expect that an exception is thrown
@@ -93,15 +93,15 @@ class AbstractIndexerTest extends UnitTest
             'topic_stringM' => 'SOLR_CLASSIFICATION',
             'categories_stringM' => 'SOLR_RELATION',
             'categories_stringM.' => [
-                'multiValue' => true
+                'multiValue' => true,
             ],
             'csv_stringM' => 'SOLR_MULTIVALUE',
-            'category_stringM' => 'SOLR_RELATION'
+            'category_stringM' => 'SOLR_RELATION',
         ];
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Every value should be treated as serialized by custom detector');
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Every value should be treated as serialized by custom detector');
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Every value should be treated as serialized by custom detector');
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM', 'Every value should be treated as serialized by custom detector'));
-        $this->assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM', 'Every value should be treated as serialized by custom detector'));
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Every value should be treated as serialized by custom detector');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Every value should be treated as serialized by custom detector');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Every value should be treated as serialized by custom detector');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM', 'Every value should be treated as serialized by custom detector'));
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM', 'Every value should be treated as serialized by custom detector'));
     }
 }

--- a/Tests/Unit/IndexQueue/FrontendHelper/InvalidFakeHelper.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/InvalidFakeHelper.php
@@ -1,4 +1,7 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
 
-class InvalidFakeHelper {}
+class InvalidFakeHelper
+{
+}

--- a/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
 
 /***************************************************************
@@ -38,9 +39,10 @@ class ManagerTest extends UnitTest
      */
     protected $manager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->manager = new Manager();
+        parent::setUp();
     }
 
     /**
@@ -49,7 +51,7 @@ class ManagerTest extends UnitTest
     public function resolveActionReturnsNullWhenNoHandlerIsRegistered()
     {
         $handler = $this->manager->resolveAction('foo');
-        $this->assertNull($handler, 'Unregistered action should return null when it will be resolved');
+        self::assertNull($handler, 'Unregistered action should return null when it will be resolved');
     }
 
     /**

--- a/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -24,4 +25,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-class InvalidSerializedValueDetector {}
+class InvalidSerializedValueDetector
+{
+}

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -43,7 +44,7 @@ class ItemTest extends UnitTest
         $item = new Item($metaData, $record);
 
         $errors = $item->getErrors();
-        $this->assertSame('error during index', $errors, 'Can not get errors from queue item');
+        self::assertSame('error during index', $errors, 'Can not get errors from queue item');
     }
 
     /**
@@ -56,7 +57,7 @@ class ItemTest extends UnitTest
         $item = new Item($metaData, $record);
 
         $type = $item->getType();
-        $this->assertSame('pages', $type, 'Can not get type from queue item');
+        self::assertSame('pages', $type, 'Can not get type from queue item');
     }
 
     /**
@@ -67,7 +68,7 @@ class ItemTest extends UnitTest
         return [
             'pending item' => [['item_type' => 'pages', 'indexed' => 3, 'changed' => '4'], Item::STATE_PENDING],
             'indexed item' => [['item_type' => 'pages', 'indexed' => 5, 'changed' => '4'], Item::STATE_INDEXED],
-            'blocked item' => [['item_type' => 'pages', 'indexed' => 5, 'changed' => '4', 'errors' => 'Something bad happened'], Item::STATE_BLOCKED]
+            'blocked item' => [['item_type' => 'pages', 'indexed' => 5, 'changed' => '4', 'errors' => 'Something bad happened'], Item::STATE_BLOCKED],
         ];
     }
 
@@ -78,7 +79,7 @@ class ItemTest extends UnitTest
     public function canGetState($metaData, $expectedState)
     {
         $item = new Item($metaData, []);
-        $this->assertSame($expectedState, $item->getState(), 'Can not get state from item as expected');
+        self::assertSame($expectedState, $item->getState(), 'Can not get state from item as expected');
     }
 
     /**
@@ -87,10 +88,10 @@ class ItemTest extends UnitTest
     public function testHasErrors()
     {
         $item = new Item([], []);
-        $this->assertFalse($item->getHasErrors(), 'Expected that item without any data has no errors');
+        self::assertFalse($item->getHasErrors(), 'Expected that item without any data has no errors');
 
         $item = new Item(['errors' => 'something is broken'], []);
-        $this->assertTrue($item->getHasErrors(), 'Item with errors was not indicated to have errors');
+        self::assertTrue($item->getHasErrors(), 'Item with errors was not indicated to have errors');
     }
 
     /**
@@ -99,9 +100,9 @@ class ItemTest extends UnitTest
     public function testHasIndexingProperties()
     {
         $item = new Item([], []);
-        $this->assertFalse($item->hasIndexingProperties(), 'Expected that empty item should not have any indexing properties');
+        self::assertFalse($item->hasIndexingProperties(), 'Expected that empty item should not have any indexing properties');
 
         $item = new Item(['has_indexing_properties' => true], []);
-        $this->assertTrue($item->hasIndexingProperties(), 'Item with proper meta data should have indexing properties');
+        self::assertTrue($item->hasIndexingProperties(), 'Item with proper meta data should have indexing properties');
     }
 }

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -49,11 +50,11 @@ class PageIndexerRequestTest extends UnitTest
         $jsonEncodedParameters = json_encode([
             'item' => 1,
             'page' => 1,
-            'hash' => md5('1|1|' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'])
+            'hash' => md5('1|1|' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']),
         ]);
 
         $request = $this->getPageIndexerRequest($jsonEncodedParameters);
-        $this->assertTrue($request->isAuthenticated());
+        self::assertTrue($request->isAuthenticated());
     }
 
     /**
@@ -64,11 +65,11 @@ class PageIndexerRequestTest extends UnitTest
         $jsonEncodedParameters = json_encode([
             'item' => 1,
             'page' => 1,
-            'hash' => md5('invalid|invalid|invalid')
+            'hash' => md5('invalid|invalid|invalid'),
         ]);
 
         $request = $this->getPageIndexerRequest($jsonEncodedParameters);
-        $this->assertFalse($request->isAuthenticated());
+        self::assertFalse($request->isAuthenticated());
     }
 
     /**
@@ -78,11 +79,11 @@ class PageIndexerRequestTest extends UnitTest
     {
         $id = uniqid();
         $jsonEncodedParameters = json_encode([
-            'requestId' => $id
+            'requestId' => $id,
         ]);
 
         $request = $this->getPageIndexerRequest($jsonEncodedParameters);
-        $this->assertEquals($id, $request->getRequestId());
+        self::assertEquals($id, $request->getRequestId());
     }
 
     /**
@@ -101,9 +102,9 @@ class PageIndexerRequestTest extends UnitTest
         $response = $requestMock->send('http://7.6.local.typo3.org/about/typo3/');
         $indexPageResult = $response->getActionResult('indexPage');
 
-        $this->assertTrue(is_array($indexPageResult));
-        $this->assertSame(1, $indexPageResult['pageIndexed']);
-        $this->assertSame($response->getRequestId(), '581f76be71f60', 'Response did not contain expected requestId');
+        self::assertTrue(is_array($indexPageResult));
+        self::assertSame(1, $indexPageResult['pageIndexed']);
+        self::assertSame($response->getRequestId(), '581f76be71f60', 'Response did not contain expected requestId');
     }
 
     /**
@@ -147,10 +148,10 @@ class PageIndexerRequestTest extends UnitTest
     public function canSetTimeOutFromPHPConfiguration()
     {
         $initialTimeout = ini_get('default_socket_timeout');
-        ini_set('default_socket_timeout',122.5);
+        ini_set('default_socket_timeout', 122.5);
 
         $pageIndexerRequest = $this->getPageIndexerRequest();
-        $this->assertSame(122.5, $pageIndexerRequest->getTimeout());
+        self::assertSame(122.5, $pageIndexerRequest->getTimeout());
         ini_set('default_socket_timeout', $initialTimeout);
     }
 
@@ -175,7 +176,7 @@ class PageIndexerRequestTest extends UnitTest
     public function authenticationHeaderIsSetWhenUsernameAndPasswordHaveBeenPassed()
     {
         $requestFactoryMock = $this->getDumbMock(RequestFactory::class);
-        $requestFactoryMock->expects($this->once())->method('request')->willReturnCallback(function($url, $method, $options) {
+        $requestFactoryMock->expects(self::once())->method('request')->willReturnCallback(function ($url, $method, $options) {
             $this->assertSame(['bob', 'topsecret'], $options['auth'], 'Authentication options have not been set');
             $this->assertSame('GET', $method, 'Unexpected http method');
 
@@ -201,13 +202,13 @@ class PageIndexerRequestTest extends UnitTest
     public function canSetParameter()
     {
         $pageIndexerRequest = $this->getPageIndexerRequest();
-        $this->assertNull($pageIndexerRequest->getParameter('foo'), 'Parameter foo should be null when nothing was set');
+        self::assertNull($pageIndexerRequest->getParameter('foo'), 'Parameter foo should be null when nothing was set');
 
         $pageIndexerRequest->setParameter('foo', 'bar');
-        $this->assertSame('bar', $pageIndexerRequest->getParameter('foo'), 'Could not get parameter foo after setting it');
+        self::assertSame('bar', $pageIndexerRequest->getParameter('foo'), 'Could not get parameter foo after setting it');
 
         $pageIndexerRequest->setParameter('test', 4711);
-        $this->assertSame(4711, $pageIndexerRequest->getParameter('test'), 'Could not get parameter foo after setting it');
+        self::assertSame(4711, $pageIndexerRequest->getParameter('test'), 'Could not get parameter foo after setting it');
     }
 
     /**
@@ -220,7 +221,7 @@ class PageIndexerRequestTest extends UnitTest
         $itemMock = $this->getDumbMock(Item::class);
         $pageIndexerRequest->setIndexQueueItem($itemMock);
         $headers = $pageIndexerRequest->getHeaders();
-        $this->assertContains('User-Agent: TYPO3', $headers, 'Header should contain a proper User-Agent');
+        self::assertContains('User-Agent: TYPO3', $headers, 'Header should contain a proper User-Agent');
     }
 
     /**
@@ -246,12 +247,12 @@ class PageIndexerRequestTest extends UnitTest
         $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
         $extensionConfigurationMock = $this->getDumbMock(ExtensionConfiguration::class);
         /** @var $requestMock PageIndexerRequest */
-        $requestMock = $this->getMockBuilder(PageIndexerRequest::class)->setMethods(['getUrl'])->setConstructorArgs([$testParameters, $solrLogManagerMock, $extensionConfigurationMock])->getMock();
+        $requestMock = $this->getMockBuilder(PageIndexerRequest::class)->onlyMethods(['getUrl'])->setConstructorArgs([$testParameters, $solrLogManagerMock, $extensionConfigurationMock])->getMock();
 
         $responseMock = $this->getFakedGuzzleResponse($fakeResponse);
 
         // we fake the response from a captured response json file
-        $requestMock->expects($this->once())->method('getUrl')->willReturn($responseMock);
+        $requestMock->expects(self::once())->method('getUrl')->willReturn($responseMock);
         return $requestMock;
     }
 
@@ -262,11 +263,11 @@ class PageIndexerRequestTest extends UnitTest
     protected function getFakedGuzzleResponse($fakeResponse): ResponseInterface
     {
         $bodyStream = $this->getDumbMock(StreamInterface::class);
-        $bodyStream->expects($this->any())->method('getContents')->willReturn($fakeResponse);
+        $bodyStream->expects(self::any())->method('getContents')->willReturn($fakeResponse);
 
         /** @var $responseMock  ResponseInterface */
         $responseMock = $this->getDumbMock(ResponseInterface::class);
-        $responseMock->expects($this->any())->method('getBody')->willReturn($bodyStream);
+        $responseMock->expects(self::any())->method('getBody')->willReturn($bodyStream);
         return $responseMock;
     }
 }

--- a/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 /***************************************************************
@@ -47,7 +48,7 @@ class PageIndexerResponseTest extends UnitTest
         $request = GeneralUtility::makeInstance(PageIndexerResponse::class);
         $request->addActionResult($action, $result);
 
-        $this->assertEquals($result, $request->getActionResult($action));
+        self::assertEquals($result, $request->getActionResult($action));
     }
 
     /**
@@ -59,9 +60,9 @@ class PageIndexerResponseTest extends UnitTest
         $request->addActionResult('action1', 'result1');
         $request->addActionResult('action2', 'result2');
 
-        $this->assertEquals([
+        self::assertEquals([
             'action1' => 'result1',
-            'action2' => 'result2'
+            'action2' => 'result2',
         ], $request->getActionResult());
     }
 }

--- a/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
+
 use ApacheSolrForTypo3\Solr\IndexQueue\SerializedValueDetector;
 
 /***************************************************************
@@ -25,7 +27,8 @@ use ApacheSolrForTypo3\Solr\IndexQueue\SerializedValueDetector;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-class ValidSerializedValueDetector implements SerializedValueDetector {
+class ValidSerializedValueDetector implements SerializedValueDetector
+{
 
     /**
      * Uses a field's configuration to detect whether its value returned by a

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Middleware;
 
@@ -48,11 +49,11 @@ class SolrRoutingMiddlewareTest extends UnitTest
      */
     protected $responseOutputHandler;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->routingServiceMock = $this->getMockBuilder(RoutingService::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSiteMatcher', 'getSlugCandidateProvider', 'fetchEnhancerInSiteConfigurationByPageUid'])
+            ->onlyMethods(['getSiteMatcher', 'getSlugCandidateProvider', 'fetchEnhancerInSiteConfigurationByPageUid'])
             ->getMock();
 
         /* @see \TYPO3\CMS\Frontend\Tests\Unit\Middleware\PageResolverTest::setUp */
@@ -77,6 +78,8 @@ class SolrRoutingMiddlewareTest extends UnitTest
                 return $this->request;
             }
         };
+
+        parent::setUp();
     }
 
     /**
@@ -91,10 +94,10 @@ class SolrRoutingMiddlewareTest extends UnitTest
         );
         $siteMatcherMock = $this->getMockBuilder(SiteMatcher::class)
             ->disableOriginalConstructor()
-            ->setMethods(['matchRequest'])
+            ->onlyMethods(['matchRequest'])
             ->getMock();
 
-        $siteMatcherMock->expects($this->any())
+        $siteMatcherMock->expects(self::any())
             ->method('matchRequest')
             ->willReturn(
                 new SiteRouteResult(
@@ -103,26 +106,26 @@ class SolrRoutingMiddlewareTest extends UnitTest
                     new SiteLanguage(0, 'en_US', new Uri('https://domain.example/'), [])
                 )
             );
-        $this->routingServiceMock->expects($this->exactly(1))
+        $this->routingServiceMock->expects(self::exactly(1))
             ->method('getSiteMatcher')
             ->willReturn($siteMatcherMock);
 
         $pageSlugCandidateMock = $this->getMockBuilder(PageSlugCandidateProvider::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCandidatesForPath'])
+            ->onlyMethods(['getCandidatesForPath'])
             ->getMock();
-        $pageSlugCandidateMock->expects($this->atLeastOnce())
+        $pageSlugCandidateMock->expects(self::atLeastOnce())
             ->method('getCandidatesForPath')
             ->willReturn([['slug' => '/facet', 'uid' => '1']]);
-        $this->routingServiceMock->expects($this->atLeastOnce())
+        $this->routingServiceMock->expects(self::atLeastOnce())
             ->method('getSlugCandidateProvider')
             ->willReturn($pageSlugCandidateMock);
-        $this->routingServiceMock->expects($this->atLeastOnce())
+        $this->routingServiceMock->expects(self::atLeastOnce())
             ->method('fetchEnhancerInSiteConfigurationByPageUid')
             ->willReturn([]);
 
         $solrRoutingMiddleware = new SolrRoutingMiddleware();
-        $solrRoutingMiddleware->setLogger(New NullLogger());
+        $solrRoutingMiddleware->setLogger(new NullLogger());
         $solrRoutingMiddleware->injectRoutingService($this->routingServiceMock);
         $solrRoutingMiddleware->process(
             $serverRequest,
@@ -132,7 +135,7 @@ class SolrRoutingMiddlewareTest extends UnitTest
         /* @var Uri $uri */
         $uri = $request->getUri();
 
-        $this->assertEquals(
+        self::assertEquals(
             '/facet/bar,buz,foo',
             $uri->getPath()
         );

--- a/Tests/Unit/Mvc/SolrControllerContextTest.php
+++ b/Tests/Unit/Mvc/SolrControllerContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Mvc\ControllerContext;
 
 /***************************************************************
@@ -24,10 +25,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Mvc\ControllerContext;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Mvc\Controller\SolrControllerContext;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -37,11 +38,12 @@ class SolrControllerContextTest extends UnitTest
     /**
      * @var SolrControllerContext
      */
-    protected $controllerContext = null;
+    protected $controllerContext;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->controllerContext = new SolrControllerContext();
+        parent::setUp();
     }
 
     /**
@@ -52,7 +54,7 @@ class SolrControllerContextTest extends UnitTest
         /** @var TypoScriptConfiguration $typoScriptConfigurationMock */
         $typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $this->controllerContext->setTypoScriptConfiguration($typoScriptConfigurationMock);
-        $this->assertSame($this->controllerContext->getTypoScriptConfiguration(), $typoScriptConfigurationMock, 'Can not get and set TypoScriptConfiguration');
+        self::assertSame($this->controllerContext->getTypoScriptConfiguration(), $typoScriptConfigurationMock, 'Can not get and set TypoScriptConfiguration');
     }
 
     /**
@@ -62,6 +64,6 @@ class SolrControllerContextTest extends UnitTest
     {
         $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
         $this->controllerContext->setSearchResultSet($searchResultSetMock);
-        $this->assertSame($this->controllerContext->getSearchResultSet(), $searchResultSetMock, 'Can not get and set SearchResultSet');
+        self::assertSame($this->controllerContext->getSearchResultSet(), $searchResultSetMock, 'Can not get and set SearchResultSet');
     }
 }

--- a/Tests/Unit/Query/Modifier/ElevationTest.php
+++ b/Tests/Unit/Query/Modifier/ElevationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Elevation;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
@@ -45,8 +46,8 @@ class ElevationTest extends UnitTest
         $query = $this->getDumbMock(Query::class);
 
         $queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
-        $queryBuilderMock->expects($this->once())->method('startFrom')->willReturn($queryBuilderMock);
-        $queryBuilderMock->expects($this->once())->method('useElevationFromTypoScript')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('startFrom')->willReturn($queryBuilderMock);
+        $queryBuilderMock->expects(self::once())->method('useElevationFromTypoScript')->willReturn($queryBuilderMock);
 
         $modifier = new Elevation($queryBuilderMock);
         $modifier->modifyQuery($query);

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
 
 /*
@@ -40,11 +41,10 @@ class FacetingTest extends UnitTest
      */
     private function getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, SearchRequest $fakeSearchRequest)
     {
-
-        $fakeObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->setMethods(['get'])->getMock();
-        $fakeObjectManager->expects($this->any())->method('get')->will($this->returnCallback(function($className) {
+        $fakeObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->onlyMethods(['get'])->getMock();
+        $fakeObjectManager->expects(self::any())->method('get')->willReturnCallback(function ($className) {
             return new $className();
-        }));
+        });
 
         $facetRegistry = new FacetRegistry();
         // @extensionScannerIgnoreLine
@@ -85,20 +85,20 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting'] = 1;
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
-                'field' => 'type'
-            ]
+                'field' => 'type',
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $expectedJsonFacet = '{"type":{"type":"terms","field":"type","limit":100,"mincount":1}}';
-        $this->assertSame($expectedJsonFacet,  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
+        self::assertSame($expectedJsonFacet, $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
     /**
@@ -120,17 +120,17 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'sortBy' => 'index'
-            ]
+                'sortBy' => 'index',
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
 
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertStringContainsString('"sort":"index"',  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('"sort":"index"', $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
     /**
@@ -152,18 +152,18 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'sortBy' => 'count'
-            ]
+                'sortBy' => 'count',
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
-        $this->assertStringContainsString('"sort":"count"',  $queryParameter['json.facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('"sort":"count"', $queryParameter['json.facet'], 'Query string did not contain expected snipped');
     }
 
     /**
@@ -195,20 +195,20 @@ class FacetingTest extends UnitTest
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $jsonData = \json_decode($queryParameter['json.facet']);
-        $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
     }
 
     /**
@@ -237,20 +237,20 @@ class FacetingTest extends UnitTest
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $jsonData = \json_decode($queryParameter['json.facet']);
-        $this->assertEmpty(($jsonData->type->domain->excludeTags ?? ''), 'Query string did not contain expected snipped');
-        $this->assertEmpty(($jsonData->color->domain->excludeTags ?? ''), 'Query string did not contain expected snipped');
+        self::assertEmpty(($jsonData->type->domain->excludeTags ?? ''), 'Query string did not contain expected snipped');
+        self::assertEmpty(($jsonData->color->domain->excludeTags ?? ''), 'Query string did not contain expected snipped');
     }
 
     /**
@@ -278,23 +278,23 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'keepAllOptionsOnSelection' => 1
+                'keepAllOptionsOnSelection' => 1,
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue([]));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
         $jsonData = \json_decode($queryParameter['json.facet']);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
-        $this->assertEquals('type',  $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('color',  $jsonData->color->field, 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertEquals('type', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('color', $jsonData->color->field, 'Query string did not contain expected snipped');
     }
 
     /**
@@ -308,30 +308,30 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'keepAllOptionsOnSelection' => 1
+                'keepAllOptionsOnSelection' => 1,
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+        $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $jsonData = \json_decode($queryParameter['json.facet']);
 
-        $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
+        self::assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
 
-        $this->assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
+        self::assertEquals('type,color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
     }
 
     /**
@@ -347,34 +347,33 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'keepAllOptionsOnSelection' => 1
+                'keepAllOptionsOnSelection' => 1,
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+        $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $jsonData = \json_decode($queryParameter['json.facet']);
 
-        $this->assertEquals('type', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
+        self::assertEquals('type', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('type', $jsonData->type->field, 'Did not build json field properly');
 
-        $this->assertEquals('color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
+        self::assertEquals('color', $jsonData->color->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
     }
 
     /**
-     *
      * @test
      */
     public function testCanAddQueryFilters()
@@ -387,22 +386,22 @@ class FacetingTest extends UnitTest
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+        $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         //do we have a filter query for both present?
-        $this->assertEquals('(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
-        $this->assertEquals('(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
+        self::assertEquals('(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
+        self::assertEquals('(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
     /**
@@ -415,25 +414,25 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'type.' => [
                 'field' => 'type',
-                'keepAllOptionsOnSelection' => 1
+                'keepAllOptionsOnSelection' => 1,
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+        $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         //do we have a filter query for both present?
-        $this->assertEquals('(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
-        $this->assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
+        self::assertEquals('(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
+        self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
     /**
@@ -450,22 +449,22 @@ class FacetingTest extends UnitTest
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $fakeArguments = ['filter' => [urlencode('color:red'),urlencode('type:product')]];
+        $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         //do we have a filter query for both present?
-        $this->assertEquals('{!tag=color}(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
-        $this->assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
+        self::assertEquals('{!tag=color}(color:"red")', $queryParameter['fq'][0], 'Did not build filter query from color');
+        self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
     /**
@@ -479,28 +478,27 @@ class FacetingTest extends UnitTest
             'type.' => [
                 'field' => 'type',
                 'additionalExcludeTags' => 'type,color',
-                'addFieldAsTag' => 1
+                'addFieldAsTag' => 1,
             ],
             'color.' => [
                 'field' => 'color',
-            ]
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $fakeArguments = ['filter' => [urlencode('type:product')]];
 
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
-        $this->assertStringContainsString('true',  $queryParameter['facet'], 'Query string did not contain expected snipped');
+        self::assertStringContainsString('true', $queryParameter['facet'], 'Query string did not contain expected snipped');
 
         $jsonData = \json_decode($queryParameter['json.facet']);
-        $this->assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
-        $this->assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'], 'Did not build filter query from color');
+        self::assertEquals('type,color', $jsonData->type->domain->excludeTags, 'Query string did not contain expected snipped');
+        self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'], 'Did not build filter query from color');
     }
-
 
     /**
      * @test
@@ -511,8 +509,8 @@ class FacetingTest extends UnitTest
             'filter' => [
                 'something0%3AA+B',
                 'something1%3AA%2BB',
-                'something2%3AA%20B'
-            ]
+                'something2%3AA%20B',
+            ],
         ];
 
         $fakeConfigurationArray = [];
@@ -520,27 +518,27 @@ class FacetingTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['keepAllFacetsOnSelection'] = 1;
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['faceting.']['facets.'] = [
             'something0.' => [
-                'field' => 'something0'
+                'field' => 'something0',
             ],
             'something1.' => [
-                'field' => 'something1'
+                'field' => 'something1',
             ],
             'something2.' => [
-                'field' => 'something2'
-            ]
+                'field' => 'something2',
+            ],
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest $fakeRequest */
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
-        $fakeRequest->expects($this->once())->method('getArguments')->will($this->returnValue($fakeArguments));
-        $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($fakeConfiguration));
+        $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
+        $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
 
-        $this->assertEquals('{!tag=something0}(something0:"A+B")', $queryParameter['fq'][0], 'Can handle plus as plus');
-        $this->assertEquals('{!tag=something1}(something1:"A+B")', $queryParameter['fq'][1], 'Can handle %2B as plus');
-        $this->assertEquals('{!tag=something2}(something2:"A B")', $queryParameter['fq'][2], 'Can handle %20 as space');
+        self::assertEquals('{!tag=something0}(something0:"A+B")', $queryParameter['fq'][0], 'Can handle plus as plus');
+        self::assertEquals('{!tag=something1}(something1:"A+B")', $queryParameter['fq'][1], 'Can handle %2B as plus');
+        self::assertEquals('{!tag=something2}(something2:"A B")', $queryParameter['fq'][2], 'Can handle %20 as space');
     }
 
     /**
@@ -556,27 +554,27 @@ class FacetingTest extends UnitTest
         };
 
         $typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $typoScriptConfigurationMock->expects($this->once())
+        $typoScriptConfigurationMock->expects(self::once())
             ->method('getSearchFacetingUrlParameterStyle')
-            ->will($this->returnValue(UrlFacetContainer::PARAMETER_STYLE_ASSOC));
+            ->willReturn(UrlFacetContainer::PARAMETER_STYLE_ASSOC);
         $searchRequestMock = $this->getDumbMock(SearchRequest::class);
-        $searchRequestMock->expects($this->once())
+        $searchRequestMock->expects(self::once())
             ->method('getContextTypoScriptConfiguration')
-            ->will($this->returnValue($typoScriptConfigurationMock));
+            ->willReturn($typoScriptConfigurationMock);
 
         $facetingModifierStub->setSearchRequest($searchRequestMock);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'age' => [0 => 'week'],
-                'type' => [0 => 'tx_news_domain_model_news']
+                'type' => [0 => 'tx_news_domain_model_news'],
             ],
             $facetingModifierStub->callGetFiltersByFacetName(
                 [
                     'filter' => [
                         'age:week' => '1',
                         'type:tx_news_domain_model_news' => '1',
-                    ]
+                    ],
                 ],
                 [
                     'type.' => [
@@ -590,9 +588,9 @@ class FacetingTest extends UnitTest
                         'queryGroup.' => [
                             'week.' => [
                                 'query' => '[NOW/DAY-7DAYS TO *]',
-                            ]
-                        ]
-                    ]
+                            ],
+                        ],
+                    ],
                 ]
             ),
             'The assoc parameters/keys for parameters of selected facets are not as expected.' . PHP_EOL

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Report;
 
 /***************************************************************
@@ -28,7 +29,6 @@ use ApacheSolrForTypo3\Solr\Report\SolrConfigurationStatus;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use TYPO3\CMS\Reports\Status;
 
-
 /**
  * Testcase for the SolrConfigurationStatus class.
  *
@@ -36,43 +36,41 @@ use TYPO3\CMS\Reports\Status;
  */
 class SolrConfigurationStatusTest extends UnitTest
 {
-
     /**
      * @var SolrConfigurationStatus
      */
     protected $report;
 
-
-    public function setUp(): void
+    protected function setUp(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         // we mock the methods to external dependencies.
 
-        $this->report = $this->getMockBuilder(SolrConfigurationStatus::class)->setMethods(
+        $this->report = $this->getMockBuilder(SolrConfigurationStatus::class)->onlyMethods(
             [
-                'getDomainRecordsForRootPagesIds',
                 'getRootPages',
                 'getIsSolrEnabled',
                 'getIsIndexingEnabled',
-                'initializeTSFE',
-                'getRenderedReport'
+                'getRenderedReport',
             ]
         )->getMock();
+        parent::setUp();
     }
 
     /**
      * @test
      */
-    public function canGetEmptyResultWhenEverythingIsOK() {
+    public function canGetEmptyResultWhenEverythingIsOK()
+    {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];
 
-        $this->report->expects($this->any())->method('getRootPages')->will($this->returnValue($fakedRootPages));
+        $this->report->expects(self::any())->method('getRootPages')->willReturn($fakedRootPages);
 
-        $this->report->expects($this->any())->method('getIsSolrEnabled')->will($this->returnValue(false));
-        $this->report->expects($this->any())->method('getIsIndexingEnabled')->will($this->returnValue(false));
+        $this->report->expects(self::any())->method('getIsSolrEnabled')->willReturn(false);
+        $this->report->expects(self::any())->method('getIsIndexingEnabled')->willReturn(false);
 
         // everything should be ok, so no report should be rendered
-        $this->report->expects($this->never())->method('getRenderedReport');
+        $this->report->expects(self::never())->method('getRenderedReport');
 
         $this->report->getStatus();
     }
@@ -80,27 +78,27 @@ class SolrConfigurationStatusTest extends UnitTest
     /**
      * @test
      */
-    public function canGetViolationWhenSolrIsEnabledButIndexingNot() {
+    public function canGetViolationWhenSolrIsEnabledButIndexingNot()
+    {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];
 
-        $this->report->expects($this->any())->method('getRootPages')->will($this->returnValue($fakedRootPages));
+        $this->report->expects(self::any())->method('getRootPages')->willReturn($fakedRootPages);
 
-        $this->report->expects($this->any())->method('getIsSolrEnabled')->will($this->returnValue(true));
-        $this->report->expects($this->any())->method('getIsIndexingEnabled')->will($this->returnValue(false));
+        $this->report->expects(self::any())->method('getIsSolrEnabled')->willReturn(true);
+        $this->report->expects(self::any())->method('getIsIndexingEnabled')->willReturn(false);
 
         // one report should be rendered because solr is enabled but indexing not
-        $this->report->expects($this->once())->method('getRenderedReport')->with(
+        $this->report->expects(self::once())->method('getRenderedReport')->with(
             'SolrConfigurationStatusIndexing.html',
             ['pages' => [$fakedRootPages[1]]]
-        )->will($this->returnValue('faked report output'));
-
+        )->willReturn('faked report output');
 
         $states = $this->report->getStatus();
 
-        $this->assertCount(1, $states, 'Expected to have one violation');
+        self::assertCount(1, $states, 'Expected to have one violation');
 
-            /** @var $firstState Status */
+        /** @var $firstState Status */
         $firstState = $states[0];
-        $this->assertSame(Status::WARNING, $firstState->getSeverity(), 'Expected to have one violation');
+        self::assertSame(Status::WARNING, $firstState->getSeverity(), 'Expected to have one violation');
     }
 }

--- a/Tests/Unit/Routing/RoutingServiceTest.php
+++ b/Tests/Unit/Routing/RoutingServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -36,13 +37,14 @@ class RoutingServiceTest extends UnitTest
      */
     protected $site;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->site = new Site(
             'example',
             1,
             Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'))
         );
+        parent::setUp();
     }
 
     /**
@@ -53,7 +55,7 @@ class RoutingServiceTest extends UnitTest
     {
         $routingService = new RoutingService([]);
 
-        $this->assertEquals(
+        self::assertEquals(
             ',',
             $routingService->getDefaultMultiValueSeparator()
         );
@@ -67,11 +69,11 @@ class RoutingServiceTest extends UnitTest
     {
         $routingService = new RoutingService(
             [
-                'multiValueSeparator' => '+'
+                'multiValueSeparator' => '+',
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             '+',
             $routingService->getDefaultMultiValueSeparator()
         );
@@ -85,7 +87,7 @@ class RoutingServiceTest extends UnitTest
     {
         $routingService = new RoutingService([]);
 
-        $this->assertEquals(
+        self::assertEquals(
             'bar,buz,foo',
             $routingService->facetsToString(['foo', 'bar', 'buz'])
         );
@@ -99,11 +101,11 @@ class RoutingServiceTest extends UnitTest
     {
         $routingService = new RoutingService(
             [
-                'multiValueSeparator' => '+'
+                'multiValueSeparator' => '+',
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'bar+buz+foo',
             $routingService->facetsToString(['foo', 'bar', 'buz'])
         );
@@ -116,10 +118,10 @@ class RoutingServiceTest extends UnitTest
     public function canConvertStringToUriTest()
     {
         $routingService = new RoutingService();
-        $this->assertNotNull(
+        self::assertNotNull(
             $routingService->convertStringIntoUri('https://domain.example')
         );
-        $this->assertNotNull(
+        self::assertNotNull(
             $routingService->convertStringIntoUri('://domain.example')
         );
     }
@@ -154,8 +156,8 @@ class RoutingServiceTest extends UnitTest
                     'taste:sour,matcha',
                     'color:red',
                     'product:candy',
-                ]
-            ]
+                ],
+            ],
         ];
         /*
          * The order of the facet name based on their first appearance in the given filter array
@@ -166,13 +168,13 @@ class RoutingServiceTest extends UnitTest
                 'filter' => [
                     'color:green,red,yellow',
                     'taste:matcha,sour,sour°matcha',
-                    'product:candy,sweets'
-                ]
-            ]
+                    'product:candy,sweets',
+                ],
+            ],
         ];
 
-        $this->assertTrue($routingService->shouldConcatQueryParameters());
-        $this->assertEquals(
+        self::assertTrue($routingService->shouldConcatQueryParameters());
+        self::assertEquals(
             $expectedResult,
             $routingService->concatQueryParameter($queryParameters)
         );
@@ -191,9 +193,9 @@ class RoutingServiceTest extends UnitTest
                 'filter' => [
                     'color:green,red,yellow',
                     'product:candy,sweets',
-                    'taste:matcha,sour,sour°matcha'
-                ]
-            ]
+                    'taste:matcha,sour,sour°matcha',
+                ],
+            ],
         ];
 
         /*
@@ -209,13 +211,13 @@ class RoutingServiceTest extends UnitTest
                     'product:sweets',
                     'taste:matcha',
                     'taste:sour',
-                    'taste:sour,matcha'
-                ]
-            ]
+                    'taste:sour,matcha',
+                ],
+            ],
         ];
 
-        $this->assertTrue($routingService->shouldConcatQueryParameters());
-        $this->assertEquals(
+        self::assertTrue($routingService->shouldConcatQueryParameters());
+        self::assertEquals(
             $expectedResult,
             $routingService->inflateQueryParameter($filter)
         );
@@ -238,8 +240,8 @@ class RoutingServiceTest extends UnitTest
                     'taste:matcha',
                     'color:red',
                     'product:candy',
-                ]
-            ]
+                ],
+            ],
         ];
         /*
          * The order of the facet name based on their first appearance in the given filter array
@@ -248,13 +250,13 @@ class RoutingServiceTest extends UnitTest
         $expectedResult = [
             'color' => 'green,red,yellow',
             'taste' => 'matcha,sour',
-            'product' => 'candy,sweets'
+            'product' => 'candy,sweets',
         ];
 
-        $this->assertTrue($routingService->shouldMaskQueryParameter());
+        self::assertTrue($routingService->shouldMaskQueryParameter());
         $queryParameters = $routingService->concatQueryParameter($queryParameters);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $routingService->maskQueryParameters($queryParameters)
         );
@@ -270,7 +272,7 @@ class RoutingServiceTest extends UnitTest
         $queryParameters = [
             'color' => 'green,red,yellow',
             'taste' => 'matcha,sour',
-            'product' => 'candy,sweets'
+            'product' => 'candy,sweets',
         ];
 
         /*
@@ -287,13 +289,13 @@ class RoutingServiceTest extends UnitTest
                     'taste:sour',
                     'product:candy',
                     'product:sweets',
-                ]
-            ]
+                ],
+            ],
         ];
-        $this->assertTrue($routingService->shouldMaskQueryParameter());
+        self::assertTrue($routingService->shouldMaskQueryParameter());
         $queryParameters = $routingService->unmaskQueryParameters($queryParameters);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             $routingService->inflateQueryParameter($queryParameters)
         );
@@ -313,18 +315,18 @@ class RoutingServiceTest extends UnitTest
         $newRequest = $routingService->addPathArgumentsToQuery(
             $request,
             [
-                'color' => 'filter-colorType'
+                'color' => 'filter-colorType',
             ],
             [
-                'color' => 'blue'
+                'color' => 'blue',
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'tx_solr' => [
-                    'filter' => ['colorType:blue']
-                ]
+                    'filter' => ['colorType:blue'],
+                ],
             ],
             $newRequest->getQueryParams()
         );
@@ -344,23 +346,22 @@ class RoutingServiceTest extends UnitTest
         $newRequest = $routingService->addPathArgumentsToQuery(
             $request,
             [
-                'color' => 'filter-colorType'
+                'color' => 'filter-colorType',
             ],
             [
-                'color' => 'green,blue'
+                'color' => 'green,blue',
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'tx_solr' => [
-                    'filter' => ['colorType:blue', 'colorType:green']
-                ]
+                    'filter' => ['colorType:blue', 'colorType:green'],
+                ],
             ],
             $newRequest->getQueryParams()
         );
     }
-
 
     /**
      * @test
@@ -378,10 +379,10 @@ class RoutingServiceTest extends UnitTest
         $request = $routingService->addPathArgumentsToQuery(
             $request,
             [
-                'color' => 'filter-colorType'
+                'color' => 'filter-colorType',
             ],
             [
-                'color' => 'green,blue'
+                'color' => 'green,blue',
             ]
         );
 
@@ -394,16 +395,16 @@ class RoutingServiceTest extends UnitTest
         $queryParams = $routingService->inflateQueryParameter($queryParams);
         $request = $request->withQueryParams($queryParams);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'tx_solr' => [
                     'filter' => [
                         'taste:sweet',
                         'taste:sour',
                         'colorType:blue',
-                        'colorType:green'
-                    ]
-                ]
+                        'colorType:green',
+                    ],
+                ],
             ],
             $request->getQueryParams()
         );

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Search\RelevanceComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use Solarium\QueryType\Select\RequestBuilder;
@@ -58,9 +59,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'phrase' => 1,
                 'phrase.' => [
-                    'querySlop' => 2
-                ]
-            ]
+                    'querySlop' => 2,
+                ],
+            ],
         ];
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
@@ -69,12 +70,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('qs', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('qs', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame(2, $this->getQueryParameters($query)['qs'], 'querySlop was not applied as qs parameter');
+        self::assertSame(2, $this->getQueryParameters($query)['qs'], 'querySlop was not applied as qs parameter');
     }
 
     /**
@@ -86,9 +87,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'phrase' => 0,
                 'phrase.' => [
-                    'querySlop' => 2
-                ]
-            ]
+                    'querySlop' => 2,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -96,12 +97,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('qs', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('qs', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertArrayNotHasKey('qs', $this->getQueryParameters($query), 'querySlop should still be null because phrase is disabled');
+        self::assertArrayNotHasKey('qs', $this->getQueryParameters($query), 'querySlop should still be null because phrase is disabled');
     }
 
     /**
@@ -113,9 +114,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'phrase' => 1,
                 'phrase.' => [
-                    'slop' => 3
-                ]
-            ]
+                    'slop' => 3,
+                ],
+            ],
         ];
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
@@ -124,12 +125,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('ps', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame(3, $this->getQueryParameters($query)['ps'], 'slop was not applied as qs parameter');
+        self::assertSame(3, $this->getQueryParameters($query)['ps'], 'slop was not applied as qs parameter');
     }
 
     /**
@@ -141,9 +142,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'phrase' => 0,
                 'phrase.' => [
-                    'slop' => 3
-                ]
-            ]
+                    'slop' => 3,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -151,12 +152,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('ps', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertArrayNotHasKey('ps', $this->getQueryParameters($query), 'PhraseSlop should be null, when phrase is disabled');
+        self::assertArrayNotHasKey('ps', $this->getQueryParameters($query), 'PhraseSlop should be null, when phrase is disabled');
     }
 
     /**
@@ -168,9 +169,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'bigramPhrase' => 1,
                 'bigramPhrase.' => [
-                    'slop' => 4
-                ]
-            ]
+                    'slop' => 4,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -179,12 +180,12 @@ class RelevanceComponentTest extends UnitTest
         $query = new Query();
         $query->setQuery('test');
 
-        $this->assertArrayNotHasKey('ps2', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps2', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame(4, $this->getQueryParameters($query)['ps2'], 'slop was not applied as qs parameter');
+        self::assertSame(4, $this->getQueryParameters($query)['ps2'], 'slop was not applied as qs parameter');
     }
 
     /**
@@ -196,9 +197,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'bigramPhrase' => 0,
                 'bigramPhrase.' => [
-                    'slop' => 4
-                ]
-            ]
+                    'slop' => 4,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -206,12 +207,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('ps2', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps2', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertArrayNotHasKey('ps2', $this->getQueryParameters($query), 'ps2 parameter should be empty because bigramPhrases are disabled');
+        self::assertArrayNotHasKey('ps2', $this->getQueryParameters($query), 'ps2 parameter should be empty because bigramPhrases are disabled');
     }
 
     /**
@@ -223,9 +224,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'trigramPhrase' => 1,
                 'trigramPhrase.' => [
-                    'slop' => 4
-                ]
-            ]
+                    'slop' => 4,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -233,12 +234,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('ps3', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps3', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame(4, $this->getQueryParameters($query)['ps3'], 'slop was not applied as qs parameter');
+        self::assertSame(4, $this->getQueryParameters($query)['ps3'], 'slop was not applied as qs parameter');
     }
 
     /**
@@ -250,9 +251,9 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'trigramPhrase' => 0,
                 'trigramPhrase.' => [
-                    'slop' => 4
-                ]
-            ]
+                    'slop' => 4,
+                ],
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -260,14 +261,13 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('ps3', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('ps3', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertArrayNotHasKey('ps3', $this->getQueryParameters($query), 'ps3 parameter should be empty because bigramPhrases are disabled');
+        self::assertArrayNotHasKey('ps3', $this->getQueryParameters($query), 'ps3 parameter should be empty because bigramPhrases are disabled');
     }
-
 
     /**
      * @test
@@ -277,7 +277,7 @@ class RelevanceComponentTest extends UnitTest
         $searchConfiguration = [
             'query.' => [
                 'tieParameter' => '0.78',
-            ]
+            ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -285,12 +285,12 @@ class RelevanceComponentTest extends UnitTest
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('tie', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('tie', $this->getQueryParameters($query));
 
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame((float)'0.78', $this->getQueryParameters($query)['tie'], 'tieParameter was not applied as tie parameter');
+        self::assertSame((float)'0.78', $this->getQueryParameters($query)['tie'], 'tieParameter was not applied as tie parameter');
     }
 
     /**
@@ -301,12 +301,12 @@ class RelevanceComponentTest extends UnitTest
         $searchConfiguration = [
             'query.' => [
                 'boostQuery' => 'type:pages^100',
-            ]
+            ],
         ];
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('bq', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('bq', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -316,7 +316,7 @@ class RelevanceComponentTest extends UnitTest
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame('type:pages^100', $this->getQueryParameters($query)['bq'], 'Configured boostQuery was not applied');
+        self::assertSame('type:pages^100', $this->getQueryParameters($query)['bq'], 'Configured boostQuery was not applied');
     }
 
     /**
@@ -328,14 +328,14 @@ class RelevanceComponentTest extends UnitTest
             'query.' => [
                 'boostQuery.' => [
                     'type:pages^100',
-                    'type:tx_solr_file^400'
-                 ]
-            ]
+                    'type:tx_solr_file^400',
+                 ],
+            ],
         ];
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('bq', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('bq', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -345,8 +345,8 @@ class RelevanceComponentTest extends UnitTest
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame('type:pages^100', $this->getQueryParameters($query)['bq'][0], 'Configured boostQuery was not applied');
-        $this->assertSame('type:tx_solr_file^400', $this->getQueryParameters($query)['bq'][1], 'Configured boostQuery was not applied');
+        self::assertSame('type:pages^100', $this->getQueryParameters($query)['bq'][0], 'Configured boostQuery was not applied');
+        self::assertSame('type:tx_solr_file^400', $this->getQueryParameters($query)['bq'][1], 'Configured boostQuery was not applied');
     }
 
     /**
@@ -356,13 +356,13 @@ class RelevanceComponentTest extends UnitTest
     {
         $searchConfiguration = [
             'query.' => [
-                'boostFunction' => 'sum(clicks)^100'
-            ]
+                'boostFunction' => 'sum(clicks)^100',
+            ],
         ];
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('bf', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('bf', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -372,7 +372,7 @@ class RelevanceComponentTest extends UnitTest
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame('sum(clicks)^100', $this->getQueryParameters($query)['bf'], 'Configured boostFunction was not applied');
+        self::assertSame('sum(clicks)^100', $this->getQueryParameters($query)['bf'], 'Configured boostFunction was not applied');
     }
 
     /**
@@ -382,13 +382,13 @@ class RelevanceComponentTest extends UnitTest
     {
         $searchConfiguration = [
             'query.' => [
-                'minimumMatch' => '<1'
-            ]
+                'minimumMatch' => '<1',
+            ],
         ];
 
         $query = new Query();
         $query->setQuery('test');
-        $this->assertArrayNotHasKey('mm', $this->getQueryParameters($query));
+        self::assertArrayNotHasKey('mm', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
         $queryBuilder = new QueryBuilder($typoscriptConfiguration);
@@ -398,7 +398,7 @@ class RelevanceComponentTest extends UnitTest
         $relevanceComponent->setQuery($query);
         $relevanceComponent->initializeSearchComponent();
 
-        $this->assertSame('<1', $this->getQueryParameters($query)['mm'], 'Configured minimumMatch was not applied');
+        self::assertSame('<1', $this->getQueryParameters($query)['mm'], 'Configured minimumMatch was not applied');
     }
 
     /**
@@ -410,9 +410,9 @@ class RelevanceComponentTest extends UnitTest
         return new TypoScriptConfiguration([
             'plugin.' => [
                 'tx_solr.' => [
-                    'search.' => $searchConfiguration
-                ]
-            ]
+                    'search.' => $searchConfiguration,
+                ],
+            ],
         ]);
     }
 }

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Search;
 
 /***************************************************************
@@ -55,7 +56,7 @@ class SortingComponentTest extends UnitTest
     /**
      * SortingComponentTest constructor.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->query = new Query();
         $this->query->setQuery('');
@@ -64,6 +65,7 @@ class SortingComponentTest extends UnitTest
         $this->sortingComponent = new SortingComponent();
         $this->sortingComponent->setQuery($this->query);
         $this->sortingComponent->setSearchRequest($this->searchRequestMock);
+        parent::setUp();
     }
 
     /**
@@ -71,9 +73,9 @@ class SortingComponentTest extends UnitTest
      */
     public function sortingFromUrlIsNotAppliedWhenSortingIsDisabled()
     {
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title asc']);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame([], $this->query->getSorts(), 'No sorting should be present in query');
+        self::assertSame([], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
     /**
@@ -87,13 +89,13 @@ class SortingComponentTest extends UnitTest
                 'options.' => [
                     'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
                     'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
-                    'type.' => ['field' => 'type', 'label' => 'Type']
-                ]
-            ]
+                    'type.' => ['field' => 'type', 'label' => 'Type'],
+                ],
+            ],
         ]);
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title asc']);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame(['sortTitle' => 'asc'], $this->query->getSorts(), 'Sorting was not applied in the query as expected');
+        self::assertSame(['sortTitle' => 'asc'], $this->query->getSorts(), 'Sorting was not applied in the query as expected');
     }
 
     /**
@@ -107,13 +109,13 @@ class SortingComponentTest extends UnitTest
                 'options.' => [
                     'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
                     'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
-                    'type.' => ['field' => 'type', 'label' => 'Type']
-                ]
-            ]
+                    'type.' => ['field' => 'type', 'label' => 'Type'],
+                ],
+            ],
         ]);
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn(['sort' => 'title INVALID']);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title INVALID']);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame([], $this->query->getSorts(), 'No sorting should be present in query');
+        self::assertSame([], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
     /**
@@ -123,12 +125,12 @@ class SortingComponentTest extends UnitTest
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [
-                'sortBy' => 'price desc'
-            ]
+                'sortBy' => 'price desc',
+            ],
         ]);
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn([]);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn([]);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame(['price' => 'desc'], $this->query->getSorts(), 'No sorting should be present in query');
+        self::assertSame(['price' => 'desc'], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
     /**
@@ -138,20 +140,20 @@ class SortingComponentTest extends UnitTest
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [
-                'sortBy' => 'price desc'
+                'sortBy' => 'price desc',
             ],
             'sorting' => 1,
             'sorting.' => [
                 'options.' => [
                     'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
                     'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
-                    'type.' => ['field' => 'type', 'label' => 'Type']
-                ]
-            ]
+                    'type.' => ['field' => 'type', 'label' => 'Type'],
+                ],
+            ],
         ]);
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title asc']);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame(['sortTitle' =>  'asc'], $this->query->getSorts(), 'No sorting should be present in query');
+        self::assertSame(['sortTitle' =>  'asc'], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
     /**
@@ -161,19 +163,19 @@ class SortingComponentTest extends UnitTest
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [
-                'sortBy' => 'price desc'
+                'sortBy' => 'price desc',
             ],
             'sorting' => 0,
             'sorting.' => [
                 'options.' => [
                     'relevance.' => ['field' => 'relevance', 'label' => 'Title'],
                     'title.' => ['field' => 'sortTitle', 'label' => 'Title'],
-                    'type.' => ['field' => 'type', 'label' => 'Type']
-                ]
-            ]
+                    'type.' => ['field' => 'type', 'label' => 'Type'],
+                ],
+            ],
         ]);
-        $this->searchRequestMock->expects($this->any())->method('getArguments')->willReturn(['sort' => 'title asc']);
+        $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title asc']);
         $this->sortingComponent->initializeSearchComponent();
-        $this->assertSame(['price' => 'desc'],  $this->query->getSorts(), 'No sorting should be present in query');
+        self::assertSame(['price' => 'desc'], $this->query->getSorts(), 'No sorting should be present in query');
     }
 }

--- a/Tests/Unit/Search/StatisticsComponentTest.php
+++ b/Tests/Unit/Search/StatisticsComponentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -40,24 +41,23 @@ class StatisticsComponentTest extends UnitTest
     public function canRegisterStatisticsComponents()
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics']  = null;
-        $this->assertEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that no statistic component was registered');
-
+        self::assertEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that no statistic component was registered');
 
         $typoScriptConfiguration = new TypoScriptConfiguration([
             'plugin.' => [
                 'tx_solr.' => [
-                    'statistics' => 1
-                ]
-            ]
+                    'statistics' => 1,
+                ],
+            ],
         ]);
 
         $searchRequestMock = $this->getDumbMock(SearchRequest::class);
-        $searchRequestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+        $searchRequestMock->expects(self::once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
 
         $statisticsComponent = new StatisticsComponent();
         $statisticsComponent->setSearchRequest($searchRequestMock);
         $statisticsComponent->initializeSearchComponent();
-        $this->assertNotEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that a statistic component was registered');
+        self::assertNotEmpty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], 'Expected that a statistic component was registered');
     }
 
     /**
@@ -71,18 +71,17 @@ class StatisticsComponentTest extends UnitTest
         $typoScriptConfiguration = new TypoScriptConfiguration([
             'plugin.' => [
                 'tx_solr.' => [
-                    'statistics' => 1
-                ]
-            ]
+                    'statistics' => 1,
+                ],
+            ],
         ]);
 
         $searchRequestMock = $this->getDumbMock(SearchRequest::class);
-        $searchRequestMock->expects($this->once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+        $searchRequestMock->expects(self::once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
 
         $statisticsComponent = new StatisticsComponent();
         $statisticsComponent->setSearchRequest($searchRequestMock);
         $statisticsComponent->initializeSearchComponent();
-        $this->assertEquals($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], $className);
+        self::assertEquals($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['afterSearch']['statistics'], $className);
     }
-
 }

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -47,13 +48,13 @@ class SearchTest extends UnitTest
      */
     protected $search;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->solrReadServiceMock = $this->getDumbMock(SolrReadService::class);
         $this->solrConnectionMock = $this->getDumbMock(SolrConnection::class);
-        $this->solrConnectionMock->expects($this->any())->method('getReadService')->willReturn($this->solrReadServiceMock);
+        $this->solrConnectionMock->expects(self::any())->method('getReadService')->willReturn($this->solrReadServiceMock);
         $this->search = new Search($this->solrConnectionMock);
+        parent::setUp();
     }
 
     /**
@@ -63,8 +64,8 @@ class SearchTest extends UnitTest
     {
         $query = new SearchQuery();
         $limit = 99;
-        $this->solrReadServiceMock->expects($this->once())->method('search')->willReturnCallback(
-            function($query) use ($limit) {
+        $this->solrReadServiceMock->expects(self::once())->method('search')->willReturnCallback(
+            function ($query) use ($limit) {
                 $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
             }
         );
@@ -81,13 +82,12 @@ class SearchTest extends UnitTest
         $limit = 99;
         $query->setRows($limit);
 
-        $this->solrReadServiceMock->expects($this->once())->method('search')->willReturnCallback(
-            function($query) use ($limit) {
+        $this->solrReadServiceMock->expects(self::once())->method('search')->willReturnCallback(
+            function ($query) use ($limit) {
                 $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
             }
         );
 
         $this->search->search($query, 0, null);
     }
-
 }

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Cache;
 
 /***************************************************************
@@ -26,10 +27,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Cache;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
-use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
 
 /**
  * Unit testcase to check if the two level cache is working as expected.
@@ -51,13 +52,12 @@ class TwoLevelCacheTest extends UnitTest
 
     /**
      * Prepare
-     *
-     * @see \PHPUnit\Framework\TestCase::setUp()
      */
     protected function setUp(): void
     {
         $this->secondLevelCacheMock = $this->getDumbMock(FrontendInterface::class);
         $this->twoLevelCache = new TwoLevelCache('test', $this->secondLevelCacheMock);
+        parent::setUp();
     }
 
     /**
@@ -75,7 +75,7 @@ class TwoLevelCacheTest extends UnitTest
      */
     public function getOnSecondaryCacheIsNeverCalledWhenValueIsPresentInFirstLevelCache(): void
     {
-        $this->secondLevelCacheMock->expects($this->never())->method('get');
+        $this->secondLevelCacheMock->expects(self::never())->method('get');
 
         // when we add a value with the identifier to the two level cache, the second level
         // cache should not be asked because the value should allready be found in the first
@@ -83,7 +83,7 @@ class TwoLevelCacheTest extends UnitTest
         $this->twoLevelCache->set('foo', 'bar');
 
         $value = $this->twoLevelCache->get('foo');
-        $this->assertSame($value, 'bar', 'Did not get expected value from two level cache');
+        self::assertSame($value, 'bar', 'Did not get expected value from two level cache');
     }
 
     /**
@@ -93,7 +93,7 @@ class TwoLevelCacheTest extends UnitTest
     public function canHandleInvalidCacheIdentifierOnSet(): void
     {
         $cacheBackendMock = $this->createMock(BackendInterface::class);
-        $cacheBackendMock->expects($this->once())->method('set');
+        $cacheBackendMock->expects(self::once())->method('set');
         $variableFrontend = new VariableFrontend('TwoLevelCacheTest', $cacheBackendMock);
         $this->twoLevelCache = new TwoLevelCache('test', $variableFrontend);
 
@@ -107,10 +107,10 @@ class TwoLevelCacheTest extends UnitTest
     public function canHandleInvalidCacheIdentifierOnGet(): void
     {
         $cacheBackendMock = $this->createMock(BackendInterface::class);
-        $cacheBackendMock->expects($this->once())->method('get')->willReturn($this->returnValue(''));
+        $cacheBackendMock->expects(self::once())->method('get')->willReturn(self::returnValue(''));
         $variableFrontend = new VariableFrontend('TwoLevelCacheTest', $cacheBackendMock);
         $this->twoLevelCache = new TwoLevelCache('test', $variableFrontend);
 
-        $this->assertFalse($this->twoLevelCache->get('I.Am.An.Invalid.Identifier-#ß%&!'));
+        self::assertFalse($this->twoLevelCache->get('I.Am.An.Invalid.Identifier-#ß%&!'));
     }
 }

--- a/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
 
 /***************************************************************
@@ -36,11 +37,10 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ExtensionConfigurationTest extends UnitTest
 {
-
-
-    public function setUp(): void
+    protected function setUp(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
+        parent::setUp();
     }
 
     /**
@@ -49,11 +49,11 @@ class ExtensionConfigurationTest extends UnitTest
     public function testGetIsUseConfigurationFromClosestTemplateEnabled()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertFalse($defaultConfiguration->getIsUseConfigurationFromClosestTemplateEnabled());
+        self::assertFalse($defaultConfiguration->getIsUseConfigurationFromClosestTemplateEnabled());
         $configurationWithClosestTemplateEnabled = new ExtensionConfiguration(
             ['useConfigurationFromClosestTemplate' => 1]
         );
-        $this->assertTrue($configurationWithClosestTemplateEnabled->getIsUseConfigurationFromClosestTemplateEnabled());
+        self::assertTrue($configurationWithClosestTemplateEnabled->getIsUseConfigurationFromClosestTemplateEnabled());
     }
 
     /**
@@ -62,11 +62,11 @@ class ExtensionConfigurationTest extends UnitTest
     public function testIsGetUseConfigurationTrackRecordsOutsideSiterootEnabled()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertTrue($defaultConfiguration->getIsUseConfigurationTrackRecordsOutsideSiteroot());
+        self::assertTrue($defaultConfiguration->getIsUseConfigurationTrackRecordsOutsideSiteroot());
         $configurationUseConfigurationTrackRecordsOutsideSiteroot = new ExtensionConfiguration(
             ['useConfigurationTrackRecordsOutsideSiteroot' => 0]
         );
-        $this->assertFalse($configurationUseConfigurationTrackRecordsOutsideSiteroot->getIsUseConfigurationTrackRecordsOutsideSiteroot());
+        self::assertFalse($configurationUseConfigurationTrackRecordsOutsideSiteroot->getIsUseConfigurationTrackRecordsOutsideSiteroot());
     }
 
     /**
@@ -75,13 +75,13 @@ class ExtensionConfigurationTest extends UnitTest
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredKnownTable()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
+        self::assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
         $configurationUseConfigurationTrackRecordsOutsideSiteroot = new ExtensionConfiguration(
             ['useConfigurationMonitorTables' => 'pages, tt_content']
         );
         $tableList = $configurationUseConfigurationTrackRecordsOutsideSiteroot->getIsUseConfigurationMonitorTables();
         $result = in_array('pages', $tableList);
-        $this->assertTrue($result);
+        self::assertTrue($result);
     }
 
     /**
@@ -90,13 +90,13 @@ class ExtensionConfigurationTest extends UnitTest
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredUnknownTable()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
+        self::assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
         $configurationUseConfigurationTrackRecordsOutsideSiteroot = new ExtensionConfiguration(
             ['useConfigurationMonitorTables' => 'pages, tt_content']
         );
         $tableList = $configurationUseConfigurationTrackRecordsOutsideSiteroot->getIsUseConfigurationMonitorTables();
         $result = in_array('unknowntable', $tableList);
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     /**
@@ -105,12 +105,12 @@ class ExtensionConfigurationTest extends UnitTest
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredEmptyList()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
+        self::assertEquals([], $defaultConfiguration->getIsUseConfigurationMonitorTables());
         $configurationUseConfigurationTrackRecordsOutsideSiteroot = new ExtensionConfiguration(
             ['useConfigurationMonitorTables' => '']
         );
         $tableList = $configurationUseConfigurationTrackRecordsOutsideSiteroot->getIsUseConfigurationMonitorTables();
-        $this->assertSame([], $tableList);
+        self::assertSame([], $tableList);
     }
 
     /**
@@ -119,10 +119,10 @@ class ExtensionConfigurationTest extends UnitTest
     public function testIsGetIsSelfSignedCertificatesEnabled()
     {
         $defaultConfiguration = new ExtensionConfiguration();
-        $this->assertFalse($defaultConfiguration->getIsSelfSignedCertificatesEnabled());
+        self::assertFalse($defaultConfiguration->getIsSelfSignedCertificatesEnabled());
         $configurationUseConfigurationAllowSelfSignedCertificates = new ExtensionConfiguration(
             ['allowSelfSignedCertificates' => 1]
         );
-        $this->assertTrue($configurationUseConfigurationAllowSelfSignedCertificates->getIsSelfSignedCertificatesEnabled());
+        self::assertTrue($configurationUseConfigurationAllowSelfSignedCertificates->getIsSelfSignedCertificatesEnabled());
     }
 }

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
 
 /***************************************************************
@@ -40,15 +41,13 @@ class TypoScriptConfigurationTest extends UnitTest
      */
     protected $configuration;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfigurationArray['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content'] = 'SOLR_CONTENT';
         $fakeConfigurationArray['plugin.']['tx_solr.']['index.']['queue.']['tt_news.']['fields.']['content.']['field'] = 'bodytext';
         $this->configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+        parent::setUp();
     }
 
     /**
@@ -57,7 +56,7 @@ class TypoScriptConfigurationTest extends UnitTest
     public function canGetValueByPath()
     {
         $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
-        $this->assertSame('SOLR_CONTENT', $this->configuration->getValueByPath($testPath), 'Could not get configuration value by path');
+        self::assertSame('SOLR_CONTENT', $this->configuration->getValueByPath($testPath), 'Could not get configuration value by path');
     }
 
     /**
@@ -68,10 +67,10 @@ class TypoScriptConfigurationTest extends UnitTest
         $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
         $expectedResult = [
             'content' => 'SOLR_CONTENT',
-            'content.' => ['field' => 'bodytext']
+            'content.' => ['field' => 'bodytext'],
         ];
 
-        $this->assertSame($expectedResult, $this->configuration->getObjectByPath($testPath), 'Could not get configuration object by path');
+        self::assertSame($expectedResult, $this->configuration->getObjectByPath($testPath), 'Could not get configuration object by path');
     }
 
     /**
@@ -86,19 +85,19 @@ class TypoScriptConfigurationTest extends UnitTest
                     'facets.' => [
                         'color.' => [],
                         'type.' => [
-                            'showEvenWhenEmpty' => true
-                        ]
-                    ]
-                ]
-            ]
+                            'showEvenWhenEmpty' => true,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $showEmptyType = $configuration->getSearchFacetingShowEmptyFacetsByName('type');
-        $this->assertTrue($showEmptyType);
+        self::assertTrue($showEmptyType);
 
         $showEmptyColor = $configuration->getSearchFacetingShowEmptyFacetsByName('color');
-        $this->assertTrue($showEmptyColor);
+        self::assertTrue($showEmptyColor);
 
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'search.' => [
@@ -106,20 +105,20 @@ class TypoScriptConfigurationTest extends UnitTest
                     'facets.' => [
                         'color.' => [],
                         'type.' => [
-                            'showEvenWhenEmpty' => true
-                        ]
-                    ]
-                ]
-            ]
+                            'showEvenWhenEmpty' => true,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $showEmptyType = $configuration->getSearchFacetingShowEmptyFacetsByName('type');
-        $this->assertTrue($showEmptyType);
+        self::assertTrue($showEmptyType);
 
         $showEmptyColor = $configuration->getSearchFacetingShowEmptyFacetsByName('color');
-        $this->assertFalse($showEmptyColor);
+        self::assertFalse($showEmptyColor);
     }
 
     /**
@@ -133,19 +132,19 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                        'table' => 'tx_model_custom'
-                    ]
-                ]
-            ]
+                        'table' => 'tx_model_custom',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $customTableExpected = $configuration->getIndexQueueTableNameOrFallbackToConfigurationName('pages');
-        $this->assertSame($customTableExpected, 'pages', 'Can not fallback to configurationName');
+        self::assertSame($customTableExpected, 'pages', 'Can not fallback to configurationName');
 
         $customTableExpected = $configuration->getIndexQueueTableNameOrFallbackToConfigurationName('custom');
-        $this->assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
+        self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
     }
 
     /**
@@ -160,24 +159,24 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                        'table' => 'tx_model_custom'
-                    ]
-                ]
-            ]
+                        'table' => 'tx_model_custom',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $enabledIndexQueueNames = $configuration->getEnabledIndexQueueConfigurationNames();
 
-        $this->assertCount(1, $enabledIndexQueueNames, 'Retrieved unexpected amount of index queue configurations');
-        $this->assertContains('pages', $enabledIndexQueueNames, 'Pages was no enabled index queue configuration');
+        self::assertCount(1, $enabledIndexQueueNames, 'Retrieved unexpected amount of index queue configurations');
+        self::assertContains('pages', $enabledIndexQueueNames, 'Pages was no enabled index queue configuration');
 
         $fakeConfigurationArray['plugin.']['tx_solr.']['index.']['queue.']['custom'] = 1;
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $enabledIndexQueueNames = $configuration->getEnabledIndexQueueConfigurationNames();
 
-        $this->assertCount(2, $enabledIndexQueueNames, 'Retrieved unexpected amount of index queue configurations');
-        $this->assertContains('custom', $enabledIndexQueueNames, 'Pages was no enabled index queue configuration');
+        self::assertCount(2, $enabledIndexQueueNames, 'Retrieved unexpected amount of index queue configurations');
+        self::assertContains('custom', $enabledIndexQueueNames, 'Pages was no enabled index queue configuration');
     }
 
     /**
@@ -190,17 +189,17 @@ class TypoScriptConfigurationTest extends UnitTest
                 'queue.' => [
                     'pages' => 1,
                     'pages.' => [
-                        'recursiveUpdateFields' => ''
+                        'recursiveUpdateFields' => '',
                     ],
                     'custom.' => [
-                        'recursiveUpdateFields' => ''
-                    ]
-                ]
-            ]
+                        'recursiveUpdateFields' => '',
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
-        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+        self::assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        self::assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
 
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'index.' => [
@@ -209,30 +208,30 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
-        $this->assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+        self::assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        self::assertEquals([], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
 
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'index.' => [
                 'queue.' => [
                     'pages' => 1,
                     'pages.' => [
-                        'recursiveUpdateFields' => 'title, subtitle'
+                        'recursiveUpdateFields' => 'title, subtitle',
                     ],
                     'custom.' => [
-                        'recursiveUpdateFields' => 'title, subtitle'
-                    ]
-                ]
-            ]
+                        'recursiveUpdateFields' => 'title, subtitle',
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
-        $this->assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
+        self::assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('pages'));
+        self::assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
     }
 
     /**
@@ -247,17 +246,17 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                        'initialPagesAdditionalWhereClause' => '1=1'
-                    ]
-                ]
-            ]
+                        'initialPagesAdditionalWhereClause' => '1=1',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $this->assertEquals('', $configuration->getInitialPagesAdditionalWhereClause('pages'));
-        $this->assertEquals('1=1', $configuration->getInitialPagesAdditionalWhereClause('custom'));
-        $this->assertEquals('', $configuration->getInitialPagesAdditionalWhereClause('notconfigured'));
+        self::assertEquals('', $configuration->getInitialPagesAdditionalWhereClause('pages'));
+        self::assertEquals('1=1', $configuration->getInitialPagesAdditionalWhereClause('custom'));
+        self::assertEquals('', $configuration->getInitialPagesAdditionalWhereClause('notconfigured'));
     }
 
     /**
@@ -272,17 +271,17 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                        'additionalWhereClause' => '1=1'
-                    ]
-                ]
-            ]
+                        'additionalWhereClause' => '1=1',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $this->assertEquals('', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('pages'));
-        $this->assertEquals(' AND 1=1', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('custom'));
-        $this->assertEquals('', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('notconfigured'));
+        self::assertEquals('', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('pages'));
+        self::assertEquals(' AND 1=1', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('custom'));
+        self::assertEquals('', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('notconfigured'));
     }
 
     /**
@@ -298,19 +297,19 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar'
+                        'table' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news'
-                    ]
-                ]
-            ]
+                        'table' => 'tx_model_news',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['tx_model_news', 'custom_two'], $configuration->getIndexQueueConfigurationNamesByTableName('tx_model_news'));
+        self::assertEquals(['tx_model_news', 'custom_two'], $configuration->getIndexQueueConfigurationNamesByTableName('tx_model_news'));
     }
 
     /**
@@ -326,22 +325,22 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar'
+                        'table' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news'
+                        'table' => 'tx_model_news',
                     ],
                     'pages' => 1,
-                    'pages.' => []
-                ]
-            ]
+                    'pages.' => [],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $monitoredTables =  $configuration->getIndexQueueMonitoredTables();
-        $this->assertEquals(['tx_model_news', 'tx_model_bar', 'pages'], $monitoredTables);
+        self::assertEquals(['tx_model_news', 'tx_model_bar', 'pages'], $monitoredTables);
     }
 
     /**
@@ -357,26 +356,26 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar'
+                        'table' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news'
+                        'table' => 'tx_model_news',
                     ],
                     'pages' => 1,
-                    'pages.' => []
-                ]
-            ]
+                    'pages.' => [],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $this->assertFalse($configuration->getIndexQueueIsMonitoredTable('tx_mycustom_table2'), 'tx_mycustom_table2 was not expected to be monitored');
+        self::assertFalse($configuration->getIndexQueueIsMonitoredTable('tx_mycustom_table2'), 'tx_mycustom_table2 was not expected to be monitored');
 
-        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('pages'), 'pages was expected to be monitored');
-        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_bar'), 'tx_model_bar was expected to be monitored');
-        $this->assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_news'), 'tx_model_news was expected to be monitored');
+        self::assertTrue($configuration->getIndexQueueIsMonitoredTable('pages'), 'pages was expected to be monitored');
+        self::assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_bar'), 'tx_model_bar was expected to be monitored');
+        self::assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_news'), 'tx_model_news was expected to be monitored');
     }
 
     /**
@@ -388,17 +387,21 @@ class TypoScriptConfigurationTest extends UnitTest
             'logging.' => [
                 'indexing.' => [
                     'queue.' => [
-                        'pages' => 1
-                    ]
-                ]
-            ]
+                        'pages' => 1,
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertTrue($configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('pages'),
-            'Wrong logging state for pages index queue');
-        $this->assertFalse($configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('tt_content'),
-            'Wrong logging state for tt_content index queue');
+        self::assertTrue(
+            $configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('pages'),
+            'Wrong logging state for pages index queue'
+        );
+        self::assertFalse(
+            $configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('tt_content'),
+            'Wrong logging state for tt_content index queue'
+        );
     }
 
     /**
@@ -411,17 +414,21 @@ class TypoScriptConfigurationTest extends UnitTest
                 'indexing' => 1,
                 'indexing.' => [
                     'queue.' => [
-                        'pages' => 0
-                    ]
-                ]
-            ]
+                        'pages' => 0,
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertTrue($configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('pages'),
-            'Wrong logging state for pages index queue');
-        $this->assertTrue($configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('tt_content'),
-            'Wrong logging state for tt_content index queue');
+        self::assertTrue(
+            $configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('pages'),
+            'Wrong logging state for pages index queue'
+        );
+        self::assertTrue(
+            $configuration->getLoggingIndexingQueueOperationsByConfigurationNameWithFallBack('tt_content'),
+            'Wrong logging state for tt_content index queue'
+        );
     }
 
     /**
@@ -434,17 +441,17 @@ class TypoScriptConfigurationTest extends UnitTest
                 'queue.' => [
                     'pages.' => [
                         'fields.' => [
-                            'sortSubTitle_stringS' => 'subtitle'
-                        ]
-                    ]
-                ]
-            ]
+                            'sortSubTitle_stringS' => 'subtitle',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedConfiguration = $configuration->getIndexQueueFieldsConfigurationByConfigurationName('pages');
-        $this->assertEquals(['sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
+        self::assertEquals(['sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
     }
 
     /**
@@ -459,17 +466,17 @@ class TypoScriptConfigurationTest extends UnitTest
                         'fields.' => [
                             'sortSubTitle_stringS' => 'subtitle',
                             'subTitle_stringM' => 'subtitle',
-                            'fooShouldBeSkipped.' => []
-                        ]
-                    ]
-                ]
-            ]
+                            'fooShouldBeSkipped.' => [],
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $mappedFieldNames = $configuration->getIndexQueueMappedFieldsByConfigurationName('pages');
-        $this->assertEquals(['sortSubTitle_stringS', 'subTitle_stringM'], $mappedFieldNames);
+        self::assertEquals(['sortSubTitle_stringS', 'subTitle_stringM'], $mappedFieldNames);
     }
 
     /**
@@ -480,15 +487,15 @@ class TypoScriptConfigurationTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'index.' => [
                 'additionalFields.' => [
-                    'additional_sortSubTitle_stringS' => 'subtitle'
-                ]
-            ]
+                    'additional_sortSubTitle_stringS' => 'subtitle',
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedConfiguration = $configuration->getIndexAdditionalFieldsConfiguration();
-        $this->assertEquals(['additional_sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
+        self::assertEquals(['additional_sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
     }
 
     /**
@@ -499,15 +506,15 @@ class TypoScriptConfigurationTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'index.' => [
                 'additionalFields.' => [
-                    'additional_sortSubTitle_stringS' => 'subtitle'
-                ]
-            ]
+                    'additional_sortSubTitle_stringS' => 'subtitle',
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedConfiguration = $configuration->getIndexMappedAdditionalFieldNames();
-        $this->assertEquals(['additional_sortSubTitle_stringS'], $retrievedConfiguration);
+        self::assertEquals(['additional_sortSubTitle_stringS'], $retrievedConfiguration);
     }
 
     /**
@@ -519,14 +526,14 @@ class TypoScriptConfigurationTest extends UnitTest
             'index.' => [
                 'queue.' => [
                     'pages.' => [
-                        'indexer' => 'Foobar'
-                    ]
-                ]
-            ]
+                        'indexer' => 'Foobar',
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $configuredIndexer = $configuration->getIndexQueueIndexerByConfigurationName('pages');
-        $this->assertSame('Foobar', $configuredIndexer, 'Retrieved unexpected indexer from typoscript configuration');
+        self::assertSame('Foobar', $configuredIndexer, 'Retrieved unexpected indexer from typoscript configuration');
     }
 
     /**
@@ -539,14 +546,14 @@ class TypoScriptConfigurationTest extends UnitTest
                 'queue.' => [
                     'pages.' => [
                         'indexer' => 'Foobar',
-                        'indexer.' => ['configuration' => 'test']
-                    ]
-                ]
-            ]
+                        'indexer.' => ['configuration' => 'test'],
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $configuredIndexer = $configuration->getIndexQueueIndexerConfigurationByConfigurationName('pages');
-        $this->assertSame(['configuration' => 'test'], $configuredIndexer, 'Retrieved unexpected indexer configuration from typoscript configuration');
+        self::assertSame(['configuration' => 'test'], $configuredIndexer, 'Retrieved unexpected indexer configuration from typoscript configuration');
     }
 
     /**
@@ -558,14 +565,14 @@ class TypoScriptConfigurationTest extends UnitTest
             'index.' => [
                 'queue.' => [
                     'pages.' => [
-                        'excludeContentByClass' => 'excludeClass'
-                    ]
-                ]
-            ]
+                        'excludeContentByClass' => 'excludeClass',
+                    ],
+                ],
+            ],
         ];
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
         $excludeClasses = $configuration->getIndexQueuePagesExcludeContentByClassArray();
-        $this->assertEquals(['excludeClass'], $excludeClasses, 'Can not get exclude patterns from configuration');
+        self::assertEquals(['excludeClass'], $excludeClasses, 'Can not get exclude patterns from configuration');
     }
 
     /**
@@ -574,9 +581,9 @@ class TypoScriptConfigurationTest extends UnitTest
     public function canSetSearchQueryFilterConfiguration()
     {
         $configuration = new TypoScriptConfiguration([]);
-        $this->assertEquals([], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals([], $configuration->getSearchQueryFilterConfiguration());
         $configuration->setSearchQueryFilterConfiguration(['foo']);
-        $this->assertEquals(['foo'], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals(['foo'], $configuration->getSearchQueryFilterConfiguration());
     }
 
     /**
@@ -588,17 +595,17 @@ class TypoScriptConfigurationTest extends UnitTest
             'search.' => [
                 'query.' => [
                     'filter.' => [
-                        '__pageSections' => '1,2,3'
-                    ]
-                ]
-            ]
+                        '__pageSections' => '1,2,3',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals(['__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
 
         $configuration->removeSearchQueryFilterForPageSections();
-        $this->assertEquals([], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals([], $configuration->getSearchQueryFilterConfiguration());
     }
 
     /**
@@ -610,17 +617,17 @@ class TypoScriptConfigurationTest extends UnitTest
             'search.' => [
                 'query.' => [
                     'filter.' => [
-                        'type:pages', '__pageSections' => '1,2,3'
-                    ]
-                ]
-            ]
+                        'type:pages', '__pageSections' => '1,2,3',
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['type:pages', '__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals(['type:pages', '__pageSections' => '1,2,3'], $configuration->getSearchQueryFilterConfiguration());
 
         $configuration->removeSearchQueryFilterForPageSections();
-        $this->assertEquals(['type:pages'], $configuration->getSearchQueryFilterConfiguration());
+        self::assertEquals(['type:pages'], $configuration->getSearchQueryFilterConfiguration());
     }
 
     /**
@@ -631,12 +638,12 @@ class TypoScriptConfigurationTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'search.' => [
                 'query.' => [
-                ]
-            ]
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals([], $configuration->GetSearchQueryReturnFieldsAsArray());
+        self::assertEquals([], $configuration->GetSearchQueryReturnFieldsAsArray());
     }
 
     /**
@@ -647,13 +654,13 @@ class TypoScriptConfigurationTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'search.' => [
                 'query.' => [
-                    'returnFields' => 'foo, bar'
-                ]
-            ]
+                    'returnFields' => 'foo, bar',
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertEquals(['foo', 'bar'], $configuration->GetSearchQueryReturnFieldsAsArray());
+        self::assertEquals(['foo', 'bar'], $configuration->GetSearchQueryReturnFieldsAsArray());
     }
 
     /**
@@ -668,17 +675,17 @@ class TypoScriptConfigurationTest extends UnitTest
                     'options.' => [
                         'title.' => [
                             'field' => 'title',
-                            'label' => 'Titel'
-                        ]
-                    ]
-                ]
-            ]
+                            'label' => 'Titel',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
-        $this->assertEquals('desc', $retrievedSorting);
+        self::assertEquals('desc', $retrievedSorting);
     }
 
     /**
@@ -694,17 +701,17 @@ class TypoScriptConfigurationTest extends UnitTest
                         'title.' => [
                             'defaultOrder' => 'asc',
                             'field' => 'title',
-                            'label' => 'Titel'
-                        ]
-                    ]
-                ]
-            ]
+                            'label' => 'Titel',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
-        $this->assertEquals('asc', $retrievedSorting);
+        self::assertEquals('asc', $retrievedSorting);
     }
 
     /**
@@ -719,17 +726,17 @@ class TypoScriptConfigurationTest extends UnitTest
                         'title.' => [
                             'defaultOrder' => 'DESC',
                             'field' => 'title',
-                            'label' => 'Titel'
-                        ]
-                    ]
-                ]
-            ]
+                            'label' => 'Titel',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $retrievedSorting = $configuration->getSearchSortingDefaultOrderBySortOptionName('title');
-        $this->assertEquals('desc', $retrievedSorting);
+        self::assertEquals('desc', $retrievedSorting);
     }
 
     /**
@@ -744,21 +751,21 @@ class TypoScriptConfigurationTest extends UnitTest
                     'groups.' => [
                         'typeGroup.' => [
                             'field' => 'type',
-                            'numberOfResultsPerGroup' => 5
+                            'numberOfResultsPerGroup' => 5,
                         ],
                         'priceGroup.' => [
                             'field' => 'price',
-                            'numberOfResultsPerGroup' => 2
-                        ]
-                    ]
-                ]
-            ]
+                            'numberOfResultsPerGroup' => 2,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $highestResultsPerGroup = $configuration->getSearchGroupingHighestGroupResultsLimit();
-        $this->assertEquals(5, $highestResultsPerGroup, 'Can not get highest result per group value');
+        self::assertEquals(5, $highestResultsPerGroup, 'Can not get highest result per group value');
     }
 
     /**
@@ -773,21 +780,21 @@ class TypoScriptConfigurationTest extends UnitTest
                     'groups.' => [
                         'typeGroup.' => [
                             'field' => 'type',
-                            'numberOfResultsPerGroup' => 5
+                            'numberOfResultsPerGroup' => 5,
                         ],
                         'priceGroup.' => [
                             'field' => 'price',
-                            'numberOfResultsPerGroup' => 2
-                        ]
-                    ]
-                ]
-            ]
+                            'numberOfResultsPerGroup' => 2,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         $highestResultsPerGroup = $configuration->getSearchGroupingHighestGroupResultsLimit();
-        $this->assertEquals(8, $highestResultsPerGroup, 'Can not get highest result per group value');
+        self::assertEquals(8, $highestResultsPerGroup, 'Can not get highest result per group value');
     }
 
     /**
@@ -803,16 +810,16 @@ class TypoScriptConfigurationTest extends UnitTest
                     'groups.' => [
                         'typeGroup.' => [
                             'field' => 'type',
-                            'numberOfResultsPerGroup' => 5
-                        ]
-                    ]
-                ]
-            ]
+                            'numberOfResultsPerGroup' => 5,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $this->assertFalse($configuration->getSearchGrouping(), 'Expected grouping to be disabled');
+        self::assertFalse($configuration->getSearchGrouping(), 'Expected grouping to be disabled');
     }
 
     /**
@@ -821,7 +828,7 @@ class TypoScriptConfigurationTest extends UnitTest
     public function getSearchAdditionalPersistentArgumentNamesReturnsEmptyArrayWhenNothingIsConfigured()
     {
         $configuration = new TypoScriptConfiguration([]);
-        $this->assertSame([], $configuration->getSearchAdditionalPersistentArgumentNames(), 'Expected to get an empty array, when nothing configured');
+        self::assertSame([], $configuration->getSearchAdditionalPersistentArgumentNames(), 'Expected to get an empty array, when nothing configured');
     }
 
     /**
@@ -832,10 +839,10 @@ class TypoScriptConfigurationTest extends UnitTest
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
             'search.' => [
                 'additionalPersistentArgumentNames' => 'customA, customB',
-            ]
+            ],
         ];
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $this->assertSame(['customA','customB'], $configuration->getSearchAdditionalPersistentArgumentNames(), 'Can not get configured custom parameters');
+        self::assertSame(['customA', 'customB'], $configuration->getSearchAdditionalPersistentArgumentNames(), 'Can not get configured custom parameters');
     }
 }

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace  ApacheSolrForTypo3\Solr\Tests\Unit\System\ContentObject;
 
 /***************************************************************
@@ -46,10 +47,11 @@ class ContentObjectServiceTest extends UnitTest
      */
     protected $contentObjectService;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->contentObjectRendererMock = $this->getDumbMock(ContentObjectRenderer::class);
         $this->contentObjectService = new ContentObjectService($this->contentObjectRendererMock);
+        parent::setUp();
     }
 
     /**
@@ -59,10 +61,10 @@ class ContentObjectServiceTest extends UnitTest
     {
         $fakeStdWrapConfiguration = [
             'field' => 'TEXT',
-            'field.' => ['value' => 'test']
+            'field.' => ['value' => 'test'],
         ];
 
-        $this->contentObjectRendererMock->expects($this->once())->method('cObjGetSingle')->with('TEXT',  ['value' => 'test']);
+        $this->contentObjectRendererMock->expects(self::once())->method('cObjGetSingle')->with('TEXT', ['value' => 'test']);
         $this->contentObjectService->renderSingleContentObjectByArrayAndKey($fakeStdWrapConfiguration, 'field');
     }
 
@@ -72,11 +74,11 @@ class ContentObjectServiceTest extends UnitTest
     public function renderSingleContentObjectByArrayAndKeyWillReturnNameWhenConfigIsNotAnArray()
     {
         $fakeStdWrapConfiguration = [
-            'field' => 'fooo'
+            'field' => 'fooo',
         ];
 
-        $this->contentObjectRendererMock->expects($this->never())->method('cObjGetSingle');
+        $this->contentObjectRendererMock->expects(self::never())->method('cObjGetSingle');
         $result = $this->contentObjectService->renderSingleContentObjectByArrayAndKey($fakeStdWrapConfiguration, 'field');
-        $this->assertSame('fooo', $result);
+        self::assertSame('fooo', $result);
     }
 }

--- a/Tests/Unit/System/Data/DateTimeTest.php
+++ b/Tests/Unit/System/Data/DateTimeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Data;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Data;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\System\Data\DateTime;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -37,8 +38,8 @@ class DateTimeTest extends UnitTest
      */
     public function testCanWrapDateTimeAndConvertToString()
     {
-        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone("UTC"));
-        $this->assertSame('2003-12-13T18:30:02+0000', (string) $proxy);
+        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone('UTC'));
+        self::assertSame('2003-12-13T18:30:02+0000', (string)$proxy);
     }
 
     /**
@@ -46,7 +47,7 @@ class DateTimeTest extends UnitTest
      */
     public function testCanDispatchCallToUnderlyingDateTime()
     {
-        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone("UTC"));
-        $this->assertSame('2003-12-13T18:30:02+0000', $proxy->format(\DateTime::ISO8601));
+        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone('UTC'));
+        self::assertSame('2003-12-13T18:30:02+0000', $proxy->format(\DateTime::ISO8601));
     }
 }

--- a/Tests/Unit/System/DateTime/FormatServiceTest.php
+++ b/Tests/Unit/System/DateTime/FormatServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\DateTime;
 
 /***************************************************************
@@ -39,12 +40,10 @@ class FormatServiceTest extends UnitTest
      */
     protected $formatService;
 
-    /**
-     * @return void
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->formatService = new FormatService();
+        parent::setUp();
     }
 
     /**
@@ -52,7 +51,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canFormatLegalDate()
     {
-        $this->assertSame('2017-02-16', $this->formatService->format('2017-02-16'));
+        self::assertSame('2017-02-16', $this->formatService->format('2017-02-16'));
     }
 
     /**
@@ -60,7 +59,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canFormatIllegalDate()
     {
-        $this->assertSame('20170216', $this->formatService->format('20170216'));
+        self::assertSame('20170216', $this->formatService->format('20170216'));
     }
 
     /**
@@ -68,7 +67,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canFormatLegalDateOtherInputFormat()
     {
-        $this->assertSame('16-02-17', $this->formatService->format('02-16-2017', 'm-d-Y'));
+        self::assertSame('16-02-17', $this->formatService->format('02-16-2017', 'm-d-Y'));
     }
 
     /**
@@ -76,7 +75,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canFormatIllegalDateOtherInputFormat()
     {
-        $this->assertSame('02162017', $this->formatService->format('02162017', 'm-d-Y'));
+        self::assertSame('02162017', $this->formatService->format('02162017', 'm-d-Y'));
     }
 
     /**
@@ -84,7 +83,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToIsoLegalDate()
     {
-        $this->assertSame('2017-02-16T20:13:57Z', $this->formatService->TimestampToIso(1487272437));
+        self::assertSame('2017-02-16T20:13:57Z', $this->formatService->TimestampToIso(1487272437));
     }
 
     /**
@@ -92,7 +91,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToIsoIllegalDate()
     {
-        $this->assertEquals('1970-01-01T00:59:59Z', $this->formatService->TimestampToIso(-1));
+        self::assertEquals('1970-01-01T00:59:59Z', $this->formatService->TimestampToIso(-1));
     }
 
     /**
@@ -100,7 +99,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToIsoNull()
     {
-        $this->assertEquals('1970-01-01T01:00:00Z', $this->formatService->TimestampToIso(null));
+        self::assertEquals('1970-01-01T01:00:00Z', $this->formatService->TimestampToIso(null));
     }
 
     /**
@@ -108,7 +107,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canIsoToTimestampLegalDate()
     {
-        $this->assertEquals(1487272437, $this->formatService->IsoToTimestamp('2017-02-16T20:13:57Z'));
+        self::assertEquals(1487272437, $this->formatService->IsoToTimestamp('2017-02-16T20:13:57Z'));
     }
 
     /**
@@ -116,7 +115,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canIsoToTimestampIllegalDate()
     {
-        $this->assertEquals(0, $this->formatService->IsoToTimestamp('02-16-2017T20:13:57Z'));
+        self::assertEquals(0, $this->formatService->IsoToTimestamp('02-16-2017T20:13:57Z'));
     }
 
     /**
@@ -124,7 +123,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canIsoToTimestampEpoch()
     {
-        $this->assertEquals(0, $this->formatService->IsoToTimestamp('1970-01-01T00:00:00'));
+        self::assertEquals(0, $this->formatService->IsoToTimestamp('1970-01-01T00:00:00'));
     }
 
     /**
@@ -132,7 +131,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToUtcIsoLegalDate()
     {
-        $this->assertEquals('2017-02-16T19:13:57Z', $this->formatService->timestampToUtcIso(1487272437));
+        self::assertEquals('2017-02-16T19:13:57Z', $this->formatService->timestampToUtcIso(1487272437));
     }
 
     /**
@@ -140,7 +139,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToUtcIsoIllegalDate()
     {
-        $this->assertEquals('1969-12-31T23:59:59Z', $this->formatService->timestampToUtcIso(-1));
+        self::assertEquals('1969-12-31T23:59:59Z', $this->formatService->timestampToUtcIso(-1));
     }
 
     /**
@@ -148,7 +147,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canTimestampToUtcIsoNull()
     {
-        $this->assertEquals('1970-01-01T00:00:00Z', $this->formatService->timestampToUtcIso(null));
+        self::assertEquals('1970-01-01T00:00:00Z', $this->formatService->timestampToUtcIso(null));
     }
 
     /**
@@ -156,7 +155,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canUtcIsoToTimestampLegalDate()
     {
-        $this->assertEquals(1487276037, $this->formatService->utcIsoToTimestamp('2017-02-16T20:13:57Z'));
+        self::assertEquals(1487276037, $this->formatService->utcIsoToTimestamp('2017-02-16T20:13:57Z'));
     }
 
     /**
@@ -164,7 +163,7 @@ class FormatServiceTest extends UnitTest
      */
     public function canUtcIsoToTimestampIllegalDate()
     {
-        $this->assertEquals(0, $this->formatService->utcIsoToTimestamp('02-16-2017T20:13:57Z'));
+        self::assertEquals(0, $this->formatService->utcIsoToTimestamp('02-16-2017T20:13:57Z'));
     }
 
     /**
@@ -172,6 +171,6 @@ class FormatServiceTest extends UnitTest
      */
     public function canUtcIsoToTimestampEpoch()
     {
-        $this->assertEquals(0, $this->formatService->utcIsoToTimestamp('1970-01-01T00:00:00'));
+        self::assertEquals(0, $this->formatService->utcIsoToTimestamp('1970-01-01T00:00:00'));
     }
 }

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Logging;
 
 /***************************************************************
@@ -40,12 +41,12 @@ class DebugWriterTest extends UnitTest
     public function testDebugMessageIsWrittenForMessageFromSolr()
     {
         /** @var $logWriter DebugWriter */
-        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
-        $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(true);
+        $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(true);
 
-            //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
-        $logWriter->expects($this->once())->method('writeDebugMessage');
+        //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
+        $logWriter->expects(self::once())->method('writeDebugMessage');
         $logWriter->write(SolrLogManager::INFO, 'test');
     }
 
@@ -55,12 +56,12 @@ class DebugWriterTest extends UnitTest
     public function testDebugMessageIsNotWrittenWhenDevIpMaskIsNotMatching()
     {
         /** @var $logWriter DebugWriter */
-        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
-        $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(false));
-        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(true));
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(false);
+        $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(true);
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
-        $logWriter->expects($this->never())->method('writeDebugMessage');
+        $logWriter->expects(self::never())->method('writeDebugMessage');
         $logWriter->write(SolrLogManager::INFO, 'test');
     }
 
@@ -70,12 +71,12 @@ class DebugWriterTest extends UnitTest
     public function testDebugMessageIsNotWrittenWhenDebugOutputIsDisabled()
     {
         /** @var $logWriter DebugWriter */
-        $logWriter = $this->getMockBuilder(DebugWriter::class)->setMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
-        $logWriter->expects($this->any())->method('getIsAllowedByDevIPMask')->will($this->returnValue(true));
-        $logWriter->expects($this->any())->method('getIsdebugOutputEnabled')->will($this->returnValue(false));
+        $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
+        $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(true);
+        $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(false);
 
         //we have a matching devIpMask and the debugOutput of log messages is enabled => debug should be written
-        $logWriter->expects($this->never())->method('writeDebugMessage');
+        $logWriter->expects(self::never())->method('writeDebugMessage');
         $logWriter->write(SolrLogManager::INFO, 'test');
     }
 }

--- a/Tests/Unit/System/Page/RootlineTest.php
+++ b/Tests/Unit/System/Page/RootlineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Page;
 
 /***************************************************************
@@ -38,58 +39,63 @@ class RootlineTest extends UnitTest
     /**
      * @test
      */
-    public function getRootPageIdReturnUidOfRootPage() {
+    public function getRootPageIdReturnUidOfRootPage()
+    {
         $testRootLineArray = [
-            ['uid' => 100,'pid' => 10, 'title' => 'level 2'],
-            ['uid' => 10,'pid' => 1, 'title' => 'level 1'],
-            ['uid' => 1,'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1]
+            ['uid' => 100, 'pid' => 10, 'title' => 'level 2'],
+            ['uid' => 10, 'pid' => 1, 'title' => 'level 1'],
+            ['uid' => 1, 'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1],
         ];
 
         $rootline = new Rootline($testRootLineArray);
-        $this->assertSame(1, $rootline->getRootPageId(), 'GetRootPageId does not return expected root page id');
+        self::assertSame(1, $rootline->getRootPageId(), 'GetRootPageId does not return expected root page id');
     }
 
     /**
      * @test
      */
-    public function getRootPageIdReturnsZeroWhenNoSiteRootIsPresent() {
+    public function getRootPageIdReturnsZeroWhenNoSiteRootIsPresent()
+    {
         $rootline = new Rootline([]);
-        $this->assertSame(0, $rootline->getRootPageId(), 'Expecting null when no rootline given');
+        self::assertSame(0, $rootline->getRootPageId(), 'Expecting null when no rootline given');
     }
 
     /**
      * @test
      */
-    public function getHasRootPageReturnsFalseOnEmptyRootLine() {
+    public function getHasRootPageReturnsFalseOnEmptyRootLine()
+    {
         $rootline = new Rootline([]);
-        $this->assertFalse($rootline->getHasRootPage(), 'Expecting false when no rootline given');
+        self::assertFalse($rootline->getHasRootPage(), 'Expecting false when no rootline given');
     }
 
     /**
      * @test
      */
-    public function getHasRootPageRturnsTrueWithGivenRootLine() {
+    public function getHasRootPageRturnsTrueWithGivenRootLine()
+    {
         $testRootLineArray = [
-            ['uid' => 100,'pid' => 10, 'title' => 'level 2'],
-            ['uid' => 10,'pid' => 1, 'title' => 'level 1'],
-            ['uid' => 1,'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1]
+            ['uid' => 100, 'pid' => 10, 'title' => 'level 2'],
+            ['uid' => 10, 'pid' => 1, 'title' => 'level 1'],
+            ['uid' => 1, 'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1],
         ];
 
         $rootline = new Rootline($testRootLineArray);
-        $this->assertTrue($rootline->getHasRootPage(), 'Expecting true when rootline with rootpage given');
+        self::assertTrue($rootline->getHasRootPage(), 'Expecting true when rootline with rootpage given');
     }
 
     /**
      * @test
      */
-    public function canGetParentPageIds() {
+    public function canGetParentPageIds()
+    {
         $testRootLineArray = [
-            ['uid' => 100,'pid' => 10, 'title' => 'level 2'],
-            ['uid' => 10,'pid' => 1, 'title' => 'level 1'],
-            ['uid' => 1,'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1]
+            ['uid' => 100, 'pid' => 10, 'title' => 'level 2'],
+            ['uid' => 10, 'pid' => 1, 'title' => 'level 1'],
+            ['uid' => 1, 'pid' => 0, 'title' => 'rootpage', 'is_siteroot' => 1],
         ];
 
         $rootline = new Rootline($testRootLineArray);
-        $this->assertEquals([100,10,1], $rootline->getParentPageIds(), 'Expecting true when rootline with rootpage given');
+        self::assertEquals([100, 10, 1], $rootline->getParentPageIds(), 'Expecting true when rootline with rootpage given');
     }
 }

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Service;
 
 /***************************************************************
@@ -25,11 +26,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Service;
  ***************************************************************/
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\System\Service\ConfigurationService;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Service\FlexFormService;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -44,7 +45,7 @@ class ConfigurationServiceTest extends UnitTest
     {
         return [
             'simpleInteger' => ['id', 4711, 'id:4711'],
-            'escapedString' => ['id', 'foo"bar', 'id:"foo\"bar"']
+            'escapedString' => ['id', 'foo"bar', 'id:"foo\"bar"'],
         ];
     }
 
@@ -59,25 +60,25 @@ class ConfigurationServiceTest extends UnitTest
                 [
                     'query' => [
                         'filter' => [
-                            ['field' => ['field' => $filterField, 'value' => $filterValue]]
-                        ]
-                    ]
-                ]
+                            ['field' => ['field' => $filterField, 'value' => $filterValue]],
+                        ],
+                    ],
+                ],
           ];
         $flexFormServiceMock = $this->getDumbMock(FlexFormService::class);
-        $flexFormServiceMock->expects($this->once())->method('convertflexFormContentToArray')->will($this->returnValue($fakeFlexFormArrayData));
+        $flexFormServiceMock->expects(self::once())->method('convertflexFormContentToArray')->willReturn($fakeFlexFormArrayData);
 
         $typoScriptConfiguration = new TypoScriptConfiguration(['plugin.' => ['tx_solr.' => []]]);
         $configurationService = new ConfigurationService();
         $configurationService->setFlexFormService($flexFormServiceMock);
         $configurationService->setTypoScriptService(GeneralUtility::makeInstance(TypoScriptService::class));
 
-        $this->assertEquals([], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
+        self::assertEquals([], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
 
-            // the passed flexform data is empty because the convertflexFormContentToArray retrieves tha faked converted data
+        // the passed flexform data is empty because the convertflexFormContentToArray retrieves tha faked converted data
         $configurationService->overrideConfigurationWithFlexFormSettings('foobar', $typoScriptConfiguration);
 
-            // the filter should be overwritten by the flexform
-        $this->assertEquals([$expectedFilterString], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
+        // the filter should be overwritten by the flexform
+        self::assertEquals([$expectedFilterString], $typoScriptConfiguration->getSearchQueryFilterConfiguration());
     }
 }

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Session;
 
 /***************************************************************
@@ -46,11 +47,11 @@ class FrontendSessionTest extends UnitTest
      */
     protected $session;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->feUserMock = $this->getDumbMock(FrontendUserAuthentication::class);
         $this->session = new FrontendUserSession($this->feUserMock);
+        parent::setUp();
     }
 
     /**
@@ -59,7 +60,7 @@ class FrontendSessionTest extends UnitTest
     public function getEmptyArrayWhenNoLastSearchesInSession()
     {
         $lastSearches = $this->session->getLastSearches();
-        $this->assertSame([], $lastSearches, 'Expected to get an empty lastSearches array');
+        self::assertSame([], $lastSearches, 'Expected to get an empty lastSearches array');
     }
 
     /**
@@ -68,8 +69,8 @@ class FrontendSessionTest extends UnitTest
     public function sessionDataWillBeRetrievedFromSessionForLastSearches()
     {
         $fakeSessionData = ['foo', 'bar'];
-        $this->feUserMock->expects($this->once())->method('getKey')->with('ses', 'tx_solr_lastSearches')->will($this->returnValue($fakeSessionData));
-        $this->assertSame($fakeSessionData, $this->session->getLastSearches(), 'Session data from fe_user was not returned from session');
+        $this->feUserMock->expects(self::once())->method('getKey')->with('ses', 'tx_solr_lastSearches')->willReturn($fakeSessionData);
+        self::assertSame($fakeSessionData, $this->session->getLastSearches(), 'Session data from fe_user was not returned from session');
     }
 
     /**
@@ -78,7 +79,7 @@ class FrontendSessionTest extends UnitTest
     public function canSetLastSearchesInSession()
     {
         $lastSearches = ['TYPO3', 'solr'];
-        $this->feUserMock->expects($this->once())->method('setKey')->with('ses', 'tx_solr_lastSearches', $lastSearches);
+        $this->feUserMock->expects(self::once())->method('setKey')->with('ses', 'tx_solr_lastSearches', $lastSearches);
         $this->session->setLastSearches($lastSearches);
     }
 
@@ -87,7 +88,7 @@ class FrontendSessionTest extends UnitTest
      */
     public function getHasPerPageReturnsFalseWhenNothingIsSet()
     {
-        $this->assertFalse($this->session->getHasPerPage(), 'Has per page should be false');
+        self::assertFalse($this->session->getHasPerPage(), 'Has per page should be false');
     }
 
     /**
@@ -95,7 +96,7 @@ class FrontendSessionTest extends UnitTest
      */
     public function getPerPageReturnsZeroWhenNothingIsSet()
     {
-        $this->assertSame(0, $this->session->getPerPage(), 'Expected to get 0 when nothing was set');
+        self::assertSame(0, $this->session->getPerPage(), 'Expected to get 0 when nothing was set');
     }
 
     /**
@@ -104,8 +105,8 @@ class FrontendSessionTest extends UnitTest
     public function getPerPageFromSessionData()
     {
         $fakeSessionData = 12;
-        $this->feUserMock->expects($this->once())->method('getKey')->with('ses', 'tx_solr_resultsPerPage')->will($this->returnValue($fakeSessionData));
-        $this->assertSame(12, $this->session->getPerPage(), 'Could not get per page from session data');
+        $this->feUserMock->expects(self::once())->method('getKey')->with('ses', 'tx_solr_resultsPerPage')->willReturn($fakeSessionData);
+        self::assertSame(12, $this->session->getPerPage(), 'Could not get per page from session data');
     }
 
     /**
@@ -114,8 +115,7 @@ class FrontendSessionTest extends UnitTest
     public function canSetPerPageInSessionData()
     {
         $lastSearches = 45;
-        $this->feUserMock->expects($this->once())->method('setKey')->with('ses', 'tx_solr_resultsPerPage', $lastSearches);
+        $this->feUserMock->expects(self::once())->method('setKey')->with('ses', 'tx_solr_resultsPerPage', $lastSearches);
         $this->session->setPerPage($lastSearches);
     }
-
 }

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 /***************************************************************
@@ -43,7 +44,7 @@ class SchemaParserTest extends UnitTest
     {
         $parser = new SchemaParser();
         $schema = $parser->parseJson($this->getFixtureContentByName('schema.json'));
-        $this->assertSame('core_de', $schema->getManagedResourceId(), 'Could not parse id of managed resources from schema response.');
+        self::assertSame('core_de', $schema->getManagedResourceId(), 'Could not parse id of managed resources from schema response.');
     }
 
     /**
@@ -53,7 +54,7 @@ class SchemaParserTest extends UnitTest
     {
         $parser = new SchemaParser();
         $schema = $parser->parseJson($this->getFixtureContentByName('schema.json'));
-        $this->assertSame('tx_solr-6-0-0--20161122', $schema->getName(), 'Could not parser name from schema response');
+        self::assertSame('tx_solr-6-0-0--20161122', $schema->getName(), 'Could not parser name from schema response');
     }
 
     /**
@@ -63,7 +64,6 @@ class SchemaParserTest extends UnitTest
     {
         $parser = new SchemaParser();
         $schema = $parser->parseJson('{}');
-        $this->assertInstanceOf(Schema::class, $schema, 'Can not get schema object from empty response');
+        self::assertInstanceOf(Schema::class, $schema, 'Can not get schema object from empty response');
     }
-
 }

--- a/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 /***************************************************************
@@ -42,6 +43,6 @@ class StopWordParserTest extends UnitTest
     {
         $parser = new StopWordParser();
         $stopwords = $parser->parseJson($this->getFixtureContentByName('stopword.json'));
-        $this->assertSame(['badword'], $stopwords, 'Could not parser stopwords from stopwords response');
+        self::assertSame(['badword'], $stopwords, 'Could not parser stopwords from stopwords response');
     }
 }

--- a/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 /***************************************************************
@@ -41,7 +42,7 @@ class SynonymParserTest extends UnitTest
     public function canParseSynonyms()
     {
         $parser = new SynonymParser();
-        $synonyms = $parser->parseJson('foo',$this->getFixtureContentByName('synonym.json'));
-        $this->assertSame(['bar'], $synonyms, 'Could not parser synonyms from synonyms response');
+        $synonyms = $parser->parseJson('foo', $this->getFixtureContentByName('synonym.json'));
+        self::assertSame(['bar'], $synonyms, 'Could not parser synonyms from synonyms response');
     }
 }

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 
 /***************************************************************
@@ -53,20 +54,20 @@ class SolrAdminServiceTest extends UnitTest
      */
     protected $endpointMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->endpointMock = $this->getDumbMock(Endpoint::class);
-        $this->endpointMock->expects($this->any())->method('getScheme')->willReturn('http');
-        $this->endpointMock->expects($this->any())->method('getHost')->willReturn('localhost');
-        $this->endpointMock->expects($this->any())->method('getPort')->willReturn(8983);
-        $this->endpointMock->expects($this->any())->method('getPath')->willReturn('/solr');
-        $this->endpointMock->expects($this->any())->method('getCore')->willReturn('core_en');
-        $this->endpointMock->expects($this->any())->method('getCoreBaseUri')->willReturn('http://localhost:8983/solr/core_en/');
+        $this->endpointMock->expects(self::any())->method('getScheme')->willReturn('http');
+        $this->endpointMock->expects(self::any())->method('getHost')->willReturn('localhost');
+        $this->endpointMock->expects(self::any())->method('getPort')->willReturn(8983);
+        $this->endpointMock->expects(self::any())->method('getPath')->willReturn('/solr');
+        $this->endpointMock->expects(self::any())->method('getCore')->willReturn('core_en');
+        $this->endpointMock->expects(self::any())->method('getCoreBaseUri')->willReturn('http://localhost:8983/solr/core_en/');
 
         $this->clientMock = $this->getDumbMock(Client::class);
-        $this->clientMock->expects($this->any())->method('getEndpoints')->willReturn([$this->endpointMock]);
-        $this->adminService = $this->getMockBuilder(SolrAdminService::class)->setConstructorArgs([$this->clientMock])->setMethods(['_sendRawGet'])->getMock();
+        $this->clientMock->expects(self::any())->method('getEndpoints')->willReturn([$this->endpointMock]);
+        $this->adminService = $this->getMockBuilder(SolrAdminService::class)->setConstructorArgs([$this->clientMock])->onlyMethods(['_sendRawGet'])->getMock();
+        parent::setUp();
     }
     /**
      * @test
@@ -77,7 +78,7 @@ class SolrAdminServiceTest extends UnitTest
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/luke?numTerms=50&wt=json&fl=%2A', $fakedLukeResponse);
         $result = $this->adminService->getLukeMetaData(50);
 
-        $this->assertSame($fakedLukeResponse, $result, 'Could not get expected result from getLukeMetaData');
+        self::assertSame($fakedLukeResponse, $result, 'Could not get expected result from getLukeMetaData');
     }
 
     /**
@@ -89,7 +90,7 @@ class SolrAdminServiceTest extends UnitTest
         $fakePluginsResponse->responseHeader = null;
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/plugins?wt=json', $fakePluginsResponse);
         $result = $this->adminService->getPluginsInformation();
-        $this->assertSame($fakePluginsResponse, $result, 'Could not get expected result from getPluginsInformation');
+        self::assertSame($fakePluginsResponse, $result, 'Could not get expected result from getPluginsInformation');
     }
 
     /**
@@ -100,7 +101,7 @@ class SolrAdminServiceTest extends UnitTest
         $fakeSystemInformationResponse = $this->getDumbMock(ResponseAdapter::class);
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/system?wt=json', $fakeSystemInformationResponse);
         $result = $this->adminService->getSystemInformation();
-        $this->assertSame($fakeSystemInformationResponse, $result, 'Could not get expected result from getSystemInformation');
+        self::assertSame($fakeSystemInformationResponse, $result, 'Could not get expected result from getSystemInformation');
     }
 
     /**
@@ -113,7 +114,7 @@ class SolrAdminServiceTest extends UnitTest
         $fakeSystemInformationResponse->lucene->{'solr-spec-version'} = '6.2.1';
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/system?wt=json', $fakeSystemInformationResponse);
         $result = $this->adminService->getSolrServerVersion();
-        $this->assertSame('6.2.1', $result, 'Can not get solr version from faked response');
+        self::assertSame('6.2.1', $result, 'Can not get solr version from faked response');
     }
 
     /**
@@ -123,11 +124,11 @@ class SolrAdminServiceTest extends UnitTest
     {
         $fakeTestSchema = $this->getFixtureContentByName('solrconfig.xml');
         $fakedSolrConfigResponse = $this->getDumbMock(ResponseAdapter::class);
-        $fakedSolrConfigResponse->expects($this->once())->method('getRawResponse')->willReturn($fakeTestSchema);
+        $fakedSolrConfigResponse->expects(self::once())->method('getRawResponse')->willReturn($fakeTestSchema);
 
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/file?file=solrconfig.xml', $fakedSolrConfigResponse);
         $expectedSchemaVersion = 'tx_solr-9-9-9--20221020';
-        $this->assertSame($expectedSchemaVersion, $this->adminService->getSolrconfigName(), 'SolrAdminService could not parse the solrconfig version as expected');
+        self::assertSame($expectedSchemaVersion, $this->adminService->getSolrconfigName(), 'SolrAdminService could not parse the solrconfig version as expected');
     }
 
     /**
@@ -136,6 +137,6 @@ class SolrAdminServiceTest extends UnitTest
      */
     protected function assertGetRequestIsTriggered($url, $fakeResponse)
     {
-        $this->adminService->expects($this->once())->method('_sendRawGet')->with($url)->will($this->returnValue($fakeResponse));
+        $this->adminService->expects(self::once())->method('_sendRawGet')->with($url)->willReturn($fakeResponse);
     }
 }

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 
 /***************************************************************
@@ -66,16 +67,16 @@ class SolrReadServiceTest extends UnitTest
      */
     protected $service;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->responseMock = $this->getDumbMock(Response::class);
         $this->requestMock = $this->getDumbMock(Request::class);
         $this->clientMock = $this->getDumbMock(Client::class);
-        $this->clientMock->expects($this->any())->method('createRequest')->willReturn($this->requestMock);
-        $this->clientMock->expects($this->any())->method('executeRequest')->willReturn($this->responseMock);
+        $this->clientMock->expects(self::any())->method('createRequest')->willReturn($this->requestMock);
+        $this->clientMock->expects(self::any())->method('executeRequest')->willReturn($this->responseMock);
 
         $this->service = new SolrReadService($this->clientMock);
+        parent::setUp();
     }
 
     /**
@@ -84,8 +85,8 @@ class SolrReadServiceTest extends UnitTest
     public function pingIsOnlyDoingOnePingCallWhenCacheIsEnabled()
     {
         // we fake a 200 OK response and expect that
-        $this->responseMock->expects($this->once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects($this->once())->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
+        $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
+        $this->clientMock->expects(self::once())->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
         $this->service->ping();
         $this->service->ping();
     }
@@ -96,8 +97,8 @@ class SolrReadServiceTest extends UnitTest
     public function pingIsOnlyDoingManyPingCallsWhenCacheIsDisabled()
     {
         // we fake a 200 OK response and expect that
-        $this->responseMock->expects($this->exactly(2))->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects($this->exactly(2))->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
+        $this->responseMock->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
+        $this->clientMock->expects(self::exactly(2))->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
         $this->service->ping(false);
         $this->service->ping(false);
     }
@@ -107,15 +108,15 @@ class SolrReadServiceTest extends UnitTest
      */
     public function searchMethodIsTriggeringGetRequest()
     {
-        $this->responseMock->expects($this->once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects($this->once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
+        $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
+        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
 
         $searchQuery = new SearchQuery();
         $searchQuery->setQuery('foo');
         $result = $this->service->search($searchQuery);
 
-        $this->assertSame(200, $result->getHttpStatus(), 'Expecting to get a 200 OK response');
-        $this->assertTrue($this->service->hasSearched(), 'hasSearch indicates that no search was triggered');
+        self::assertSame(200, $result->getHttpStatus(), 'Expecting to get a 200 OK response');
+        self::assertTrue($this->service->hasSearched(), 'hasSearch indicates that no search was triggered');
     }
 
     /**
@@ -126,7 +127,7 @@ class SolrReadServiceTest extends UnitTest
         return [
             'Communication error' => ['exceptionClass' => SolrUnavailableException::class, 0],
             'Internal Server eror' => ['expcetionClass' => SolrInternalServerErrorException::class, 500],
-            'Other unspecific error' => ['expcetionClass' => SolrCommunicationException::class, 555]
+            'Other unspecific error' => ['expcetionClass' => SolrCommunicationException::class, 555],
         ];
     }
 
@@ -138,10 +139,10 @@ class SolrReadServiceTest extends UnitTest
      */
     public function searchThrowsExpectedExceptionForStatusCode($exceptionClass, $statusCode)
     {
-        $this->responseMock->expects($this->any())->method('getStatusCode')->willReturn($statusCode);
-        $this->clientMock->expects($this->once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
+        $this->responseMock->expects(self::any())->method('getStatusCode')->willReturn($statusCode);
+        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
 
-        $this->clientMock->expects($this->once())->method('executeRequest')->willReturnCallback(function() use ($statusCode) {
+        $this->clientMock->expects(self::once())->method('executeRequest')->willReturnCallback(function () use ($statusCode) {
             throw new HttpException('Solr error', $statusCode);
         });
         $searchQuery = new SearchQuery();

--- a/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 
 /***************************************************************
@@ -58,16 +59,16 @@ class SolrWriteServiceTest extends UnitTest
      */
     protected $service;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->responseMock = $this->getDumbMock(Response::class);
 
         $this->resultMock = $this->getDumbMock(Result::class);
-        $this->resultMock->expects($this->any())->method('getResponse')->willReturn($this->responseMock);
+        $this->resultMock->expects(self::any())->method('getResponse')->willReturn($this->responseMock);
         $this->clientMock = $this->getDumbMock(Client::class);
 
         $this->service = new SolrWriteService($this->clientMock);
+        parent::setUp();
     }
 
     /**
@@ -75,11 +76,11 @@ class SolrWriteServiceTest extends UnitTest
      */
     public function canRunOptimizeIndex()
     {
-        $this->responseMock->expects($this->once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects($this->once())->method('createUpdate')->willReturn($this->getDumbMock(Query::class));
-        $this->clientMock->expects($this->once())->method('update')->willReturn($this->resultMock);
+        $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
+        $this->clientMock->expects(self::once())->method('createUpdate')->willReturn($this->getDumbMock(Query::class));
+        $this->clientMock->expects(self::once())->method('update')->willReturn($this->resultMock);
 
         $result = $this->service->optimizeIndex();
-        $this->assertSame(200, $result->getResponse()->getStatusCode(), 'Expecting to get a 200 OK response');
+        self::assertSame(200, $result->getResponse()->getStatusCode(), 'Expecting to get a 200 OK response');
     }
 }

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr;
 
 /***************************************************************
@@ -32,20 +33,17 @@ use ApacheSolrForTypo3\Solr\System\Solr\Parser\StopWordParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Solarium\Client;
-use Solarium\Core\Client\Adapter\TimeoutAwareInterface;
 use Solarium\Core\Client\Endpoint;
-use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 
 /**
  * Class SolrConnectionTest
- * @package ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr
+ *
+ * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrConnectionTest extends UnitTest
 {
@@ -76,7 +74,7 @@ class SolrConnectionTest extends UnitTest
         RequestFactoryInterface $requestFactory = null,
         StreamFactoryInterface $streamFactory = null,
         EventDispatcherInterface $eventDispatcher = null
-    ): SolrConnection {
+    ): ?SolrConnection {
         try {
             return new SolrConnection(
                 $readNode ?? $this->getDumbMock(Node::class),
@@ -94,6 +92,7 @@ class SolrConnectionTest extends UnitTest
         } catch (\Throwable $e) {
             // No exception will be ever happen, this is for saving up the lines in test cases.
         }
+        return null;
     }
 
     /**
@@ -105,7 +104,7 @@ class SolrConnectionTest extends UnitTest
         $endpointMock = $this->getDumbMock(Endpoint::class);
         /* @var Client $clientMock */
         $clientMock = $this->getDumbMock(Client::class);
-        $clientMock->expects($this->any())->method('getEndpoints')->willReturn([$endpointMock]);
+        $clientMock->expects(self::any())->method('getEndpoints')->willReturn([$endpointMock]);
 
         $readNode = Node::fromArray(
             ['host' => 'localhost', 'port' => 8080, 'path' => '/solr/core_en/', 'scheme' => 'https', 'username' => '', 'password' => '']
@@ -114,7 +113,7 @@ class SolrConnectionTest extends UnitTest
         $connection = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);
         $connection->setClient($clientMock, 'admin');
 
-        $endpointMock->expects($this->never())->method('setAuthentication');
+        $endpointMock->expects(self::never())->method('setAuthentication');
         $connection->getAdminService();
     }
 
@@ -125,7 +124,7 @@ class SolrConnectionTest extends UnitTest
     {
         $endpointMock = $this->getDumbMock(Endpoint::class);
         $clientMock = $this->getDumbMock(Client::class);
-        $clientMock->expects($this->any())->method('getEndpoints')->willReturn([$endpointMock]);
+        $clientMock->expects(self::any())->method('getEndpoints')->willReturn([$endpointMock]);
 
         $readNode = Node::fromArray(
             ['host' => 'localhost', 'port' => 8080, 'path' => '/solr/core_en/', 'scheme' => 'https', 'username' => 'foo', 'password' => 'bar']
@@ -134,7 +133,7 @@ class SolrConnectionTest extends UnitTest
         $connection = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);
         $connection->setClient($clientMock, 'admin');
 
-        $endpointMock->expects($this->once())->method('setAuthentication');
+        $endpointMock->expects(self::once())->method('setAuthentication');
         $connection->getAdminService();
     }
 
@@ -145,7 +144,7 @@ class SolrConnectionTest extends UnitTest
     {
         return [
             ['path' => '/solr/bla', 'expectedName' => 'bla'],
-            ['path' => '/somewherelese/solr/corename', 'expectedName' => 'corename']
+            ['path' => '/somewherelese/solr/corename', 'expectedName' => 'corename'],
         ];
     }
 
@@ -161,7 +160,7 @@ class SolrConnectionTest extends UnitTest
         );
         $writeNode = $readNode;
         $solrService = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode, $fakeConfiguration);
-        $this->assertSame($expectedCoreName, $solrService->getReadService()->getPrimaryEndpoint()->getCore());
+        self::assertSame($expectedCoreName, $solrService->getReadService()->getPrimaryEndpoint()->getCore());
     }
 
     /**
@@ -171,7 +170,7 @@ class SolrConnectionTest extends UnitTest
     {
         return [
             ['path' => '/solr/bla', 'expectedPath' => ''],
-            ['path' => '/somewherelese/solr/corename', 'expectedCoreBasePath' => '/somewherelese']
+            ['path' => '/somewherelese/solr/corename', 'expectedCoreBasePath' => '/somewherelese'],
         ];
     }
 
@@ -186,7 +185,7 @@ class SolrConnectionTest extends UnitTest
         );
         $writeNode = $readNode;
         $solrService = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);
-        $this->assertSame($expectedCoreBasePath, $solrService->getReadService()->getPrimaryEndpoint()->getPath());
+        self::assertSame($expectedCoreBasePath, $solrService->getReadService()->getPrimaryEndpoint()->getPath());
     }
 
     /**
@@ -199,6 +198,6 @@ class SolrConnectionTest extends UnitTest
         );
         $writeNode = $readNode;
         $solrService = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);
-        $this->assertSame('http://localhost:8080/solr/core_de/', (string) $solrService->getNode('read'), 'Could not get string representation of connection');
+        self::assertSame('http://localhost:8080/solr/core_de/', (string)$solrService->getNode('read'), 'Could not get string representation of connection');
     }
 }

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\TCA;
 
 /***************************************************************
@@ -26,6 +27,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\TCA;
 
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use DateTimeImmutable;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to test the TCAService.
@@ -40,23 +45,24 @@ class TCAServiceTest extends UnitTest
      *
      * @test
      */
-    public function getIsEnabledRecordDetectDeletedRecord() {
+    public function getIsEnabledRecordDetectDeletedRecord()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
-                    'delete' => 'deleted'
-                ]
-            ]
+                    'delete' => 'deleted',
+                ],
+            ],
         ];
 
         $fakePageRecord = [
-            'deleted' => 1
+            'deleted' => 1,
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $isVisible = $tcaService->isEnabledRecord('pages', $fakePageRecord);
 
-        $this->assertFalse($isVisible);
+        self::assertFalse($isVisible);
     }
 
     /**
@@ -64,23 +70,24 @@ class TCAServiceTest extends UnitTest
      *
      * @test
      */
-    public function getIsEnabledRecordDetectNonDeletedRecord() {
+    public function getIsEnabledRecordDetectNonDeletedRecord()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
-                    'delete' => 'deleted'
-                ]
-            ]
+                    'delete' => 'deleted',
+                ],
+            ],
         ];
 
         $fakePageRecord = [
-            'title' => 'hello world'
+            'title' => 'hello world',
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $isVisible = $tcaService->isEnabledRecord('pages', $fakePageRecord);
 
-        $this->assertTrue($isVisible);
+        self::assertTrue($isVisible);
     }
 
     /**
@@ -88,23 +95,24 @@ class TCAServiceTest extends UnitTest
      *
      * @test
      */
-    public function getIsEnabledRecordDetectsPageConfiguredWithNoSearch() {
+    public function getIsEnabledRecordDetectsPageConfiguredWithNoSearch()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
-                    'delete' => 'deleted'
-                ]
-            ]
+                    'delete' => 'deleted',
+                ],
+            ],
         ];
 
         $fakePageRecord = [
-            'no_search' => 1
+            'no_search' => 1,
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $isVisible = $tcaService->isEnabledRecord('pages', $fakePageRecord);
 
-        $this->assertFalse($isVisible);
+        self::assertFalse($isVisible);
     }
 
     /**
@@ -112,13 +120,14 @@ class TCAServiceTest extends UnitTest
      *
      * @test
      */
-    public function getIsEnabledRecordEmptyRecord() {
+    public function getIsEnabledRecordEmptyRecord()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
-                    'delete' => 'deleted'
-                ]
-            ]
+                    'delete' => 'deleted',
+                ],
+            ],
         ];
 
         $fakePageRecord = [];
@@ -126,196 +135,208 @@ class TCAServiceTest extends UnitTest
         $tcaService = new TCAService($fakeTCA);
         $isVisible = $tcaService->isEnabledRecord('pages', $fakePageRecord);
 
-        $this->assertFalse($isVisible);
+        self::assertFalse($isVisible);
     }
 
     /**
      * @test
      */
-    public function isEndTimeInPastCanDetectedEndtimeThatIsInPast() {
+    public function isEndTimeInPastCanDetectedEndtimeThatIsInPast()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'endtime' => 'end'
-                    ]
-                ]
-            ]
+                        'endtime' => 'end',
+                    ],
+                ],
+            ],
         ];
 
-        $GLOBALS['EXEC_TIME'] = 1000;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new DateTimeImmutable('@1000')));
         $fakePageRecord = [
-            'end' => 999
+            'end' => 999,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isEndTimeInPast = $tcaService->isEndTimeInPast('pages', $fakePageRecord);
 
-        $this->assertTrue($isEndTimeInPast, 'Endtime in past was not detected as endtime in past');
+        self::assertTrue($isEndTimeInPast, 'Endtime in past was not detected as endtime in past');
     }
-
 
     /**
      * @test
      */
-    public function isEndTimeInPastCanDetectedEndtimeThatIsNotInPast() {
+    public function isEndTimeInPastCanDetectedEndtimeThatIsNotInPast()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'endtime' => 'end'
-                    ]
-                ]
-            ]
+                        'endtime' => 'end',
+                    ],
+                ],
+            ],
         ];
 
-        $GLOBALS['EXEC_TIME'] = 1000;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new DateTimeImmutable('@1000')));
         $fakePageRecord = [
-            'end' => 1001
+            'end' => 1001,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isEndTimeInPast = $tcaService->isEndTimeInPast('pages', $fakePageRecord);
 
-        $this->assertFalse($isEndTimeInPast, 'Endtime in future, was detected as endtime in past');
+        self::assertFalse($isEndTimeInPast, 'Endtime in future, was detected as endtime in past');
     }
 
     /**
      * @test
      */
-    public function isEndTimeInPastCanDetectedEndtimeIsEmpty(){
+    public function isEndTimeInPastCanDetectedEndtimeIsEmpty()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'endtime' => 'end'
-                    ]
-                ]
-            ]
+                        'endtime' => 'end',
+                    ],
+                ],
+            ],
         ];
 
-        $GLOBALS['EXEC_TIME'] = 1000;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new DateTimeImmutable('@1000')));
         $fakePageRecord = [
-            'end' => 0
+            'end' => 0,
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $isEndTimeInPast = $tcaService->isEndTimeInPast('pages', $fakePageRecord);
 
-        $this->assertFalse($isEndTimeInPast, 'Not set endtime(default 0), was detected as endtime in past.');
+        self::assertFalse($isEndTimeInPast, 'Not set endtime(default 0), was detected as endtime in past.');
     }
 
     /**
      * @test
      */
-    public function isStartTimeInFutureCanDetectedStartTimeInFuture() {
+    public function isStartTimeInFutureCanDetectedStartTimeInFuture()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'starttime' => 'start'
-                    ]
-                ]
-            ]
+                        'starttime' => 'start',
+                    ],
+                ],
+            ],
         ];
 
-        $GLOBALS['EXEC_TIME'] = 1000;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new DateTimeImmutable('@1000')));
         $fakePageRecord = [
-            'start' => 1001
+            'start' => 1001,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isStartTimeInFuture = $tcaService->isStartTimeInFuture('pages', $fakePageRecord);
 
-        $this->assertTrue($isStartTimeInFuture, 'Starttime in future was not detected as start time in future');
+        self::assertTrue($isStartTimeInFuture, 'Starttime in future was not detected as start time in future');
     }
 
     /**
      * @test
      */
-    public function isStartTimeInFutureCanDetectedStartTimeNotInFuture() {
+    public function isStartTimeInFutureCanDetectedStartTimeNotInFuture()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'starttime' => 'start'
-                    ]
-                ]
-            ]
+                        'starttime' => 'start',
+                    ],
+                ],
+            ],
         ];
 
-        $GLOBALS['EXEC_TIME'] = 1000;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new DateTimeImmutable('@1000')));
         $fakePageRecord = [
-            'start' => 999
+            'start' => 999,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isStartTimeInFuture = $tcaService->isStartTimeInFuture('pages', $fakePageRecord);
 
-        $this->assertFalse($isStartTimeInFuture, 'Start time in past was detected as starttime in future');
+        self::assertFalse($isStartTimeInFuture, 'Start time in past was detected as starttime in future');
     }
 
     /**
      * @test
      */
-    public function isHiddenCanDetectHiddenRecord() {
+    public function isHiddenCanDetectHiddenRecord()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'disabled' => 'hidden'
-                    ]
-                ]
-            ]
+                        'disabled' => 'hidden',
+                    ],
+                ],
+            ],
         ];
 
         $fakePageRecord = [
-            'hidden' => 1
+            'hidden' => 1,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isHidden = $tcaService->isHidden('pages', $fakePageRecord);
 
-        $this->assertTrue($isHidden, 'Page was expected to be hidden');
+        self::assertTrue($isHidden, 'Page was expected to be hidden');
     }
 
     /**
      * @test
      */
-    public function isHiddenCanDetectNonHiddenRecord() {
+    public function isHiddenCanDetectNonHiddenRecord()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'disabled' => 'hidden'
-                    ]
-                ]
-            ]
+                        'disabled' => 'hidden',
+                    ],
+                ],
+            ],
         ];
 
         $fakePageRecord = [
-            'hidden' => 0
+            'hidden' => 0,
         ];
         $tcaService = new TCAService($fakeTCA);
         $isHidden = $tcaService->isHidden('pages', $fakePageRecord);
 
-        $this->assertFalse($isHidden, 'Page was not expected to be hidden');
+        self::assertFalse($isHidden, 'Page was not expected to be hidden');
     }
 
     /**
      * @test
      */
-    public function canNormalizeFrontendGroupField() {
+    public function canNormalizeFrontendGroupField()
+    {
         $fakeTCA = [
             'pages' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'fe_group' => 'fe_groups'
-                    ]
-                ]
-            ]
+                        'fe_group' => 'fe_groups',
+                    ],
+                ],
+            ],
         ];
 
         $fakePageRecord = [];
         $tcaService = new TCAService($fakeTCA);
         $normalizedRecord = $tcaService->normalizeFrontendGroupField('pages', $fakePageRecord);
 
-        $this->assertSame($normalizedRecord['fe_groups'], '0', 'Empty fe_group field was not normalized to 0');
+        self::assertSame($normalizedRecord['fe_groups'], '0', 'Empty fe_group field was not normalized to 0');
     }
 
     /**
@@ -326,8 +347,8 @@ class TCAServiceTest extends UnitTest
         $tcaService = new TCAService([]);
         $visibilityFields = $tcaService->getVisibilityAffectingFieldsByTable('pages');
 
-        $this->assertStringContainsString('doktype', $visibilityFields, 'Expected to have doktype as visibility affecting field as default for pages');
-        $this->assertStringContainsString('no_search', $visibilityFields, 'Expected to have no_search as visibility affecting field as default for pages');
+        self::assertStringContainsString('doktype', $visibilityFields, 'Expected to have doktype as visibility affecting field as default for pages');
+        self::assertStringContainsString('no_search', $visibilityFields, 'Expected to have no_search as visibility affecting field as default for pages');
     }
 
     /**
@@ -337,7 +358,7 @@ class TCAServiceTest extends UnitTest
     {
         $tcaService = new TCAService([]);
         $visibilityFields = $tcaService->getVisibilityAffectingFieldsByTable('tx_domain_model_faketable');
-        $this->assertEquals('uid, pid', $visibilityFields, 'TCA Service should return uid and pid of visibility affecting fields for record table where no TCA is configured');
+        self::assertEquals('uid, pid', $visibilityFields, 'TCA Service should return uid and pid of visibility affecting fields for record table where no TCA is configured');
     }
 
     /**
@@ -348,14 +369,14 @@ class TCAServiceTest extends UnitTest
         $fakeTCA = [
             'tx_domain_model_faketable' => [
                 'ctrl' => [
-                    'delete' => 'deleted'
-                ]
-            ]
+                    'delete' => 'deleted',
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $visibilityFields = $tcaService->getVisibilityAffectingFieldsByTable('tx_domain_model_faketable');
-        $this->assertStringContainsString('deleted', $visibilityFields, 'The deleted field should be retrieved as visibility affecting field');
+        self::assertStringContainsString('deleted', $visibilityFields, 'The deleted field should be retrieved as visibility affecting field');
     }
 
     /**
@@ -367,15 +388,15 @@ class TCAServiceTest extends UnitTest
             'tx_domain_model_faketable' => [
                 'ctrl' => [
                     'enablecolumns' => [
-                        'fe_group' => 'fe_groups'
-                    ]
-                ]
-            ]
+                        'fe_group' => 'fe_groups',
+                    ],
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $visibilityFields = $tcaService->getVisibilityAffectingFieldsByTable('tx_domain_model_faketable');
-        $this->assertStringContainsString('fe_groups', $visibilityFields, 'The field fe_groups should be retrieved as visbility affecting field');
+        self::assertStringContainsString('fe_groups', $visibilityFields, 'The field fe_groups should be retrieved as visbility affecting field');
     }
 
     /**
@@ -386,16 +407,16 @@ class TCAServiceTest extends UnitTest
         $fakeTCA = [
             'tx_domain_model_faketable' => [
                 'ctrl' => [
-                    'transOrigPointerField' => 'l10n_parent'
-                ]
-            ]
+                    'transOrigPointerField' => 'l10n_parent',
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $fakeRecord = ['l10n_parent' => 999];
 
         $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
-        $this->assertSame(999, $l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+        self::assertSame(999, $l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
     /**
@@ -406,16 +427,16 @@ class TCAServiceTest extends UnitTest
         $fakeTCA = [
             'tx_domain_model_faketable' => [
                 'ctrl' => [
-                    'transOrigPointerField' => 'l10n_parent'
-                ]
-            ]
+                    'transOrigPointerField' => 'l10n_parent',
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
         $fakeRecord = [];
 
         $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
-        $this->assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+        self::assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
     /**
@@ -426,7 +447,7 @@ class TCAServiceTest extends UnitTest
         $tcaService = new TCAService([]);
         $fakeRecord = [];
         $l10nParentUid = $tcaService->getTranslationOriginalUid('tx_domain_model_faketable', $fakeRecord);
-        $this->assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
+        self::assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
     /**
@@ -437,16 +458,16 @@ class TCAServiceTest extends UnitTest
         $fakeTCA = [
             'tx_domain_model_faketable' => [
                 'ctrl' => [
-                    'transOrigPointerField' => 'l10n_parent'
-                ]
-            ]
+                    'transOrigPointerField' => 'l10n_parent',
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
 
-        $this->assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 0]), 'Item with l10n_parent => 0 should not be indicated as translation');
-        $this->assertTrue($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 9999]), 'Item with l10n_parent => 9999 should be indicated as translation');
-        $this->assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999]), 'Item without tca should not be indicated as translation');
+        self::assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 0]), 'Item with l10n_parent => 0 should not be indicated as translation');
+        self::assertTrue($tcaService->isLocalizedRecord('tx_domain_model_faketable', ['l10n_parent' => 9999]), 'Item with l10n_parent => 9999 should be indicated as translation');
+        self::assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999]), 'Item without tca should not be indicated as translation');
     }
 
     /**
@@ -457,15 +478,15 @@ class TCAServiceTest extends UnitTest
         $fakeTCA = [
             'tx_domain_model_faketable' => [
                 'ctrl' => [
-                    'transOrigPointerField' => 'l10n_parent'
-                ]
-            ]
+                    'transOrigPointerField' => 'l10n_parent',
+                ],
+            ],
         ];
 
         $tcaService = new TCAService($fakeTCA);
 
-        $this->assertSame(4711, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 0], 4711), 'No translation, original uid should be returned');
-        $this->assertSame(9999, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 9999], 4711), 'Valid translation, uid of parent should be returned');
-        $this->assertSame(4711,$tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999], 4711), 'No translation, original uid should be returned');
+        self::assertSame(4711, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 0], 4711), 'No translation, original uid should be returned');
+        self::assertSame(9999, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable', ['l10n_parent' => 9999], 4711), 'Valid translation, uid of parent should be returned');
+        self::assertSame(4711, $tcaService->getTranslationOriginalUidIfTranslated('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999], 4711), 'No translation, original uid should be returned');
     }
 }

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
 
 /***************************************************************
@@ -44,28 +45,28 @@ class UrlHelperTest extends UnitTest
             'cHash at the end' => [
                 'input' => 'index.php?id=1&cHash=ddd',
                 'queryParameterToRemove' => 'cHash',
-                'expectedUrl' => '/index.php?id=1'
+                'expectedUrl' => '/index.php?id=1',
              ],
             'cHash at the beginning' => [
                 'input' => 'index.php?cHash=ddd&id=1',
                 'queryParameterToRemove' => 'cHash',
-                'expectedUrl' => '/index.php?id=1'
+                'expectedUrl' => '/index.php?id=1',
             ],
             'cHash in the middle' => [
                 'input' => 'index.php?foo=bar&cHash=ddd&id=1',
                 'queryParameterToRemove' => 'cHash',
-                'expectedUrl' => '/index.php?foo=bar&id=1'
+                'expectedUrl' => '/index.php?foo=bar&id=1',
             ],
             'result is urlencoded' => [
                 'input' => 'index.php?foo[1]=bar&cHash=ddd&id=1',
                 'queryParameterToRemove' => 'cHash',
-                'expectedUrl' => '/index.php?foo%5B1%5D=bar&id=1'
+                'expectedUrl' => '/index.php?foo%5B1%5D=bar&id=1',
             ],
             'result is urlencoded with unexisting remove param' => [
                 'input' => 'index.php?foo[1]=bar&cHash=ddd&id=1',
                 'queryParameterToRemove' => 'notExisting',
-                'expectedUrl' => '/index.php?foo%5B1%5D=bar&cHash=ddd&id=1'
-            ]
+                'expectedUrl' => '/index.php?foo%5B1%5D=bar&cHash=ddd&id=1',
+            ],
         ];
     }
     /**
@@ -76,7 +77,7 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper($input);
         $urlHelper->removeQueryParameter($queryParameterToRemove);
-        $this->assertSame($expectedUrl, $urlHelper->getUrl(), 'Can not remove query parameter as expected');
+        self::assertSame($expectedUrl, $urlHelper->getUrl(), 'Can not remove query parameter as expected');
     }
 
     /**
@@ -101,7 +102,7 @@ class UrlHelperTest extends UnitTest
     public function testGetUrl($inputUrl, $expectedOutputUrl)
     {
         $urlHelper = new UrlHelper($inputUrl);
-        $this->assertSame($expectedOutputUrl, $urlHelper->getUrl(), 'Can not get expected output url');
+        self::assertSame($expectedOutputUrl, $urlHelper->getUrl(), 'Can not get expected output url');
     }
 
     /**
@@ -111,7 +112,7 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper('http://www.google.de/test/index.php?foo=bar');
         $urlHelper->setHost('www.test.de');
-        $this->assertSame('http://www.test.de/test/index.php?foo=bar', $urlHelper->getUrl());
+        self::assertSame('http://www.test.de/test/index.php?foo=bar', $urlHelper->getUrl());
     }
 
     /**
@@ -121,7 +122,7 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper('http://www.google.de/test/index.php?foo=bar');
         $urlHelper->setHost('www.test.de:8080');
-        $this->assertSame('http://www.test.de:8080/test/index.php?foo=bar', $urlHelper->getUrl());
+        self::assertSame('http://www.test.de:8080/test/index.php?foo=bar', $urlHelper->getUrl());
     }
 
     /**
@@ -131,7 +132,7 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper('http://www.google.de/test/index.php?foo=bar');
         $urlHelper->setScheme('https');
-        $this->assertSame('https://www.google.de/test/index.php?foo=bar', $urlHelper->getUrl());
+        self::assertSame('https://www.google.de/test/index.php?foo=bar', $urlHelper->getUrl());
     }
 
     /**
@@ -141,7 +142,7 @@ class UrlHelperTest extends UnitTest
     {
         $urlHelper = new UrlHelper('http://www.google.de/one/two?foo=bar');
         $urlHelper->setPath('/one/two');
-        $this->assertSame('http://www.google.de/one/two?foo=bar', $urlHelper->getUrl());
+        self::assertSame('http://www.google.de/one/two?foo=bar', $urlHelper->getUrl());
     }
 
     public function unmodifiedUrl()
@@ -149,7 +150,7 @@ class UrlHelperTest extends UnitTest
         return [
             'noQuery' => ['http://www.site.de/en/test'],
             'withQuery' => ['http://www.site.de/en/test?id=1'],
-            'withQueries' => ['http://www.site.de/en/test?id=1&L=2']
+            'withQueries' => ['http://www.site.de/en/test?id=1&L=2'],
 
         ];
     }
@@ -159,6 +160,6 @@ class UrlHelperTest extends UnitTest
     public function testGetUnmodifiedUrl($uri)
     {
         $urlHelper = new UrlHelper($uri);
-        $this->assertSame($uri, $urlHelper->getUrl(), 'Could not get unmodified url');
+        self::assertSame($uri, $urlHelper->getUrl(), 'Could not get unmodified url');
     }
 }

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Service;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Service;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -41,18 +42,18 @@ class FlexFormUserFunctionsTest extends UnitTest
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
 
-        $userFunc->expects($this->once())->method('getFieldNamesFromSolrMetaDataForPage')->will($this->returnValue(['type', 'pid', 'uid']));
-        $userFunc->expects($this->once())->method('getConfiguredFacetsForPage')->will($this->returnValue([]));
+        $userFunc->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')->willReturn(['type', 'pid', 'uid']);
+        $userFunc->expects(self::once())->method('getConfiguredFacetsForPage')->willReturn([]);
 
         $parentInformation = [
             'flexParentDatabaseRow' => [
-                'pid' => 4711
-            ]
+                'pid' => 4711,
+            ],
         ];
 
         $userFunc->getFacetFieldsFromSchema($parentInformation);
-        $this->assertCount(3, $parentInformation['items']);
-        $this->assertEquals(0, $parentInformation['items'][0][0] ?? null);
+        self::assertCount(3, $parentInformation['items']);
+        self::assertEquals(0, $parentInformation['items'][0][0] ?? null);
     }
 
     /**
@@ -62,25 +63,25 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
+            ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
 
-        $userFunc->expects($this->once())->method('getFieldNamesFromSolrMetaDataForPage')->will($this->returnValue(['type', 'pid', 'uid']));
-        $userFunc->expects($this->once())->method('getConfiguredFacetsForPage')->will($this->returnValue([
+        $userFunc->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')->willReturn(['type', 'pid', 'uid']);
+        $userFunc->expects(self::once())->method('getConfiguredFacetsForPage')->willReturn([
             'myType.' => [
                 'field' => 'type',
-                'label' => 'The type'
-            ]
-        ]));
+                'label' => 'The type',
+            ],
+        ]);
 
         $parentInformation = [
             'flexParentDatabaseRow' => [
-                'pid' => 4711
-            ]
+                'pid' => 4711,
+            ],
         ];
 
         $userFunc->getFacetFieldsFromSchema($parentInformation);
-        $this->assertCount(3, $parentInformation['items']);
-        $this->assertEquals('type (Facet Label: "The type")', $parentInformation['items']['type'][0]);
+        self::assertCount(3, $parentInformation['items']);
+        self::assertEquals('type (Facet Label: "The type")', $parentInformation['items']['type'][0]);
     }
 
     /**
@@ -90,30 +91,31 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
-        $flexFormUserFunctionsMock->expects($this->once())->method('getFieldNamesFromSolrMetaDataForPage')
-            ->will($this->returnValue(['some_field', 'someOther_field'])
-        );
+            ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
+        $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
+            ->willReturn(
+                ['some_field', 'someOther_field']
+            );
 
-        $flexFormUserFunctionsMock->expects($this->once())->method('getConfiguredFacetsForPage')
-            ->will($this->returnValue([
+        $flexFormUserFunctionsMock->expects(self::once())->method('getConfiguredFacetsForPage')
+            ->willReturn([
                 'someFacet.' => [
                     'field' => 'some_field',
-                    'label' => 'TEXT'
+                    'label' => 'TEXT',
                 ],
                 'someOtherFacet.' => [
                     'field' => 'someOther_field',
-                    'label' => 'TEXT'
-                ]
-            ]));
+                    'label' => 'TEXT',
+                ],
+            ]);
 
         $parentInformation = [
             'flexParentDatabaseRow' => [
-                'pid' => 4711
-            ]
+                'pid' => 4711,
+            ],
         ];
         $flexFormUserFunctionsMock->getFacetFieldsFromSchema($parentInformation);
-        $this->assertCount(2, $parentInformation['items']);
+        self::assertCount(2, $parentInformation['items']);
     }
 
     /**
@@ -123,48 +125,47 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage','getTranslation'])->getMock();
-        $flexFormUserFunctionsMock->expects($this->once())->method('getFieldNamesFromSolrMetaDataForPage')
-            ->will($this->returnValue(['some_field', 'someOther_field', 'someQuiteOther_field', 'uid', 'pid']));
+            ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage', 'getTranslation'])->getMock();
+        $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
+            ->willReturn(['some_field', 'someOther_field', 'someQuiteOther_field', 'uid', 'pid']);
 
-        $flexFormUserFunctionsMock->expects($this->once())->method('getConfiguredFacetsForPage')
-            ->will($this->returnValue([
+        $flexFormUserFunctionsMock->expects(self::once())->method('getConfiguredFacetsForPage')
+            ->willReturn([
                 'someFacet.' => [
                     'field' => 'some_field',
-                    'label' => 'LLL:EXT:some_ext/locallang.xlf:existing_label'
+                    'label' => 'LLL:EXT:some_ext/locallang.xlf:existing_label',
                 ],
                 'someOtherFacet.' => [
                     'field' => 'someOther_field',
-                    'label' => 'LLL:EXT:some_ext/locallang.xlf:not_existing_label'
+                    'label' => 'LLL:EXT:some_ext/locallang.xlf:not_existing_label',
                 ],
                 'someQuiteOtherFacet.' => [
                     'field' => 'someQuiteOther_field',
-                    'label' => 'LLL:EXT:some_ext/locallang.xlf:not_existing_label'
-                ]
-            ]));
+                    'label' => 'LLL:EXT:some_ext/locallang.xlf:not_existing_label',
+                ],
+            ]);
 
-        $flexFormUserFunctionsMock->expects($this->any())->method('getTranslation')->will(
-            $this->returnCallback(function() {
+        $flexFormUserFunctionsMock->expects(self::any())->method('getTranslation')->willReturnCallback(
+            function () {
                 $args = func_get_args();
                 if ($args[0] === 'LLL:EXT:some_ext/locallang.xlf:existing_label') {
                     return 'Translated Facet';
                 }
                 return '';
-            })
+            }
         );
-
 
         $parentInformation = [
             'flexParentDatabaseRow' => [
-                'pid' => 4711
-            ]
+                'pid' => 4711,
+            ],
         ];
         $flexFormUserFunctionsMock->getFacetFieldsFromSchema($parentInformation);
 
-        $this->assertCount(5, $parentInformation['items']);
-        $this->assertEquals('some_field (Facet Label: "Translated Facet")', $parentInformation['items']['some_field'][0]);
-        $this->assertEquals('someOther_field (Facet Label: "LLL:EXT:some_ext/locallang.xlf:not_existing_label")', $parentInformation['items']['someOther_field'][0]);
-        $this->assertEquals('someQuiteOther_field (Facet Label: "LLL:EXT:some_ext/locallang.xlf:not_existing_label")', $parentInformation['items']['someQuiteOther_field'][0]);
+        self::assertCount(5, $parentInformation['items']);
+        self::assertEquals('some_field (Facet Label: "Translated Facet")', $parentInformation['items']['some_field'][0]);
+        self::assertEquals('someOther_field (Facet Label: "LLL:EXT:some_ext/locallang.xlf:not_existing_label")', $parentInformation['items']['someOther_field'][0]);
+        self::assertEquals('someQuiteOther_field (Facet Label: "LLL:EXT:some_ext/locallang.xlf:not_existing_label")', $parentInformation['items']['someQuiteOther_field'][0]);
     }
 
     /**
@@ -174,27 +175,27 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
-        $flexFormUserFunctionsMock->expects($this->once())->method('getFieldNamesFromSolrMetaDataForPage')
-            ->will($this->returnValue(['some_field', 'someOther_field', 'someQuiteOther_field']));
+            ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
+        $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
+            ->willReturn(['some_field', 'someOther_field', 'someQuiteOther_field']);
 
-        $flexFormUserFunctionsMock->expects($this->once())->method('getConfiguredFacetsForPage')
-            ->will($this->returnValue([
+        $flexFormUserFunctionsMock->expects(self::once())->method('getConfiguredFacetsForPage')
+            ->willReturn([
                 'someFacet.' => [
                     'field' => 'some_field',
                     'label' => 'TEXT',
-                    'label.' => 'LLL:EXT:some_ext/locallang.xlf:existing_label'
-                ]
-            ]));
+                    'label.' => 'LLL:EXT:some_ext/locallang.xlf:existing_label',
+                ],
+            ]);
         $parentInformation = [
             'flexParentDatabaseRow' => [
-                'pid' => 4711
-            ]
+                'pid' => 4711,
+            ],
         ];
         $flexFormUserFunctionsMock->getFacetFieldsFromSchema($parentInformation);
 
-        $this->assertCount(3, $parentInformation['items']);
-        $this->assertEquals('some_field (Facet Label: "cObject[...faceting.facets.someFacet.label]")', $parentInformation['items']['some_field'][0]);
+        self::assertCount(3, $parentInformation['items']);
+        self::assertEquals('some_field (Facet Label: "cObject[...faceting.facets.someFacet.label]")', $parentInformation['items']['some_field'][0]);
     }
 
     /**
@@ -204,21 +205,21 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods(['getConfiguredFacetsForPage'])->getMock();
+            ->onlyMethods(['getConfiguredFacetsForPage'])->getMock();
 
-        $userFunc->expects($this->once())->method('getConfiguredFacetsForPage')->will($this->returnValue([
+        $userFunc->expects(self::once())->method('getConfiguredFacetsForPage')->willReturn([
             'myType.' => [
                 'field' => 'type',
-                'label' => 'The type'
-            ]
-        ]));
+                'label' => 'The type',
+            ],
+        ]);
 
         $parentInformation = [
-            'flexParentDatabaseRow' => null
+            'flexParentDatabaseRow' => null,
         ];
 
         $userFunc->getFacetFieldsFromSchema($parentInformation);
-        $this->assertCount(0, $parentInformation['items']);
+        self::assertCount(0, $parentInformation['items']);
     }
 
     /**
@@ -228,31 +229,30 @@ class FlexFormUserFunctionsTest extends UnitTest
     {
         /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
-            ->setMethods([
+            ->onlyMethods([
                 'getAvailableTemplateFromTypoScriptConfiguration',
-                'getConfigurationFromPageId'
+                'getConfigurationFromPageId',
             ])->getMock();
 
-        $userFunc->expects($this->once())->method('getAvailableTemplateFromTypoScriptConfiguration')
+        $userFunc->expects(self::once())->method('getAvailableTemplateFromTypoScriptConfiguration')
             ->with(4711, 'results')
-            ->will($this->returnValue([
+            ->willReturn([
             'myTemplate.' => [
                 'label' => 'MyCustomTemplate',
-                'file' => 'Results'
-            ]
-        ]));
+                'file' => 'Results',
+            ],
+        ]);
 
         $parentInformation = [
             'flexParentDatabaseRow' => [
                 'pid' => 4711,
             ],
-            'field' => 'view.templateFiles.results'
+            'field' => 'view.templateFiles.results',
         ];
 
         $userFunc->getAvailableTemplates($parentInformation);
 
         // we expect to get to options, the configured option and a default reset option
-        $this->assertCount(2, $parentInformation['items']);
+        self::assertCount(2, $parentInformation['items']);
     }
-
 }

--- a/Tests/Unit/System/Util/ArrayAccessorTest.php
+++ b/Tests/Unit/System/Util/ArrayAccessorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
 
 /***************************************************************
@@ -41,16 +42,16 @@ class ArrayAccessorTest extends UnitTest
     {
         $data = ['foo' => ['bla' => 1]];
         $arrayAccessor = new ArrayAccessor($data);
-        $this->assertSame(1, $arrayAccessor->get('foo:bla'));
+        self::assertSame(1, $arrayAccessor->get('foo:bla'));
 
         $data = [];
         $data['one']['two']['three']['four'] = 'test';
         $arrayAccessor = new ArrayAccessor($data);
-        $this->assertSame('test', $arrayAccessor->get('one:two:three:four'));
+        self::assertSame('test', $arrayAccessor->get('one:two:three:four'));
 
         $emptyArray = [];
         $arrayAccessor = new ArrayAccessor($emptyArray);
-        $this->assertSame(null, $arrayAccessor->get('one:two:three:four'));
+        self::assertNull($arrayAccessor->get('one:two:three:four'));
     }
 
     /**
@@ -61,13 +62,13 @@ class ArrayAccessorTest extends UnitTest
         // can set and get a simple value
         $arrayAccessor = new ArrayAccessor();
         $arrayAccessor->set('foo', 'bar');
-        $this->assertSame('bar', $arrayAccessor->get('foo'));
+        self::assertSame('bar', $arrayAccessor->get('foo'));
 
         $arrayAccessor->set('one:two:three', 'test');
-        $this->assertSame('test', $arrayAccessor->get('one:two:three'));
+        self::assertSame('test', $arrayAccessor->get('one:two:three'));
 
         $arrayAccessor->set('one:two:three', ['four' => 'test2']);
-        $this->assertSame('test2', $arrayAccessor->get('one:two:three:four'));
+        self::assertSame('test2', $arrayAccessor->get('one:two:three:four'));
     }
 
     /**
@@ -78,13 +79,13 @@ class ArrayAccessorTest extends UnitTest
         $data = ['one' => ['two' => ['a' => 111, 'b' => 222]]];
         // can set and get a simple value
         $arrayAccessor = new ArrayAccessor($data);
-        $this->assertSame(111, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+        self::assertSame(111, $arrayAccessor->get('one:two:a'));
+        self::assertSame(222, $arrayAccessor->get('one:two:b'));
 
         $arrayAccessor->reset('one:two:a');
 
-        $this->assertSame(null, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+        self::assertNull($arrayAccessor->get('one:two:a'));
+        self::assertSame(222, $arrayAccessor->get('one:two:b'));
     }
 
     /**
@@ -95,14 +96,14 @@ class ArrayAccessorTest extends UnitTest
         $data = ['one' => ['two' => ['a' => 111, 'b' => 222]]];
         // can set and get a simple value
         $arrayAccessor = new ArrayAccessor($data);
-        $this->assertSame(111, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+        self::assertSame(111, $arrayAccessor->get('one:two:a'));
+        self::assertSame(222, $arrayAccessor->get('one:two:b'));
 
         $arrayAccessor->reset('one:two:a');
 
-        $this->assertSame(null, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
-        $this->assertSame(['b' => 222], $arrayAccessor->get('one:two'));
+        self::assertNull($arrayAccessor->get('one:two:a'));
+        self::assertSame(222, $arrayAccessor->get('one:two:b'));
+        self::assertSame(['b' => 222], $arrayAccessor->get('one:two'));
     }
 
     /**
@@ -113,20 +114,20 @@ class ArrayAccessorTest extends UnitTest
         $data = [
             'one' => [
                 'two' => ['a' => 111, 'b' => 222],
-                'three' => 333
-            ]
+                'three' => 333,
+            ],
         ];
         // can set and get a simple value
         $arrayAccessor = new ArrayAccessor($data);
-        $this->assertSame(111, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(222, $arrayAccessor->get('one:two:b'));
+        self::assertSame(111, $arrayAccessor->get('one:two:a'));
+        self::assertSame(222, $arrayAccessor->get('one:two:b'));
 
         $arrayAccessor->reset('one:two');
 
-        $this->assertSame(null, $arrayAccessor->get('one:two:a'));
-        $this->assertSame(null, $arrayAccessor->get('one:two:b'));
-        $this->assertSame(null, $arrayAccessor->get('one:two'));
+        self::assertNull($arrayAccessor->get('one:two:a'));
+        self::assertNull($arrayAccessor->get('one:two:b'));
+        self::assertNull($arrayAccessor->get('one:two'));
 
-        $this->assertSame(333, $arrayAccessor->get('one:three'));
+        self::assertSame(333, $arrayAccessor->get('one:three'));
     }
 }

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
 
 /***************************************************************
@@ -36,9 +37,10 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
  */
 class SiteUtilityTest extends UnitTest
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         SiteUtility::$languages = [];
+        parent::tearDown();
     }
 
     /**
@@ -48,13 +50,13 @@ class SiteUtilityTest extends UnitTest
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
         $languageMock = $this->getDumbMock(SiteLanguage::class);
-        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+        $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $property = SiteUtility::getConnectionProperty($siteMock, 'core', 2, 'write');
 
-        $this->assertSame('readcore', $property, 'Can not fallback to read property when write property is undefined');
+        self::assertSame('readcore', $property, 'Can not fallback to read property when write property is undefined');
     }
 
     /**
@@ -64,15 +66,15 @@ class SiteUtilityTest extends UnitTest
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
         $languageMock = $this->getDumbMock(SiteLanguage::class);
-        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+        $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
         $globalConfiguration = ['solr_host_read' => 'readhost'];
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
-        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($globalConfiguration);
+        $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects(self::any())->method('getConfiguration')->willReturn($globalConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
 
-        $this->assertSame('readhost', $property, 'Can not fallback to read property when write property is undefined');
+        self::assertSame('readhost', $property, 'Can not fallback to read property when write property is undefined');
     }
 
     /**
@@ -86,24 +88,24 @@ class SiteUtilityTest extends UnitTest
                 'expectedSiteMockConfiguration' => [
                     'solr_host_read' => 'readhost',
                     'solr_use_write_connection' => true,
-                    'solr_host_write' => 'writehost'
-                ]
+                    'solr_host_write' => 'writehost',
+                ],
             ],
             [ // enabling solr_use_write_connection but not specifying write host, falls back to specified read host
                 'expectedSolrHost' => 'readhost',
                 'expectedSiteMockConfiguration' => [
                     'solr_host_read' => 'readhost',
-                    'solr_use_write_connection' => true
-                ]
+                    'solr_use_write_connection' => true,
+                ],
             ],
             [ // disabling solr_use_write_connection and specifying write host, falls back to specified read host
                 'expectedSolrHost' => 'readhost',
                 'expectedSiteMockConfiguration' => [
                     'solr_host_read' => 'readhost',
                     'solr_use_write_connection' => false,
-                    'solr_host_write' => 'writehost'
-                ]
-            ]
+                    'solr_host_write' => 'writehost',
+                ],
+            ],
         ];
     }
 
@@ -116,12 +118,15 @@ class SiteUtilityTest extends UnitTest
     public function solr_use_write_connectionSiteSettingInfluencesTheWriteConnection(string $expectedSolrHost, array $expectedSiteMockConfiguration)
     {
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($expectedSiteMockConfiguration);
+        $siteMock->expects(self::any())->method('getConfiguration')->willReturn($expectedSiteMockConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 0, 'write');
 
-        $this->assertEquals($expectedSolrHost, $property,
+        self::assertEquals(
+            $expectedSolrHost,
+            $property,
             'The setting "solr_use_write_connection" from sites config.yaml has no influence on system.' .
-            'The setting "solr_use_write_connection=true/false" must enable or disable the write connection respectively.');
+            'The setting "solr_use_write_connection=true/false" must enable or disable the write connection respectively.'
+        );
     }
 
     /**
@@ -131,15 +136,15 @@ class SiteUtilityTest extends UnitTest
     {
         $languageConfiguration = ['solr_host_read' => 'readhost.local.de'];
         $languageMock = $this->getDumbMock(SiteLanguage::class);
-        $languageMock->expects($this->any())->method('toArray')->willReturn($languageConfiguration);
+        $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
         $globalConfiguration = ['solr_host_read' => 'readhost.global.de'];
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
-        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($globalConfiguration);
+        $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects(self::any())->method('getConfiguration')->willReturn($globalConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
 
-        $this->assertSame('readhost.local.de', $property, 'Can not fallback to read property when write property is undefined');
+        self::assertSame('readhost.local.de', $property, 'Can not fallback to read property when write property is undefined');
     }
 
     /**
@@ -149,10 +154,10 @@ class SiteUtilityTest extends UnitTest
     {
         $languageMock = $this->getDumbMock(SiteLanguage::class);
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getLanguageById')->willReturn($languageMock);
+        $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $property = SiteUtility::getConnectionProperty($siteMock, 'some_property', 2, 'read', 'value-of_some_property');
 
-        $this->assertEquals('value-of_some_property', $property, 'Can not fall back to defaultValue.');
+        self::assertEquals('value-of_some_property', $property, 'Can not fall back to defaultValue.');
     }
 
     /**
@@ -165,86 +170,86 @@ class SiteUtilityTest extends UnitTest
         return [
             [ // directly set boolean value (true) for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => true
+                    'solr_enabled_read' => true,
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => true
+                'expectedConfigurationValue' => true,
             ],
             [ // directly set boolean value (false) for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => false
+                    'solr_enabled_read' => false,
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => false
+                'expectedConfigurationValue' => false,
             ],
             [ // boolean value (true) set via environment variable for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => 'true'
+                    'solr_enabled_read' => 'true',
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => true
+                'expectedConfigurationValue' => true,
             ],
             [ // boolean value (false) set via environment variable for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => 'false'
+                    'solr_enabled_read' => 'false',
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => false
+                'expectedConfigurationValue' => false,
             ],
             [ // string '0' for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => '0'
+                    'solr_enabled_read' => '0',
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => '0'
+                'expectedConfigurationValue' => '0',
             ],
             [ // int 0 value for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => 0
+                    'solr_enabled_read' => 0,
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => 0
+                'expectedConfigurationValue' => 0,
             ],
             [ // int 0 value for solr_enabled_read
                 'fakeConfiguration' => [
-                    'solr_enabled_read' => 0
+                    'solr_enabled_read' => 0,
                 ],
                 'property' => 'enabled',
                 'scope' => 'read',
-                'expectedConfigurationValue' => 0
+                'expectedConfigurationValue' => 0,
             ],
             [ // int 8080 value for solr_port_read
                 'fakeConfiguration' => [
-                    'solr_port_read' => 8080
+                    'solr_port_read' => 8080,
                 ],
                 'property' => 'port',
                 'scope' => 'read',
-                'expectedConfigurationValue' => 8080
+                'expectedConfigurationValue' => 8080,
             ],
             [ // core_en value for solr_core_read
                 'fakeConfiguration' => [
                     'solr_core_read' => 'core_en',
-                    'solr_core_write' => 'core_en_write'
+                    'solr_core_write' => 'core_en_write',
                 ],
                 'property' => 'core',
                 'scope' => 'read',
-                'expectedConfigurationValue' => 'core_en'
+                'expectedConfigurationValue' => 'core_en',
             ],
             [ // core_en_write value for solr_core_write, use right scope
                 'fakeConfiguration' => [
                     'solr_use_write_connection' => 1,
                     'solr_core_read' => 'core_en',
-                    'solr_core_write' => 'core_en_write'
+                    'solr_core_write' => 'core_en_write',
                 ],
                 'property' => 'core',
                 'scope' => 'write',
-                'expectedConfigurationValue' => 'core_en_write'
+                'expectedConfigurationValue' => 'core_en_write',
             ],
             [ // core_en value for solr_core_read, tests fallback to read
                 'fakeConfiguration' => [
@@ -253,18 +258,18 @@ class SiteUtilityTest extends UnitTest
                 ],
                 'property' => 'core',
                 'scope' => 'write',
-                'expectedConfigurationValue' => 'core_en'
+                'expectedConfigurationValue' => 'core_en',
             ],
             [ // disabled write connection via int 0 for solr_enabled_write, use right scope
                 'fakeConfiguration' => [
                     'solr_use_write_connection' => 1,
                     'solr_enabled_read' => '1',
-                    'solr_enabled_write' => '0'
+                    'solr_enabled_write' => '0',
                 ],
                 'property' => 'enabled',
                 'scope' => 'write',
-                'expectedConfigurationValue' => '0'
-            ]
+                'expectedConfigurationValue' => '0',
+            ],
         ];
     }
 
@@ -279,16 +284,16 @@ class SiteUtilityTest extends UnitTest
      * @test
      * @dataProvider siteConfigurationValueHandlingDataProvider
      */
-    public function canHandleSiteConfigurationValues (
+    public function canHandleSiteConfigurationValues(
         array $fakeConfiguration,
         string $property,
         string $scope,
         $expectedConfigurationValue
     ) {
         $siteMock = $this->getDumbMock(Site::class);
-        $siteMock->expects($this->any())->method('getConfiguration')->willReturn($fakeConfiguration);
+        $siteMock->expects(self::any())->method('getConfiguration')->willReturn($fakeConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, $property, 0, $scope);
 
-        $this->assertEquals($expectedConfigurationValue, $property, 'Value from site configuration not read/handled correctly.');
+        self::assertEquals($expectedConfigurationValue, $property, 'Value from site configuration not read/handled correctly.');
     }
 }

--- a/Tests/Unit/System/Validator/PathTest.php
+++ b/Tests/Unit/System/Validator/PathTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Validator;
 
 /***************************************************************
@@ -43,7 +44,7 @@ class PathTest extends UnitTest
         $path = GeneralUtility::makeInstance(Path::class);
         $isValidPath = $path->isValidSolrPath('/sorl/core_da');
 
-        $this->assertTrue($isValidPath);
+        self::assertTrue($isValidPath);
     }
 
     /**
@@ -54,7 +55,7 @@ class PathTest extends UnitTest
         $path = GeneralUtility::makeInstance(Path::class);
         $isValidPath = $path->isValidSolrPath('');
 
-        $this->assertFalse($isValidPath);
+        self::assertFalse($isValidPath);
     }
 
     /**
@@ -65,7 +66,7 @@ class PathTest extends UnitTest
         $path = GeneralUtility::makeInstance(Path::class);
         $isValidPath = $path->isValidSolrPath('/sorl/#/core_da');
 
-        $this->assertFalse($isValidPath);
+        self::assertFalse($isValidPath);
     }
 
     /**
@@ -76,7 +77,6 @@ class PathTest extends UnitTest
         $path = GeneralUtility::makeInstance(Path::class);
         $isValidPath = $path->isValidSolrPath('/sorl/core_da?bogus');
 
-        $this->assertFalse($isValidPath);
+        self::assertFalse($isValidPath);
     }
-
 }

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 /***************************************************************
@@ -25,16 +26,16 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingFinishedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Scheduler\Scheduler;
 use TYPO3\CMS\Scheduler\Execution;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
-use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingFinishedEvent;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * Testcase for EventQueueWorkerTask
@@ -46,18 +47,19 @@ class EventQueueWorkerTaskTest extends UnitTest
     /**
      * @var EventQueueWorkerTask
      */
-    protected  $task;
+    protected $task;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         GeneralUtility::setSingletonInstance(Scheduler::class, $this->createMock(Scheduler::class));
         GeneralUtility::addInstance(Execution::class, $this->createMock(Execution::class));
 
         $this->task = new EventQueueWorkerTask();
         $this->task->setLimit(99);
+        parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GeneralUtility::purgeInstances();
         parent::tearDown();
@@ -80,38 +82,38 @@ class EventQueueWorkerTaskTest extends UnitTest
         $unserializedEvent = unserialize($serializedEvent);
         $queueItem = [
             'uid' => 10,
-            'event' => $serializedEvent
+            'event' => $serializedEvent,
         ];
 
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getEventQueueItems')
             ->with(99)
             ->willReturn([$queueItem]);
 
         $dispatchedEvents = [];
         $eventDispatcherMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('dispatch')
-            ->will($this->returnCallback(function() use (&$dispatchedEvents) {
+            ->willReturnCallback(function () use (&$dispatchedEvents) {
                 $dispatchedEvents[] = func_get_arg(0);
-            }));
+            });
 
         $eventQueueItemRepositoryMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('updateEventQueueItem');
 
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteEventQueueItems')
             ->with([10]);
 
         $this->task->execute();
 
         $unserializedEvent->setForceImmediateProcessing(true);
-        $this->assertCount(2, $dispatchedEvents);
-        $this->assertEquals($unserializedEvent, $dispatchedEvents[0]);
-        $this->assertTrue($dispatchedEvents[1] instanceof DelayedProcessingFinishedEvent);
+        self::assertCount(2, $dispatchedEvents);
+        self::assertEquals($unserializedEvent, $dispatchedEvents[0]);
+        self::assertTrue($dispatchedEvents[1] instanceof DelayedProcessingFinishedEvent);
     }
 
     /**
@@ -133,32 +135,32 @@ class EventQueueWorkerTaskTest extends UnitTest
         $unserializedEvent = unserialize($serializedEvent);
         $queueItem = [
             'uid' => 10,
-            'event' => $serializedEvent
+            'event' => $serializedEvent,
         ];
 
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getEventQueueItems')
             ->with(99)
             ->willReturn([$queueItem]);
 
         $eventDispatcherMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch')
             ->willThrowException(new \Exception('', 1641889238));
 
         $solrLogManagerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('log')
-            ->with(SolrLogManager::ERROR, $this->anything(), $this->anything());
+            ->with(SolrLogManager::ERROR, self::anything(), self::anything());
 
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateEventQueueItem')
             ->with(10, ['error' => 1, 'error_message' => '[1641889238]']);
 
         $eventQueueItemRepositoryMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteEventQueueItems')
             ->with([]);
 

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 /***************************************************************
@@ -44,19 +45,19 @@ class IndexQueueWorkerTaskTest extends UnitTest
         /** @var $indexQueuerWorker IndexQueueWorkerTask */
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
             ->disableOriginalConstructor()
-            ->setMethods(['execute'])
+            ->onlyMethods(['execute'])
             ->getMock();
 
         // by default the webroot should be Environment::getPublicPath()
-        $this->assertSame(Environment::getPublicPath() . '/', $indexQueuerWorker->getWebRoot(), 'Not using PATH_site as webroot');
+        self::assertSame(Environment::getPublicPath() . '/', $indexQueuerWorker->getWebRoot(), 'Not using PATH_site as webroot');
 
         // can we overwrite it?
         $indexQueuerWorker->setForcedWebRoot('/var/www/foobar.de/subdir');
-        $this->assertSame('/var/www/foobar.de/subdir', $indexQueuerWorker->getWebRoot(), 'Can not force a webroot');
+        self::assertSame('/var/www/foobar.de/subdir', $indexQueuerWorker->getWebRoot(), 'Can not force a webroot');
 
         // can we use a marker?
         $indexQueuerWorker->setForcedWebRoot('###PATH_site###../test/');
-        $this->assertSame(Environment::getPublicPath() . '/../test/', $indexQueuerWorker->getWebRoot(), 'Could not use a marker in forced webroot');
+        self::assertSame(Environment::getPublicPath() . '/../test/', $indexQueuerWorker->getWebRoot(), 'Could not use a marker in forced webroot');
     }
 
     /**
@@ -64,14 +65,14 @@ class IndexQueueWorkerTaskTest extends UnitTest
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-            /** @var $indexQueuerWorker IndexQueueWorkerTask */
+        /** @var $indexQueuerWorker IndexQueueWorkerTask */
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSite'])
+            ->onlyMethods(['getSite'])
             ->getMock();
 
         $mesage = $indexQueuerWorker->getAdditionalInformation();
         $expectedMessage = 'Invalid site configuration for scheduler please re-create the task!';
-        $this->assertSame($expectedMessage, $mesage, 'Expect to get error message of non existing site');
+        self::assertSame($expectedMessage, $mesage, 'Expect to get error message of non existing site');
     }
 }

--- a/Tests/Unit/Task/OptimizeIndexTaskTest.php
+++ b/Tests/Unit/Task/OptimizeIndexTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 /*
@@ -29,14 +30,14 @@ class OptimizeIndexTaskTest extends UnitTest
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-            /** @var $indexQueuerWorker OptimizeIndexTask */
+        /** @var $indexQueuerWorker OptimizeIndexTask */
         $indexQueuerWorker = $this->getMockBuilder(OptimizeIndexTask::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSite'])
+            ->onlyMethods(['getSite'])
             ->getMock();
 
         $message = $indexQueuerWorker->getAdditionalInformation();
         $expectedMessage = 'Invalid site configuration for scheduler please re-create the task!';
-        $this->assertSame($expectedMessage, $message, 'Expect to get error message of non existing site');
+        self::assertSame($expectedMessage, $message, 'Expect to get error message of non existing site');
     }
 }

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 /***************************************************************
@@ -40,14 +41,14 @@ class ReIndexTaskTest extends UnitTest
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-            /** @var $indexQueuerWorker ReIndexTask */
+        /** @var $indexQueuerWorker ReIndexTask */
         $indexQueuerWorker = $this->getMockBuilder(ReIndexTask::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSite'])
+            ->onlyMethods(['getSite'])
             ->getMock();
 
         $mesage = $indexQueuerWorker->getAdditionalInformation();
         $expectedMessage = 'Invalid site configuration for scheduler please re-create the task!';
-        $this->assertSame($expectedMessage, $mesage, 'Expect to get error message of non existing site');
+        self::assertSame($expectedMessage, $mesage, 'Expect to get error message of non existing site');
     }
 }

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -41,12 +42,13 @@ class Typo3PageContentExtractorTest extends UnitTest
      */
     protected $typoScripConfigurationMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->typoScripConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->typoScripConfigurationMock->expects($this->once())->method(
+        $this->typoScripConfigurationMock->expects(self::once())->method(
             'getIndexQueuePagesExcludeContentByClassArray'
-        )->will($this->returnValue(['typo3-search-exclude']));
+        )->willReturn(['typo3-search-exclude']);
+        parent::setUp();
     }
 
     /**
@@ -60,7 +62,7 @@ class Typo3PageContentExtractorTest extends UnitTest
         $contentExtractor = GeneralUtility::makeInstance(Typo3PageContentExtractor::class, $content);
         $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
         $actualResult = $contentExtractor->getIndexableContent();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -75,7 +77,7 @@ class Typo3PageContentExtractorTest extends UnitTest
         $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -90,8 +92,8 @@ class Typo3PageContentExtractorTest extends UnitTest
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
 
-        $this->assertStringContainsString('Was ein schöner Tag', $actualResult);
-        $this->assertStringNotContainsString('Remove me', $actualResult);
+        self::assertStringContainsString('Was ein schöner Tag', $actualResult);
+        self::assertStringNotContainsString('Remove me', $actualResult);
     }
 
     /**
@@ -106,49 +108,49 @@ class Typo3PageContentExtractorTest extends UnitTest
 
         $actualResult = $contentExtractor->excludeContentByClass($content);
 
-        $this->assertStringContainsString('100€', $actualResult);
-        $this->assertStringNotContainsString('Remove me', $actualResult);
+        self::assertStringContainsString('100€', $actualResult);
+        self::assertStringNotContainsString('Remove me', $actualResult);
     }
 
-    public function canGetIndexableContentDataProvider() {
+    public function canGetIndexableContentDataProvider()
+    {
         return [
             'can extract simple text' => [
                 'content' => '<p>Hello solr for TYPO3</p>',
-                'expectedResult' => 'Hello solr for TYPO3'
+                'expectedResult' => 'Hello solr for TYPO3',
             ],
             'can extract umlauts' => [
                 'content' => '<p>Heute ist ein sch&ouml;ner tag</p>',
-                'expectedResult' => 'Heute ist ein schöner tag'
+                'expectedResult' => 'Heute ist ein schöner tag',
             ],
             'can extract subtag content' => [
                 'content' => '<p>Heute ist ein <strong>sch&ouml;ner</strong> tag</p>',
-                'expectedResult' => 'Heute ist ein schöner tag'
+                'expectedResult' => 'Heute ist ein schöner tag',
             ],
             'removes inline styles' => [
                 'content' => '<style> body { background-color: linen; }</style><p>Heute ist ein <strong>sch&ouml;ner</strong> tag</p>',
-                'expectedResult' => 'Heute ist ein schöner tag'
+                'expectedResult' => 'Heute ist ein schöner tag',
             ],
             'removes a line break' => [
                 'content' => '<p>If <b>the value</b> is <br/> please contact me</p>',
-                'expectedResult' => 'If the value is please contact me'
+                'expectedResult' => 'If the value is please contact me',
             ],
             'keep less then character' => [
                 'content' => '<p>If <b>the value</b> is &lt;50 please contact me</p>',
-                'expectedResult' => 'If the value is <50 please contact me'
+                'expectedResult' => 'If the value is <50 please contact me',
             ],
             'keep escaped html' => [
                 'content' => '<em>this</em> is how to make &lt;b&gt;fat&lt;/b&gt;',
-                'expectedResult' => 'this is how to make <b>fat</b>'
+                'expectedResult' => 'this is how to make <b>fat</b>',
             ],
             'support chinese characters' => [
                 'content' => '媒体和投资者 新闻 财务报告 公司股票信息 概览',
-                'expectedResult' => '媒体和投资者 新闻 财务报告 公司股票信息 概览'
+                'expectedResult' => '媒体和投资者 新闻 财务报告 公司股票信息 概览',
             ],
         ];
     }
 
     /**
-     *
      * @dataProvider canGetIndexableContentDataProvider
      * @test
      */
@@ -160,6 +162,6 @@ class Typo3PageContentExtractorTest extends UnitTest
         $contentExtractor->setConfiguration($this->typoScripConfigurationMock);
 
         $actualResult = $contentExtractor->getIndexableContent();
-        $this->assertStringContainsString($expectedResult, $actualResult);
+        self::assertStringContainsString($expectedResult, $actualResult);
     }
 }

--- a/Tests/Unit/UnitTest.php
+++ b/Tests/Unit/UnitTest.php
@@ -1,42 +1,39 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2010-2015 Timo Schmidt <timo.schmidt@dkd.de>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Information\Typo3Version;
+use ReflectionClass;
+use ReflectionException;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Base class for all unit tests in the solr project
  *
- * @author Timo Schmidt
+ * @author Timo Hund
  */
 abstract class UnitTest extends UnitTestCase
 {
     protected $resetSingletonInstances = true;
+
+    protected function setUp(): void
+    {
+        date_default_timezone_set('Europe/Berlin');
+        parent::setUp();
+    }
 
     /**
      * Returns a mock class where every behaviour is mocked, just to full fill
@@ -45,9 +42,9 @@ abstract class UnitTest extends UnitTestCase
      * @param string $className
      * @return MockObject
      */
-    protected function getDumbMock($className)
+    protected function getDumbMock(string $className): MockObject
     {
-        return $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+        return $this->createMock($className);
     }
 
     /**
@@ -55,7 +52,7 @@ abstract class UnitTest extends UnitTestCase
      *
      * @return string
      */
-    protected function getFixtureRootPath()
+    protected function getFixtureRootPath(): string
     {
         return $this->getRuntimeDirectory() . '/Fixtures/';
     }
@@ -66,7 +63,7 @@ abstract class UnitTest extends UnitTestCase
      * @param $fixtureName
      * @return string
      */
-    protected function getFixturePathByName($fixtureName)
+    protected function getFixturePathByName($fixtureName): string
     {
         return $this->getFixtureRootPath() . $fixtureName;
     }
@@ -77,7 +74,7 @@ abstract class UnitTest extends UnitTestCase
      * @param string $fixtureName
      * @return string
      */
-    protected function getFixtureContentByName($fixtureName)
+    protected function getFixtureContentByName($fixtureName): string
     {
         return file_get_contents($this->getFixturePathByName($fixtureName));
     }
@@ -89,18 +86,8 @@ abstract class UnitTest extends UnitTestCase
      */
     protected function getRuntimeDirectory()
     {
-        $rc = new \ReflectionClass(get_class($this));
+        $rc = new ReflectionClass(get_class($this));
         return dirname($rc->getFileName());
-    }
-
-    /**
-     * @param string $version
-     */
-    protected function skipInVersionBelow($version)
-    {
-        if (version_compare(GeneralUtility::makeInstance(Typo3Version::class)->getBranch(), $version, '<')) {
-            $this->markTestSkipped('This test requires at least version ' . $version);
-        }
     }
 
     /**
@@ -110,6 +97,7 @@ abstract class UnitTest extends UnitTestCase
      * @param string $name the name of the method to call
      * @param mixed $arguments
      * @return mixed
+     * @throws ReflectionException
      */
     protected function callInaccessibleMethod($object, $name, ...$arguments)
     {
@@ -128,7 +116,6 @@ abstract class UnitTest extends UnitTestCase
      * @param object $target The instance which needs the dependency
      * @param string $name Name of the property to be injected
      * @param mixed $dependency The dependency to inject – usually an object but can also be any other type
-     * @return void
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */

--- a/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Backend;
 
 /***************************************************************
@@ -41,13 +42,13 @@ class IsStringViewHelperTest extends UnitTest
     {
         $arguments = [
             'value' => 'givenString',
-            '__thenClosure' => function() { return 'thenResult'; },
-            '__elseClosures' => [function() { return 'elseResult'; }]
+            '__thenClosure' => function () { return 'thenResult'; },
+            '__elseClosures' => [function () { return 'elseResult'; }],
         ];
 
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $result = IsStringViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
-        $this->assertSame('thenResult', $result, 'thenClosure was not rendered');
+        $result = IsStringViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
+        self::assertSame('thenResult', $result, 'thenClosure was not rendered');
     }
 
     /**
@@ -57,12 +58,12 @@ class IsStringViewHelperTest extends UnitTest
     {
         $arguments = [
             'value' => ['givenStringInArray'],
-            '__thenClosure' => function() { return 'thenResult'; },
-            '__elseClosures' => [function() { return 'elseResult'; }]
+            '__thenClosure' => function () { return 'thenResult'; },
+            '__elseClosures' => [function () { return 'elseResult'; }],
         ];
 
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $result = IsStringViewHelper::renderStatic($arguments, function(){}, $renderingContextMock);
-        $this->assertSame('elseResult', $result, 'elseResult was not rendered');
+        $result = IsStringViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
+        self::assertSame('elseResult', $result, 'elseResult was not rendered');
     }
 }

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Document;
 
 /***************************************************************
@@ -24,12 +25,12 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Document;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\HighlightResultViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -42,26 +43,26 @@ class HighlightingResultViewHelperTest extends UnitTest
     /**
      * @return array
      */
-    public function canRenderCreateHighlightSnippedDataProvider() {
+    public function canRenderCreateHighlightSnippedDataProvider()
+    {
         return [
             [
-                ['hello <em>world</em>','hi <em>world</em>'],
+                ['hello <em>world</em>', 'hi <em>world</em>'],
                 'hello <em>world</em> ### hi <em>world</em>',
-                '<em>|</em>'
+                '<em>|</em>',
             ],
             [
-                ['hello <em>world</em>','hi <em>world</em> <h1>somethingelse</h1>'],
+                ['hello <em>world</em>', 'hi <em>world</em> <h1>somethingelse</h1>'],
                 'hello <em>world</em> ### hi <em>world</em> &lt;h1&gt;somethingelse&lt;/h1&gt;',
-                '<em>|</em>'
+                '<em>|</em>',
             ],
             [
-                ['hello <em>world</em>','hi <em>world</em> <h1>somethingelse</h1>'],
+                ['hello <em>world</em>', 'hi <em>world</em> <h1>somethingelse</h1>'],
                 'hello &lt;em&gt;world&lt;/em&gt; ### hi &lt;em&gt;world&lt;/em&gt; &lt;h1&gt;somethingelse&lt;/h1&gt;',
-                ' '
-            ]
+                ' ',
+            ],
         ];
     }
-
 
     /**
      * @dataProvider canRenderCreateHighlightSnippedDataProvider
@@ -72,50 +73,49 @@ class HighlightingResultViewHelperTest extends UnitTest
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
 
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $configurationMock->expects($this->once())->method('getSearchResultsHighlightingFragmentSeparator')->will(
-            $this->returnValue('###')
+        $configurationMock->expects(self::once())->method('getSearchResultsHighlightingFragmentSeparator')->willReturn(
+            '###'
         );
-        $configurationMock->expects($this->once())->method('getSearchResultsHighlightingWrap')->will(
-            $this->returnValue($configuredWrap)
+        $configurationMock->expects(self::once())->method('getSearchResultsHighlightingWrap')->willReturn(
+            $configuredWrap
         );
 
         $searchRequestMock = $this->getDumbMock(SearchRequest::class);
-        $searchRequestMock->expects($this->any())->method('getContextTypoScriptConfiguration')->will(
-            $this->returnValue($configurationMock)
+        $searchRequestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn(
+            $configurationMock
         );
-
 
         $fakeHighlightedContent = new \stdClass();
         $fakeHighlightedContent->foo = new \stdClass();
         $fakeHighlightedContent->foo->content = $input;
 
         $searchMock = $this->getDumbMock(Search::class);
-        $searchMock->expects($this->once())->method('getHighlightedContent')->will(
-            $this->returnValue($fakeHighlightedContent)
+        $searchMock->expects(self::once())->method('getHighlightedContent')->willReturn(
+            $fakeHighlightedContent
         );
 
-
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $resultSetMock->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue(
-           $searchRequestMock
-        ));
+        $resultSetMock->expects(self::any())->method('getUsedSearchRequest')->willReturn(
+            $searchRequestMock
+        );
 
-        $resultSetMock->expects($this->any())->method('getUsedSearch')->will($this->returnValue(
-           $searchMock
-        ));
+        $resultSetMock->expects(self::any())->method('getUsedSearch')->willReturn(
+            $searchMock
+        );
 
         $documentMock = $this->getDumbMock(SearchResult::class);
-        $documentMock->expects($this->any())->method('getId')->will($this->returnValue("foo"));
+        $documentMock->expects(self::any())->method('getId')->willReturn('foo');
 
         $viewHelper = new HighlightResultViewHelper();
         $viewHelper->setRenderingContext($renderingContextMock);
-        $viewHelper->setArguments([
+        $viewHelper->setArguments(
+            [
             'resultSet' => $resultSetMock,
             'document' => $documentMock,
-            'fieldName' => 'content']
+            'fieldName' => 'content', ]
         );
 
         $output = $viewHelper->render();
-        $this->assertSame($expectedOutput, $output);
+        self::assertSame($expectedOutput, $output);
     }
 }

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Document;
 
 /***************************************************************
@@ -24,9 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Document;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\RelevanceViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -42,19 +43,19 @@ class RelevanceViewHelperTest extends UnitTest
     public function canCalculateRelevance()
     {
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $resultSetMock->expects($this->any())->method('getMaximumScore')->will($this->returnValue(5.5));
+        $resultSetMock->expects(self::any())->method('getMaximumScore')->willReturn(5.5);
 
         $documentMock = $this->getDumbMock(SearchResult::class);
-        $documentMock->expects($this->once())->method('getScore')->will($this->returnValue(0.55));
+        $documentMock->expects(self::once())->method('getScore')->willReturn(0.55);
 
         $arguments = [
             'resultSet' => $resultSetMock,
-            'document' => $documentMock
+            'document' => $documentMock,
         ];
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
         $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
 
-        $this->assertEquals(10.0, $score, 'Unexpected score');
+        self::assertEquals(10.0, $score, 'Unexpected score');
     }
 
     /**
@@ -63,19 +64,19 @@ class RelevanceViewHelperTest extends UnitTest
     public function canCalculateRelevanceFromPassedMaximumScore()
     {
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $resultSetMock->expects($this->never())->method('getMaximumScore');
+        $resultSetMock->expects(self::never())->method('getMaximumScore');
 
         $documentMock = $this->getDumbMock(SearchResult::class);
-        $documentMock->expects($this->once())->method('getScore')->will($this->returnValue(0.55));
+        $documentMock->expects(self::once())->method('getScore')->willReturn(0.55);
 
         $arguments = [
             'resultSet' => $resultSetMock,
             'document' => $documentMock,
-            'maximumScore' => 11
+            'maximumScore' => 11,
         ];
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
         $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
 
-        $this->assertEquals(5.0, $score, 'Unexpected score');
+        self::assertEquals(5.0, $score, 'Unexpected score');
     }
 }

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Area;
 
 /***************************************************************
@@ -24,10 +25,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Area;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Area\GroupViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
@@ -44,24 +45,23 @@ class GroupViewHelperTest extends UnitTest
     {
         $facetCollection = $this->getTestFacetCollection();
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['facets'] = $facetCollection;
         $testArguments['groupName'] = 'left';
 
         GroupViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
-        $this->assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
+        self::assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
 
-            /** @var  $facetCollection FacetCollection */
+        /** @var  $facetCollection FacetCollection */
         $facetCollection = $variableContainer->get('areaFacets');
-        $this->assertEquals(2, $facetCollection->getCount());
+        self::assertEquals(2, $facetCollection->getCount());
 
         $facetKeys = array_keys($facetCollection->getArrayCopy());
-        $this->assertEquals(['color', 'brand'], $facetKeys);
+        self::assertEquals(['color', 'brand'], $facetKeys);
     }
-
 
     /**
      * @test
@@ -70,23 +70,23 @@ class GroupViewHelperTest extends UnitTest
     {
         $facetCollection = $this->getTestFacetCollection();
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
-        $viewHelper = $this->getMockBuilder(GroupViewHelper::class)->setMethods(['renderChildren'])->getMock();
+        $viewHelper = $this->getMockBuilder(GroupViewHelper::class)->onlyMethods(['renderChildren'])->getMock();
         $viewHelper->setRenderingContext($renderingContextMock);
         $viewHelper->setArguments(['facets' => $facetCollection, 'groupName' => 'left']);
         $viewHelper->render();
 
-        $this->assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
+        self::assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
 
         /** @var  $facetCollection FacetCollection */
         $facetCollection = $variableContainer->get('areaFacets');
-        $this->assertEquals(2, $facetCollection->getCount());
+        self::assertEquals(2, $facetCollection->getCount());
 
         $facetKeys = array_keys($facetCollection->getArrayCopy());
-        $this->assertEquals(['color', 'brand'], $facetKeys);
+        self::assertEquals(['color', 'brand'], $facetKeys);
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Options\Group\Prefix;
 
 /***************************************************************
@@ -26,9 +27,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Options\Group\Pre
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelFilterViewHelper;
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -57,20 +58,20 @@ class LabelFilterViewHelperTest extends UnitTest
         $optionCollection->add($red);
         $optionCollection->add($royalGreen);
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
         $testArguments['prefix'] = 'p';
 
         LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
-        $this->assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
+        self::assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
 
         /** @var  $optionCollection OptionCollection */
         $optionCollection = $variableContainer->get('filteredOptions');
-        $this->assertSame(1, $optionCollection->getCount());
-        $this->assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
+        self::assertSame(1, $optionCollection->getCount());
+        self::assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
     }
 
     /**
@@ -87,19 +88,19 @@ class LabelFilterViewHelperTest extends UnitTest
         $optionCollection->add($ben);
         $optionCollection->add($ole);
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
         $testArguments['prefix'] = 'ø';
 
         LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
-        $this->assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
+        self::assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
 
         /** @var  $optionCollection OptionCollection */
         $optionCollection = $variableContainer->get('filteredOptions');
-        $this->assertSame(1, $optionCollection->getCount());
-        $this->assertSame('Øle', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
+        self::assertSame(1, $optionCollection->getCount());
+        self::assertSame('Øle', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
     }
 }

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Options\Group\Prefix;
 
 /***************************************************************
@@ -26,8 +27,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Options\Group\Pre
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\OptionCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelPrefixesViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
@@ -44,16 +45,16 @@ class LabelPrefixesViewHelperTest extends UnitTest
     {
         $optionCollection = $this->getTestFacetOptionCollection();
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
         $testArguments['length'] = 1;
         LabelPrefixesViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
-        $this->assertTrue($variableContainer->exists('prefixes'), 'Expected that prefixes has been set');
+        self::assertTrue($variableContainer->exists('prefixes'), 'Expected that prefixes has been set');
         $prefixes = $variableContainer->get('prefixes');
-        $this->assertSame(['r','p','l'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
+        self::assertSame(['r', 'p', 'l'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
     }
 
     /**
@@ -63,16 +64,16 @@ class LabelPrefixesViewHelperTest extends UnitTest
     {
         $optionCollection = $this->getTestFacetOptionCollection();
 
-        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['remove'])->getMock();
+        $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
         $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
-        $renderingContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableContainer));
+        $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
         $testArguments['length'] = 1;
         $testArguments['sortBy'] = 'alpha';
         LabelPrefixesViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
         $prefixes = $variableContainer->get('prefixes');
-        $this->assertSame(['l','p','r'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
+        self::assertSame(['l', 'p', 'r'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Facet\Options\Group\Prefix;
 
 /***************************************************************
@@ -51,40 +52,39 @@ class SearchFormViewHelperTest extends UnitTest
      */
     protected $typoScriptConfigurationMock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->uriBuilderMock = $this->getDumbMock(UriBuilder::class);
         $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $controllerContextMock = $this->getDumbMock(ControllerContext::class);
-        $controllerContextMock->expects($this->once())->method('getUriBuilder')->willReturn($this->uriBuilderMock);
+        $controllerContextMock->expects(self::once())->method('getUriBuilder')->willReturn($this->uriBuilderMock);
 
-        $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)->setMethods(['getControllerContext', 'getTypoScriptConfiguration', 'getTemplateVariableContainer', 'getSearchResultSet', 'renderChildren', 'getIsSiteManagedSite'])->getMock();
-        $this->viewHelper->expects($this->any())->method('getControllerContext')->willReturn($controllerContextMock);
-        $this->viewHelper->expects($this->any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
-        $this->viewHelper->expects($this->any())->method('getTemplateVariableContainer')->willReturn($this->getDumbMock(VariableProviderInterface::class));
-        $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn('');
-        $this->viewHelper->expects($this->once())->method('getIsSiteManagedSite')->willReturn(false);
-
+        $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)->onlyMethods(['getControllerContext', 'getTypoScriptConfiguration', 'getTemplateVariableContainer', 'getSearchResultSet', 'renderChildren', 'getIsSiteManagedSite'])->getMock();
+        $this->viewHelper->expects(self::any())->method('getControllerContext')->willReturn($controllerContextMock);
+        $this->viewHelper->expects(self::any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
+        $this->viewHelper->expects(self::any())->method('getTemplateVariableContainer')->willReturn($this->getDumbMock(VariableProviderInterface::class));
+        $this->viewHelper->expects(self::once())->method('renderChildren')->willReturn('');
+        $this->viewHelper->expects(self::once())->method('getIsSiteManagedSite')->willReturn(false);
+        parent::setUp();
     }
 
     /**
-     * @param integer $pageUid
+     * @param int $pageUid
      */
     protected function assertUriIsBuildForPageUid($pageUid)
     {
-        $this->uriBuilderMock->expects($this->any())->method('reset')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setTargetPageUid')->with($pageUid)->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setTargetPageType')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setNoCache')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setArguments')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setCreateAbsoluteUri')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setArgumentsToBeExcludedFromQueryString')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setAddQueryStringMethod')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('setSection')->willReturn($this->uriBuilderMock);
-        $this->uriBuilderMock->expects($this->once())->method('build')->willReturn('index.php?id=' . $pageUid);
+        $this->uriBuilderMock->expects(self::any())->method('reset')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setTargetPageUid')->with($pageUid)->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setTargetPageType')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setNoCache')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setArguments')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setCreateAbsoluteUri')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setArgumentsToBeExcludedFromQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setAddQueryStringMethod')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setAddQueryString')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('setSection')->willReturn($this->uriBuilderMock);
+        $this->uriBuilderMock->expects(self::once())->method('build')->willReturn('index.php?id=' . $pageUid);
     }
 
     /**
@@ -92,8 +92,8 @@ class SearchFormViewHelperTest extends UnitTest
      */
     public function canSetTargetPageUidFromConfigurationWhenNullWasPassed()
     {
-        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(888);
-        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(888);
+        $this->viewHelper->expects(self::once())->method('getSearchResultSet')->willReturn(null);
         $this->viewHelper->setArguments(['additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
 
         $this->assertUriIsBuildForPageUid(888);
@@ -105,8 +105,8 @@ class SearchFormViewHelperTest extends UnitTest
      */
     public function canUsePassedPageUidWhenNoTargetPageIsConfigured()
     {
-        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(0);
-        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(0);
+        $this->viewHelper->expects(self::once())->method('getSearchResultSet')->willReturn(null);
         $this->viewHelper->setArguments(['pageUid' => 4711, 'additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
 
         $this->assertUriIsBuildForPageUid(4711);
@@ -118,8 +118,8 @@ class SearchFormViewHelperTest extends UnitTest
      */
     public function passedPageUidHasPriorityOverConfiguredTargetPageUid()
     {
-        $this->typoScriptConfigurationMock->expects($this->any())->method('getSearchTargetPage')->willReturn(888);
-        $this->viewHelper->expects($this->once())->method('getSearchResultSet')->willReturn(null);
+        $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(888);
+        $this->viewHelper->expects(self::once())->method('getSearchResultSet')->willReturn(null);
         $this->viewHelper->setArguments(['pageUid' => 4711, 'additionalParams' => [], 'argumentsToBeExcludedFromQueryString' => []]);
 
         $this->assertUriIsBuildForPageUid(4711);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AbstractFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AbstractFacetItemViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -24,11 +25,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -42,7 +43,7 @@ abstract class AbstractFacetItemViewHelperTest extends UnitTest
     {
         $searchRequest = new SearchRequest();
         $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $searchResultSetMock->expects($this->any())->method('getUsedSearchRequest')->will($this->returnValue($searchRequest));
+        $searchResultSetMock->expects(self::any())->method('getUsedSearchRequest')->willReturn($searchRequest);
 
         $facet = new OptionsFacet($searchResultSetMock, 'Color', 'color');
         $option = new Option($facet, 'Red', 'red', 4);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -34,7 +35,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 class AddFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 {
 
-
     /**
      * @test
      */
@@ -48,8 +48,8 @@ class AddFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 
         $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
 
-            // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
-        $searchUriBuilderMock->expects($this->once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
+        // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
+        $searchUriBuilderMock->expects(self::once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
         // @extensionScannerIgnoreLine
         $viewHelper->setArguments(['facet' => $facet, 'facetItem' => $facet->getOptions()->getByPosition(0)]);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -24,8 +25,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveAllFacetsViewHelper;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
@@ -46,25 +47,25 @@ class RemoveAllFacetsViewHelperTest extends AbstractFacetItemViewHelperTest
     {
         $mockedPreviousFakedRequest = $this->getDumbMock(SearchRequest::class);
         $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
-        $searchResultSetMock->expects($this->once())->method('getUsedSearchRequest')->will($this->returnValue($mockedPreviousFakedRequest));
+        $searchResultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($mockedPreviousFakedRequest);
 
         $uriBuilderMock = $this->getDumbMock(UriBuilder::class);
         $controllerContextMock = $this->getDumbMock(ControllerContext::class);
-        $controllerContextMock->expects($this->any())->method('getUriBuilder')->will($this->returnValue($uriBuilderMock));
+        $controllerContextMock->expects(self::any())->method('getUriBuilder')->willReturn($uriBuilderMock);
 
         $variableProvideMock = $this->getDumbMock(StandardVariableProvider::class);
-        $variableProvideMock->expects($this->once())->method('get')->with('resultSet')->will($this->returnValue($searchResultSetMock));
+        $variableProvideMock->expects(self::once())->method('get')->with('resultSet')->willReturn($searchResultSetMock);
         $renderContextMock = $this->getDumbMock(RenderingContext::class);
-        $renderContextMock->expects($this->any())->method('getVariableProvider')->will($this->returnValue($variableProvideMock));
-        $renderContextMock->expects($this->any())->method('getControllerContext')->will($this->returnValue($controllerContextMock));
+        $renderContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableProvideMock);
+        $renderContextMock->expects(self::any())->method('getControllerContext')->willReturn($controllerContextMock);
 
         $viewHelper = new RemoveAllFacetsViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
         $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
 
-            // we expected that the getRemoveAllFacetsUri will be called on the searchUriBuilder in the end.
-        $searchUriBuilderMock->expects($this->once())->method('getRemoveAllFacetsUri')->with($mockedPreviousFakedRequest);
+        // we expected that the getRemoveAllFacetsUri will be called on the searchUriBuilder in the end.
+        $searchUriBuilderMock->expects(self::once())->method('getRemoveAllFacetsUri')->with($mockedPreviousFakedRequest);
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
 
         $viewHelper->render();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -24,7 +25,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetItemViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -48,8 +48,8 @@ class RemoveFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 
         $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
 
-            // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
-        $searchUriBuilderMock->expects($this->once())->method('getRemoveFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
+        // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
+        $searchUriBuilderMock->expects(self::once())->method('getRemoveFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
         // @extensionScannerIgnoreLine
         $viewHelper->setArguments(['facet' => $facet, 'facetItem' => $facet->getOptions()->getByPosition(0)]);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -48,8 +49,8 @@ class RemoveFacetViewHelperTest extends AbstractFacetItemViewHelperTest
 
         $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
 
-            // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
-        $searchUriBuilderMock->expects($this->once())->method('getRemoveFacetUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color');
+        // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
+        $searchUriBuilderMock->expects(self::once())->method('getRemoveFacetUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color');
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
         // @extensionScannerIgnoreLine
         $viewHelper->setArguments(['facet' => $facet, 'facetItem' => $facet->getOptions()->getByPosition(0)]);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 /***************************************************************
@@ -24,11 +25,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\SetFacetItemViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -49,8 +48,8 @@ class SetFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 
         $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
 
-            // we expected that the getSetFacetValueUri will be called on the searchUriBuilder in the end.
-        $searchUriBuilderMock->expects($this->once())->method('getSetFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
+        // we expected that the getSetFacetValueUri will be called on the searchUriBuilder in the end.
+        $searchUriBuilderMock->expects(self::once())->method('getSetFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
         // @extensionScannerIgnoreLine
         $viewHelper->setArguments(['facet' => $facet, 'facetItem' => $facet->getOptions()->getByPosition(0)]);

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,20 @@
       "extension-key": "solr",
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web"
+    },
+    "TYPO3-Solr": {
+      "version-matrix": {
+        "ext-tika": "^11.0",
+        "ext-solrfal": "^11.0",
+        "ext-solrconsole": "^11.0",
+        "ext-solrdebugtools": "^11.0",
+        "ext-solrfluidgrouping": "^11.0",
+        "ext-solrmlt": "^11.0",
+        "Apache-Solr": "8.11.1",
+        "configset": "ext_solr_11_5_0"
+      },
+      "ext-solrfal": {
+      }
     }
   }
 }


### PR DESCRIPTION
Contains following changes:

* [TASK] Add proper annotations on GH actions job failures.
* [TASK] Migrate to PhpUnit 9+ Api and cleanup the obsolete method mocks