### PR TITLE
[BUGFIX:BP:11.2] Fix write connection

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -304,8 +304,8 @@ class SiteRepository
                         'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'write', 8983),
                         // @todo: transform core to path
                         'path' =>
-                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
-                            SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read', 'core_en') . '/' ,
+                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'write', '/solr/') .
+                            SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'write', 'core_en') . '/' ,
                         'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'write', ''),
                         'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'write', '')
                     ],


### PR DESCRIPTION
# What this pr does

Path of write connection is read from read scope, so different paths
couldn't be used, this is fixed by inserting the right scope.

# How to test

Configure and test write connection

Fixes: #2916
