### PR TITLE
[BUGFIX] core optimization module PHP 8.1 compatibility

### DIFF
--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -371,7 +371,7 @@ class SolrAdminService extends AbstractSolrService
      */
     protected function initializeSynonymsUrl()
     {
-        if (trim($this->_synonymsUrl) !== '') {
+        if (trim((string)$this->_synonymsUrl) !== '') {
             return;
         }
         $this->_synonymsUrl = $this->_constructUrl(self::SYNONYMS_SERVLET) . $this->getSchema()->getManagedResourceId();
@@ -382,7 +382,7 @@ class SolrAdminService extends AbstractSolrService
      */
     protected function initializeStopWordsUrl()
     {
-        if (trim($this->_stopWordsUrl) !== '') {
+        if (trim((string)$this->_stopWordsUrl) !== '') {
             return;
         }
 


### PR DESCRIPTION
Fixes typecasting issues when the variables are not initialized yet.

# What this pr does

Improved PHP 8.1 compatibility

# How to test

- Install PHP 8.1
- Do basic configuration
- Try to access backend module "Core Optimization"
- Exception is thrown