### PR TITLE
[BUGFIX] Skip rootline check in be for records stored at pid 0

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -158,9 +158,12 @@ class RootPageResolver implements SingletonInterface
         bool $forceFallback = false,
         string $mountPointIdentifier = ''
     ): int {
+        if (0 === $pageId) {
+            return 0;
+        }
+
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
-        $rootPageId = $pageId ?: (int)($GLOBALS['TSFE']->id);
 
         // frontend
         if (!empty($GLOBALS['TSFE']->rootLine)) {
@@ -168,7 +171,7 @@ class RootPageResolver implements SingletonInterface
         }
 
         // fallback, backend
-        if ($pageId != 0 && ($forceFallback || !$rootLine->getHasRootPage())) {
+        if ($forceFallback || !$rootLine->getHasRootPage()) {
             $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageId, $mountPointIdentifier);
             try {
                 $rootLineArray = $rootlineUtility->get();
@@ -178,9 +181,7 @@ class RootPageResolver implements SingletonInterface
             $rootLine->setRootLineArray($rootLineArray);
         }
 
-        $rootPageFromRootLine = $rootLine->getRootPageId();
-
-        return $rootPageFromRootLine === 0 ? $rootPageId : $rootPageFromRootLine;
+        return $rootLine->getRootPageId() ?: $pageId;
     }
 
     /**

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -311,7 +311,7 @@ class PageIndexer extends Indexer
         if ($this->loggingEnabled) {
             $logSeverity = SolrLogManager::INFO;
             $logStatus = 'Info';
-            if ($indexActionResult['pageIndexed']) {
+            if (!empty($indexActionResult['pageIndexed'])) {
                 $logSeverity = SolrLogManager::NOTICE;
                 $logStatus = 'Success';
             }
@@ -331,7 +331,7 @@ class PageIndexer extends Indexer
             );
         }
 
-        if (!$indexActionResult['pageIndexed']) {
+        if (empty($indexActionResult['pageIndexed'])) {
             $message = 'Failed indexing page Index Queue item: ' . $item->getIndexQueueUid() . ' url: ' . $indexRequestUrl;
 
             throw new RuntimeException($message, 1331837081);


### PR DESCRIPTION

I got the folowing error in **TYPO3 11** with **PHP 8** after editing a be_user:
```
PHP Warning: Undefined array key "TSFE" in ./typo3conf/ext/solr/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php line 169
```


This PR fixes an issue in backend for records located on page id 0 like be_users.
If there is no TSFE and the page id is 0, there is no need to check the rootline to get the root page id.

Trace:
```php
[
    0 => './typo3/index.php:{closure}#21',
    1 => './typo3/index.php:TYPO3\\CMS\\Core\\Http\\AbstractApplication->run#20',
    2 => './typo3/sysext/core/Classes/Http/AbstractApplication.php:TYPO3\\CMS\\Backend\\Http\\Application->handle#100',
    3 => './typo3/sysext/backend/Classes/Http/Application.php:TYPO3\\CMS\\Core\\Http\\AbstractApplication->handle#72',
    4 => './typo3/sysext/core/Classes/Http/AbstractApplication.php:TYPO3\\CMS\\Core\\Http\\MiddlewareDispatcher->handle#86',
    5 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#78',
    6 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Core\\Middleware\\VerifyHostHeader->process#172',
    7 => './typo3/sysext/core/Classes/Middleware/VerifyHostHeader.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#55',
    8 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Core\\Middleware\\NormalizedParamsAttribute->process#172',
    9 => './typo3/sysext/core/Classes/Middleware/NormalizedParamsAttribute.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#45',
    10 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:DMK\\MkSanitizedParameters\\Middleware\\GlobalInputSanitizerMiddleware->process#172',
    11 => './typo3conf/ext/mksanitizedparameters/Classes/Middleware/GlobalInputSanitizerMiddleware.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#80',
    12 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\LockedBackendGuard->process#172',
    13 => './typo3/sysext/backend/Classes/Middleware/LockedBackendGuard.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#75',
    14 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\ForcedHttpsBackendRedirector->process#172',
    15 => './typo3/sysext/backend/Classes/Middleware/ForcedHttpsBackendRedirector.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#55',
    16 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\BackendRouteInitialization->process#172',
    17 => './typo3/sysext/backend/Classes/Middleware/BackendRouteInitialization.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#86',
    18 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\BackendUserAuthenticator->process#172',
    19 => './typo3/sysext/backend/Classes/Middleware/BackendUserAuthenticator.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#165',
    20 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\OutputCompression->process#172',
    21 => './typo3/sysext/backend/Classes/Middleware/OutputCompression.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#47',
    22 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\AdditionalResponseHeaders->process#172',
    23 => './typo3/sysext/backend/Classes/Middleware/AdditionalResponseHeaders.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#41',
    24 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Backend\\Middleware\\SiteResolver->process#172',
    25 => './typo3/sysext/backend/Classes/Middleware/SiteResolver.php:Psr\\Http\\Server\\RequestHandlerInterface@anonymous' . "\0" . './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:138$41b->handle#69',
    26 => './typo3/sysext/core/Classes/Http/MiddlewareDispatcher.php:TYPO3\\CMS\\Core\\Middleware\\ResponsePropagation->process#172',
    27 => './typo3/sysext/core/Classes/Middleware/ResponsePropagation.php:TYPO3\\CMS\\Backend\\Http\\RequestHandler->handle#34',
    28 => './typo3/sysext/backend/Classes/Http/RequestHandler.php:TYPO3\\CMS\\Backend\\Http\\RouteDispatcher->dispatch#110',
    29 => './typo3/sysext/backend/Classes/Http/RouteDispatcher.php:TYPO3\\CMS\\Backend\\Controller\\EditDocumentController->mainAction#91',
    30 => './typo3/sysext/backend/Classes/Controller/EditDocumentController.php:TYPO3\\CMS\\Backend\\Controller\\EditDocumentController->processData#411',
    31 => './typo3/sysext/backend/Classes/Controller/EditDocumentController.php:TYPO3\\CMS\\Core\\DataHandling\\DataHandler->process_datamap#563',
    32 => './typo3/sysext/core/Classes/DataHandling/DataHandler.php:TYPO3\\CMS\\Core\\DataHandling\\DataHandler->hook_processDatamap_afterDatabaseOperations#1134',
    33 => './typo3/sysext/core/Classes/DataHandling/DataHandler.php:ApacheSolrForTypo3\\Solr\\IndexQueue\\RecordMonitor->processDatamap_afterDatabaseOperations#781',
    34 => './typo3conf/ext/solr/Classes/IndexQueue/RecordMonitor.php:TYPO3\\CMS\\Core\\EventDispatcher\\EventDispatcher->dispatch#144',
    35 => './typo3/sysext/core/Classes/EventDispatcher/EventDispatcher.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\UpdateHandler\\EventListener\\ImmediateProcessingEventListener->__invoke#51',
    36 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\UpdateHandler\\EventListener\\ImmediateProcessingEventListener->handleRecordUpdatedEvent#58',
    37 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\UpdateHandler\\DataUpdateHandler->handleRecordUpdate#122',
    38 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\UpdateHandler\\DataUpdateHandler->getRecordRootPageIds#229',
    39 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\RecordMonitor\\Helper\\RootPageResolver->getResponsibleRootPageIds#371',
    40 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\RecordMonitor\\Helper\\RootPageResolver->buildResponsibleRootPageIds#94',
    41 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\RecordMonitor\\Helper\\RootPageResolver->getRootPageIdByTableAndUid#204',
    42 => './typo3conf/ext/solr/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php:ApacheSolrForTypo3\\Solr\\Domain\\Index\\Queue\\RecordMonitor\\Helper\\RootPageResolver->getRootPageId#235',
];
```

Relates: #3173