### PR TITLE
[TASK] Ignore github configuration for export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 /.styleci.yml export-ignore
 /Dockerfile export-ignore
 /CONTRIBUTING.md export-ignore
+/.github


### PR DESCRIPTION
# What this pr does

The github configuration should be removed for production environment.

# How to test

1. Checkout project
    ```
    git clone git@github.com:TYPO3-Solr/ext-solr.git
    ```
2. Create archive
    ```
    cd ext-solr
    git archive --output=./ext-solr.tar --format=tar HEAD
    ```
3. Check content of archive
    ```
    tar -tvf ext-solr.tar | grep '.github'
    ```
    The result should not contain ".github".

Fixes: #3212 