### PR TITLE
FIX: Argument 1 passed to UrlHelper::setPort() must be of the type int, string given

### DIFF
--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
@@ -63,7 +63,7 @@ abstract class AbstractUriStrategy
 
         // overwriting the port
         if (!empty($overrideConfiguration['port'])) {
-            $urlHelper->setPort($overrideConfiguration['port']);
+            $urlHelper->setPort((int)$overrideConfiguration['port']);
         }
 
         // setting a path if TYPO3 is installed in a subdirectory


### PR DESCRIPTION
# What this pr does

Fixes exception that occures when trying to override port for page indexer:

![Bildschirmfoto vom 2022-03-08 14-20-52](https://user-images.githubusercontent.com/1405149/157246117-e2d13a2d-a37a-4a74-a180-4a86a05f2976.png)

# How to test

```
plugin.tx_solr.index.queue {
    pages = 1
    pages {
        indexer {
            frontendDataHelper {
                scheme = http
                host = localhost
                port = 80
            }
        }
    }
}
```
