### PR TITLE
FIX: Argument 1 passed to AbstractSolrTask::setRootPageId() must be of the type int, string given

### DIFF
--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -222,7 +222,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
             return;
         }
 
-        $task->setRootPageId($submittedData['site']);
+        $task->setRootPageId((int)$submittedData['site']);
 
         $indexingConfigurations = [];
         if (!empty($submittedData['indexingConfigurations'])) {


### PR DESCRIPTION
# What this pr does

Fixes exception when setting up the scheduler task for force reindexing page.

![Bildschirmfoto vom 2022-03-08 14-40-28](https://user-images.githubusercontent.com/1405149/157249244-9b8f5506-8363-40e0-b0f7-9706f268aa90.png)

