### PR TITLE
[DOCS] Provide info about the virtual field __solr_contents in Docs

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -306,6 +306,8 @@ queue.[indexConfig].fields
 
 Mapping of Solr field names on the left side to database table field names or content objects on the right side. You must at least provide the title, content, and url fields. TYPO3 system fields like uid, pid, crdate, tstamp and so on are added automatically by the indexer depending on the TCA information of a table.
 
+You can also use a virtual field called :code:`__solr_content`, which holds the content of the current page.
+
 Example:
 
 .. code-block:: typoscript

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -653,3 +653,18 @@ The PHP class must have a certain structure, which is specified by the interface
            return $resultSet;
        }
    }
+
+**I want to use the page content for a dynamic field , how can i do that?**
+
+You can use a virtual field called :code:`__solr_content`, which holds the content of the current page.
+
+Example:
+
+::
+
+    plugin.tx_solr.index.queue.pages.fields {
+        content_textEdgeNgramS = SOLR_CONTENT
+        content_textEdgeNgramS {
+            field = __solr_content
+        }
+    }


### PR DESCRIPTION
Added explanations of the virtual field in [queue.[indexConfig].fields](https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Configuration/Reference/TxSolrIndex.html#id12) and [FAQ](https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/FAQ/Index.html)

Slack Conversation: https://app.slack.com/client/T024TUMLZ/C02FF05Q4/thread/C02FF05Q4-1646727764.460269