### PR TITLE
[DOCS] Align README.md with other extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Apache Solr for TYPO3 CMS
 
+[![Latest Stable Version](https://poser.pugx.org/apache-solr-for-typo3/solr/v/stable)](https://extensions.typo3.org/extension/solr)
+[![Latest Unstable Version](https://poser.pugx.org/apache-solr-for-typo3/solr/v/unstable)](https://extensions.typo3.org/extension/solr)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+[![Total Downloads](http://poser.pugx.org/apache-solr-for-typo3/solr/downloads)](https://packagist.org/packages/apache-solr-for-typo3/solr)
+[![Monthly Downloads](https://poser.pugx.org/apache-solr-for-typo3/solr/d/monthly)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 [![Build Status](https://github.com/TYPO3-Solr/ext-solr/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/TYPO3-Solr/ext-solr/actions?query=branch:main)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/?branch=main)
 [![Code Coverage](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/badges/coverage.png?b=main)](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/?branch=main)
-[![Latest Stable Version](https://poser.pugx.org/apache-solr-for-typo3/solr/v/stable)](https://packagist.org/packages/apache-solr-for-typo3/solr)
-[![Latest Unstable Version](https://poser.pugx.org/apache-solr-for-typo3/solr/v/unstable)](https://packagist.org/packages/apache-solr-for-typo3/solr)
-[![License](https://poser.pugx.org/apache-solr-for-typo3/solr/license)](https://packagist.org/packages/apache-solr-for-typo3/solr)
-[![Monthly Downloads](https://poser.pugx.org/apache-solr-for-typo3/solr/d/monthly)](https://packagist.org/packages/apache-solr-for-typo3/solr)
-[![Total Downloads](http://poser.pugx.org/apache-solr-for-typo3/solr/downloads)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 
 A TYPO3 extension that integrates the [Apache Solr](https://solr.apache.org/) Enterprise Search Server into the
 TYPO3 CMS.

--- a/README.md
+++ b/README.md
@@ -9,60 +9,27 @@
 [![Monthly Downloads](https://poser.pugx.org/apache-solr-for-typo3/solr/d/monthly)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 [![Total Downloads](http://poser.pugx.org/apache-solr-for-typo3/solr/downloads)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 
-A TYPO3 extension that integrates the Apache Solr enterprise search server with TYPO3 CMS.
+A TYPO3 extension that integrates the [Apache Solr](https://solr.apache.org/) Enterprise Search Server into the
+TYPO3 CMS.
 
-The extension has initially been developed by dkd Internet Service GmbH and is now being continued as a community project. The version you find here is a version that does not contain all the features that have been implemented yet. These features can be obtained through add-ons for the extension.
+This extension serves as a base module that covers the most frequently used functionalities.
 
-In case you need access to the full feature set, please feel free to contact us for details.
+Additional features can be obtained through the following free add-ons:
 
-Things we are working on or got working already include the following:
+1. [Apache Tika for TYPO3](https://extensions.typo3.org/extension/tika)
+2. [Apache Solr for TYPO3 - More Like This](https://extensions.typo3.org/extension/solrmlt)
+3. [Apache Solr for TYPO3 - Grouping for fluid rendering](https://extensions.typo3.org/extension/solrfluidgrouping)
 
-- Statistics
-- An Indexing Queue to be independent from frontend rendering and adding content to Solr as soon as an editor creates a content element in the backend
-- Suggest / Autocomplete
-- More Like This
-- Several Reports
-- Advanced faceting features including hierarchical facets
-- Backend Module for Solr administration
-- Results Grouping
-- Language Detection
-- Crawling of External non-TYPO3 Websites
-- more ...
+and many more by searching for "solr" in the TYPO3 Extension Repository (TER).
 
-We're open for [contributions](./CONTRIBUTING.md) !
+In case you need access to additional features, consider to become a funding partner of the program.
+Further details including a comparison chart are provided at the program homepage.
 
-Please find further information regarding Apache Solr and its related projects at the following links:
+|                  | URL                                                             |
+|------------------|-----------------------------------------------------------------|
+| **Repository:**  | https://github.com/TYPO3-Solr/ext-solr                          |
+| **Read online:** | https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/solr                     |
+| **Homepage:**    | https://www.typo3-solr.com/                                     |
 
-- http://www.typo3-solr.com/
-- https://www.dkd.de/de/leistungen/enterprise-websites/enterprise-search/
-- https://github.com/TYPO3-Solr
-- http://lucene.apache.org/
-- http://lucene.apache.org/solr/
-- http://tomcat.apache.org
-- http://www.eclipse.org/jetty/
-
-To try out Apache Solr for TYPO3 visit [www.typo3-solr.com](http://www.typo3-solr.com) where we've set up a basic configuration.
-
-![dkd Internet Service GmbH](./Resources/Public/Images/dkd_logo.png)
-
-## Documentation and Support
-
--   **Main Documentation:**
-
-   https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Index.html
-
-
--   **Slack Channel:**
-
-    https://typo3.slack.com/messages/ext-solr/
-
-    (request your invite for Slack here: https://forger.typo3.org/slack)
-
-
--   **Mailinglist:**
-
-    http://lists.typo3.org/cgi-bin/mailman/listinfo/typo3-project-solr
-
-## <a name="Contributions"></a>Contributions
-
-[You want to contribute and like to know how? Check our guidelines about how to contribute to EXT:solr](./CONTRIBUTING.md)
+Powered by the TYPO3 community and <br><br>![dkd Internet Service GmbH](./Resources/Public/Images/dkd_logo.png)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "issues": "https://github.com/TYPO3-Solr/ext-solr/issues",
     "forum": "https://talk.typo3.org",
     "slack": "https://typo3.slack.com/app_redirect?channel=C02FF05Q4",
-    "source": "https://github.com/TYPO3-Solr/ext-solr"
+    "source": "https://github.com/TYPO3-Solr/ext-solr",
+    "docs": "https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/"
   },
   "require": {
     "php": ">=7.4.0",


### PR DESCRIPTION
Reduce README.md to an abstract and links to important pages
that cover the user's next steps, especially the full
documentation and TER page for installation, but also add-ons
and the paid services.

The details of the contribution are already in CONTRIBUTION.md
and in the full documentation - and obvious if you look at the
git history.

The contact details should be moved to the full documentation.

Keep outgoing links to a minimum to not distract the user.

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182