### PR TITLE
[TASK] Supress warnings of strftime

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -150,7 +150,8 @@ class InfoModuleController extends AbstractModuleController
         $data = [];
         $chartData = $statisticsRepository->getQueriesOverTime($siteRootPageId, 30, 86400);
         foreach ($chartData as $bucket) {
-            $labels[] = strftime('%x', $bucket['timestamp']);
+            // @todo Replace deprecated strftime in php 8.1. Suppress warning for now
+            $labels[] = @strftime('%x', $bucket['timestamp']);
             $data[] = (int)$bucket['numQueries'];
         }
 


### PR DESCRIPTION
As strftime is deprecated, its warning must be supressed as there is no dropin replacement. See https://review.typo3.org/c/Packages/TYPO3.CMS/+/72055 which solved it in the same way

