### PR TITLE
[TASK] Remove unnecessary bootstrap_package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
     "typo3/cms-frontend": "*",
     "typo3/cms-reports": "*",
     "typo3/cms-scheduler": "*",
-    "typo3/cms-tstemplate": "*",
-    "bk2k/bootstrap-package": "^12.0"
+    "typo3/cms-tstemplate": "*"
   },
   "require-dev": {
     "typo3/coding-standards": ">=0.5.0",


### PR DESCRIPTION
This extension seems not to be necessary for ext:solr.
Maybe it was required by mistake.

Fixes: #3226

# What this pr does

It removes the requirement of ext:bootstrap_package.

# How to test

No PHP warning with version 8.0. See issue #3226 .

Fixes: #3226 
