### PR TITLE
[BUGFIX] Fix feuser initialisation in BE context

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -142,15 +142,19 @@ class Tsfe implements SingletonInterface
                 )
             );
 
+            /** @var FrontendUserAuthentication $feUser */
             $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
             // for certain situations we need to trick TSFE into granting us
             // access to the page in any case to make getPageAndRootline() work
             // see http://forge.typo3.org/issues/42122
             $pageRecord = BackendUtility::getRecord('pages', $pageId, 'fe_group');
-            $userGroups = [0, -1];
             if (!empty($pageRecord['fe_group'])) {
-                $userGroups = array_unique(array_merge($userGroups, explode(',', $pageRecord['fe_group'])));
+                $userGroups = explode(',', $pageRecord['fe_group']);
+            } else {
+                $userGroups = [0, -1];
             }
+            $feUser->user = ['uid' => 0, 'username' => '', 'usergroup' => implode(',', $userGroups) ];
+            $feUser->fetchGroupData();
             $context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $userGroups));
 
             /* @var PageArguments $pageArguments */

--- a/Tests/Integration/IndexQueue/Fixtures/update_access_restricted_page.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_access_restricted_page.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>2</uid>
+		<pid>1</pid>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+		<title>Access protected page</title>
+		<fe_group>2</fe_group>
+	</pages>
+
+	<fe_groups>
+		<uid>2</uid>
+		<pid>1</pid>
+		<title>dummy group</title>
+	</fe_groups>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -1895,6 +1895,30 @@ class RecordMonitorTest extends IntegrationTest
     }
 
     /**
+     * Tests if updates on access restricted pages lead to index queue updates
+     *
+     * https://github.com/TYPO3-Solr/ext-solr/issues/3225
+     * @test
+     */
+    public function canQueueAccessRestrictedPageOnPageUpdate(): void
+    {
+        $this->importDataSetFromFixture('update_access_restricted_page.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->recordMonitor->processDatamap_afterDatabaseOperations(
+            'update',
+            'pages',
+            2,
+            [
+                'title' => 'Access restricted page',
+            ],
+            $this->dataHandler
+        );
+
+        $this->assertIndexQueueContainsItemAmount(1);
+    }
+
+    /**
      * Triggers event queue processing
      */
     protected function processEventQueue(): void


### PR DESCRIPTION
# What this pr does

Observation of database records that might be indexed require an own initialization of TSFE and frontend users, as the fe_user initialization is incomplete access restricted pages can't be observed correctly.

This commit fixes this issue by simulating the required frontend groups.

# How to test

Configure page indexing, clear index queue and change an access protected page, page must be added to the index queue.

Resolves: #3225
