### PR TITLE
[TASK] Reenable skipped test of SearchControllerTest

### DIFF
--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -268,11 +268,9 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     /**
      * @test
      * @group frontend
-     * @todo: https://github.com/TYPO3-Solr/ext-solr/issues/3150
      */
     public function canDoAnInitialEmptySearchWithoutResults()
     {
-        self::markTestSkipped('Something is wrong with refactored pagination. See https://github.com/TYPO3-Solr/ext-solr/issues/3150');
         $this->importDataSetFromFixture('SearchAndSuggestControllerTest_indexing_data.xml');
         $this->addTypoScriptToTemplateRecord(
             1,


### PR DESCRIPTION
# What this pr does

Reenables test case "canDoAnInitialEmptySearchWithoutResults" of SearchControllerTest, as issue was already fixed in #3112.

# How to test

Check integration test results 

Resolves: #3150
Releated: #3112
