### PR TITLE
Release 11.5.0-rc-1

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -17,7 +17,7 @@ Apache Solr for TYPO3 (EXT:solr)
 		solr
 
 	:Version:
-		11.5.0-beta2
+		11.5.0-rc-1
 
 	:Language:
 		en

--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -6,7 +6,7 @@
 .. include:: ../Includes.txt
 
 
-.. _releases-11-1:
+.. _releases-11-5:
 
 ============================
 Apache Solr for TYPO3 11.5.0
@@ -15,12 +15,25 @@ Apache Solr for TYPO3 11.5.0
 We are happy to release EXT:solr 11.5.0.
 The focus of this release has been on TYPO3 11 LTS compatibility.
 
+#standwithukraine #nowar
+
 **Important**: This version is installable with TYPO3 11 LTS only and contains some breaking changes, see details below.
 
 New in this release
 ===================
 
-TBD
+Support of TYPO3 11 LTS
+-----------------------
+
+With EXT:solr 11.5 we provide the support of TYPO3 11 LTS.
+
+
+Bootstrap 5.1
+-------------
+
+The default templates provided by EXT:solr were adapted for Bootstrap 5.1.
+
+The templates are also prepared to display some icons with Bootstrap Icons, but the usage is optional and the icons are no longer provided with EXT:solr as the former Glyphicons were.
 
 Contributors
 ============

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,8 +1,8 @@
 [general]
 
 project     = ApacheSolrForTypo3 EXT:solr
-version     = 11.5.0-beta2
-release     = 11.5.0-beta2
+version     = 11.5.0-rc-1
+release     = 11.5.0-rc-1
 t3author    = Ingo Renner, Markus Friedrich, Rafael Kähm, Timo Hund
 copyright   = 2022
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '11.5.0-beta-2',
+    'version' => '11.5.0-rc-1',
     'state' => 'beta',
     'category' => 'plugin',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich',


### PR DESCRIPTION
# Release 11.5.0-rc-1

First release candidate of 11.5.0 for TYPO3 11 LTS

#standwithukraine #nowar

## Huge improvements:

* TYPO3 11 LTS compatibility
* Improved data update handling

## Known issues:

* #3166 

## Open tasks:

* #3160
* #3169 
* #3220 

## Note for non-composer instances:

This release candidate is not available in TYPO3 TER, if you want to try this
release, please download and install this release manually from:

* https://github.com/TYPO3-Solr/ext-solr/releases/tag/11.5.0-rc-1


---

# How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
   existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing
   development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0


Resolves: #3229 