### PR TITLE
[TASK] Improve error handling in index queue module

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -120,7 +120,25 @@ class IndexQueueModuleController extends AbstractModuleController
         $indexingConfigurationsToInitialize = GeneralUtility::_POST('tx_solr-index-queue-initialization');
         if ((!empty($indexingConfigurationsToInitialize)) && (is_array($indexingConfigurationsToInitialize))) {
             // initialize selected indexing configuration
-            $initializedIndexingConfigurations = $this->indexQueue->getInitializationService()->initializeBySiteAndIndexConfigurations($this->selectedSite, $indexingConfigurationsToInitialize);
+            try {
+                $initializedIndexingConfigurations = $this->indexQueue->getInitializationService()->initializeBySiteAndIndexConfigurations($this->selectedSite, $indexingConfigurationsToInitialize);
+            } catch (\Throwable $e) {
+                $this->addFlashMessage(
+                    sprintf(
+                        LocalizationUtility::translate(
+                            'solr.backend.index_queue_module.flashmessage.initialize_failure',
+                            'Solr'
+                        ),
+                        $e->getMessage(),
+                        $e->getCode()
+                    ),
+                    LocalizationUtility::translate(
+                        'solr.backend.index_queue_module.flashmessage.initialize_failure.title',
+                        'Solr'
+                    ),
+                    FlashMessage::ERROR
+                );
+            }
         } else {
             $messageLabel = 'solr.backend.index_queue_module.flashmessage.initialize.no_selection';
             $titleLabel = 'solr.backend.index_queue_module.flashmessage.not_initialized.title';

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -208,6 +208,15 @@
 				<target>Top Treffer</target>
 			</trans-unit>
 
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize_failure.title" xml:space="preserve">
+				<source>Error occured while initializing</source>
+				<target>Beim Initialisieren ist ein Fehler aufgetreten</target>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize_failure" xml:space="preserve">
+				<source>An error occurred while initializing the index queue: %1$s [%2$d]</source>
+				<target>Bei der Initialisierung der Index-Queue ist ein Fehler aufgetreten: %1$s [%2$d]</target>
+			</trans-unit>
+
 			<!-- From locallang_db.xlf -->
 			<trans-unit id="tt_content.list_type_pi_frequentsearches" xml:space="preserve" approved="yes">
 				<source>Search: Frequent Searches</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -277,6 +277,12 @@
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.title" xml:space="preserve">
 				<source>Index Queue initialized</source>
 			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize_failure.title" xml:space="preserve">
+				<source>Error occured while initializing</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize_failure" xml:space="preserve">
+				<source>An error occurred while initializing the index queue: %1$s [%2$d]</source>
+			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.not_initialized.title" xml:space="preserve">
 				<source>Index Queue not initialized</source>
 			</trans-unit>


### PR DESCRIPTION
# What this pr does

Not all kind of errors while initializing the index queue are currently handled and so an error page or debug trace might be
shown. This commit adds an additional check and implements a more pleasant error message.

# How to test

Force an error during queue initializing, e.g. activate solrfal logging and deny access to the log file.

Related: TYPO3-Solr/ext-solrfal#148
