### PR TITLE
[BUGFIX] Add type cast to TaskProviders

### DIFF
--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -118,7 +118,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
         $currentAction = $schedulerModule->getCurrentAction();
 
         if ($currentAction->equals(Action::EDIT)) {
-            $this->site = $this->siteRepository->getSiteByRootPageId($task->getRootPageId());
+            $this->site = $this->siteRepository->getSiteByRootPageId((int)$task->getRootPageId());
         }
     }
 

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -106,7 +106,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
         $currentAction = $schedulerModule->getCurrentAction();
 
         if ($currentAction->equals(Action::EDIT)) {
-            $this->site = $this->siteRepository->getSiteByRootPageId($task->getRootPageId());
+            $this->site = $this->siteRepository->getSiteByRootPageId((int)$task->getRootPageId());
         }
     }
 


### PR DESCRIPTION
Fix exception which happens with PHP8 because the returned page id is actually a string but an integer is required
