### PR TITLE
[BUGFIX] Minor TYPO3 11 bugfixes and improvements

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
@@ -16,6 +16,8 @@
 namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
@@ -89,29 +91,22 @@ abstract class AbstractFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManager $objectManager
      */
     public function __construct(
         SearchResultSet $resultSet,
         string $name,
         string $field,
         string $label = '',
-        array $configuration = []
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
     ) {
         $this->resultSet = $resultSet;
         $this->name = $name;
         $this->field = $field;
         $this->label = $label;
         $this->configuration = $configuration;
-    }
-
-    /**
-     * Injects the object manager
-     *
-     * @param ObjectManagerInterface $objectManager
-     */
-    public function injectObjectManager(ObjectManagerInterface $objectManager)
-    {
-        $this->objectManager = $objectManager;
+        $this->objectManager = $objectManager ?? GeneralUtility::makeInstance(ObjectManager::class);
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionsFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionsFacet.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Class AbstractOptionsFacet
@@ -42,15 +43,17 @@ class AbstractOptionsFacet extends AbstractFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
     public function __construct(
         SearchResultSet $resultSet,
         string $name,
         string $field,
         string $label = '',
-        array $configuration = []
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
     ) {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
         $this->options = new OptionCollection();
     }
 

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Value object that represent the options facet.
@@ -59,15 +60,17 @@ class HierarchyFacet extends AbstractFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
     public function __construct(
         SearchResultSet $resultSet,
         string $name,
         string $field,
         string $label = '',
-        array $configuration = []
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
     ) {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
         $this->childNodes = new NodeCollection();
         $this->allNodes = new NodeCollection();
     }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
@@ -50,7 +50,7 @@ class HierarchyFacetParser extends AbstractFacetParser
         }
 
         /** @var $facet HierarchyFacet */
-        $facet = $this->objectManager->get(HierarchyFacet::class, $resultSet, $facetName, $fieldName, $label, $facetConfiguration);
+        $facet = $this->objectManager->get(HierarchyFacet::class, $resultSet, $facetName, $fieldName, $label, $facetConfiguration, $this->objectManager);
 
         $hasActiveOptions = count($optionsFromRequest) > 0;
         $facet->setIsUsed($hasActiveOptions);

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacet.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Opt
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractOptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Value object that represent a options facet.
@@ -42,9 +43,16 @@ class OptionsFacet extends AbstractOptionsFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
-    public function __construct(SearchResultSet $resultSet, $name, $field, $label = '', array $configuration = [])
-    {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+    public function __construct(
+        SearchResultSet $resultSet,
+        $name,
+        $field,
+        $label = '',
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
+    ) {
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -76,7 +76,8 @@ class OptionsFacetParser extends AbstractFacetParser
             $facetName,
             $fieldName,
             $label,
-            $facetConfiguration
+            $facetConfiguration,
+            $this->objectManager
         );
 
         $hasActiveOptions = count($optionsFromRequest) > 0;

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacet.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Que
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractOptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Class QueryGroupFacet
@@ -42,9 +43,16 @@ class QueryGroupFacet extends AbstractOptionsFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
-    public function __construct(SearchResultSet $resultSet, $name, $field, $label = '', array $configuration = [])
-    {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+    public function __construct(
+        SearchResultSet $resultSet,
+        $name,
+        $field,
+        $label = '',
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
+    ) {
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
@@ -56,7 +56,8 @@ class QueryGroupFacetParser extends AbstractFacetParser
             $facetName,
             $fieldName,
             $label,
-            $facetConfiguration
+            $facetConfiguration,
+            $this->objectManager
         );
 
         $activeFacets = $resultSet->getUsedSearchRequest()->getActiveFacetNames();

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -65,7 +65,8 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
             $facetName,
             $fieldName,
             $label,
-            $facetConfiguration
+            $facetConfiguration,
+            $this->objectManager
         );
 
         $facet->setIsAvailable(count($valuesFromResponse) > 0);

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacet.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Date
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Value object that represent a date range facet.
@@ -50,15 +51,17 @@ class DateRangeFacet extends AbstractFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
     public function __construct(
         SearchResultSet $resultSet,
         string $name,
         string $field,
         string $label = '',
-        array $configuration = []
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
     ) {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacet.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Nume
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
  * Value object that represent a date range facet.
@@ -50,15 +51,17 @@ class NumericRangeFacet extends AbstractFacet
      * @param string $field
      * @param string $label
      * @param array $configuration Facet configuration passed from typoscript
+     * @param ObjectManagerInterface $objectManager
      */
     public function __construct(
         SearchResultSet $resultSet,
         string $name,
         string $field,
         string $label = '',
-        array $configuration = []
+        array $configuration = [],
+        ObjectManagerInterface $objectManager = null
     ) {
-        parent::__construct($resultSet, $name, $field, $label, $configuration);
+        parent::__construct($resultSet, $name, $field, $label, $configuration, $objectManager);
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -40,6 +40,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrIncompleteResponseException;
 use Exception;
 use function get_class;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use UnexpectedValueException;
 
@@ -94,7 +95,7 @@ class SearchResultSetService
     protected QueryBuilder $queryBuilder;
 
     /**
-     * @var ObjectManagerInterface
+     * @var ObjectManager
      */
     protected ObjectManagerInterface $objectManager;
 
@@ -104,27 +105,22 @@ class SearchResultSetService
      * @param SolrLogManager|null $solrLogManager
      * @param SearchResultBuilder|null $resultBuilder
      * @param QueryBuilder|null $queryBuilder
+     * @param ObjectManagerInterface|null $objectManager
      */
     public function __construct(
         TypoScriptConfiguration $configuration,
         Search $search,
-        SolrLogManager $solrLogManager = null,
-        SearchResultBuilder $resultBuilder = null,
-        QueryBuilder $queryBuilder = null
+        ?SolrLogManager $solrLogManager = null,
+        ?SearchResultBuilder $resultBuilder = null,
+        ?QueryBuilder $queryBuilder = null,
+        ?ObjectManagerInterface $objectManager = null
     ) {
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
         $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
         $this->searchResultBuilder = $resultBuilder ?? GeneralUtility::makeInstance(SearchResultBuilder::class);
         $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, /** @scrutinizer ignore-type */ $configuration, /** @scrutinizer ignore-type */ $solrLogManager);
-    }
-
-    /**
-     * @param ObjectManagerInterface $objectManager
-     */
-    public function injectObjectManager(ObjectManagerInterface $objectManager)
-    {
-        $this->objectManager = $objectManager;
+        $this->objectManager = $objectManager ?? GeneralUtility::makeInstance(ObjectManager::class);
     }
 
     /**

--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -123,8 +123,8 @@ class TypoScript implements SingletonInterface
     {
         $parts = explode('.', $theKey, 2);
         if ((string)$parts[0] !== '' && is_array($theSetup[$parts[0] . '.'])) {
-            if (trim($parts[1]) !== '') {
-                return $this->ext_getSetup($theSetup[$parts[0] . '.'], trim($parts[1]));
+            if (trim($parts[1] ?? '') !== '') {
+                return $this->ext_getSetup($theSetup[$parts[0] . '.'], trim($parts[1] ?? ''));
             }
             return [$theSetup[$parts[0] . '.'], $theSetup[$parts[0]]];
         }

--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -118,7 +118,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
         $currentAction = $schedulerModule->getCurrentAction();
 
         if ($currentAction->equals(Action::EDIT)) {
-            $this->site = $this->siteRepository->getSiteByRootPageId($task->getRootPageId());
+            $this->site = $this->siteRepository->getSiteByRootPageId((int)$task->getRootPageId());
         }
     }
 

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -106,7 +106,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
         $currentAction = $schedulerModule->getCurrentAction();
 
         if ($currentAction->equals(Action::EDIT)) {
-            $this->site = $this->siteRepository->getSiteByRootPageId($task->getRootPageId());
+            $this->site = $this->siteRepository->getSiteByRootPageId((int)$task->getRootPageId());
         }
     }
 

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -104,6 +104,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         if ($pageUid === null && !empty($this->getTypoScriptConfiguration()->getSearchTargetPage())) {
             $pageUid = $this->getTypoScriptConfiguration()->getSearchTargetPage();
         }
+        $pageUid = (int)$pageUid;
 
         $uri = $this->buildUriFromPageUidAndArguments($pageUid);
 
@@ -190,10 +191,10 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
      * When no speaking urls are active (e.g. with TYPO3 8 and no realurl) this information is passed as query parameter
      * and would get lost when it is only part of the query arguments in the action parameter of the form.
      *
-     * @param $pageId
+     * @param int $pageId
      * @return bool
      */
-    protected function getIsSiteManagedSite($pageId): bool
+    protected function getIsSiteManagedSite(int $pageId): bool
     {
         return SiteUtility::getIsSiteManagedSite($pageId);
     }
@@ -248,7 +249,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         $uriBuilder = $this->getControllerContext()->getUriBuilder();
         return $uriBuilder
             ->reset()
-            ->setTargetPageUid($pageUid)
+            ->setTargetPageUid((int)$pageUid)
             ->setTargetPageType($this->arguments['pageType'] ?? 0)
             ->setNoCache($this->arguments['noCache'] ?? false)
             ->setArguments($this->arguments['additionalParams'] ?? [])

--- a/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
@@ -41,7 +41,7 @@ class AddSearchWordListViewHelper extends AbstractSolrFrontendViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('url', 'string', 'The context searchResultSet', true);
-        $this->registerArgument('searchWords', 'string', 'The document to highlight', true);
+        $this->registerArgument('searchWords', 'string', 'The document to highlight', true, '');
         $this->registerArgument('addNoCache', 'boolean', 'Should no_cache=1 be added or not', false, true);
         $this->registerArgument('keepCHash', 'boolean', 'Should cHash be kept or not', false, false);
     }
@@ -67,7 +67,7 @@ class AddSearchWordListViewHelper extends AbstractSolrFrontendViewHelper
             return $url;
         }
 
-        $searchWords = $arguments['searchWords'];
+        $searchWords = $arguments['searchWords'] ?? '';
         $addNoCache = $arguments['addNoCache'];
         $keepCHash = $arguments['keepCHash'];
 

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -272,12 +272,18 @@ class SearchResultSetServiceTest extends IntegrationTest
     protected function doSearchWithResultSetService($solrConnection, $typoScriptConfiguration, $queryString = '*')
     {
         $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
-        /** @var $searchResultsSetService SearchResultSetService */
-        $searchResultSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
-
         $fakeObjectManager = $this->getFakeObjectManager();
 
-        $searchResultSetService->injectObjectManager($fakeObjectManager);
+        /** @var $searchResultsSetService SearchResultSetService */
+        $searchResultSetService = GeneralUtility::makeInstance(
+            SearchResultSetService::class,
+            $typoScriptConfiguration,
+            $search,
+            null,
+            null,
+            null,
+            $fakeObjectManager
+        );
 
         /** @var $searchRequest SearchRequest */
         $searchRequest = GeneralUtility::makeInstance(SearchRequest::class, [], 0, 0, $typoScriptConfiguration);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class FacetCollectionTest
@@ -35,9 +36,10 @@ class FacetCollectionTest extends UnitTest
     {
         $facetCollection = new FacetCollection();
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $objectManagerMock = $this->createMock(ObjectManager::class);
 
-        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
-        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
+        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left'], $objectManagerMock);
+        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left'], $objectManagerMock);
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 
@@ -52,9 +54,10 @@ class FacetCollectionTest extends UnitTest
     {
         $facetCollection = new FacetCollection();
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $objectManagerMock = $this->createMock(ObjectManager::class);
 
-        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
-        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
+        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left'], $objectManagerMock);
+        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left'], $objectManagerMock);
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 
@@ -69,9 +72,10 @@ class FacetCollectionTest extends UnitTest
     {
         $facetCollection = new FacetCollection();
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $objectManagerMock = $this->createMock(ObjectManager::class);
 
-        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top']);
-        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
+        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top'], $objectManagerMock);
+        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left'], $objectManagerMock);
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 
@@ -87,9 +91,10 @@ class FacetCollectionTest extends UnitTest
     {
         $facetCollection = new FacetCollection();
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $objectManagerMock = $this->createMock(ObjectManager::class);
 
-        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top']);
-        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
+        $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top'], $objectManagerMock);
+        $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left'], $objectManagerMock);
         $facetCollection->addFacet($colorFacet);
         $facetCollection->addFacet($brandFacet);
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Unit test for the OptionsFacet
@@ -27,6 +29,18 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class OptionCollectionTest extends UnitTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Unit test for the OptionsFacet
@@ -28,6 +30,17 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class OptionsFacetTest extends UnitTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
 
     /**
      * @test

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGrou
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Unit test for the QueryGroupFacet options collection
@@ -33,6 +35,8 @@ class OptionCollectionTest extends UnitTest
      */
     public function canGetManualSortedCopy()
     {
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+
         $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
         $facet = new QueryGroupFacet($searchResultSetMock, 'age', 'created');
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGrou
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Unit test for the QueryGroupFacet
@@ -28,6 +30,17 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class QueryGroupFacetTest extends UnitTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
 
     /**
      * @test

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -20,6 +20,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RequirementsService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Testcase to test the RequirementsService
@@ -27,6 +29,18 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class RequirementsServiceTest extends UnitTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -73,9 +73,8 @@ class SearchResultSetServiceTest extends UnitTest
         $this->searchMock = $this->getDumbMock(Search::class);
         $this->searchResultBuilderMock = $this->getDumbMock(SearchResultBuilder::class);
         $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
-        $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock);
         $this->objectManagerMock = $this->createMock(ObjectManager::class);
-        $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
+        $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock, $this->objectManagerMock);
         parent::setUp();
     }
 

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -88,12 +88,18 @@ class SearchResultSetTest extends UnitTest
         $this->escapeServiceMock = $this->getDumbMock(EscapeService::class);
         $this->escapeServiceMock->expects(self::any())->method('escape')->willReturnArgument(0);
 
+        $this->objectManagerMock = $this->createMock(ObjectManager::class);
         $this->searchResultSetService = $this->getMockBuilder(SearchResultSetService::class)
             ->onlyMethods(['getRegisteredSearchComponents'])
-            ->setConstructorArgs([$this->configurationMock, $this->searchMock, $this->solrLogManagerMock])
+            ->setConstructorArgs([
+                $this->configurationMock,
+                $this->searchMock,
+                $this->solrLogManagerMock,
+                null,
+                null,
+                $this->objectManagerMock,
+            ])
             ->getMock();
-        $this->objectManagerMock = $this->createMock(ObjectManager::class);
-        $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
         parent::setUp();
     }
 

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -20,6 +20,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Area\GroupViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -86,6 +88,7 @@ class GroupViewHelperTest extends UnitTest
     {
         $facetCollection = new FacetCollection();
         $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AbstractFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AbstractFacetItemViewHelperTest.php
@@ -20,12 +20,26 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractFacetItemViewHelperTest extends UnitTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->createMock(ObjectManager::class));
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     /**
      * @return OptionsFacet
      */


### PR DESCRIPTION
# What this pr does

This pull requests contains several bugfixes and improvements for TYPO3 11
- variable and argument types are enforced to prevent type errors
- ObjectManager in SearchResultSetService is now instantiated via class constructor to simplify the replacement of the ObjectManager in other solr add-ons
- AbstractFacet instantiates the ObjectManager via class constructor to ensure ObjectManager is correctly initialized (#3235)

# How to test

- configure and uses all facet types
- debug Solr result set in the frontend
- run tests

Fixes: #3235 
