### PR TITLE
[BUGFIX] User groups always compared as integers

### DIFF
--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -216,8 +216,8 @@ class GarbageCollector implements SingletonInterface
 
         $frontendGroupsField = $GLOBALS['TCA'][$table]['ctrl']['enablecolumns']['fe_group'];
 
-        $previousGroups = explode(',', (string)$this->trackedRecords[$table][$updatedRecord['uid']][$frontendGroupsField]);
-        $currentGroups = explode(',', (string)$updatedRecord[$frontendGroupsField]);
+        $previousGroups = GeneralUtility::intExplode(',', (string)$this->trackedRecords[$table][$updatedRecord['uid']][$frontendGroupsField]);
+        $currentGroups = GeneralUtility::intExplode(',', (string)$updatedRecord[$frontendGroupsField]);
         $removedGroups = array_diff($previousGroups, $currentGroups);
 
         return !empty($removedGroups);


### PR DESCRIPTION


# What this pr does

Replaces explode with GeneralUtility::intExplode

Fixes: #3249