### PR TITLE
[BUG] Make pageRangeFirst and pageRangeLast accessible in fluid

### DIFF
--- a/Classes/Pagination/ResultsPagination.php
+++ b/Classes/Pagination/ResultsPagination.php
@@ -108,6 +108,26 @@ class ResultsPagination implements PaginationInterface
     }
 
     /**
+     * Get page range first
+     *
+     * @return int
+     */
+    public function getPageRangeFirst(): int
+    {
+        return $this->pageRangeFirst;
+    }
+
+    /**
+     * Get page range last
+     *
+     * @return int
+     */
+    public function getPageRangeLast(): int
+    {
+        return $this->pageRangeLast;
+    }
+
+    /**
      * Get previous page number
      *
      * @return int|null


### PR DESCRIPTION
With these two additional getters it is possible to access the variables
in fluid templates.

Fixes: #3254