### PR TITLE
[BUGFIX] Fix return type error for option facet

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -109,7 +109,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildLimitForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return $facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit() ?? -1);
+        return (int)($facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit() ?? -1));
     }
 
     /**
@@ -119,7 +119,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildMincountForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return $facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount() ?? 1);
+        return (int)($facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount() ?? 1));
     }
 
     /**


### PR DESCRIPTION
Type cast the return values in OptionFacetQueryBuilder::buildLimitForJson()
and OptionFacetQueryBuilder::buildMincountForJson() to avoid php type
error.

Resolves: #3260

# What this pr does

Add type casting to method return values to avoid string instead of integer.

# How to test

See issue #3260 

Fixes: #3260 
