### PR TITLE
[BUGFIX] AbstractSolrTask::setRootPageId(): Argument #1 () must be of…

### DIFF
--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -245,7 +245,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
         }
 
         $task->/** @scrutinizer ignore-call */
-            setRootPageId($submittedData['site']);
+            setRootPageId((int)$submittedData['site']);
 
         $cores = [];
         if (!empty($submittedData['cores'])) {


### PR DESCRIPTION
… type int, string given

# What this pr does

Fixes exception when setting up the scheduler task for OptimizeIndexTask. Has been already fixed for the other  FieldProviders, but not for this one.

# How to test

Please add a testing instruction here

Fixes: #3267
