### PR TITLE
[BUGFIX] Ensure array value is set when accessing

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -130,7 +130,11 @@ class RecordMonitor
         }
 
         if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
-            $recordUid = $tceMain->substNEWwithIDs[$recordUid];
+            if (isset($this->dh->substNEWwithIDs[$recordUid])) {
+                $recordUid = $this->dh->substNEWwithIDs[$recordUid];
+            } else {
+                return; 
+            }
         }
         if (Util::isDraftRecord($table, (int)$recordUid)) {
             // skip workspaces: index only LIVE workspace

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -130,10 +130,10 @@ class RecordMonitor
         }
 
         if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
-            if (isset($this->dh->substNEWwithIDs[$recordUid])) {
-                $recordUid = $this->dh->substNEWwithIDs[$recordUid];
+            if (isset($tceMain->substNEWwithIDs[$recordUid])) {
+                $recordUid = $tceMain->substNEWwithIDs[$recordUid];
             } else {
-                return; 
+                return;
             }
         }
         if (Util::isDraftRecord($table, (int)$recordUid)) {


### PR DESCRIPTION
Before accessing the dataHandler array ensure the requested key is available and skip, if this is not the case. 

Fixes: #3269
