### PR TITLE
[BUGFIX] Avoid 404 handler deadlock in special case

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -30,6 +30,7 @@ use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Core\Error\Http\InternalServerErrorException;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\Locales;
@@ -191,7 +192,9 @@ class Tsfe implements SingletonInterface
                 if ($backedUpBackendUser) {
                     $GLOBALS['BE_USER'] = $backedUpBackendUser;
                 }
-                return;
+                if (!($exception instanceof InternalServerErrorException)) {
+                    return;
+                }
             }
             // Restore backend user, happens when initializeTsfe() is called from Backend context
             if ($backedUpBackendUser) {


### PR DESCRIPTION
# What this pr does

The error occurs in a special case when:
- there is no "page" object in TypoScript
- a 404 handler is configured in site configuration
- there is a language without translated root page

In this case, the 404 handler will be stuck in a deadlock, increasing
the RAM usage until it uses all of the available RAM.

This deadlock happens, when the tsfeCache is null. Therefore we ensure
TSFE is set in cache when internal server errors occurred.

# How to test

See #3274. With this fix, the error should not happen anymore.

Fixes: #3274