### PR TITLE
[BUGFIX] Respect indexing configuration for new and updated subpages

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -25,8 +25,10 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Util;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Exception\Page\PageNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * A class that monitors changes to the records so that the changed record get
@@ -57,6 +59,7 @@ class RecordMonitor
      * @param string $command The command.
      * @param string $table The table the record belongs to
      * @param int $uid The record's uid
+     * @noinspection PhpMissingParamTypeInspection, because it is the TYPO3 core implementation.
      */
     public function processCmdmap_preProcess(
         $command,
@@ -78,6 +81,7 @@ class RecordMonitor
      * @param string $table The table the record belongs to
      * @param int $uid The record's uid
      * @param mixed $value
+     * @noinspection PhpMissingParamTypeInspection, because it is the TYPO3 core implementation.
      */
     public function processCmdmap_postProcess(
         $command,
@@ -129,6 +133,17 @@ class RecordMonitor
             return;
         }
 
+        $recordPid = $fields['pid'] ?? null;
+        if (is_null($recordPid) && MathUtility::canBeInterpretedAsInteger($recordUid)) {
+            $recordInfo = $tceMain->recordInfo($table, (int)$recordUid, 'pid');
+            if (!is_null($recordInfo)) {
+                $recordPid = $recordInfo['pid'] ?? null;
+            }
+        }
+        if (!is_null($recordPid) && $this->skipRecordByRootlineConfiguration((int)$recordPid)) {
+            return;
+        }
+
         if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
             $recordUid = $tceMain->substNEWwithIDs[$recordUid];
         }
@@ -163,5 +178,28 @@ class RecordMonitor
         }
 
         return !in_array($table, $configurationMonitorTables);
+    }
+
+    /**
+     * Check if at least one page in the record's rootline is configured to exclude sub-entries from indexing
+     *
+     * @param int $pid
+     * @return bool
+     */
+    protected function skipRecordByRootlineConfiguration(int $pid): bool
+    {
+        /** @var RootlineUtility $rootlineUtility */
+        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pid);
+        try {
+            $rootline = $rootlineUtility->get();
+        } catch (PageNotFoundException $e) {
+            return true;
+        }
+        foreach ($rootline as $page) {
+            if ($page['no_search_sub_entries']) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -27,6 +27,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * Testcase for the RecordMonitor class.
@@ -36,9 +37,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class RecordMonitorTest extends UnitTest
 {
     /**
-     * @var RecordMonitor
+     * @var RecordMonitor|null
      */
-    protected $recordMonitor;
+    protected ?RecordMonitor $recordMonitor;
 
     /**
      * @var EventDispatcherInterface|MockObject
@@ -56,12 +57,22 @@ class RecordMonitorTest extends UnitTest
             ExtensionConfiguration::class,
             $this->getDumbMock(ExtensionConfiguration::class)
         );
+
+        $rootlineUtilityMock = $this->getDumbMock(RootlineUtility::class);
+        $rootlineUtilityMock->method('get')->willReturn([]);
+        GeneralUtility::addInstance(
+            RootlineUtility::class,
+            $rootlineUtilityMock
+        );
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['BE_USER']);
+        unset(
+            $GLOBALS['BE_USER'],
+            $this->recordMonitor
+        );
         GeneralUtility::purgeInstances();
         parent::tearDown();
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -277,6 +277,13 @@ if (!function_exists('strptime')) {
      */
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['enhancers']['SolrFacetMaskAndCombineEnhancer'] =
         \ApacheSolrForTypo3\Solr\Routing\Enhancer\SolrFacetMaskAndCombineEnhancer::class;
+
+    // add solr field to rootline fields
+    if ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] === '') {
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] = 'no_search_sub_entries';
+    } else {
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',no_search_sub_entries';
+    }
 })();
 
 $isComposerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE;


### PR DESCRIPTION
This pull request respects the indexing configuration for new and updated subpages. On each save of a subpage or a record on a subpage the rootline is checked for at least one page that is configured to exclude all subentries from search. If this is the case the subpage is not added to the indexing queue.

Fixes: #3276