### PR TITLE
[BUGFIX] Class properties must not be accessed before initialization

### DIFF
--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -53,9 +53,9 @@ class SearchResultSet
     protected ?Search $usedSearch = null;
 
     /**
-     * @var ResponseAdapter
+     * @var ?ResponseAdapter
      */
-    protected ResponseAdapter $response;
+    protected ?ResponseAdapter $response = null;
 
     /**
      * @var int
@@ -237,9 +237,9 @@ class SearchResultSet
     }
 
     /**
-     * @return ResponseAdapter
+     * @return ?ResponseAdapter
      */
-    public function getResponse(): ResponseAdapter
+    public function getResponse(): ?ResponseAdapter
     {
         return $this->response;
     }

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -75,9 +75,9 @@ class SearchUriBuilder
     protected EventDispatcherInterface $eventDispatcher;
 
     /**
-     * @var RoutingService
+     * @var ?RoutingService
      */
-    protected RoutingService $routingService;
+    protected ?RoutingService $routingService = null;
 
     /**
      * @param UriBuilder $uriBuilder


### PR DESCRIPTION
This change fixes two issues for class properties initialized by inject or setter methods.
The properties and getters must be nullable, 
if inject method or setter methods initialise properties.

This patch applies on:
* \ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder::$routingService
* \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet::$response

Fixes: #3288

ToDos:
- [x] port to main