### PR TITLE
[BUGFIX] slow response when allowedSites = __all

### DIFF
--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site;
 
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Throwable;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -77,20 +78,19 @@ class SiteHashService
     }
 
     /**
-     * Returns a comma separated list of all domains from all sites.
+     * Returns a comma separated list with domains of all sites.
      *
      * @return string
-     * @throws DBALDriverException
      * @throws Throwable
      */
     protected function getDomainListOfAllSites(): string
     {
-        $sites = $this->getAvailableSites();
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        $sites = $siteFinder->getAllSites();
         $domains = [];
         foreach ($sites as $site) {
-            $domains[] = $site->getDomain();
+            $domains[] = $site->getBase()->getHost();
         }
-
         return implode(',', $domains);
     }
 

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -53,9 +53,11 @@ class SiteHashServiceTest extends UnitTest
         $siteB = $this->getDumbMock(Site::class);
         $siteB->expects(self::any())->method('getDomain')->willReturn('solrtestb.local');
         $allSites = [$siteA, $siteB];
+        $allSitesString = ('solrtesta.local,solrtestb.local');
 
         /** @var $siteHashServiceMock SiteHashService */
-        $siteHashServiceMock = $this->getMockBuilder(SiteHashService::class)->onlyMethods(['getAvailableSites', 'getSiteByPageId'])->getMock();
+        $siteHashServiceMock = $this->getMockBuilder(SiteHashService::class)->onlyMethods(['getDomainListOfAllSites', 'getAvailableSites', 'getSiteByPageId'])->getMock();
+        $siteHashServiceMock->expects(self::any())->method('getDomainListOfAllSites')->willReturn($allSitesString);
         $siteHashServiceMock->expects(self::any())->method('getAvailableSites')->willReturn($allSites);
         $siteHashServiceMock->expects(self::any())->method('getSiteByPageId')->willReturn($siteA);
 


### PR DESCRIPTION
# What this pr does

Fixes very slow response when search.query.allowedSites = __all, esp. on multi-site installations.

# How to test

Add a couple of extra sites with their own domain or subdomain and measure the time it takes for the method getDomainListOfAllSites to complete. Without the patch, this could easily run up to 0.3 or 0.5 seconds for each domain. With this fix, the time is negligible (and so it should, because this method is process uncached).

Fixes: #3292 