### PR TITLE
Fix empty suggest query triggering a PHP error

### DIFF
--- a/Classes/Domain/Search/Query/SuggestQuery.php
+++ b/Classes/Domain/Search/Query/SuggestQuery.php
@@ -58,8 +58,8 @@ class SuggestQuery extends Query
         } else {
             $matches = [];
             preg_match('/^(:?(.* |))([^ ]+)$/', $keywords, $matches);
-            $fullKeywords = trim($matches[2]);
-            $partialKeyword = trim($matches[3]);
+            $fullKeywords = trim($matches[2] ?? '');
+            $partialKeyword = trim($matches[3] ?? '');
 
             $this->setQuery($fullKeywords);
             $this->prefix = $partialKeyword;

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -19,7 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Core\Utility\DebugUtility;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Core\Utility\DebugUtility;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class
@@ -56,5 +57,20 @@ class SuggestQueryTest extends UnitTest
         $queryBuilder->startFrom($suggestQuery)->useFilter('+type:pages');
         $queryParameters = $suggestQuery->getRequestBuilder()->build($suggestQuery)->getParams();
         self::assertSame('+type:pages', $queryParameters['fq'], 'Filter was not added to the suggest query parameters');
+    }
+
+    /**
+     * @test
+     */
+    public function testSuggestQueryDoesNotErrorOnEmptyKeywords()
+    {
+        $fakeConfiguration = new TypoScriptConfiguration([]);
+        $suggestQuery = new SuggestQuery(' ', $fakeConfiguration);
+
+        $queryBuilder = new QueryBuilder($fakeConfiguration);
+        $queryBuilder->startFrom($suggestQuery)->useFilter('+type:pages');
+        $queryParameters = $suggestQuery->getRequestBuilder()->build($suggestQuery)->getParams();
+        self::assertSame('', $queryParameters['q'], 'Query is expected to be empty, but is not');
+        self::assertSame('', $queryParameters['facet.prefix'], 'Facet prefix is expected to be empty, but is not');
     }
 }


### PR DESCRIPTION
# What this pr does

Sending a suggest query containing only spaces causes PHP 8+ to throw a
TypeError exception because the result of the regular expression will
not have a third entry in its matches array.

Use null-coalescing operator to ensure a string is given to the trim
function in the SuggestQuery constructor.

# How to test

Enter only spaces into the search field (which has the autocomplete/suggest function properly configured)  of a TYPO3 installation that uses PHP 8.0 or newer.

Additionally a test was added: \ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\SuggestQueryTest->testSuggestQueryDoesNotErrorOnEmptyKeywords

Fixes: #3302
