### PR TITLE
[BUGFIX] Fix type errors in OptionsFacetQueryBuilder

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config->getFinder()
+$config
+    ->addRules(['modernize_strpos' => false])
+    ->getFinder()
     ->exclude([
         '.Build'
     ])

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -109,7 +109,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildLimitForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return $facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit() ?? -1);
+        return (int)($facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit() ?? -1));
     }
 
     /**
@@ -119,7 +119,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildMincountForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return $facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount() ?? 1);
+        return (int)($facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount() ?? 1));
     }
 
     /**

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -220,7 +220,7 @@ abstract class IntegrationTest extends FunctionalTestCase
      */
     protected function getRuntimeDirectory(): string
     {
-        $rc = new ReflectionClass(get_class($this));
+        $rc = new ReflectionClass(static::class);
         return dirname($rc->getFileName());
     }
 

--- a/Tests/Unit/UnitTest.php
+++ b/Tests/Unit/UnitTest.php
@@ -86,7 +86,7 @@ abstract class UnitTest extends UnitTestCase
      */
     protected function getRuntimeDirectory()
     {
-        $rc = new ReflectionClass(get_class($this));
+        $rc = new ReflectionClass(static::class);
         return dirname($rc->getFileName());
     }
 


### PR DESCRIPTION
# What this pr does

Ensures correct return types in OptionsFacetQueryBuilder for settings
facetLimit and minimum count.

# How to test

Configure facetLimit and/or minimumCount, e.g.:

- facets.facetxy.facetLimit
- facets.facetxy.minimumCount


Fixes: #3304
