### PR TITLE
[TASK:BP:11.5] Adjust typo3/coding-standards settings

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config->getFinder()
+$config
+    ->addRules(['modernize_strpos' => false])
+    ->getFinder()
     ->exclude([
         '.Build'
     ])

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -220,7 +220,7 @@ abstract class IntegrationTest extends FunctionalTestCase
      */
     protected function getRuntimeDirectory(): string
     {
-        $rc = new ReflectionClass(get_class($this));
+        $rc = new ReflectionClass(static::class);
         return dirname($rc->getFileName());
     }
 

--- a/Tests/Unit/UnitTest.php
+++ b/Tests/Unit/UnitTest.php
@@ -86,7 +86,7 @@ abstract class UnitTest extends UnitTestCase
      */
     protected function getRuntimeDirectory()
     {
-        $rc = new ReflectionClass(get_class($this));
+        $rc = new ReflectionClass(static::class);
         return dirname($rc->getFileName());
     }
 


### PR DESCRIPTION
# What this pr does

typo3/coding-standards 0.5.4 includes rule modernize_strpos, which is not possible with PHP 7.4 as str_contains requires
PHP 8.

This pull request removes rule modernize_strpos and contains some minor adaptions.