### PR TITLE
[DOCS:BP:11.2] add missing doc for plugin.tx_solr.logging.indexing.pageIndexed

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrLogging.rst
+++ b/Documentation/Configuration/Reference/TxSolrLogging.rst
@@ -67,6 +67,17 @@ indexing.indexQueuePageIndexerGetData
 
 If enabled, the requested data will be logged. Request data includes item, url, parameters, headers, data, decodedData and report.
 
+indexing.pageIndexed
+--------------------
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.logging.indexing.pageIndexed
+:Default: 0
+:Options: 0,1
+:Since: 2.0
+
+If enabled, it will be logged if a page was indexed successful or not. Additionally, an error is logged if indexing is disabled (via `config.index_enable`)
+
 query.filters
 -------------
 


### PR DESCRIPTION
# What this pr does

Add missing doc for plugin.tx_solr.logging.indexing.pageIndexed

Related: #3102 