### PR TITLE
[TASK:BP:11.5] Require TYPO3 11.5.14

### DIFF
--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -9,7 +9,7 @@ fi
 EXTENSION_ROOTPATH="$SCRIPTPATH/../../"
 SOLR_INSTALL_PATH="/opt/solr-tomcat/"
 
-DEFAULT_TYPO3_VERSION="^11.5"
+DEFAULT_TYPO3_VERSION="^11.5.14"
 DEFAULT_PHP_CS_FIXER_VERSION="^3.2.1"
 DEFAULT_TYPO3_DATABASE_HOST="localhost"
 DEFAULT_TYPO3_DATABASE_NAME="test"
@@ -65,7 +65,7 @@ echo "Using database user: $TYPO3_DATABASE_USERNAME"
 echo "Using database password: $TYPO3_DATABASE_PASSWORD"
 
 if [ -z $TYPO3_VERSION ]; then
-  echo "Must set env var TYPO3_VERSION (e.g. dev-master or ^10.4)"
+  echo "Must set env var TYPO3_VERSION (e.g. dev-main or ^11.5)"
   exit 1
 fi
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-simplexml": "*",
     "solarium/solarium": "6.2.3",
     "typo3/cms-backend": "*",
-    "typo3/cms-core": "^11.5.4",
+    "typo3/cms-core": "^11.5.14",
     "typo3/cms-extbase": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-frontend": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '11.5.4-11.5.99',
+            'typo3' => '11.5.14-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
With EXT:solr 11.5 we're increasingly using local objects, but most ContentObjects in the TYPO3 core required a global version of the TypoScriptFrontendController which leads to problems during indexing. TYPO3 11.5.14 contains some adaptions to support the usage of local TypoScriptFrontendController objects, these adaptions are fixing this issue, so we require at least TYPO3 11.5.14.

Resolves: #3239
Resolves: #3244
