### PR TITLE
[FEATURE:BP:11.5] Add custom field processors

### DIFF
--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\FieldProcessor;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception as DBALException;
+use Exception;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -96,6 +97,18 @@ class Service
                     case 'uppercase':
                         $fieldValue = array_map('mb_strtoupper', $fieldValue);
                         break;
+                    default:
+                        $classReference = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['fieldProcessor'][$instruction] ?? false;
+                        if ($classReference) {
+                            $customFieldProcessor = GeneralUtility::makeInstance($classReference);
+                            if ($customFieldProcessor instanceof FieldProcessor) {
+                                $fieldValue = $customFieldProcessor->process($fieldValue);
+                            } else {
+                                throw new Exception('A FieldProcessor must implement the FieldProcessor interface', 1635082295);
+                            }
+                        } else {
+                            throw new Exception(sprintf('FieldProcessor %s is not implemented', $instruction), 1635082296);
+                        }
                 }
 
                 if ($isSingleValueField) {

--- a/Documentation/Frontend/Facets.rst
+++ b/Documentation/Frontend/Facets.rst
@@ -218,6 +218,11 @@ When you follow this convention by writing date into a solr field you can render
 
 In this case the "fieldProcessingInstruction" "pageUidToHierarchy" is used to create the rootline for solr in the conventional way.
 
+Custom field processors can be registered with
+
+.. code-block:: php
+
+   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['fieldProcessor']['yourFieldProcessor'] = ACustomFieldProcessor::class;
 
 Date Range
 ----------

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -120,4 +120,22 @@ class ServiceTest extends UnitTest
             'field was not processed with timestampToIsoDate'
         );
     }
+
+    /**
+     * @test
+     */
+    public function customFieldProcessorTurnsFooIntoBar()
+    {
+        $this->documentMock->setField('stringField', 'foo');
+        $configuration = ['stringField' => 'turnFooIntoBar'];
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['fieldProcessor']['turnFooIntoBar'] = TestFieldProcessor::class;
+
+        $this->service->processDocument($this->documentMock, $configuration);
+        self::assertEquals(
+            $this->documentMock['stringField'],
+            'bar',
+            'field was not processed with TestFieldProcessor'
+        );
+    }
 }

--- a/Tests/Unit/FieldProcessor/TestFieldProcessor.php
+++ b/Tests/Unit/FieldProcessor/TestFieldProcessor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
+
+use ApacheSolrForTypo3\Solr\FieldProcessor\FieldProcessor;
+
+class TestFieldProcessor implements FieldProcessor
+{
+    public function process(array $values): array
+    {
+        foreach ($values as $no => $value) {
+            if ($value === 'foo') {
+                $values[$no] = 'bar';
+            }
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
Relates: #1811

# What this pr does

Be able to register custom field processors.

# How to test

Execute the test `\ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor\ServiceTest::customFieldProcessorTurnsFooIntoBar`

Fixes: #1811
