### PR TITLE
[FEATURE] add logging for failed http requests

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -23,6 +23,7 @@ use Exception;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LogLevel;
 use RuntimeException;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -412,6 +413,24 @@ class PageIndexerRequest
             $response = $this->requestFactory->request($url, 'GET', $options);
         } catch (ClientException|ServerException $e) {
             $response = $e->getResponse();
+            if (isset($options['auth']['password'])) {
+                $options['auth']['password'] = '*****';
+            }
+            // Log with INFO severity because this is what configured for Testing & Development contexts
+            $this->logger->log(
+                LogLevel::INFO,
+                sprintf(
+                    'Exception while fetching \'%s\': [%d] "%s". HTTP status: %d"',
+                    $url,
+                    $e->getCode(),
+                    $e->getMessage(),
+                    $response->getStatusCode()
+                ),
+                [
+                    'HTTP headers' => $response->getHeaders(),
+                    'options' => $options,
+                ]
+            );
         }
         return $response;
     }


### PR DESCRIPTION
# What this pr does

This PR adds logging for failed site requests. This helps to detect what exactly happened. Messages will appear in the log file for Testing and Development contexts by default. Preview password will be masked in logs.

# How to test

Test by placing password protection in front of the site and starting indexing without user name and password. You will get a vague error in the queue module but a good description of the problem in the log file.

We had a more complicated case, which cost us several lost hours due to missing logging of errors: the site was password protected and we supplied the password. But it still failed to index. When we added logging, we found that the site was accessed using proxy, which we had on this host and proxy did not care to pass on http authentication. It took a lot of time to understand this simple cause. If we had this logging, it could take minutes.

Fixes: #3318
