### PR TITLE
[BUG] make sure that $currentPageNumber in resultsAction is always >= 1

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -116,7 +116,7 @@ class SearchController extends AbstractBaseController
             $currentPage = $this->request->hasArgument('page') ? (int)$this->request->getArgument('page') : 1;
 
             // prevent currentPage < 1 (i.e for GET request like &tx_solr[page]=0)
-            if($currentPage < 1) {
+            if ($currentPage < 1) {
                 $currentPage = 1;
             }
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -116,10 +116,10 @@ class SearchController extends AbstractBaseController
             $currentPage = $this->request->hasArgument('page') ? (int)$this->request->getArgument('page') : 1;
 
             // prevent currentPage < 1 (i.e for GET request like &tx_solr[page]=0)
-            if($currentPage < 1) { 
-                $currentPage = 1;    
+            if($currentPage < 1) {
+                $currentPage = 1;
             }
-            
+
             $itemsPerPage = ($searchResultSet->getUsedResultsPerPage() ?: $this->typoScriptConfiguration->getSearchResultsPerPage(10));
             $paginator = GeneralUtility::makeInstance(ResultsPaginator::class, $searchResultSet, $currentPage, $itemsPerPage);
             $pagination = GeneralUtility::makeInstance(ResultsPagination::class, $paginator);

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -114,6 +114,12 @@ class SearchController extends AbstractBaseController
             $this->controllerContext->setSearchResultSet($searchResultSet);
 
             $currentPage = $this->request->hasArgument('page') ? (int)$this->request->getArgument('page') : 1;
+
+            // prevent currentPage < 1 (i.e for GET request like &tx_solr[page]=0)
+            if($currentPage < 1) { 
+                $currentPage = 1;    
+            }
+            
             $itemsPerPage = ($searchResultSet->getUsedResultsPerPage() ?: $this->typoScriptConfiguration->getSearchResultsPerPage(10));
             $paginator = GeneralUtility::makeInstance(ResultsPaginator::class, $searchResultSet, $currentPage, $itemsPerPage);
             $pagination = GeneralUtility::makeInstance(ResultsPagination::class, $paginator);


### PR DESCRIPTION
fixes #3323

# What this pr does

While paginating searchResults, this pr makes sure that the currentPage never gets below 1 and prevents an exception and a 503 error on the client side. 

This can happen i.e. through the GET parameter ?[page]=0 or ?[page]=-20
 
# How to test

Open a searchResult page and set the page to 0 or lower than 0. Now instead of an exception and 503 error on the client side, the current page should be set to 1:
https://xyz.de/suche?tx_solr[page]=0

Fixes: #3323
