### PR TITLE
[BUGFIX] fix infinite loop in Tsfe::getPidToUseForTsfeInitialization()

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -355,6 +355,9 @@ class Tsfe implements SingletonInterface
      */
     protected function getPidToUseForTsfeInitialization(int $pidToUse, ?int $rootPageId = null): ?int
     {
+        $incomingPidToUse = $pidToUse;
+        $incomingRootPageId = $rootPageId;
+
         // handle plugin.tx_solr.index.queue.[indexConfig].additionalPageIds
         if (isset($rootPageId) && !$this->isRequestedPageAPartOfRequestedSite($pidToUse)) {
             return $rootPageId;
@@ -377,6 +380,15 @@ class Tsfe implements SingletonInterface
         if (isset($rootPageId)) {
             return $rootPageId;
         }
+
+        // Check for recursion that can happen if the root page is a sysfolder with a typoscript template
+        if ($pidToUse === $incomingPidToUse && $rootPageId === $incomingRootPageId) {
+            throw new Exception\Exception(
+                "Infinite recursion detected while looking for the closest page with active template to page \"$askedPid\" . Please note that the page with active template (usually the root page of the current tree) MUST NOT be a sysfolder.",
+                1637339476
+            );
+        }
+
         return $this->getPidToUseForTsfeInitialization($pidToUse, $rootPageId);
     }
 


### PR DESCRIPTION
…in Tsfe->getPidToUseForTsfeInitialization. Fixes #3306

# What this pr does

Before calling Tsfe->getPidToUseForTsfeInitialization recursively from itself, checks if the function parameters are different from the current call. If they are not, calling recursively will end in an infinite loop, crashing the application by running into PHPs memory limit.

# How to test

- In TYPO3, create a sysfolder named "General Storage"
- Add a typoscript root template to that sysfolder
- Create a subfolder containing some indexable records, for example "news"
- Add an indexable record (news item)
- Setup SOLR to index the record (include the default news indexing configuration typoscript)
- Build index query for news
- Run indexer

Without the fix, php memory limit will be reached ("Allowed memory size of xyz bytes exhausted").
The fix prevents this and provides a meaningful error message by throwing an exception

Fixes: #3306
