### PR TITLE
[TASK:11.5] Fix TYPO3 coding standards issues after upgrade to v0.5.5

### DIFF
--- a/Classes/Access/RootlineElement.php
+++ b/Classes/Access/RootlineElement.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RootlineElement
 {
-
     /**
      * Page access rootline element.
      *

--- a/Classes/Api.php
+++ b/Classes/Api.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr;
  */
 class Api
 {
-
     /**
      * Checks whether a string is a valid API key.
      *

--- a/Classes/Domain/Index/Classification/ClassificationService.php
+++ b/Classes/Domain/Index/Classification/ClassificationService.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
  */
 class ClassificationService
 {
-
     /**
      * @param string $stringToMatch
      * @param Classification[] $classifications

--- a/Classes/Domain/Index/Queue/QueueInitializationService.php
+++ b/Classes/Domain/Index/Queue/QueueInitializationService.php
@@ -36,7 +36,6 @@ use UnexpectedValueException;
  */
 class QueueInitializationService
 {
-
     /**
      * @var Queue
      */

--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -36,7 +36,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Repository implements SingletonInterface
 {
-
     /**
      * Search
      *

--- a/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class LastSearchesWriterProcessor implements SearchResultSetProcessor
 {
-
     /**
      * @param SearchResultSet $resultSet
      *

--- a/Classes/Domain/Search/Query/ParameterBuilder/Spellchecking.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Spellchecking.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
  */
 class Spellchecking extends AbstractDeactivatable implements ParameterBuilderInterface
 {
-
     /**
      * @var int
      */

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
  */
 class Node extends AbstractOptionFacetItem
 {
-
     /**
      * @var NodeCollection
      */

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
  */
 class NodeCollection extends AbstractFacetItemCollection
 {
-
     /**
      * @param AbstractFacetItem|null $item
      * @return NodeCollection

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
  */
 class QueryGroupFacetParser extends AbstractFacetParser
 {
-
     /**
      * @param SearchResultSet $resultSet
      * @param string $facetName

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCollection.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
  */
 class DateRangeCollection extends AbstractFacetItemCollection
 {
-
     /**
      * @param AbstractFacetItem|null $item
      * @return DateRangeCollection

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
@@ -24,7 +24,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\Nume
 
 class NumericRangeCount
 {
-
     /**
      * @var float
      */

--- a/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
@@ -32,7 +32,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class FormatDate
 {
-
     /**
      * @var FormatService
      */

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DefaultResultParser.php
@@ -27,7 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DefaultResultParser extends AbstractResultParser
 {
-
     /**
      * @param SearchResultSet $resultSet
      * @param bool $useRawDocuments

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Util;
  */
 class DocumentEscapeService
 {
-
     /**
      * @var TypoScriptConfiguration
      */

--- a/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
+++ b/Classes/Domain/Search/ResultSet/Sorting/SortingHelper.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SortingHelper
 {
-
     /**
      * @var array
      */

--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -23,7 +23,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Score;
  */
 class ScoreCalculationService
 {
-
     /**
      * Renders an overview of how the score for a certain document has been
      * calculated.

--- a/Classes/Domain/Search/SearchRequestAware.php
+++ b/Classes/Domain/Search/SearchRequestAware.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search;
  */
 interface SearchRequestAware
 {
-
     /**
      * Provides a component that is aware of the current SearchRequest
      *

--- a/Classes/Eid/Api.php
+++ b/Classes/Eid/Api.php
@@ -26,7 +26,6 @@ if (!Api::isValidApiKey($apiKey)) {
     echo json_encode(['errorMessage' => 'Invalid API key']);
 } else {
     switch ($api) {
-
         case 'siteHash':
             include('SiteHash.php');
             break;

--- a/Classes/FieldProcessor/AbstractHierarchyProcessor.php
+++ b/Classes/FieldProcessor/AbstractHierarchyProcessor.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\FieldProcessor;
  */
 abstract class AbstractHierarchyProcessor
 {
-
     /**
      * Builds a Solr hierarchy from an array of uids that make up a rootline.
      *

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -326,8 +326,8 @@ abstract class AbstractIndexer
                 break;
 
             default:
-            // assume things are correct for non-dynamic fields
-            }
+                // assume things are correct for non-dynamic fields
+        }
 
         return $value;
     }

--- a/Classes/IndexQueue/AdditionalIndexQueueItemIndexer.php
+++ b/Classes/IndexQueue/AdditionalIndexQueueItemIndexer.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
  */
 interface AdditionalIndexQueueItemIndexer
 {
-
     /**
      * Provides additional documents that should be indexed together with an Index Queue item.
      *

--- a/Classes/IndexQueue/FrontendHelper/FrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/FrontendHelper.php
@@ -27,7 +27,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
  */
 interface FrontendHelper
 {
-
     /**
      * Activates a frontend helper by registering for hooks and other
      * resources required by the frontend helper to work.

--- a/Classes/IndexQueue/FrontendHelper/Manager.php
+++ b/Classes/IndexQueue/FrontendHelper/Manager.php
@@ -27,7 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Manager
 {
-
     /**
      * Frontend helper descriptions.
      *

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -43,7 +43,6 @@ use UnexpectedValueException;
  */
 class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
 {
-
     /**
      * This frontend helper's executed action.
      *

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -38,7 +38,6 @@ class UserGroupDetector extends AbstractFrontendHelper implements
     PageRepositoryGetPageHookInterface,
     PageRepositoryGetPageOverlayHookInterface
 {
-
     /**
      * This frontend helper's executed action.
      */

--- a/Classes/IndexQueue/InitializationPostProcessor.php
+++ b/Classes/IndexQueue/InitializationPostProcessor.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
  */
 interface InitializationPostProcessor
 {
-
     /**
      * Post process Index Queue initialization
      *

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -37,7 +37,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 abstract class AbstractInitializer implements IndexQueueInitializer
 {
-
     /**
      * Site to initialize
      *

--- a/Classes/IndexQueue/Initializer/IndexQueueInitializer.php
+++ b/Classes/IndexQueue/Initializer/IndexQueueInitializer.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
  */
 interface IndexQueueInitializer
 {
-
     /**
      * Sets the site for the initializer.
      *

--- a/Classes/IndexQueue/Initializer/Record.php
+++ b/Classes/IndexQueue/Initializer/Record.php
@@ -23,6 +23,5 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Initializer;
  */
 class Record extends AbstractInitializer
 {
-
     // just the default behavior as in the abstract class
 }

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -85,7 +85,6 @@ class PageIndexer extends Indexer
      */
     protected function isPageIndexable(Item $item): bool
     {
-
         // TODO do we still need this?
         // shouldn't those be sorted out by the record monitor / garbage collector already?
 

--- a/Classes/IndexQueue/PageIndexerDataUrlModifier.php
+++ b/Classes/IndexQueue/PageIndexerDataUrlModifier.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  */
 interface PageIndexerDataUrlModifier
 {
-
     /**
      * Modifies the given data url
      *

--- a/Classes/IndexQueue/PageIndexerDocumentsModifier.php
+++ b/Classes/IndexQueue/PageIndexerDocumentsModifier.php
@@ -23,7 +23,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  */
 interface PageIndexerDocumentsModifier
 {
-
     /**
      * Modifies the given documents
      *

--- a/Classes/IndexQueue/SerializedValueDetector.php
+++ b/Classes/IndexQueue/SerializedValueDetector.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
  */
 interface SerializedValueDetector
 {
-
     /**
      * Uses a field's configuration to detect whether its value returned by a
      * content object is expected to be serialized and thus needs to be

--- a/Classes/Migrations/RemoveSiteFromScheduler.php
+++ b/Classes/Migrations/RemoveSiteFromScheduler.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RemoveSiteFromScheduler implements Migration
 {
-
     /**
      * Called by the extension manager to determine if the update menu entry
      * should be showed.

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -39,7 +39,6 @@ use InvalidArgumentException;
  */
 class Faceting implements Modifier, SearchRequestAware
 {
-
     /**
      * @var FacetRegistry
      */

--- a/Classes/Search/AbstractComponent.php
+++ b/Classes/Search/AbstractComponent.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\Search;
  */
 abstract class AbstractComponent implements SearchComponent
 {
-
     /**
      * Search configuration - plugin.tx_solr.search
      *

--- a/Classes/Search/FacetsModifier.php
+++ b/Classes/Search/FacetsModifier.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\Search;
  */
 interface FacetsModifier
 {
-
     /**
      * Modifies the given facets and returns the modified facets as array
      *

--- a/Classes/Search/ResponseModifier.php
+++ b/Classes/Search/ResponseModifier.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
  */
 interface ResponseModifier
 {
-
     /**
      * Modifies the given response and returns the modified response as result
      *

--- a/Classes/Search/SearchAware.php
+++ b/Classes/Search/SearchAware.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Search;
  */
 interface SearchAware
 {
-
     /**
      * Provides the extension component with an instance of the currently
      * active search.

--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -30,7 +30,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  */
 class ConfigurationPageResolver
 {
-
     /**
      * @var SystemTemplateRepository
      */

--- a/Classes/System/Logging/DebugWriter.php
+++ b/Classes/System/Logging/DebugWriter.php
@@ -31,7 +31,6 @@ use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
  */
 class DebugWriter
 {
-
     /**
      * When the feature is enabled with: plugin.tx_solr.logging.debugOutput the log writer uses the extbase
      * debug functionality in the frontend, or the console in the backend to display the devlog messages.

--- a/Classes/System/Session/FrontendUserSession.php
+++ b/Classes/System/Session/FrontendUserSession.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
  */
 class FrontendUserSession
 {
-
     /**
      * @var FrontendUserAuthentication|null
      */

--- a/Classes/System/Util/ArrayAccessor.php
+++ b/Classes/System/Util/ArrayAccessor.php
@@ -37,7 +37,6 @@ namespace ApacheSolrForTypo3\Solr\System\Util;
  */
 class ArrayAccessor
 {
-
     /**
      * @var array|null
      */

--- a/Classes/System/Validator/Path.php
+++ b/Classes/System/Validator/Path.php
@@ -22,7 +22,6 @@ namespace ApacheSolrForTypo3\Solr\System\Validator;
  */
 class Path
 {
-
     /**
      * Validate that a path is a valid Solr Path
      *

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Typo3PageContentExtractor extends HtmlContentExtractor
 {
-
     /**
      * @var SolrLogManager|null
      */

--- a/Classes/ViewHelpers/AbstractSolrViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrViewHelper.php
@@ -19,7 +19,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 abstract class AbstractSolrViewHelper extends AbstractViewHelper
 {
-
     /**
      * @var bool
      */

--- a/Classes/ViewHelpers/Backend/IsStringViewHelper.php
+++ b/Classes/ViewHelpers/Backend/IsStringViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsStringViewHelper extends AbstractConditionViewHelper
 {
-
     /**
      * Initialize ViewHelper arguments
      *

--- a/Classes/ViewHelpers/Format/ArrayViewHelper.php
+++ b/Classes/ViewHelpers/Format/ArrayViewHelper.php
@@ -25,7 +25,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ArrayViewHelper extends AbstractViewHelper
 {
-
     /**
      * Make sure values is a array else convert
      *

--- a/Classes/ViewHelpers/LastSearchesViewHelper.php
+++ b/Classes/ViewHelpers/LastSearchesViewHelper.php
@@ -27,7 +27,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class LastSearchesViewHelper extends AbstractSolrViewHelper
 {
-
     /**
      * @var bool
      */

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveFacetItemViewHelper extends AbstractValueViewHelper
 {
-
     /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure

--- a/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class SetFacetItemViewHelper extends AbstractValueViewHelper
 {
-
     /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure

--- a/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class CurrentSearchViewHelper extends AbstractUriViewHelper
 {
-
     /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure

--- a/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class StartNewSearchViewHelper extends AbstractUriViewHelper
 {
-
     /**
      * Initializes the arguments
      */

--- a/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveSortingViewHelper extends AbstractUriViewHelper
 {
-
     /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure

--- a/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class SetSortingViewHelper extends AbstractUriViewHelper
 {
-
     /**
      * Initializes the arguments
      */

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -30,7 +30,6 @@ use function vsprintf;
  */
 class ConnectionManagerTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class RelationTest extends IntegrationTest
 {
-
     /**
      * @test
      *

--- a/Tests/Integration/Controller/CategoryPathProvider.php
+++ b/Tests/Integration/Controller/CategoryPathProvider.php
@@ -9,7 +9,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
  */
 class CategoryPathProvider
 {
-
     /**
      * Returns a list of paths concatenated with , only for testing
      * @return string

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -36,7 +36,6 @@ use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
  */
 class ResultSetReconstitutionProcessorTest extends IntegrationTest
 {
-
     /**
      * @test
      *

--- a/Tests/Integration/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Integration/Domain/Site/SiteHashServiceTest.php
@@ -31,7 +31,6 @@ use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
  */
 class SiteHashServiceTest extends IntegrationTest
 {
-
     /**
      * @throws NoSuchCacheException
      * @throws TestingFrameworkCoreException

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -36,7 +36,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class PageIndexerTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestAdditionalPageIndexer.php
@@ -22,7 +22,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 
 class TestAdditionalPageIndexer implements AdditionalPageIndexer
 {
-
     /**
      * Provides additional documents that should be indexed together with a page.
      *

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class QueueTest extends IntegrationTest
 {
-
     /**
      * @var Queue
      */

--- a/Tests/Integration/Report/SiteHandlingStatusTest.php
+++ b/Tests/Integration/Report/SiteHandlingStatusTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Reports\Status;
  */
 class SiteHandlingStatusTest extends IntegrationTest
 {
-
     /**
      * @test
      */

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -37,7 +37,6 @@ class SolrConfigStatusTest extends IntegrationTest
      */
     public function canGetAGreenSolrConfigStatusAgainstTestServer()
     {
-
         /** @var $schemaStatus  SolrConfigStatus */
         $schemaStatus = GeneralUtility::makeInstance(SolrConfigStatus::class);
         $violations = $schemaStatus->getStatus();

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrConfigurationStatusTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -36,7 +36,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SearchTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -24,7 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConfigurationPageResolverTest extends IntegrationTest
 {
-
     /**
      * @test
      */

--- a/Tests/Integration/System/Environment/CliEnvironmentTest.php
+++ b/Tests/Integration/System/Environment/CliEnvironmentTest.php
@@ -27,7 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CliEnvironmentTest extends IntegrationTest
 {
-
     /**
      * @test
      */

--- a/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
+++ b/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
@@ -24,7 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PagesRepositoryTest extends IntegrationTest
 {
-
     /**
      * @var PagesRepository
      */

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SystemTemplateRepositoryTest extends IntegrationTest
 {
-
     /**
      * @test
      * @throws DBALDriverException

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -30,7 +30,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrAdminServiceTest extends IntegrationTest
 {
-
     /**
      * @var SolrAdminService
      */

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -37,7 +37,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrWriteServiceTest extends IntegrationTest
 {
-
     /**
      * @var SolrWriteService
      */

--- a/Tests/Integration/TSFEBootstrapResult.php
+++ b/Tests/Integration/TSFEBootstrapResult.php
@@ -10,7 +10,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class TSFEBootstrapResult
 {
-
     /**
      * @var TypoScriptFrontendController
      */

--- a/Tests/Integration/Task/IndexQueueDependencyFaker.php
+++ b/Tests/Integration/Task/IndexQueueDependencyFaker.php
@@ -15,7 +15,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Task;
  */
 class IndexQueueDependencyFaker
 {
-
     /**
      * @var string
      */

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class IndexQueueWorkerTaskTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -33,7 +33,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ReIndexTaskTest extends IntegrationTest
 {
-
     /**
      * @inheritdoc
      * @todo: Remove unnecessary fixtures and remove that property as intended.

--- a/Tests/Integration/TestGarbageCollectorPostProcessor.php
+++ b/Tests/Integration/TestGarbageCollectorPostProcessor.php
@@ -10,7 +10,6 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 class TestGarbageCollectorPostProcessor implements SingletonInterface, GarbageCollectorPostProcessor
 {
-
     /**
      * @var bool
      */

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
  */
 class AbstractIndexerTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class RootlineTest extends UnitTest
 {
-
     /**
      * @return array
      */

--- a/Tests/Unit/Controller/Backend/Search/AbstractModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/AbstractModuleControllerTest.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 
 abstract class AbstractModuleControllerTest extends UnitTest
 {
-
     /**
      * @var AbstractModuleController|MockObject
      */

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
  */
 class IndexQueueModuleControllerTest extends AbstractModuleControllerTest
 {
-
     /**
      * @var Queue
      */

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueTestUpdateHandler.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueTestUpdateHandler.php
@@ -20,7 +20,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
  */
 class IndexQueueTestUpdateHandler
 {
-
     /**
      * @param string $type
      * @param int $uid

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ClassificationServiceTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
@@ -17,7 +17,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TYPO3SiteStrategyTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -27,7 +27,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class QueueInitializerServiceTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -34,7 +34,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class RepositoryTest extends UnitTest
 {
-
     /**
      * @var Search
      */

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class EscapeHelperTest extends UnitTest
 {
-
     /**
      * @return array
      */

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -46,7 +46,6 @@ use function str_starts_with;
  */
 class QueryBuilderTest extends UnitTest
 {
-
     /**
      * @var TypoScriptConfiguration|MockObject
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class DefaultUrlDecoderTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  */
 class FacetCollectionTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\AbstractFa
  */
 class HierarchyFacetParserTest extends AbstractFacetParserTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class NodeTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -26,13 +26,11 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class QueryGroupFacetQueryBuilderTest extends UnitTest
 {
-
     /**
      * @test
      */
     public function canBuildQueryGroupFacetWithKeepAllOptionsOnSelection()
     {
-
         /**
          * queryGroup {
          *    keepAllOptionsOnSelection = 1
@@ -75,7 +73,6 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
      */
     public function canBuildQueryGroupFacetWithKeepAllFacetsOnSelection()
     {
-
         /**
          * faceting {
          *    keepAllFacetsOnSelection = 1
@@ -128,7 +125,6 @@ class QueryGroupFacetQueryBuilderTest extends UnitTest
      */
     public function canBuild()
     {
-
         /**
          * queryGroup {
          *    week {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class DateRangeFacetQueryBuilderTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DateRangeUrlDecoderTest extends UnitTest
 {
-
     /**
      * @var DateRangeUrlDecoder
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class NumericRangeFacetQueryBuilderTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class FormatDateTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
@@ -8,7 +8,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 class TestParser extends AbstractFacetParser
 {
-
     /**
      * @param SearchResultSet $resultSet
      * @param string $facetName

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class GroupCollectionTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class GroupItemTest extends UnitTest
 {
-
     /**
      * @var GroupItem
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class GroupTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ResultParserRegistryTest extends UnitTest
 {
-
     /**
      * @var ResultParserRegistry
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
@@ -27,7 +27,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SearchResultCollectionTest extends UnitTest
 {
-
     /**
      * @var SearchResultCollection
      */

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -37,7 +37,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  */
 class SearchResultSetTest extends UnitTest
 {
-
     /**
      * @var TypoScriptConfiguration
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SortingHelperTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
+++ b/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ScoreCalculationServiceTest extends UnitTest
 {
-
     /**
      * @var ScoreCalculationService
      */

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SearchRequestBuilderTest extends UnitTest
 {
-
     /**
      * @var FrontendUserSession
      */

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SearchRequestTest extends UnitTest
 {
-
     /**
      * @var SearchRequest
      */

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SiteHashServiceTest extends UnitTest
 {
-
     /**
      * @return array
      */

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class IdBuilderTest extends UnitTest
 {
-
     /**
      * @var string
      */

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class PathToHierarchyTest extends UnitTest
 {
-
     /**
      * @var PathToHierarchy
      */

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ServiceTest extends UnitTest
 {
-
     /**
      * @var Document
      */

--- a/Tests/Unit/Helper/FakeObjectManager.php
+++ b/Tests/Unit/Helper/FakeObjectManager.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
  */
 class FakeObjectManager implements ObjectManagerInterface
 {
-
     /**
      * Returns TRUE if an object with the given name is registered
      *

--- a/Tests/Unit/HtmlContentExtractorTest.php
+++ b/Tests/Unit/HtmlContentExtractorTest.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
  */
 class HtmlContentExtractorTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ManagerTest extends UnitTest
 {
-
     /**
      * @var Manager
      */

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ItemTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -31,7 +31,6 @@ use TYPO3\CMS\Core\Http\RequestFactory;
  */
 class PageIndexerRequestTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/ValidSerializedValueDetector.php
@@ -19,7 +19,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\SerializedValueDetector;
 
 class ValidSerializedValueDetector implements SerializedValueDetector
 {
-
     /**
      * Uses a field's configuration to detect whether its value returned by a
      * content object is expected to be serialized and thus needs to be

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -29,7 +29,6 @@ use Solarium\QueryType\Select\RequestBuilder;
  */
 class RelevanceComponentTest extends UnitTest
 {
-
     /**
      * @param $query
      * @return array

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -27,7 +27,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SortingComponentTest extends UnitTest
 {
-
     /**
      * @var Query
      */

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
  */
 class TwoLevelCacheTest extends UnitTest
 {
-
     /**
      * @var TwoLevelCache
      */

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class TypoScriptConfigurationTest extends UnitTest
 {
-
     /**
      * @var TypoScriptConfiguration
      */

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class ContentObjectServiceTest extends UnitTest
 {
-
     /**
      * @var ContentObjectRenderer|MockObject
      */

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class DebugWriterTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/System/Page/RootlineTest.php
+++ b/Tests/Unit/System/Page/RootlineTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class RootlineTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -27,7 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConfigurationServiceTest extends UnitTest
 {
-
     /**
      * @return array
      */

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
  */
 class FrontendUserSessionTest extends UnitTest
 {
-
     /**
      * @var FrontendUserAuthentication
      */

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SchemaParserTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class StopWordParserTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class SynonymParserTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -28,7 +28,6 @@ use Solarium\Core\Client\Endpoint;
  */
 class SolrAdminServiceTest extends UnitTest
 {
-
     /**
      * @var SolrAdminService
      */

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -36,7 +36,6 @@ use Solarium\QueryType\Ping\Query as PingQuery;
  */
 class SolrReadServiceTest extends UnitTest
 {
-
     /**
      * @var Request
      */

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -37,7 +37,6 @@ use Solarium\Core\Client\Endpoint;
  */
 class SolrConnectionTest extends UnitTest
 {
-
     /**
      * @param Node|null $readNode
      * @param Node|null $writeNode

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TCAServiceTest extends UnitTest
 {
-
     /**
      * When a deleted record is passed (has 1 in the TCA deleted field, this should be detected).
      *

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class UrlHelperTest extends UnitTest
 {
-
     /**
      * @return array
      */

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Core\Core\Environment;
  */
 class IndexQueueWorkerTaskTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
  */
 class ReIndexTaskTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Typo3PageContentExtractorTest extends UnitTest
 {
-
     /**
      * @var TypoScriptConfiguration
      */

--- a/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -24,7 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class IsStringViewHelperTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RelevanceViewHelperTest extends UnitTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -24,7 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class AddFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -29,7 +29,6 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 class RemoveAllFacetsViewHelperTest extends AbstractFacetItemViewHelperTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -24,7 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -25,7 +25,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveFacetViewHelperTest extends AbstractFacetItemViewHelperTest
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -24,7 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class SetFacetItemViewHelperTest extends AbstractFacetItemViewHelperTest
 {
-
     /**
      * @test
      */

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,7 +11,6 @@ if (!function_exists('strptime')) {
 }
 
 (function () {
-
     // ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
     // registering Index Queue page indexer helpers
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][\ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer::class] = \ApacheSolrForTypo3\Solr\AdditionalFieldsIndexer::class;


### PR DESCRIPTION
See: https://github.com/TYPO3/coding-standards/releases/tag/v0.5.5

Ports: #3329