### PR TITLE
Ensure keywords string does not exceed database field length

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -123,6 +123,8 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
     ): string {
         $keywords = $query->getQuery();
         $keywords = $this->sanitizeString($keywords);
+        // Ensure string does not exceed database field length
+        $keywords = substr($keywords, 0, 128);
         if ($lowerCaseQuery) {
             $keywords = mb_strtolower($keywords);
         }


### PR DESCRIPTION
The keywords field of the statistics database is only 128 characters
long. If a search keyword with more than 128 chars is used, the 
database insert fails if statistics are enabled.

Fixes: #3321
Ports: #3322