### PR TITLE
[BUGFIX] Do not handle page update for failed new page creation

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -204,6 +204,9 @@ class DataUpdateHandler extends AbstractUpdateHandler
      */
     public function handlePageUpdate(int $uid, array $updatedFields = []): void
     {
+        if ($uid === 0) {
+            return;
+        }
         try {
             if (isset($updatedFields['l10n_parent']) && (int)($updatedFields['l10n_parent']) > 0) {
                 $pid = $updatedFields['l10n_parent'];


### PR DESCRIPTION
# What this pr does

Fixes `Uncaught TYPO3 Exception` when a page with uid `0` is handed to the solr `handlePageUpdate` function.


# How to test

There are edge cases when creating a new page in the TYPO3 backend might fail – non-related to ext-solr – and usually an error gets logged or displayed.

Edge cases like development, db connection issues, migth also be on missing user permissions… 

If a new page creation in TYPO3 BE fails and ext-solr is active, this results in ext-solr failing.
And instead of showing or logging the original error message from the underlying problem, an error message from ext-solr is thrown:

```php
Core: Exception handler (WEB): Uncaught TYPO3 Exception: Argument 2 passed to ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\AbstractUpdateHandler::getAllCurrentStateFieldsMatch() must be of the type array, null given, called in /var/www/html/public/typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php on line 229 | TypeError thrown in file /var/www/html/public/typo3conf/ext/solr/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php in line 246.
```

