### PR TITLE
[BUGFIX:BP:11.5] Shortcircuit work in SolrRoutingMiddleware

### DIFF
--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Middleware;
 
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -100,6 +101,10 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if (!$request->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
+            return $handler->handle($request);
+        }
+
         /* @var SiteRouteResult $routeResult */
         $routeResult = $this->getRoutingService()
             ->getSiteMatcher()

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Middleware;
 
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
@@ -90,7 +91,10 @@ class SolrRoutingMiddlewareTest extends UnitTest
     {
         $serverRequest = new ServerRequest(
             'GET',
-            'https://domain.example/facet/bar,buz,foo'
+            'https://domain.example/facet/bar,buz,foo',
+            [
+                PageIndexerRequest::SOLR_INDEX_HEADER => '1',
+            ]
         );
         $siteMatcherMock = $this->getMockBuilder(SiteMatcher::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Shortcircuit work in SolrRoutingMiddleware like in PageIndexerFinisher: When a request does not have the X-Tx-Solr-Iq header, then it's not interesting for the Solr extension.

Background: Superflous logging 'Could not resolve page by path...' to Solr logfile.

Relates: #3202
Ports: #3339