### PR TITLE
[BUGFIX:BP:11.2] Shortcircuit work in SolrRoutingMiddleware

### DIFF
--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -14,6 +14,7 @@ namespace ApacheSolrForTypo3\Solr\Middleware;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -97,6 +98,10 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if (!$request->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
+            return $handler->handle($request);
+        }
+
         /* @var SiteRouteResult $routeResult */
         $routeResult = $this->getRoutingService()
             ->getSiteMatcher()

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -15,6 +15,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Middleware;
  * The TYPO3 project - inspiring people to share!
  */
 
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
@@ -87,7 +88,10 @@ class SolrRoutingMiddlewareTest extends UnitTest
     {
         $serverRequest = new ServerRequest(
             'GET',
-            'https://domain.example/facet/bar,buz,foo'
+            'https://domain.example/facet/bar,buz,foo',
+            [
+                PageIndexerRequest::SOLR_INDEX_HEADER => '1',
+            ]
         );
         $siteMatcherMock = $this->getMockBuilder(SiteMatcher::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Shortcircuit work in SolrRoutingMiddleware like in PageIndexerFinisher: When a request does not have the X-Tx-Solr-Iq header, then it's not interesting for the Solr extension.

Background: Superflous logging 'Could not resolve page by path...' to Solr logfile.

Relates: #3202
Ports: #3339