### PR TITLE
[BUGFIX:BP:11.2] Do not handle page updates on new page with uid 0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -59,13 +59,6 @@ build:
       version: 7.2.8
   nodes:
     analysis:
-      dependencies:
-        after:
-          - composer require --dev squizlabs/php_codesniffer:3.1.1
       tests:
         override:
           - php-scrutinizer-run
-        override:
-          -
-            command: phpcs-run
-            use_website_config: false

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -195,6 +195,9 @@ class DataUpdateHandler extends AbstractUpdateHandler
      */
     public function handlePageUpdate(int $uid, array $updatedFields = []): void
     {
+        if ($uid === 0) {
+            return;
+        }
         try {
             if (isset($updatedFields['l10n_parent']) && intval($updatedFields['l10n_parent']) > 0) {
                 $pid = $updatedFields['l10n_parent'];


### PR DESCRIPTION
Fixes Uncaught TYPO3 Exception when a page with uid 0 is  handed to the solr handlePageUpdate function.

Ports: #3338