### PR TITLE
[BUGFIX:BP:11.5] Do not handle page updates on new page with uid 0

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -204,6 +204,9 @@ class DataUpdateHandler extends AbstractUpdateHandler
      */
     public function handlePageUpdate(int $uid, array $updatedFields = []): void
     {
+        if ($uid === 0) {
+            return;
+        }
         try {
             if (isset($updatedFields['l10n_parent']) && (int)($updatedFields['l10n_parent']) > 0) {
                 $pid = $updatedFields['l10n_parent'];


### PR DESCRIPTION
Fixes Uncaught TYPO3 Exception when a page with uid 0 is  handed to the solr handlePageUpdate function.

Ports: #3338