### PR TITLE
[TEST] TSFE can be initialized for pages with fe_group="-2"

### DIFF
--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -41,8 +41,14 @@ class FrontendGroupsModifier
     {
         $pageIndexerRequest = $event->getRequest()->getAttribute('solr.pageIndexingInstructions');
         if (!$pageIndexerRequest instanceof PageIndexerRequest
-            || ((int)$pageIndexerRequest->getParameter('userGroup') === 0
-                && (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1)
+            || (
+                (int)$pageIndexerRequest->getParameter('userGroup') === 0
+                && (
+                    (int)$pageIndexerRequest->getParameter('pageUserGroup') !== -2
+                    &&
+                    (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1
+                )
+            )
         ) {
             return;
         }

--- a/Tests/Integration/FrontendEnvironment/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.csv
+++ b/Tests/Integration/FrontendEnvironment/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.csv
@@ -1,0 +1,7 @@
+"pages",
+,"uid","is_siteroot","doktype","pid","fe_group"
+,"2","0","1","1","1"
+,"3","0","1","1","-2"
+"fe_groups",
+,"uid","pid","title"
+,"1","1","dummy group"

--- a/Tests/Integration/FrontendEnvironment/TsfeTest.php
+++ b/Tests/Integration/FrontendEnvironment/TsfeTest.php
@@ -6,6 +6,7 @@ use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use RuntimeException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class TsfeTest extends IntegrationTest
 {
@@ -52,5 +53,38 @@ class TsfeTest extends IntegrationTest
 
         $tsfeManager = GeneralUtility::makeInstance(Tsfe::class);
         $tsfeManager->getTsfeByPageIdAndLanguageId(1);
+    }
+
+    /**
+     * @test
+     */
+    public function canInitializeTsfeForPageWithDifferentFeGroupsSettings()
+    {
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.csv');
+
+        $tsfeNotRestricted = GeneralUtility::makeInstance(Tsfe::class)->getTsfeByPageIdIgnoringLanguage(1);
+        self::assertInstanceOf(
+            TypoScriptFrontendController::class,
+            $tsfeNotRestricted,
+            'The TSFE can not be initialized at all, nor for public page either for access restricted(fe_group) page. ' .
+                'Most probably nothing will work.'
+        );
+
+        $tsfeRestrictedForExistingFeGroup = GeneralUtility::makeInstance(Tsfe::class)->getTsfeByPageIdIgnoringLanguage(2);
+        self::assertInstanceOf(
+            TypoScriptFrontendController::class,
+            $tsfeRestrictedForExistingFeGroup,
+            'The TSFE can not be initialized for existing fe_group. ' .
+                'This will lead to failures on editing the access restricted [sub]pages in BE.'
+        );
+
+        $tsfeForLoggedInUserOnly = GeneralUtility::makeInstance(Tsfe::class)->getTsfeByPageIdIgnoringLanguage(3);
+        self::assertInstanceOf(
+            TypoScriptFrontendController::class,
+            $tsfeForLoggedInUserOnly,
+            'The TSFE can not be initialized for page with fe_group="-2". ' .
+                'This will lead to failures on editing the [sub]pages in BE for pages with fe_group="-2".'
+        );
     }
 }

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_access_protected_page_show_at_any_login.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_access_protected_page_show_at_any_login.csv
@@ -1,0 +1,12 @@
+"fe_groups",
+,"uid","pid","title"
+,1,1,"group 1"
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp","fe_group"
+,2,1,0,1,"/any_login","any login page","",1449151779,1449151770,-2
+"tt_content",
+,"uid","pid","CType","header","fe_group"
+,11,"2","header","access restricted content for any login",0
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
+,4711,1,"pages",2,"pages",1449151778,0,0,0,0,0

--- a/Tests/Integration/IndexQueue/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/PageIndexerTest.php
@@ -139,6 +139,17 @@ class PageIndexerTest extends IntegrationTest
             ],
         ];
 
+        yield 'page for any login(-2)' => [
+            'can_index_access_protected_page_show_at_any_login',
+            1,
+            [
+                '2:-2/c:0',
+            ],
+            [
+                'access restricted content for any login',
+            ],
+        ];
+
         yield 'protected page with protected content' => [
             'can_index_access_protected_page_with_protected_contents',
             2,


### PR DESCRIPTION
The TSFE can not be initialized in record-monitoring(BE editiing) context for pages,  whichs fe_group is set to -2(show if fe_user is logged in).

This leads to following behavior:
* After editing the [sub]pages in BE, the page is removed from index and never indexed again.
* By reinitialization of pages index queue the page is indexed as expected with expected groups.

Relates: #3347, #3351
Ported from: #3819

---

**This bug is not present on TYPO3 12.4.7 + EXT:solr bbdda0cf2dfc946d09b5207c58ece034696cf63e, so the test only will be merged. The fix for EXT:solr 11.5+ will be done within #3819**

The indexing of pages with fe_group=-2 / "show at any login" was broken in 12.0.0(RC1), which is fixed in this pr.