### PR TITLE
!!![TASK] Use preAddModifyDocuments hook for pages

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -195,7 +195,7 @@ class Indexer extends AbstractIndexer
         $documents[] = $itemDocument;
         $documents = array_merge($documents, $this->getAdditionalDocuments($item, $language, $itemDocument));
         $documents = $this->processDocuments($item, $documents);
-        $documents = $this->preAddModifyDocuments($item, $language, $documents);
+        $documents = self::preAddModifyDocuments($item, $language, $documents);
 
         try {
             $response = $this->solr->getWriteService()->addDocuments($documents);
@@ -531,7 +531,7 @@ class Indexer extends AbstractIndexer
      * @param array $documents An array of documents to be indexed
      * @return array An array of modified documents
      */
-    protected function preAddModifyDocuments(Item $item, int $language, array $documents): array
+    public static function preAddModifyDocuments(Item $item, int $language, array $documents): array
     {
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'] ?? null)) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments'] as $classReference) {

--- a/Classes/PageDocumentPostProcessor.php
+++ b/Classes/PageDocumentPostProcessor.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * have been put together, but not yet submitted to Solr.
  *
  * @author Steffen Ritter <steffen.ritter@typo3.org>
+ *
+ * @deprecated in favor of PageIndexerDocumentsModifier
  */
 interface PageDocumentPostProcessor
 {

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
 use ApacheSolrForTypo3\Solr\FieldProcessor\Service;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
@@ -258,6 +259,11 @@ class Typo3PageIndexer
         $documents[] = $pageDocument;
         $documents = $this->getAdditionalDocuments($pageDocument, $documents);
         $this->processDocuments($documents);
+        $documents = Indexer::preAddModifyDocuments(
+            $this->indexQueueItem,
+            $this->page->getLanguage()->getLanguageId(),
+            $documents
+        );
 
         $pageIndexed = $this->addDocumentsToSolrIndex($documents);
         $this->documentsSentToSolr = $documents;
@@ -268,6 +274,8 @@ class Typo3PageIndexer
     /**
      * Applies the configured post processors (indexPagePostProcessPageDocument)
      *
+     * @deprecated
+     *
      * @param Document $pageDocument
      */
     protected function applyIndexPagePostProcessors(Document $pageDocument)
@@ -275,6 +283,11 @@ class Typo3PageIndexer
         if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument'] ?? null)) {
             return;
         }
+
+        trigger_error(
+            "The hook indexPagePostProcessPageDocument has been superseded by \$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments']",
+            E_USER_DEPRECATED
+        );
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument'] as $classReference) {
             $postProcessor = GeneralUtility::makeInstance($classReference);

--- a/Documentation/Development/Indexing.rst
+++ b/Documentation/Development/Indexing.rst
@@ -32,10 +32,21 @@ Required Interface: SubstitutePageIndexer
 indexPagePostProcessPageDocument
 --------------------------------
 
+This is deprecated in favor of preAddModifyDocuments.
+
 Registered classes can be used to post process a Solr document of a page.
 
 Registration with: $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument']
 Required Interface: PageDocumentPostProcessor
+
+
+preAddModifyDocuments
+---------------------
+
+Registered classes can be used to process Solr documents (pages and records) before they are added to index.
+
+Registration with: $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments']
+Required Interface: PageIndexerDocumentsModifier
 
 
 Independent indexer

--- a/Tests/Integration/Controller/AbstractFrontendControllerTest.php
+++ b/Tests/Integration/Controller/AbstractFrontendControllerTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
 use ApacheSolrForTypo3\Solr\FrontendEnvironment\Exception\Exception as SolrFrontendEnvironmentException;
 use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 use Doctrine\DBAL\DBALException;
@@ -75,6 +76,11 @@ abstract class AbstractFrontendControllerTest extends IntegrationTest
 
             /* @var $pageIndexer Typo3PageIndexer */
             $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
+            $indexQueueItemMock = $this->createMock(Item::class);
+            $indexQueueItemMock->expects(self::any())
+                ->method('getIndexingConfigurationName')
+                ->willReturn('pages');
+            $pageIndexer->setIndexQueueItem($indexQueueItemMock);
             $pageIndexer->indexPage();
         }
         $this->waitToBeVisibleInSolr();

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -211,7 +211,7 @@ class PageIndexerTest extends IntegrationTest
      */
     public function canExecutePostProcessor()
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPagePostProcessPageDocument']['TestPostProcessor'] = TestPostProcessor::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments']['TestPageIndexerDocumentsModifier'] = TestPageIndexerDocumentsModifier::class;
 
         $this->importDataSetFromFixture('can_index_into_solr.xml');
         $this->executePageIndexer();

--- a/Tests/Integration/IndexQueue/FrontendHelper/TestPageIndexerDocumentsModifier.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/TestPageIndexerDocumentsModifier.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerDocumentsModifier;
+use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
+
+class TestPageIndexerDocumentsModifier implements PageIndexerDocumentsModifier
+{
+    /**
+     * Allows Modification of the Documents before they go into index
+     *
+     * @param Item $item
+     * @param int $language
+     * @param Document[] $documents
+     * @return array|void
+     */
+    public function modifyDocuments(Item $item, int $language, array $documents)
+    {
+        foreach ($documents as $document) {
+            $document->addField('postProcessorField_stringS', 'postprocessed');
+        }
+
+        return $documents;
+    }
+}

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -16,6 +16,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 use Doctrine\DBAL\DBALException;
@@ -340,8 +341,13 @@ abstract class IntegrationTest extends FunctionalTestCase
         foreach ($importPageIds as $importPageId) {
             $fakeTSFE = $this->fakeTSFE($importPageId, $feUserGroupArray);
 
-            /** @var $pageIndexer Typo3PageIndexer */
+            /* @var Typo3PageIndexer $pageIndexer */
             $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
+            $indexQueueItemMock = $this->createMock(Item::class);
+            $indexQueueItemMock->expects(self::any())
+                ->method('getIndexingConfigurationName')
+                ->willReturn('pages');
+            $pageIndexer->setIndexQueueItem($indexQueueItemMock);
             $pageIndexer->setPageAccessRootline(Rootline::getAccessRootlineByPageId($importPageId));
             $pageIndexer->indexPage();
         }

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Slops;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\TrigramPhraseFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -71,8 +72,13 @@ class SearchTest extends IntegrationTest
         $fakeTSFE = $this->getConfiguredTSFE();
         $GLOBALS['TSFE'] = $fakeTSFE;
 
-        /** @var $pageIndexer \ApacheSolrForTypo3\Solr\Typo3PageIndexer */
+        /* @var Typo3PageIndexer $pageIndexer */
         $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
+        $indexQueueItemMock = $this->createMock(Item::class);
+        $indexQueueItemMock->expects(self::any())
+            ->method('getIndexingConfigurationName')
+            ->willReturn('pages');
+        $pageIndexer->setIndexQueueItem($indexQueueItemMock);
         $pageIndexer->indexPage();
 
         $this->waitToBeVisibleInSolr();
@@ -435,8 +441,13 @@ class SearchTest extends IntegrationTest
             $fakeTSFE = $this->getConfiguredTSFE($i);
             $GLOBALS['TSFE'] = $fakeTSFE;
 
-            /** @var $pageIndexer \ApacheSolrForTypo3\Solr\Typo3PageIndexer */
+            /* @var Typo3PageIndexer $pageIndexer */
             $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
+            $indexQueueItemMock = $this->createMock(Item::class);
+            $indexQueueItemMock->expects(self::any())
+                ->method('getIndexingConfigurationName')
+                ->willReturn('pages');
+            $pageIndexer->setIndexQueueItem($indexQueueItemMock);
             $pageIndexer->indexPage();
         }
         $this->waitToBeVisibleInSolr();


### PR DESCRIPTION
# What this pr does

It calls the hook preAddModifyDocuments also for pages and deprecates the hook indexPagePostProcessPageDocument

# How to test

* Register Hook `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueueIndexer']['preAddModifyDocuments']['TestPageIndexerDocumentsModifier'] = TestPageIndexerDocumentsModifier::class;`
* Index a page
* See `postProcessorField_stringS: postprocessed` in the indexed document

Fixes: #2285 
Ports: #3076