### PR TITLE
[BUGFIX] Fix array key access in ext_getSetup (Backport 11.5)

### DIFF
--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -115,18 +115,23 @@ class TypoScript implements SingletonInterface
     }
 
     /**
+     * Adapted from TYPO3 core
+     * @see sysext:core/Classes/TypoScript/ExtendedTemplateService until TYPO3 v11
      * @param array $theSetup
      * @param string $theKey
      * @return array
      */
     public function ext_getSetup(array $theSetup, string $theKey): array
     {
+        // 'a.b.c' --> ['a', 'b.c']
         $parts = explode('.', $theKey, 2);
         if ((string)$parts[0] !== '' && is_array($theSetup[$parts[0] . '.'])) {
             if (trim($parts[1] ?? '') !== '') {
+                // Current path segment is a sub array, check it recursively by applying the rest of the key
                 return $this->ext_getSetup($theSetup[$parts[0] . '.'], trim($parts[1] ?? ''));
             }
-            return [$theSetup[$parts[0] . '.'], $theSetup[$parts[0]]];
+            // No further path to evaluate, return current setup and the value for the current path segment - if any
+            return [$theSetup[$parts[0] . '.'], $theSetup[$parts[0]] ?? ''];
         }
         if (trim($theKey) !== '') {
             return [[], $theSetup[$theKey]];


### PR DESCRIPTION
Reading nested TypoScript will no longer log a warning when the value can not be accessed. In this case, the second value in the array returned in `TypoScript::ext_getSetup` will be an empty string. However, the second value is not used by Ext:solr anymore.

This also fixes an issue with PHP 8 where such warning would cause the indexing to fail, when the method is used inside of an indexer.

Fixes: #3359
Ports: #3360