### PR TITLE
[TASK] Indexing configuration icon fallback

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Backend\Form\Exception as BackendFormException;
 use TYPO3\CMS\Backend\Form\FormResultCompiler;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -153,10 +154,19 @@ class IndexingConfigurationSelectorField
     protected function buildSelectorItems(array $tablesToIndex): array
     {
         $selectorItems = [];
+        $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
         $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $defaultIcon = 'mimetypes-other-other';
 
         foreach ($tablesToIndex as $configurationName => $tableName) {
-            $icon = $iconFactory->mapRecordTypeToIconIdentifier($tableName, []);
+            if (isset($GLOBALS['TCA'][$tableName])) {
+                $icon = $iconFactory->mapRecordTypeToIconIdentifier($tableName, []);
+                if ($icon === $iconRegistry->getDefaultIconIdentifier() || !$iconRegistry->isRegistered($icon)) {
+                    $icon = $defaultIcon;
+                }
+            } else {
+                $icon = $defaultIcon;
+            }
 
             $labelTableName = '';
             if ($configurationName !== $tableName) {


### PR DESCRIPTION
# What this pr does

Index queue module uses the registered record icon for each indexing configuration, if no valid icon is found or no local table is used, the default fallback icon is used and indicates an error. This commit implements an icon check and a default icon that doesn't imply an error.

# How to test
Configure an indexing configuration that uses a indexing source that doesn't configure an icon. With this changeset a default icon (`mimetypes-other-other`) is used.


Resolves: #3368
