### PR TITLE
[TASK:BP:11.5] Introduce index queue type setting

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -137,7 +137,7 @@ class IndexingConfigurationSelectorField
         $solrConfiguration = $this->site->getSolrConfiguration();
         $configurationNames = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
         foreach ($configurationNames as $configurationName) {
-            $indexingTableMap[$configurationName] = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($configurationName);
+            $indexingTableMap[$configurationName] = $solrConfiguration->getIndexQueueTypeOrFallbackToConfigurationName($configurationName);
         }
 
         return $indexingTableMap;

--- a/Classes/Domain/Index/Queue/QueueInitializationService.php
+++ b/Classes/Domain/Index/Queue/QueueInitializationService.php
@@ -142,18 +142,18 @@ class QueueInitializationService
         $this->queue->deleteItemsBySite($site, $indexingConfigurationName);
 
         $solrConfiguration = $site->getSolrConfiguration();
-        $tableToIndex = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
+        $type = $solrConfiguration->getIndexQueueTypeOrFallbackToConfigurationName($indexingConfigurationName);
         $initializerClass = $solrConfiguration->getIndexQueueInitializerClassByConfigurationName($indexingConfigurationName);
         $indexConfiguration = $solrConfiguration->getIndexQueueConfigurationByName($indexingConfigurationName);
 
-        return $this->executeInitializer($site, $indexingConfigurationName, $initializerClass, $tableToIndex, $indexConfiguration);
+        return $this->executeInitializer($site, $indexingConfigurationName, $initializerClass, $type, $indexConfiguration);
     }
 
     /**
      * @param Site $site
      * @param string $indexingConfigurationName
      * @param string $initializerClass
-     * @param string $tableToIndex
+     * @param string $type
      * @param array $indexConfiguration
      * @return bool
      */
@@ -161,13 +161,13 @@ class QueueInitializationService
         Site $site,
         string $indexingConfigurationName,
         string $initializerClass,
-        string $tableToIndex,
+        string $type,
         array $indexConfiguration
     ): bool {
         $initializer = GeneralUtility::makeInstance($initializerClass);
         /* @var AbstractInitializer $initializer */
         $initializer->setSite($site);
-        $initializer->setType($tableToIndex);
+        $initializer->setType($type);
         $initializer->setIndexingConfigurationName($indexingConfigurationName);
         $initializer->setIndexingConfiguration($indexConfiguration);
 

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -163,7 +163,7 @@ class ConfigurationAwareRecordService
         string $indexingConfigurationName,
         TypoScriptConfiguration $solrConfiguration
     ): bool {
-        $tableToIndex = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
+        $tableToIndex = $solrConfiguration->getIndexQueueTypeOrFallbackToConfigurationName($indexingConfigurationName);
 
         $isMatchingTable = ($tableToIndex === $recordTable);
 

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -82,7 +82,7 @@ class ReIndexTask extends AbstractSolrTask
         $enableCommitsSetting = $solrConfiguration->getEnableCommits();
 
         foreach ($this->indexingConfigurationsToReIndex as $indexingConfigurationName) {
-            $type = $solrConfiguration->getIndexQueueTableNameOrFallbackToConfigurationName($indexingConfigurationName);
+            $type = $solrConfiguration->getIndexQueueTypeOrFallbackToConfigurationName($indexingConfigurationName);
             $typesToCleanUp[] = $type;
         }
 

--- a/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript
+++ b/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript
@@ -3,7 +3,7 @@ plugin.tx_solr.index.queue {
 
 	news = 1
 	news {
-		table = tx_news_domain_model_news
+		type = tx_news_domain_model_news
 
 		fields {
 			abstract = teaser
@@ -18,7 +18,7 @@ plugin.tx_solr.index.queue {
 				field = datetime
 				date = d.m.Y H:i
 			}
-			
+
 			datetime_dateS = TEXT
 			datetime_dateS {
 				field = datetime

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -188,13 +188,23 @@ queue.[indexConfig].table
 :Type: String
 :TS Path: plugin.tx_solr.index.queue.[indexConfig].table
 :Since: 2.0
+:Deprecated: 11.5.1
 
-Sometimes you may want to index records from a table with different configurations, f.e., to generate different single view URLs for tt_news records depending on their category or storage page ID. In these cases you can use a distinct name for the configuration and define the table explicitly.
+Defines the type to index, which is usally the database table. Setting the record type via 'table' is deprecated and will be removed in v13, use 'type' instead.
+
+queue.[indexConfig].type
+-------------------------
+
+:Type: String
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].type
+:Since: 11.5.1
+
+Defines the type to index, which is usally the database table. Sometimes you may want to index records from a table with different configurations, f.e., to generate different single view URLs for tt_news records depending on their category or storage page ID. In these cases you can use a distinct name for the configuration and define the table explicitly.
 
 .. code-block:: typoscript
 
     plugin.tx_solr.index.queue.generalNews {
-      table = tt_news
+      type = tt_news
       fields.url = URL for the general news
       // more field configurations here ...
     }
@@ -208,7 +218,7 @@ Sometimes you may want to index records from a table with different configuratio
 
     // completely different configuration
     plugin.tx_solr.index.queue.productNews {
-      table = tt_news
+      type = tt_news
       fields.url = URL for the product news
     }
 

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -44,7 +44,7 @@ class QueueInitializerServiceTest extends UnitTest
                             'my_pages' => 1,
                             'my_pages.' => [
                                 'initialization' => 'MyPagesInitializer',
-                                'table' => 'pages',
+                                'type' => 'pages',
                                 'fields.' => [
                                     'title' => 'title',
                                 ],
@@ -52,7 +52,7 @@ class QueueInitializerServiceTest extends UnitTest
                             'my_news' => 1,
                             'my_news.' => [
                                 'initialization' => 'MyNewsInitializer',
-                                'table' => 'tx_news_domain_model_news',
+                                'type' => 'tx_news_domain_model_news',
                                 'fields.' => [
                                     'title' => 'title',
                                 ],

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -112,6 +112,8 @@ class TypoScriptConfigurationTest extends UnitTest
 
     /**
      * @test
+     * @deprecated queue.[indexConfig].table is deprecated and will be removed in v13. As soon as setting is removed this
+     *             test must be removed too. For now this test ensures that 'table' and 'type' are supported.
      */
     public function canGetIndexQueueTableOrFallbackToConfigurationName()
     {
@@ -129,10 +131,40 @@ class TypoScriptConfigurationTest extends UnitTest
 
         $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        $customTableExpected = $configuration->getIndexQueueTableNameOrFallbackToConfigurationName('pages');
+        $customTableExpected = @$configuration->getIndexQueueTableNameOrFallbackToConfigurationName('pages');
+        self::assertSame($customTableExpected, 'pages', 'Can not fallback to configurationName');
+        $customTableExpected = $configuration->getIndexQueueTypeOrFallbackToConfigurationName('pages');
         self::assertSame($customTableExpected, 'pages', 'Can not fallback to configurationName');
 
-        $customTableExpected = $configuration->getIndexQueueTableNameOrFallbackToConfigurationName('custom');
+        $customTableExpected = @$configuration->getIndexQueueTableNameOrFallbackToConfigurationName('custom');
+        self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
+        $customTableExpected = @$configuration->getIndexQueueTypeOrFallbackToConfigurationName('custom');
+        self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
+    }
+
+    /**
+     * @test
+     */
+    public function canGetIndexQueueTypeOrFallbackToConfigurationName()
+    {
+        $fakeConfigurationArray['plugin.']['tx_solr.'] = [
+            'index.' => [
+                'queue.' => [
+                    'pages.' => [
+                    ],
+                    'custom.' => [
+                        'type' => 'tx_model_custom',
+                    ],
+                ],
+            ],
+        ];
+
+        $configuration = new TypoScriptConfiguration($fakeConfigurationArray);
+
+        $customTableExpected = $configuration->getIndexQueueTypeOrFallbackToConfigurationName('pages');
+        self::assertSame($customTableExpected, 'pages', 'Can not fallback to configurationName');
+
+        $customTableExpected = $configuration->getIndexQueueTypeOrFallbackToConfigurationName('custom');
         self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
     }
 
@@ -148,7 +180,7 @@ class TypoScriptConfigurationTest extends UnitTest
                     'pages.' => [
                     ],
                     'custom.' => [
-                        'table' => 'tx_model_custom',
+                        'type' => 'tx_model_custom',
                     ],
                 ],
             ],
@@ -286,12 +318,12 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar',
+                        'type' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news',
+                        'type' => 'tx_model_news',
                     ],
                 ],
             ],
@@ -314,12 +346,12 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar',
+                        'type' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news',
+                        'type' => 'tx_model_news',
                     ],
                     'pages' => 1,
                     'pages.' => [],
@@ -345,12 +377,12 @@ class TypoScriptConfigurationTest extends UnitTest
                     ],
                     'custom_one' => 1,
                     'custom_one.' => [
-                        'table' => 'tx_model_bar',
+                        'type' => 'tx_model_bar',
                     ],
 
                     'custom_two' => 1,
                     'custom_two.' => [
-                        'table' => 'tx_model_news',
+                        'type' => 'tx_model_news',
                     ],
                     'pages' => 1,
                     'pages.' => [],


### PR DESCRIPTION
# What this pr does

Backport 11.5

Queue types shouldn't be restricted to internal data, which is already prepared in some classes. As index queue setting 'table' suggests that a local table is expected, this is replaced with a new setting 'type'.

`queue.[indexConfig].table` is now deprecated and will be removed in v13, 'type' should be used instead.

# How to test

Configure an indexing configuration and configure the local table via `type` instead of `table`

Fixes: #3364
