### PR TITLE
[BUGFIX] Fix php warning undefined array key no_search_sub_entries

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -200,7 +200,7 @@ class RecordMonitor
             return true;
         }
         foreach ($rootline as $page) {
-            if ($page['no_search_sub_entries']) {
+            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries']) {
                 return true;
             }
         }


### PR DESCRIPTION
To avoid php warning for undefined array key, check if key is set in $page array.

# What this pr does

Fixing the follwing bug:

After enabling/disabling a page in page tree with the context menu the following php warning appears:

PHP Warning: Undefined array key "no_search_sub_entries" in /var/www/html/web/typo3conf/ext/solr/Classes/IndexQueue/RecordMonitor.php line 203

# How to test

Steps to reproduce the behavior:

1. Open context menu of a page in page tree
2. Click on 'Disable' or 'Enable' (depends on state of the page ;-))
3. The php warning appears

Fixes #3380
