### PR TITLE
[TASK] Prepare GitHub-Actions for task/3376-TYPO3_12_compatibility branch

### DIFF
--- a/.github/workflows/ci-matrix.json
+++ b/.github/workflows/ci-matrix.json
@@ -4,6 +4,11 @@
     "TYPO3": [ "11", "11.5.x-dev" ]
   },
 
+  "task/3376-TYPO3_12_compatibility": {
+  	"PHP": [ "8.1" ],
+  	"TYPO3": [ "12", "dev-main" ]
+  },
+
   "release-11.5.x": {
     "PHP": [ "7.4", "8.0", "8.1" ],
     "TYPO3": [ "11", "11.5.x-dev" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ main, release-11.5.x, release-11.1.x, release-11.0.x ]
+    branches: [ main, task/3376-TYPO3_12_compatibility, release-11.5.x, release-11.1.x, release-11.0.x ]
     tags:
       - "**"
   pull_request:
-    branches: [ main, release-11.5.x, release-11.1.x, release-11.0.x ]
+    branches: [ main, task/3376-TYPO3_12_compatibility, release-11.5.x, release-11.1.x, release-11.0.x ]
 
 env:
   CI_BUILD_DIRECTORY: '/home/runner/work/ext-solr/ext-solr/.Build'


### PR DESCRIPTION
The GitHub Actions must run if pull-request against task/3376-TYPO3_12_compatibility is created.

Note:
The task/3376-TYPO3_12_compatibility must be used for pull-request against main branch. The task/3376-TYPO3_12_compatibility must be used for non-stable pre-releases for TYPO3 12

Fixes: #3382
Relates:  #3376