### PR TITLE
[TASK] #3375: prepend wrong fe language on empty cache,

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -31,6 +31,7 @@ use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Registry;
@@ -262,7 +263,7 @@ class SiteRepository
      */
     protected function buildTypo3ManagedSite(array $rootPageRecord): ?Typo3ManagedSite
     {
-        $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($rootPageRecord['uid']);
+        $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($rootPageRecord['uid'], Util::getLanguageUid());
         /** @var \TYPO3\CMS\Core\Site\Entity\Site $typo3Site */
         try {
             $typo3Site = $this->siteFinder->getSiteByPageId($rootPageRecord['uid']);

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -246,7 +246,7 @@ class Indexer extends AbstractIndexer
         if ($language > 0) {
             // @TODO Information from the site configuration are required!
             /* @var Context $context */
-            $context = GeneralUtility::makeInstance(Context::class);
+            $context = clone GeneralUtility::makeInstance(Context::class);
             /* @var LanguageAspect $languageAspect */
             if ($context->hasAspect('language')) {
                 $languageAspect = $context->getAspect('language');


### PR DESCRIPTION

# What this pr does

Prepend wrong FE language on empty cache,
use a clone of context on indexing to encapsulate the index from cli process

# How to test

Clear all caches and call the frontend of a site with nondefault language

Fixes: #3375
