### PR TITLE
[FEATURE] Add signal before search in resultsAction

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -98,8 +98,10 @@ class SearchController extends AbstractBaseController
             $arguments = (array)$this->request->getArguments();
             $pageId = $this->typoScriptFrontendController->getRequestedId();
             $languageId = Util::getLanguageUid();
-            $searchRequest = $this->getSearchRequestBuilder()->buildForSearch($arguments, $pageId, $languageId);
 
+            $arguments = $this->emitActionSignal(__CLASS__, 'beforeSearch', [$arguments]);
+
+            $searchRequest = $this->getSearchRequestBuilder()->buildForSearch($arguments, $pageId, $languageId);
             $searchResultSet = $this->searchService->search($searchRequest);
 
             // we pass the search result set to the controller context, to have the possibility


### PR DESCRIPTION
What this pr does
Add a signal before search in resultsAction to be able to modify the arguments.

How to test
Check that the signal is correctly emitted by connecting to it from another extension.

Fixes: #3387