### PR TITLE
[BUGFIX] Type-hinting for SiteUtility::getConnectionProperty()

### DIFF
--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -75,7 +75,7 @@ class SiteUtility
         int $languageId,
         string $scope,
         $defaultValue = null
-    ): string {
+    ) {
         $value = self::getConnectionPropertyOrFallback($typo3Site, $property, $languageId, $scope);
         if ($value === null) {
             return $defaultValue;


### PR DESCRIPTION
`SiteUtility::getConnectionProperty()` method must handle mixed types.

Fixes: #3394