### PR TITLE
[BUGFIX] prevent undefined array key warning if filter is empty

### DIFF
--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -237,6 +237,9 @@ class Faceting implements Modifier, SearchRequestAware
             $filters = array_keys($filters);
         }
         foreach ($filters as $filter) {
+            if (strpos($filter, ':') === false) {
+                continue;
+            }
             // only split by the first colon to allow using colons in the filter value itself
             list($filterFacetName, $filterValue) = explode(':', $filter, 2);
             if (in_array($filterFacetName, $configuredFacets)) {


### PR DESCRIPTION
# What this pr does

assure valid filter are set, to prevent Exception (for PHP 8)
Fixed
```
(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception

PHP Warning: Undefined array key 1 in /var/www/html/web/typo3conf/ext/solr/Classes/Query/Modifier/Faceting.php line 247
```

https://github.com/TYPO3-Solr/ext-solr/blob/bfe1599a7533ed8aff0060ab932067ecd32dacad/Classes/Query/Modifier/Faceting.php#L241


# How to test

send an empty filter to your solr search plugin
tx_solr[filter][]=

current solr, PHP 8.1, TYPO3 11

