### PR TITLE
[TASK] Introduce generic EXT:solr exception

### DIFF
--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr;
+
+/**
+ * Generic Apache Solr for TYPO3 exception
+ */
+class Exception extends \Exception
+{
+}


### PR DESCRIPTION
# What this pr does

To simplify the exception handling a generic Apache Solr for TYPO3 exception is introduced, this will be the base exception thrown by Solr extensions.

This is a preparation for a future exception handling that should allow more specific exception handling.