### PR TITLE
[BUGFIX:BP:11.5] Fix frontend Solr connection initialization

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager as SolrCon
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Service\ConfigurationService;
-use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -223,9 +222,12 @@ abstract class AbstractBaseController extends ActionController
      */
     protected function initializeSearch()
     {
-        /** @var ConnectionManager $solrConnection */
         try {
-            $solrConnection = $this->objectManager->get(ConnectionManager::class)->getConnectionByPageId($this->typoScriptFrontendController->id, Util::getLanguageUid(), $this->typoScriptFrontendController->MP);
+            $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByTypo3Site(
+                $this->typoScriptFrontendController->getSite(),
+                $this->typoScriptFrontendController->getLanguage()->getLanguageId()
+            );
+
             $search = $this->objectManager->get(Search::class, $solrConnection);
 
             /** @noinspection PhpParamsInspection */

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -290,39 +290,9 @@ class SiteRepository
         $solrConnectionConfigurations = [];
 
         foreach ($availableLanguageIds as $languageUid) {
-            $solrEnabled = SiteUtility::getConnectionProperty($typo3Site, 'enabled', $languageUid, 'read', true);
-            $solrReadCore = SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'read');
-            $solrWriteCore = SiteUtility::getConnectionProperty($typo3Site, 'core', $languageUid, 'write');
-            if ($solrEnabled && !empty($solrReadCore) && !empty($solrWriteCore)) {
-                $solrConnectionConfigurations[$languageUid] = [
-                    'connectionKey' =>  $rootPageRecord['uid'] . '|' . $languageUid,
-                    'rootPageTitle' => $rootPageRecord['title'],
-                    'rootPageUid' => $rootPageRecord['uid'],
-                    'read' => [
-                        'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'read', 'http'),
-                        'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'read', 'localhost'),
-                        'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'read', 8983),
-                        // @todo: transform core to path
-                        'path' =>
-                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'read', '/solr/') .
-                            $solrReadCore . '/' ,
-                        'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'read', ''),
-                        'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'read', ''),
-                    ],
-                    'write' => [
-                        'scheme' => SiteUtility::getConnectionProperty($typo3Site, 'scheme', $languageUid, 'write', 'http'),
-                        'host' => SiteUtility::getConnectionProperty($typo3Site, 'host', $languageUid, 'write', 'localhost'),
-                        'port' => (int)SiteUtility::getConnectionProperty($typo3Site, 'port', $languageUid, 'write', 8983),
-                        // @todo: transform core to path
-                        'path' =>
-                            SiteUtility::getConnectionProperty($typo3Site, 'path', $languageUid, 'write', '/solr/') .
-                            $solrWriteCore . '/' ,
-                        'username' => SiteUtility::getConnectionProperty($typo3Site, 'username', $languageUid, 'write', ''),
-                        'password' => SiteUtility::getConnectionProperty($typo3Site, 'password', $languageUid, 'write', ''),
-                    ],
-
-                    'language' => $languageUid,
-                ];
+            $solrConnection = SiteUtility::getSolrConnectionConfiguration($typo3Site, $languageUid);
+            if ($solrConnection !== null) {
+                $solrConnectionConfigurations[$languageUid] = $solrConnection;
             }
         }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,6 +25,11 @@ services:
       $frontendEnvironment: '@ApacheSolrForTypo3\Solr\FrontendEnvironment'
       $tcaService: '@ApacheSolrForTypo3\Solr\System\TCA\TCAService'
       $indexQueue: '@ApacheSolrForTypo3\Solr\IndexQueue\Queue'
+
+  ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService:
+    public: true
+    autowire: true
+
   ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\CachedUrlModifier:
     tags:
       - name: event.listener

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -55,7 +55,14 @@ class RepositoryTest extends UnitTest
     public function findOneByPageIdAndByLanguageIdReturnsFirstFoundDocument()
     {
         $apacheSolrDocumentCollection = [new Document(), new Document()];
-        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['findByPageIdAndByLanguageId']);
+        $apacheSolrDocumentRepository = $this->getAccessibleMock(
+            Repository::class,
+            ['findByPageIdAndByLanguageId'],
+            [],
+            '',
+            false
+        );
+
         $apacheSolrDocumentRepository
             ->expects(self::exactly(1))
             ->method('findByPageIdAndByLanguageId')
@@ -93,7 +100,13 @@ class RepositoryTest extends UnitTest
     public function findByPageIdAndByLanguageIdReturnsEmptyCollectionIfConnectionToSolrServerCanNotBeEstablished()
     {
         /* @var $apacheSolrDocumentRepository Repository */
-        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['initializeSearch']);
+        $apacheSolrDocumentRepository = $this->getAccessibleMock(
+            Repository::class,
+            ['initializeSearch'],
+            [],
+            '',
+            false
+        );
         $apacheSolrDocumentRepository
             ->expects(self::exactly(1))
             ->method('initializeSearch')

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -93,7 +93,7 @@ class QueryBuilderTest extends UnitTest
      */
     protected function getInitializedTestSearchQuery(string $queryString = '', TypoScriptConfiguration $fakeConfiguration = null): SearchQuery
     {
-        $builder = new QueryBuilder($fakeConfiguration, $this->loggerMock);
+        $builder = new QueryBuilder($fakeConfiguration, $this->loggerMock, $this->siteHashServiceMock);
         return $builder->buildSearchQuery($queryString);
     }
 
@@ -379,7 +379,7 @@ class QueryBuilderTest extends UnitTest
     public function addsCorrectAccessFilterForAnonymousUser()
     {
         $query = $this->getInitializedTestSearchQuery();
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([-1, 0]);
         $queryParameters = $this->getAllQueryParameters($query);
         self::assertSame('{!typo3access}-1,0', $queryParameters['fq'], 'Accessfilter was not applied');
@@ -391,7 +391,7 @@ class QueryBuilderTest extends UnitTest
     public function grantsAccessToGroupZeroIfNoGroupsProvided()
     {
         $query = $this->getInitializedTestSearchQuery();
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([]);
         $queryParameters = $this->getAllQueryParameters($query);
         self::assertSame('{!typo3access}0', $queryParameters['fq'], 'Changed accessfilter was not applied');
@@ -403,7 +403,7 @@ class QueryBuilderTest extends UnitTest
     public function grantsAccessToGroupZeroIfZeroNotProvided()
     {
         $query = $this->getInitializedTestSearchQuery();
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([5]);
         $queryParameters = $this->getAllQueryParameters($query);
         self::assertSame('{!typo3access}0,5', $queryParameters['fq'], 'Access filter was not applied as expected');
@@ -415,7 +415,7 @@ class QueryBuilderTest extends UnitTest
     public function filtersDuplicateAccessGroups()
     {
         $query = $this->getInitializedTestSearchQuery();
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([1, 1]);
         $queryParameters = $this->getAllQueryParameters($query);
         self::assertSame('{!typo3access}0,1', $queryParameters['fq'], 'Access filter was not applied as expected');
@@ -427,7 +427,7 @@ class QueryBuilderTest extends UnitTest
     public function allowsOnlyOneAccessFilter()
     {
         $query = $this->getInitializedTestSearchQuery();
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $queryBuilder->startFrom($query)->useUserAccessGroups([1])->useUserAccessGroups([2]);
         $queryParameters = $this->getAllQueryParameters($query);
 
@@ -910,7 +910,7 @@ class QueryBuilderTest extends UnitTest
      */
     public function canUseConfiguredVariantsFieldWhenVariantsAreActive()
     {
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
+        $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
             'variantField' => 'myField',
         ];
@@ -926,7 +926,7 @@ class QueryBuilderTest extends UnitTest
      */
     public function canUseConfiguredVariantsExpandAndRowCount()
     {
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
+        $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
             'variantField' => 'variants',
             'expand' => true,
@@ -945,7 +945,7 @@ class QueryBuilderTest extends UnitTest
      */
     public function expandRowsIsNotSetWhenExpandIsInactive()
     {
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
+        $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants.'] = [
             'variantField' => 'variants',
             'expand' => false,
@@ -1256,7 +1256,7 @@ class QueryBuilderTest extends UnitTest
 
         $fieldCollapsing = new FieldCollapsing(true);
 
-        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock);
+        $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         $query = $queryBuilder->newSearchQuery('hello world')
             ->useFilter('color:red')
             ->useUserAccessGroups([1, 2, 3])
@@ -1612,7 +1612,7 @@ class QueryBuilderTest extends UnitTest
                 'numberOfSuggestions' => 10,
             ]);
         $this->builder = $this->getMockBuilder(QueryBuilder::class)
-            ->setConstructorArgs([$this->configurationMock, $this->loggerMock])
+            ->setConstructorArgs([$this->configurationMock, $this->loggerMock, $this->siteHashServiceMock])
             ->onlyMethods(['useSiteHashFromTypoScript'])
             ->getMock();
 
@@ -1634,7 +1634,7 @@ class QueryBuilderTest extends UnitTest
                 'numberOfSuggestions' => 10,
             ]);
         $this->builder = $this->getMockBuilder(QueryBuilder::class)
-                                ->setConstructorArgs([$this->configurationMock, $this->loggerMock])
+                                ->setConstructorArgs([$this->configurationMock, $this->loggerMock, $this->siteHashServiceMock])
                                 ->onlyMethods(['useSiteHashFromTypoScript'])
                                 ->getMock();
 

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
@@ -38,7 +39,7 @@ class SuggestQueryTest extends UnitTest
         ];
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-        $queryBuilder = new QueryBuilder($fakeConfiguration);
+        $queryBuilder = new QueryBuilder($fakeConfiguration, null, $this->createMock(SiteHashService::class));
         $suggestQuery = $queryBuilder->newSuggestQuery('type')->getQuery();
 
         self::assertNull($suggestQuery->getFilterQuery('fieldCollapsing'), 'Collapsing should never be active for a suggest query, even when active');
@@ -52,7 +53,7 @@ class SuggestQueryTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration([]);
         $suggestQuery = new SuggestQuery('typ', $fakeConfiguration);
 
-        $queryBuilder = new QueryBuilder($fakeConfiguration);
+        $queryBuilder = new QueryBuilder($fakeConfiguration, null, $this->createMock(SiteHashService::class));
         $queryBuilder->startFrom($suggestQuery)->useFilter('+type:pages');
         $queryParameters = $suggestQuery->getRequestBuilder()->build($suggestQuery)->getParams();
         self::assertSame('+type:pages', $queryParameters['fq'], 'Filter was not added to the suggest query parameters');
@@ -66,7 +67,7 @@ class SuggestQueryTest extends UnitTest
         $fakeConfiguration = new TypoScriptConfiguration([]);
         $suggestQuery = new SuggestQuery(' ', $fakeConfiguration);
 
-        $queryBuilder = new QueryBuilder($fakeConfiguration);
+        $queryBuilder = new QueryBuilder($fakeConfiguration, null, $this->createMock(SiteHashService::class));
         $queryBuilder->startFrom($suggestQuery)->useFilter('+type:pages');
         $queryParameters = $suggestQuery->getRequestBuilder()->build($suggestQuery)->getParams();
         self::assertSame('', $queryParameters['q'], 'Query is expected to be empty, but is not');

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
@@ -63,11 +64,6 @@ class SearchResultSetTest extends UnitTest
     protected $queryMock;
 
     /**
-     * @var SiteHashService
-     */
-    protected $siteHashServiceMock;
-
-    /**
      * @var EscapeService
      */
     protected $escapeServiceMock;
@@ -83,9 +79,14 @@ class SearchResultSetTest extends UnitTest
         $this->searchMock = $this->getDumbMock(Search::class);
         $this->solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
 
-        $this->siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
         $this->escapeServiceMock = $this->getDumbMock(EscapeService::class);
         $this->escapeServiceMock->expects(self::any())->method('escape')->willReturnArgument(0);
+
+        $queryBuilder = new QueryBuilder(
+            $this->configurationMock,
+            $this->solrLogManagerMock,
+            $this->createMock(SiteHashService::class)
+        );
 
         $this->objectManagerMock = $this->createMock(ObjectManager::class);
         $this->searchResultSetService = $this->getMockBuilder(SearchResultSetService::class)
@@ -95,7 +96,7 @@ class SearchResultSetTest extends UnitTest
                 $this->searchMock,
                 $this->solrLogManagerMock,
                 null,
-                null,
+                $queryBuilder,
                 $this->objectManagerMock,
             ])
             ->getMock();

--- a/Tests/Unit/Query/Modifier/ElevationTest.php
+++ b/Tests/Unit/Query/Modifier/ElevationTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Elevation;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
@@ -35,6 +36,7 @@ class ElevationTest extends UnitTest
         $query = $this->getDumbMock(Query::class);
 
         $queryBuilderMock = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([null, null, $this->createMock(SiteHashService::class)])
             ->disableProxyingToOriginalMethods()
             ->getMock();
         $queryBuilderMock->expects(self::once())->method('startFrom')->willReturn($queryBuilderMock);

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\InvalidQueryBuilderEx
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\InvalidUrlDecoderException;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Faceting;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
@@ -72,8 +73,14 @@ class FacetingTest extends UnitTest
         $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
 
         /* @var Query $query */
-        $queryBuilder = new QueryBuilder($fakeConfiguration, $solrLogManagerMock);
+        $queryBuilder = new QueryBuilder(
+            $fakeConfiguration,
+            $solrLogManagerMock,
+            $this->createMock(SiteHashService::class)
+        );
         $query = $queryBuilder->buildSearchQuery('test');
+
+        GeneralUtility::addInstance(SiteHashService::class, $this->createMock(SiteHashService::class));
 
         /* @var Faceting $facetModifier */
         $facetModifier = GeneralUtility::makeInstance(Faceting::class, $facetRegistry);

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -17,8 +17,10 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Search;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Search\RelevanceComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use Solarium\QueryType\Select\RequestBuilder;
 
@@ -55,7 +57,11 @@ class RelevanceComponentTest extends UnitTest
         ];
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -82,7 +88,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -110,7 +120,11 @@ class RelevanceComponentTest extends UnitTest
         ];
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -137,7 +151,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -164,7 +182,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -192,7 +214,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -219,7 +245,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -246,7 +276,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -270,7 +304,11 @@ class RelevanceComponentTest extends UnitTest
             ],
         ];
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $query = new Query();
@@ -299,7 +337,11 @@ class RelevanceComponentTest extends UnitTest
         self::assertArrayNotHasKey('bq', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $relevanceComponent->setSearchConfiguration($searchConfiguration);
@@ -328,7 +370,11 @@ class RelevanceComponentTest extends UnitTest
         self::assertArrayNotHasKey('bq', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $relevanceComponent->setSearchConfiguration($searchConfiguration);
@@ -355,7 +401,11 @@ class RelevanceComponentTest extends UnitTest
         self::assertArrayNotHasKey('bf', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
         $relevanceComponent = new RelevanceComponent($queryBuilder);
 
         $relevanceComponent->setSearchConfiguration($searchConfiguration);
@@ -381,7 +431,11 @@ class RelevanceComponentTest extends UnitTest
         self::assertArrayNotHasKey('mm', $this->getQueryParameters($query));
 
         $typoscriptConfiguration = $this->getTypoScriptConfigurationWithQueryConfiguration($searchConfiguration);
-        $queryBuilder = new QueryBuilder($typoscriptConfiguration);
+        $queryBuilder = new QueryBuilder(
+            $typoscriptConfiguration,
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
 
         $relevanceComponent = new RelevanceComponent($queryBuilder);
         $relevanceComponent->setSearchConfiguration($searchConfiguration);

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -16,8 +16,12 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Search;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Search\SortingComponent;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 
 /**
@@ -51,7 +55,13 @@ class SortingComponentTest extends UnitTest
         $this->query->setQuery('');
         $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
 
-        $this->sortingComponent = new SortingComponent();
+        $queryBuilder = new QueryBuilder(
+            $this->createMock(TypoScriptConfiguration::class),
+            $this->createMock(SolrLogManager::class),
+            $this->createMock(SiteHashService::class)
+        );
+
+        $this->sortingComponent = new SortingComponent($queryBuilder);
         $this->sortingComponent->setQuery($this->query);
         $this->sortingComponent->setSearchRequest($this->searchRequestMock);
         parent::setUp();


### PR DESCRIPTION
# What this pr does

Solr plugins are initializing Solr connections for all available
languages, this causes wrong language initializations in the
PageRenderer, as all created TypoScriptFrontendController instances
will overwrite the language setting.

By allowing to fetch the Solr configuration by TYPO3 site and a
specific language this issue is solved and the initialization
overhead is reduced.

# How to test

- Place a Solr plugin
- Place another Plugin relying on the SiteLanguage

Fixes: #3423 
