### PR TITLE
[ACTIONS:2022.12.22] Use fixed typo3/coding-standards 0.6.x < 0.7.0 for TYPO3 11.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         run: |
           export CURRENT_TYPO3_VERSION_REFERNCE=$(./Build/Helpers/TYPO3_SOURCE_REFERENCE.sh "$TYPO3_VERSION" --short)
           export CURRENT_SOLARIUM_VERSION=$(cat composer.json | jq --raw-output '.require."solarium/solarium"')
-          export CI_CACHE_VERSION="2022.01.24@14:45"
+          export CI_CACHE_VERSION="2022.12.22@20:00"
           export CI_BUILD_CACHE_KEY=${{ runner.os }}-PHP:${{ matrix.PHP }}-TYPO3:$TYPO3_VERSION@$CURRENT_TYPO3_VERSION_REFERNCE-SOLARIUM:$CURRENT_SOLARIUM_VERSION-"CI_CACHE_VERSION:"$CI_CACHE_VERSION
           echo "COMPOSER_GLOBAL_REQUEREMENTS=$(composer config home)" >> $GITHUB_ENV
           echo "CI_BUILD_CACHE_KEY=$CI_BUILD_CACHE_KEY" >> $GITHUB_ENV

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -43,7 +43,7 @@ else
     echo "Some files are not compliant to TYPO3 Coding Standards"
     echo "Please fix the files listed above."
     echo "Tip for auto fix: "
-    echo "  composer install && composer exec php-cs-fixer fix"
+    echo "  composer tests:setup && composer t3:standards:fix"
     exit 1
   else
     echo "The code is TYPO3 Coding Standards compliant! Great job!"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "typo3/cms-tstemplate": "*"
   },
   "require-dev": {
-    "typo3/coding-standards": ">=0.5.0",
+    "typo3/coding-standards": "~0.6.1",
     "phpunit/phpunit": "^9.5",
     "phpspec/prophecy-phpunit":"*",
     "typo3/testing-framework": "^6.12",


### PR DESCRIPTION
composer constraint >=0.5.0 doesn't fit current needs for different PHP versions. To avoid different rules for PHP 7.4 vs 8.0+, the constraint is set to use typo3/coding-standards 0.6.x only.

Todo: 
Extract coding standards test from cibuild and run it one time only directly via actions job.  
Alternatively, run it for specific version only.
