### PR TITLE
[BUGFIX:P:11.5] Proper check for config.index_enable

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -253,7 +253,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
         $configuration = Util::getSolrConfiguration();
 
         $logPageIndexed = $configuration->getLoggingIndexingPageIndexed();
-        if (!$this->page->config['config']['index_enable']) {
+        if (!$this->page->config['config']['index_enable'] ?? false) {
             if ($logPageIndexed) {
                 $this->logger->log(
                     SolrLogManager::ERROR,


### PR DESCRIPTION
Not initialized variable leads to exception using PHP 8+ in

https://github.com/TYPO3-Solr/ext-solr/blob/bfe1599a7533ed8aff0060ab932067ecd32dacad/Classes/IndexQueue/FrontendHelper/PageIndexer.php#L256

Fixes: #3403
Ports: #3404