### PR TITLE
[BUGFIX:P:11.5] Typecast $timestamp to int in TimestampToUtcIsoDate

### DIFF
--- a/Classes/FieldProcessor/TimestampToUtcIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToUtcIsoDate.php
@@ -44,7 +44,7 @@ class TimestampToUtcIsoDate implements FieldProcessor
         $formatService = GeneralUtility::makeInstance(FormatService::class);
 
         foreach ($values as $timestamp) {
-            $results[] = $formatService->timestampToUtcIso($timestamp);
+            $results[] = $formatService->timestampToUtcIso((int)$timestamp);
         }
 
         return $results;


### PR DESCRIPTION
Due to refactoring in `FormatService`, the parameter for `timestampToUtcIso` has been defined as `int` or `null`. The function is however used in `TimestampToUtcIsoDate` with the direct value of the field, which is a string. This change ensures, that an integer value is passed.

Fixes: #3406
Ports: #3405