### PR TITLE
[BUGFIX] prevent undefined array key warning if filter is empty

### DIFF
--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -237,6 +237,9 @@ class Faceting implements Modifier, SearchRequestAware
             $filters = array_keys($filters);
         }
         foreach ($filters as $filter) {
+            if (strpos($filter, ':') === false) {
+                continue;
+            }
             // only split by the first colon to allow using colons in the filter value itself
             list($filterFacetName, $filterValue) = explode(':', $filter, 2);
             if (in_array($filterFacetName, $configuredFacets)) {


### PR DESCRIPTION
An empty filter in query string of URL `tx_solr[filter][]=` leads to PHP 8+ Warninng:
```
PHP Warning: Undefined array key 1 in /var/www/html/web/typo3conf/ext/solr/Classes/Query/Modifier/Faceting.php line 241
```

See: https://github.com/TYPO3-Solr/ext-solr/blob/bfe1599a7533ed8aff0060ab932067ecd32dacad/Classes/Query/Modifier/Faceting.php#L241

Closes: #3398