### PR TITLE
[BUGFIX:P:12.0] Fix php warning undefined array key no_search_sub_entries

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -200,7 +200,7 @@ class RecordMonitor
             return true;
         }
         foreach ($rootline as $page) {
-            if ($page['no_search_sub_entries']) {
+            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries']) {
                 return true;
             }
         }


### PR DESCRIPTION
To avoid php warning for undefined array key, check if key is set in $page array.

Fixes #3380
Ports: #3381