### PR TITLE
[BUGFIX] add empty string as fallback

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupUrlDecoder.php
@@ -37,6 +37,6 @@ class QueryGroupUrlDecoder implements FacetUrlDecoderInterface
      */
     public function decode(string $value, array $configuration = []): string
     {
-        return $configuration[$value . '.']['query'];
+        return $configuration[$value . '.']['query'] ?? '';
     }
 }


### PR DESCRIPTION
# What this pr does

ensure a string is always returned, even if the query does not exist

# How to test

Define a queryGroup "A", filter by that new group, manipulate the url by hand, submit form. Page should not show error.

