### PR TITLE
[BUGFIX] Fix issue 3445 : Error when indexing pages with field proces…

### DIFF
--- a/Classes/FieldProcessor/CategoryUidToHierarchy.php
+++ b/Classes/FieldProcessor/CategoryUidToHierarchy.php
@@ -80,7 +80,7 @@ class CategoryUidToHierarchy extends AbstractHierarchyProcessor implements Field
         foreach ($values as $value) {
             $results = array_merge(
                 $results,
-                $this->getSolrRootlineForCategoryId($value)
+                $this->getSolrRootlineForCategoryId((int)$value)
             );
         }
 


### PR DESCRIPTION
Fix error whenindexing pages with field processing instruction categoryUidToHierarchy.

# What this pr does

This PR cast the category ID to int because this is the type required for CategoryUidToHierarchy::getSolrRootlineForCategoryId()

# How to test

See issue

Fixes: #3445
