### PR TITLE
[TASK:T12] Replace query generator

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php
@@ -25,7 +25,6 @@ use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Database\QueryGenerator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -33,7 +32,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * Base class for Handling updates or deletions on potential
  * relevant records
- * @todo: Replace QueryGenerator
  */
 abstract class AbstractUpdateHandler
 {
@@ -173,7 +171,7 @@ abstract class AbstractUpdateHandler
         // here we retrieve only the subpages of this page because the permission clause is not evaluated
         // on the root node.
         $permissionClause = ' 1 ' . $this->getPagesRepository()->getBackendEnableFields();
-        $treePageIdList = (string)$this->getQueryGenerator()->getTreeList($pageId, 20, 0, $permissionClause);
+        $treePageIdList = $this->getPagesRepository()->getTreeList($pageId, 20, 0, $permissionClause);
         $treePageIds = array_map('intval', explode(',', $treePageIdList));
 
         // the first one can be ignored because this is the page itself
@@ -300,14 +298,6 @@ abstract class AbstractUpdateHandler
     protected function getUpdateSubPagesRecursiveTriggerConfiguration(): array
     {
         return $this->updateSubPagesRecursiveTriggerConfiguration;
-    }
-
-    /**
-     * @return QueryGenerator
-     */
-    protected function getQueryGenerator(): QueryGenerator
-    {
-        return GeneralUtility::makeInstance(QueryGenerator::class);
     }
 
     /**

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -420,7 +420,7 @@ class PagesRepository extends AbstractRepository
      * @throws DBALException|\Doctrine\DBAL\DBALException
      * @noinspection Duplicates
      */
-    protected function getTreeList(int $id, int $depth = 999, int $begin = 0, string $permClause = ''): string
+    public function getTreeList(int $id, int $depth = 999, int $begin = 0, string $permClause = ''): string
     {
         if ($id < 0) {
             $id = abs($id);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandlerTest.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Database\QueryGenerator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -59,14 +58,9 @@ abstract class AbstractUpdateHandlerTest extends UnitTest
     protected $indexQueueMock;
 
     /**
-     * @var QueryGenerator|MockObject
-     */
-    protected $queryGeneratorMock;
-
-    /**
      * @var PagesRepository|MockObject
      */
-    protected $pagesRepositoryMock;
+    protected PagesRepository|MockObject $pagesRepositoryMock;
 
     protected function setUp(): void
     {
@@ -75,6 +69,7 @@ abstract class AbstractUpdateHandlerTest extends UnitTest
         $this->tcaServiceMock = $this->createMock(TCAService::class);
         $this->indexQueueMock = $this->createMock(Queue::class);
         $this->pagesRepositoryMock = $this->createMock(PagesRepository::class);
+        GeneralUtility::addInstance(PagesRepository::class, $this->pagesRepositoryMock);
 
         $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
         $this->frontendEnvironmentMock
@@ -82,9 +77,6 @@ abstract class AbstractUpdateHandlerTest extends UnitTest
             ->method('getSolrConfigurationFromPageId')
             ->willReturn($this->typoScriptConfigurationMock);
 
-        $this->queryGeneratorMock = $this->createMock(QueryGenerator::class);
-
-        GeneralUtility::addInstance(QueryGenerator::class, $this->queryGeneratorMock);
         parent::setUp();
     }
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -378,10 +378,10 @@ class DataUpdateHandlerTest extends AbstractUpdateHandlerTest
 
         $GLOBALS['TCA']['pages'] = ['columns' => []];
 
-        $this->queryGeneratorMock
+        $this->pagesRepositoryMock
             ->expects(self::any())
             ->method('getTreeList')
-            ->willReturn($dummyPageRecord['uid'] . ',100,200');
+            ->willReturn(implode(',', [$dummyPageRecord['uid'], 100, 200]));
 
         $this->pagesRepositoryMock
             ->expects(self::any())

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -191,10 +191,10 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
             ->with('pages', $dummyPageRecord)
             ->willReturn($dummyPageRecord);
 
-        $this->queryGeneratorMock
+        $this->pagesRepositoryMock
             ->expects(self::any())
             ->method('getTreeList')
-            ->willReturn($dummyPageRecord['uid'] . ',100,200');
+            ->willReturn(implode(',', [$dummyPageRecord['uid'], 100, 200]));
 
         $this->garbageHandler->performRecordGarbageCheck($dummyPageRecord['uid'], 'pages', ['hidden' => 1], true);
     }


### PR DESCRIPTION
The use of the `QueryGenerator::getTreeList()` was replaced with
`\ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository::getTreeList()`

Resolves: #3453
Relates: #3376