### PR TITLE
[BUGFIX:BP:11.5] Fix error when indexing pages with field processing instruction categoryUidToHierarchy

### DIFF
--- a/Classes/FieldProcessor/CategoryUidToHierarchy.php
+++ b/Classes/FieldProcessor/CategoryUidToHierarchy.php
@@ -80,7 +80,7 @@ class CategoryUidToHierarchy extends AbstractHierarchyProcessor implements Field
         foreach ($values as $value) {
             $results = array_merge(
                 $results,
-                $this->getSolrRootlineForCategoryId($value)
+                $this->getSolrRootlineForCategoryId((int)$value)
             );
         }
 


### PR DESCRIPTION
Fixes: #3445
Ports: #3446