### PR TITLE
[BUGFIX] Don't use minimum-stability dev on TYPO3 stable in build/CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "tests:restore-git": "echo \"Retore composer.json to initial state:\" && git checkout composer.json",
     "tests:env": [
       "if [ -z ${TYPO3_VERSION+x} ]; then >&2 echo \"Can not proceed, because env var TYPO3_VERSION is not set\"; exit 1; else echo \"Setup test environment for TYPO3 ${TYPO3_VERSION}\"; fi",
-      "if [ \"${TYPO3_VERSION#*dev}\" != \"dev\" ]; then $COMPOSER_BINARY config minimum-stability dev; fi"
+      "if echo $TYPO3_VERSION | grep -q \"dev\"; then $COMPOSER_BINARY config minimum-stability dev; fi"
     ],
     "tests:setup": [
       "@tests:env",


### PR DESCRIPTION
The composer script "tests:env" olways used the dev stability, even if stable TYPO3 used in matrix.
This fix uses grep instead of not working sh string substitution comparator.

---

The ports will be provided as well for:
* release-11.5.x
* release-11.2.x
* release-11.0.x(ELTS)