### PR TITLE
[BUGFIX:BP:11.5] Custom doktype is deleted from solr after saving with custom queue configuration

### DIFF
--- a/Classes/FrontendEnvironment.php
+++ b/Classes/FrontendEnvironment.php
@@ -61,7 +61,7 @@ class FrontendEnvironment implements SingletonInterface
      * @return bool
      * @throws DBALDriverException
      */
-    public function isAllowedPageType(array $pageRecord, ?string $configurationName = 'pages'): bool
+    public function isAllowedPageType(array $pageRecord, ?string $configurationName = null): bool
     {
         // $pageRecord could come from DataHandler and with all columns. So we want to fetch it again.
         $pageRecord = BackendUtility::getRecord('pages', $pageRecord['uid']);
@@ -79,7 +79,13 @@ class FrontendEnvironment implements SingletonInterface
             return false;
         }
         $configuration = $this->getConfigurationFromPageId($rootPageRecordUid, '', $tsfe->getLanguage()->getLanguageId());
-        $allowedPageTypes = $configuration->getIndexQueueAllowedPageTypesArrayByConfigurationName($configurationName);
+        if ($configurationName !== null) {
+            $allowedPageTypes = $configuration->getIndexQueueAllowedPageTypesArrayByConfigurationName($configurationName);
+        } else {
+            // If the $configurationName is not provided,
+            // we will check if one of the configurations allow the pagetype to be indexed
+            $allowedPageTypes = $configuration->getAllIndexQueueAllowedPageTypesArray();
+        }
         return in_array($pageRecord['doktype'], $allowedPageTypes);
     }
 

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -360,6 +360,34 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns an array of allowedPageTypes declared in all queue configurations.
+     *
+     * plugin.tx_solr.index.queue.*.allowedPageTypes
+     *
+     * @return array
+     */
+    public function getAllIndexQueueAllowedPageTypesArray(): array
+    {
+        $configuration = $this->configurationAccess->get('plugin.tx_solr.index.queue.');
+
+        if (!is_array($configuration)) {
+            return [];
+        }
+
+        $allowedPageTypes = [];
+        foreach ($configuration as $queueName => $queueConfiguration) {
+            if (is_array($queueConfiguration)
+                && !empty($queueConfiguration['allowedPageTypes'])
+                && $this->getIndexQueueConfigurationIsEnabled(rtrim($queueName, '.'))
+            ) {
+                $allowedPageTypes = array_merge($allowedPageTypes, GeneralUtility::trimExplode(',', $queueConfiguration['allowedPageTypes'], true));
+            }
+        }
+
+        return array_unique($allowedPageTypes);
+    }
+
+    /**
      * Returns the configured excludeContentByClass patterns as array.
      *
      * plugin.tx_solr.index.queue.pages.excludeContentByClass


### PR DESCRIPTION
# What this pr does

When a page is saved, the GarbageHandler will check in all queue configuration if the doktype is allowed, not only in "pages" queue configuration.

# How to test

1. Create a custom page type, 100 / news for example
2. Include default solr configuration
3. Add this custom configuration
```
  plugin.tx_solr.index.queue {
  pages.allowedPageTypes = 1
  pages.additionalWhereClause = doktype IN(1) AND no_search = 0
  news < .pages
  news.allowedPageTypes = 100
  news.additionalWhereClause = doktype IN(100) AND no_search = 0
}
```
4. Create a new page with the custom type 100
5. Start indexing and checks the page is right in solr
6. Update the page by changing its title
7. Check in solr, the page is still there

Fixes: #3450