### PR TITLE
[TASK:T12] Registration of cObjects for TYPO3 12 LTS 

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -73,15 +73,17 @@ class Relation extends AbstractContentObject
 
     /**
      * Relation constructor.
+     *
+     * @param ContentObjectRenderer|null $cObj
      * @param TCAService|null $tcaService
      * @param FrontendOverlayService|null $frontendOverlayService
      */
     public function __construct(
-        ContentObjectRenderer $cObj,
-        TCAService $tcaService = null,
-        FrontendOverlayService $frontendOverlayService = null
+        ?ContentObjectRenderer $cObj = null,
+        ?TCAService $tcaService = null,
+        ?FrontendOverlayService $frontendOverlayService = null
     ) {
-        parent::__construct($cObj);
+        $this->cObj = $cObj;
         $this->configuration['enableRecursiveValueResolution'] = 1;
         $this->configuration['removeEmptyValues'] = 1;
         $this->tcaService = $tcaService ?? GeneralUtility::makeInstance(TCAService::class);

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -178,7 +178,8 @@ class Tsfe implements SingletonInterface
                 $tsfe->determineId($serverRequest);
                 $serverRequest->withAttribute('frontend.controller', $tsfe);
                 $tsfe->no_cache = false;
-                $tsfe->getConfigArray($serverRequest);
+                // @todo T12: Check if following line really needed ::1
+                //$tsfe->getFromCache($serverRequest);
 
                 $tsfe->newCObj($serverRequest);
                 $tsfe->absRefPrefix = self::getAbsRefPrefixFromTSFE($tsfe);
@@ -198,6 +199,9 @@ class Tsfe implements SingletonInterface
                 $GLOBALS['BE_USER'] = $backedUpBackendUser;
             }
 
+            // @todo T12: Check if following line really needed ::1
+            // The manual releasing of locks is low level api and should be avoided in EXT:solr.
+            //$tsfe->releaseLocks();
             $this->tsfeCache[$cacheIdentifier] = $tsfe;
         }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -145,6 +145,25 @@ services:
         identifier: 'solr.index.pageIndexer.FrontendUserAuthenticator'
         event: TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontendGroupsEvent
 
+  ###  EXT:solr content objects
+  ApacheSolrForTypo3\Solr\ContentObject\Classification:
+    tags:
+      - name: frontend.contentobject
+        identifier: 'SOLR_CLASSIFICATION'
+  ApacheSolrForTypo3\Solr\ContentObject\Content:
+    tags:
+      - name: frontend.contentobject
+        identifier: 'SOLR_CONTENT'
+  ApacheSolrForTypo3\Solr\ContentObject\Multivalue:
+    tags:
+      - name: frontend.contentobject
+        identifier: 'SOLR_MULTIVALUE'
+  ApacheSolrForTypo3\Solr\ContentObject\Relation:
+    tags:
+      - name: frontend.contentobject
+        identifier: 'SOLR_RELATION'
+
+
   # Reports: Status
   ApacheSolrForTypo3\Solr\Report\SiteHandlingStatus:
     tags:

--- a/Tests/Unit/ContentObject/AbstractContentObjectTest.php
+++ b/Tests/Unit/ContentObject/AbstractContentObjectTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
+
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectFactory;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Tests setUp for EXT:solr content object classes
+ */
+abstract class AbstractContentObjectTest extends UnitTest
+{
+    use ProphecyTrait;
+
+    protected bool $resetSingletonInstances = true;
+
+    /**
+     * @var ContentObjectRenderer
+     */
+    protected ContentObjectRenderer $contentObjectRenderer;
+
+    protected AbstractContentObject $testableContentObject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)
+            ->addMethods(['dummy'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = new ServerRequest();
+        $this->contentObjectRenderer = new ContentObjectRenderer($tsfe);
+        $this->contentObjectRenderer->setRequest($request);
+        $cObjectFactoryMock = $this->getMockBuilder(ContentObjectFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->testableContentObject = new ($this->getTestableContentObjectClassName())();
+        $this->testableContentObject->setRequest($request);
+        $this->testableContentObject->setContentObjectRenderer($this->contentObjectRenderer);
+
+        $cObjectFactoryMock->method('getContentObject')->willReturnMap([
+            [($this->getTestableContentObjectClassName())::CONTENT_OBJECT_NAME, $request, $this->contentObjectRenderer, $this->testableContentObject],
+        ]);
+
+        $container = new Container();
+        $container->set(ContentObjectFactory::class, $cObjectFactoryMock);
+        GeneralUtility::setContainer($container);
+    }
+
+    abstract protected function getTestableContentObjectClassName(): string;
+}

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -16,30 +18,26 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Classification;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Tests for the SOLR_CLASSIFICATION cObj.
  *
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class ClassificationTest extends UnitTest
+class ClassificationTest extends AbstractContentObjectTest
 {
-    /**
-     * @var ContentObjectRenderer
-     */
-    protected $contentObject;
+    protected function getTestableContentObjectClassName(): string
+    {
+        return Classification::class;
+    }
 
     /**
      * @test
      */
     public function canClassifyContent()
     {
-        $GLOBALS['TSFE']->cObjectDepthCounter = 2;
         $content = 'i like TYPO3 more then joomla';
-        $this->contentObject->start(['content' => $content]);
+        $this->contentObjectRenderer->start(['content' => $content]);
 
         $configuration = [
             'field' => 'content',
@@ -55,7 +53,7 @@ class ClassificationTest extends UnitTest
             ],
         ];
 
-        $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
+        $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
         $expected = serialize(['cms']);
         self::assertEquals($expected, $actual);
     }
@@ -63,7 +61,7 @@ class ClassificationTest extends UnitTest
     /**
      * @return array
      */
-    public function excludePatternDataProvider()
+    public function excludePatternDataProvider(): array
     {
         return [
             'excludePatternShouldLeadToUnassignedClass' => [
@@ -83,8 +81,7 @@ class ClassificationTest extends UnitTest
      */
     public function canExcludePatterns($input, $expectedOutput)
     {
-        $GLOBALS['TSFE']->cObjectDepthCounter = 2;
-        $this->contentObject->start(['content' => $input]);
+        $this->contentObjectRenderer->start(['content' => $input]);
 
         $configuration = [
             'field' => 'content',
@@ -97,27 +94,8 @@ class ClassificationTest extends UnitTest
             ],
         ];
 
-        $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
+        $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
         $expected = serialize($expectedOutput);
         self::assertEquals($expected, $actual);
-    }
-
-    protected function setUp(): void
-    {
-        // fake a registered hook
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][Classification::CONTENT_OBJECT_NAME] = Classification::class;
-
-        $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);
-
-        $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
-            ->onlyMethods(['getResourceFactory', 'getEnvironmentVariable', 'getRequest'])
-            ->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TSFE']);
-        parent::tearDown();
     }
 }

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -16,35 +18,30 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
-use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Tests for the SOLR_MULTIVALUE cObj.
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class MultivalueTest extends UnitTest
+class MultivalueTest extends AbstractContentObjectTest
 {
-    /**
-     * @var ContentObjectRenderer
-     */
-    protected $contentObject;
+    protected function getTestableContentObjectClassName(): string
+    {
+        return Multivalue::class;
+    }
 
     /**
      * @test
      */
     public function convertsCommaSeparatedListFromRecordToSerializedArrayOfTrimmedValues()
     {
-        $GLOBALS['TSFE']->cObjectDepthCounter = 2;
-
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
         $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
 
-        $this->contentObject->start(['list' => $list]);
+        $this->contentObjectRenderer->start(['list' => $list]);
 
-        $actual = $this->contentObject->cObjGetSingle(
+        $actual = $this->contentObjectRenderer->cObjGetSingle(
             Multivalue::CONTENT_OBJECT_NAME,
             [
                 'field' => 'list',
@@ -63,9 +60,9 @@ class MultivalueTest extends UnitTest
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
         $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
 
-        $this->contentObject->start([]);
+        $this->contentObjectRenderer->start([]);
 
-        $actual = $this->contentObject->cObjGetSingle(
+        $actual = $this->contentObjectRenderer->cObjGetSingle(
             Multivalue::CONTENT_OBJECT_NAME,
             [
                 'value' => $list,
@@ -74,24 +71,5 @@ class MultivalueTest extends UnitTest
         );
 
         self::assertEquals($expected, $actual);
-    }
-
-    protected function setUp(): void
-    {
-        // fake a registered hook
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][Multivalue::CONTENT_OBJECT_NAME] = Multivalue::class;
-
-        $GLOBALS['TSFE'] = $this->getDumbMock(TypoScriptFrontendController::class);
-
-        $this->contentObject = $this->getMockBuilder(ContentObjectRenderer::class)
-            ->onlyMethods(['getResourceFactory', 'getEnvironmentVariable', 'getRequest'])
-            ->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TSFE']);
-        parent::tearDown();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "typo3/coding-standards": "~0.7.1",
     "phpunit/phpunit": "^9.5",
     "phpspec/prophecy-phpunit":"*",
-    "typo3/testing-framework": "7.x-dev",
+    "typo3/testing-framework": "dev-7-composerinstaller5-fix",
     "typo3/cms-fluid-styled-content": "*",
     "scrutinizer/ocular": "*",
     "sclable/xml-lint": "*"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-simplexml": "*",
     "solarium/solarium": "6.2.7",
     "typo3/cms-backend": "*",
-    "typo3/cms-core": "12.*.*@dev",
+    "typo3/cms-core": "^12",
     "typo3/cms-extbase": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-frontend": "*",
@@ -40,7 +40,7 @@
     "typo3/coding-standards": "~0.7.1",
     "phpunit/phpunit": "^9.5",
     "phpspec/prophecy-phpunit":"*",
-    "typo3/testing-framework": "dev-main",
+    "typo3/testing-framework": "7.x-dev",
     "typo3/cms-fluid-styled-content": "*",
     "scrutinizer/ocular": "*",
     "sclable/xml-lint": "*"
@@ -58,7 +58,7 @@
   "autoload-dev": {
     "psr-4": {
       "ApacheSolrForTypo3\\Solr\\Tests\\": "Tests/",
-      "TYPO3\\CMS\\Core\\Tests\\": ".Build/Web/vendor/typo3/cms-core/Tests/"
+      "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms-core/Tests/"
     }
   },
   "minimum-stability": "stable",
@@ -93,7 +93,7 @@
       "phpunit --colors --config=Build/Test/UnitTests.xml --bootstrap=Build/Test/UnitTestsBootstrap.php"
     ],
     "tests:integration": [
-      "phpunit --colors --config=Build/Test/IntegrationTests.xml --bootstrap=.Build/Web/typo3conf/ext/solr/Build/Test/IntegrationTestsBootstrap.php"
+      "phpunit --colors --config=Build/Test/IntegrationTests.xml --bootstrap=Build/Test/IntegrationTestsBootstrap.php"
     ],
     "t3:standards:fix": [
       "php-cs-fixer fix"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -131,22 +131,6 @@ defined('TYPO3') || die();
 
     // ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
-    // add custom Solr content objects
-
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][\ApacheSolrForTypo3\Solr\ContentObject\Multivalue::CONTENT_OBJECT_NAME]
-        = \ApacheSolrForTypo3\Solr\ContentObject\Multivalue::class;
-
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][\ApacheSolrForTypo3\Solr\ContentObject\Content::CONTENT_OBJECT_NAME]
-        = \ApacheSolrForTypo3\Solr\ContentObject\Content::class;
-
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][\ApacheSolrForTypo3\Solr\ContentObject\Relation::CONTENT_OBJECT_NAME]
-        = \ApacheSolrForTypo3\Solr\ContentObject\Relation::class;
-
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects'][\ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME]
-        = \ApacheSolrForTypo3\Solr\ContentObject\Classification::class;
-
-    // ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
-
     // Register cache for frequent searches
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_solr'])) {


### PR DESCRIPTION
# Main task

Move to new way of TYPO3 12+ to register custom content objects.
See: [Breaking: #96659 - Registration of cObjects via TYPO3_CONF_VARS](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96659-RegistrationOfCObjectsViaTYPO3_CONF_VARS.html)

## Tests fixed

* Unit\ContentObject\ClassificationTest::*
* Unit\ContentObject\MultivalueTest::*
* Integration\ContentObject\RelationTest::*

# Additional tasks

To avoid rewrites of xml fixtures for TYPO3 12 compatibility task, the "typo3/testing-framework" is fixed to v 7.x.

Fixes: https://github.com/TYPO3-Solr/ext-solr/issues/3476