### PR TITLE
[BUGFIX:BP:11.5] Fix value resolution in SOLR_RELATION

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -191,28 +191,31 @@ class Relation extends AbstractContentObject
             return $relatedItems;
         }
 
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $relatedRecords = $this->getRelatedRecords($foreignTableName, ...$selectUids);
         foreach ($relatedRecords as $record) {
+            $contentObject->start($record, $foreignTableName);
+
             if (isset($foreignTableTca['columns'][$foreignTableLabelField]['config']['foreign_table'])
                 && !empty($this->configuration['enableRecursiveValueResolution'])
             ) {
+                $this->configuration['localField'] = $foreignTableLabelField;
                 if (strpos($this->configuration['foreignLabelField'], '.') !== false) {
                     $foreignTableLabelFieldArr = explode('.', $this->configuration['foreignLabelField']);
                     unset($foreignTableLabelFieldArr[0]);
                     $this->configuration['foreignLabelField'] = implode('.', $foreignTableLabelFieldArr);
+                } else {
+                    unset($this->configuration['foreignLabelField']);
                 }
 
-                $this->configuration['localField'] = $foreignTableLabelField;
-
-                $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-                $contentObject->start($record, $foreignTableName);
-
-                return $this->getRelatedItems($contentObject);
+                $relatedItems = array_merge($relatedItems, $this->getRelatedItems($contentObject));
+                continue;
             }
             if ($this->getLanguageUid() > 0) {
                 $record = $this->frontendOverlayService->getOverlay($foreignTableName, $record);
             }
-            $relatedItems[] = $record[$foreignTableLabelField];
+
+            $relatedItems[] = $contentObject->stdWrap($record[$foreignTableLabelField] ?? '', $this->configuration) ?? '';
         }
 
         return $relatedItems;
@@ -266,31 +269,43 @@ class Relation extends AbstractContentObject
         $foreignTableName = $localFieldTca['config']['foreign_table'];
         $foreignTableTca = $this->tcaService->getTableConfiguration($foreignTableName);
         $foreignTableLabelField = $this->resolveForeignTableLabelField($foreignTableTca);
+        $localField = $this->configuration['localField'];
 
         /** @var $relationHandler RelationHandler */
         $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+        if (!empty($localFieldTca['config']['MM'] ?? '')) {
+            $relationHandler->start(
+                '',
+                $foreignTableName,
+                $localFieldTca['config']['MM'],
+                $localRecordUid,
+                $localTableName,
+                $localFieldTca['config']
+            );
+        } else {
+            $itemList = $parentContentObject->data[$localField] ?? '';
+            $relationHandler->start($itemList, $foreignTableName, '', $localRecordUid, $localTableName, $localFieldTca['config']);
+        }
 
-        $itemList = $parentContentObject->data[$this->configuration['localField']] ?? '';
-
-        $relationHandler->start($itemList, $foreignTableName, '', $localRecordUid, $localTableName, $localFieldTca['config']);
         $selectUids = $relationHandler->tableArray[$foreignTableName];
-
         if (!is_array($selectUids) || count($selectUids) <= 0) {
             return $relatedItems;
         }
 
         $relatedRecords = $this->getRelatedRecords($foreignTableName, ...$selectUids);
-
         foreach ($relatedRecords as $relatedRecord) {
-            $resolveRelatedValue = $this->resolveRelatedValue(
+            $resolveRelatedValues = $this->resolveRelatedValue(
                 $relatedRecord,
                 $foreignTableTca,
                 $foreignTableLabelField,
                 $parentContentObject,
                 $foreignTableName
             );
-            if (!empty($resolveRelatedValue) || !$this->configuration['removeEmptyValues']) {
-                $relatedItems[] = $resolveRelatedValue;
+
+            foreach ($resolveRelatedValues as $resolveRelatedValue) {
+                if (!empty($resolveRelatedValue) || !$this->configuration['removeEmptyValues']) {
+                    $relatedItems[] = $resolveRelatedValue;
+                }
             }
         }
 
@@ -307,7 +322,7 @@ class Relation extends AbstractContentObject
      * @param ContentObjectRenderer $parentContentObject cObject
      * @param string $foreignTableName Related record table name
      *
-     * @return string
+     * @return array
      *
      * @throws AspectNotFoundException
      * @throws DBALException
@@ -318,12 +333,12 @@ class Relation extends AbstractContentObject
         string $foreignTableLabelField,
         ContentObjectRenderer $parentContentObject,
         string $foreignTableName = ''
-    ): string {
+    ): array {
         if ($this->getLanguageUid() > 0 && !empty($foreignTableName)) {
             $relatedRecord = $this->frontendOverlayService->getOverlay($foreignTableName, $relatedRecord);
         }
 
-        $value = $relatedRecord[$foreignTableLabelField];
+        $values = [$relatedRecord[$foreignTableLabelField]];
 
         if (
             !empty($foreignTableName)
@@ -354,14 +369,17 @@ class Relation extends AbstractContentObject
                 $foreignTableTca['columns'][$foreignTableLabelField],
                 $parentContentObject
             );
-            $value = array_pop($relatedItemsFromForeignTable);
+            $values = $relatedItemsFromForeignTable;
 
             // restore
             $this->configuration = $backupConfiguration;
             $parentContentObject->data = $backupRecord;
         }
+        foreach ($values as &$value) {
+            $value = $parentContentObject->stdWrap($value, $this->configuration) ?? '';
+        }
 
-        return $parentContentObject->stdWrap($value, $this->configuration) ?? '';
+        return $values;
     }
 
     /**

--- a/Tests/Integration/ContentObject/Fixtures/TCA/tx_fakeextension_domain_model_bar.php
+++ b/Tests/Integration/ContentObject/Fixtures/TCA/tx_fakeextension_domain_model_bar.php
@@ -1,0 +1,172 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'tx_fakeextension_domain_model_bar',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'editlock' => 'editlock',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'sortby' => 'sorting',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+        ],
+        'searchFields' => 'uid',
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => 1,
+            'label' => 'sys_language_uid',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'special' => 'languages',
+                'items' => [
+                    [
+                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                        -1,
+                        'flags-multiple',
+                    ],
+                ],
+                'default' => 0,
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'l10n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0],
+                ],
+                'foreign_table' => 'tx_fakeextension_domain_model_foo',
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        'cruser_id' => [
+            'label' => 'cruser_id',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'pid' => [
+            'label' => 'pid',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'crdate' => [
+            'label' => 'crdate',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'tstamp' => [
+            'label' => 'tstamp',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'sorting' => [
+            'label' => 'sorting',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => 8,
+                'eval' => 'datetime',
+                'default' => 0,
+                'renderType' => 'inputDateTime',
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => 8,
+                'eval' => 'datetime',
+                'default' => 0,
+                'renderType' => 'inputDateTime',
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'title' => [
+            'exclude' => 0,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => 60,
+                'eval' => 'required',
+            ],
+        ],
+        'main_category' => [
+            'exclude' => 0,
+            'label' => 'main_category',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'sys_category',
+                'foreign_table_where' => ' AND (sys_category.sys_language_uid = 0 OR sys_category.l10n_parent = 0)',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'inline_relation_parent' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'mm_assignments' => [
+            'exclude' => 0,
+            'label' => 'mm_assignments',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'foreign_table' => 'tx_fakeextension_domain_model_foo',
+                'MM' => 'tx_fakeextension_foo_bar_mm',
+                'MM_opposite_field' => 'mm_assignments',
+                'foreign_table_where' => 'AND (tx_fakeextension_domain_model_foo.sys_language_uid = 0 OR tx_fakeextension_domain_model_foo.l10n_parent = 0)',
+                'size' => 10,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'l10n_parent, l10n_diffsource,title,main_category,mm_assignments',
+        ],
+    ],
+];

--- a/Tests/Integration/ContentObject/Fixtures/TCA/tx_fakeextension_domain_model_foo.php
+++ b/Tests/Integration/ContentObject/Fixtures/TCA/tx_fakeextension_domain_model_foo.php
@@ -1,0 +1,176 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'tx_fakeextension_domain_model_foo',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'editlock' => 'editlock',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'sortby' => 'sorting',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+        ],
+        'searchFields' => 'uid',
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => 1,
+            'label' => 'sys_language_uid',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'special' => 'languages',
+                'items' => [
+                    [
+                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                        -1,
+                        'flags-multiple',
+                    ],
+                ],
+                'default' => 0,
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'l10n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0],
+                ],
+                'foreign_table' => 'tx_fakeextension_domain_model_foo',
+                'foreign_table_where' => 'AND tx_fakeextension_domain_model_foo.pid=###CURRENT_PID### AND tx_fakeextension_domain_model_foo.sys_language_uid IN (-1,0)',
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => 'hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        'cruser_id' => [
+            'label' => 'cruser_id',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'pid' => [
+            'label' => 'pid',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'crdate' => [
+            'label' => 'crdate',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'tstamp' => [
+            'label' => 'tstamp',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'sorting' => [
+            'label' => 'sorting',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => 'starttime',
+            'config' => [
+                'type' => 'input',
+                'size' => 8,
+                'eval' => 'datetime',
+                'default' => 0,
+                'renderType' => 'inputDateTime',
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => 'endtime',
+            'config' => [
+                'type' => 'input',
+                'size' => 8,
+                'eval' => 'datetime',
+                'default' => 0,
+                'renderType' => 'inputDateTime',
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'title' => [
+            'exclude' => 0,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'title',
+            'config' => [
+                'type' => 'input',
+                'size' => 60,
+                'eval' => 'required',
+            ],
+        ],
+        'main_category' => [
+            'exclude' => 0,
+            'label' => 'main_category',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'foreign_table' => 'sys_category',
+                'foreign_table_where' => ' AND (sys_category.sys_language_uid = 0 OR sys_category.l10n_parent = 0)',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+                ['behaviour' => ['allowLanguageSynchronization' => true]],
+            ],
+        ],
+        'mm_assignments' => [
+            'exclude' => 0,
+            'label' => 'mm_assignments',
+            'config' => [
+                'type' => 'group',
+                'foreign_table' => 'tx_fakeextension_domain_model_bar',
+                'allowed' => 'tx_fakeextension_domain_model_bar',
+                'MM' => 'tx_fakeextension_foo_bar_mm',
+                'maxitems' => 99999,
+            ],
+        ],
+        'inline_relations' => [
+            'exclude' => 0,
+            'l10n_mode' => 'exclude',
+            'label' => 'inline_relations',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_fakeextension_domain_model_bar',
+                'foreign_field' => 'inline_relation_parent_foo',
+                'maxitems' => 9999,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'l10n_parent, l10n_diffsource,title,main_category,bar_assignments,inline_relations',
+        ],
+    ],
+];

--- a/Tests/Integration/ContentObject/Fixtures/fake_extension.sql
+++ b/Tests/Integration/ContentObject/Fixtures/fake_extension.sql
@@ -1,0 +1,80 @@
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_foo;
+CREATE TABLE tx_fakeextension_domain_model_foo (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	cruser_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_oid int(11) DEFAULT '0' NOT NULL,
+	t3ver_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
+	t3ver_label varchar(30) DEFAULT '' NOT NULL,
+	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_count int(11) DEFAULT '0' NOT NULL,
+	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
+	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
+	t3_origuid int(11) DEFAULT '0' NOT NULL,
+	editlock tinyint(4) DEFAULT '0' NOT NULL,
+	sys_language_uid int(11) DEFAULT '0' NOT NULL,
+	l10n_parent int(11) DEFAULT '0' NOT NULL,
+	l10n_diffsource mediumtext,
+	deleted tinyint(4) DEFAULT '0' NOT NULL,
+	hidden tinyint(4) DEFAULT '0' NOT NULL,
+	starttime int(11) DEFAULT '0' NOT NULL,
+	endtime int(11) DEFAULT '0' NOT NULL,
+	sorting int(11) DEFAULT '0' NOT NULL,
+
+	title varchar(128) DEFAULT '' NOT NULL,
+	main_category int(11) unsigned DEFAULT '0' NOT NULL,
+	mm_assignments int(11) unsigned DEFAULT '0',
+	inline_relations int(11) unsigned DEFAULT '0',
+
+	PRIMARY KEY (uid)
+);
+
+DROP TABLE IF EXISTS tx_fakeextension_domain_model_bar;
+CREATE TABLE tx_fakeextension_domain_model_bar (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	cruser_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_oid int(11) DEFAULT '0' NOT NULL,
+	t3ver_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
+	t3ver_label varchar(30) DEFAULT '' NOT NULL,
+	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_count int(11) DEFAULT '0' NOT NULL,
+	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
+	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
+	t3_origuid int(11) DEFAULT '0' NOT NULL,
+	editlock tinyint(4) DEFAULT '0' NOT NULL,
+	sys_language_uid int(11) DEFAULT '0' NOT NULL,
+	l10n_parent int(11) DEFAULT '0' NOT NULL,
+	l10n_diffsource mediumtext,
+	deleted tinyint(4) DEFAULT '0' NOT NULL,
+	hidden tinyint(4) DEFAULT '0' NOT NULL,
+	starttime int(11) DEFAULT '0' NOT NULL,
+	endtime int(11) DEFAULT '0' NOT NULL,
+	sorting int(11) DEFAULT '0' NOT NULL,
+
+	title varchar(128) DEFAULT '' NOT NULL,
+	main_category int(11) unsigned DEFAULT '0' NOT NULL,
+	inline_relation_parent_foo int(11) unsigned DEFAULT '0',
+	mm_assignments int(11) unsigned DEFAULT '0',
+
+	PRIMARY KEY (uid)
+);
+
+DROP TABLE IF EXISTS tx_fakeextension_foo_bar_mm;
+CREATE TABLE tx_fakeextension_foo_bar_mm (
+	uid_local int(11) unsigned DEFAULT '0' NOT NULL,
+	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+	sorting int(11) unsigned DEFAULT '0' NOT NULL,
+	sorting_foreign int(11) unsigned DEFAULT '0' NOT NULL,
+
+	KEY uid_local (uid_local),
+	KEY uid_foreign (uid_foreign)
+);

--- a/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_m_to_n_relations.xml
+++ b/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_m_to_n_relations.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>Root of Testpage testone.site aka integration_tree_one</title>
+	</pages>
+
+	<sys_category>
+		<uid>1</uid>
+		<pid>1</pid>
+		<title>Category with uid 1</title>
+		<description>This is a dummy category with uid 1</description>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<sys_category>
+		<uid>123</uid>
+		<pid>1</pid>
+		<title>Main category</title>
+		<description>This is the main category</description>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<sys_category>
+		<uid>124</uid>
+		<pid>1</pid>
+		<title>Second category</title>
+		<description>This is the second category</description>
+		<parent>123</parent>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<sys_category>
+		<uid>125</uid>
+		<pid>1</pid>
+		<title>Third category</title>
+		<description>This is the third category</description>
+		<parent>123</parent>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>1</uid>
+		<pid>1</pid>
+		<title>First foo record</title>
+		<main_category>123</main_category>
+		<mm_assignments>1</mm_assignments>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>2</uid>
+		<pid>1</pid>
+		<title>Second foo record</title>
+		<main_category>123</main_category>
+		<mm_assignments>2</mm_assignments>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>3</uid>
+		<pid>1</pid>
+		<title>Third foo record</title>
+		<main_category>123</main_category>
+		<mm_assignments>3</mm_assignments>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>10</uid>
+		<pid>1</pid>
+		<title>First bar record</title>
+		<main_category>124</main_category>
+		<mm_assignments>3</mm_assignments>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>11</uid>
+		<pid>1</pid>
+		<title>Second bar record</title>
+		<main_category>125</main_category>
+		<mm_assignments>1</mm_assignments>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>12</uid>
+		<pid>1</pid>
+		<title>Third bar record</title>
+		<main_category>124</main_category>
+		<mm_assignments>1</mm_assignments>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>1</uid_local>
+		<uid_foreign>10</uid_foreign>
+		<sorting>1</sorting>
+		<sorting_foreign>1</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>2</uid_local>
+		<uid_foreign>10</uid_foreign>
+		<sorting>2</sorting>
+		<sorting_foreign>2</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>2</uid_local>
+		<uid_foreign>11</uid_foreign>
+		<sorting>1</sorting>
+		<sorting_foreign>1</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>3</uid_local>
+		<uid_foreign>10</uid_foreign>
+		<sorting>2</sorting>
+		<sorting_foreign>2</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>3</uid_local>
+		<uid_foreign>11</uid_foreign>
+		<sorting>1</sorting>
+		<sorting_foreign>1</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>3</uid_local>
+		<uid_foreign>12</uid_foreign>
+		<sorting>3</sorting>
+		<sorting_foreign>3</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+</dataset>

--- a/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_one_to_n_relations.xml
+++ b/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_one_to_n_relations.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>Root of Testpage testone.site aka integration_tree_one</title>
+	</pages>
+
+	<sys_category>
+		<uid>123</uid>
+		<pid>1</pid>
+		<title>Main category</title>
+		<description>This is the main category</description>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<sys_category>
+		<uid>124</uid>
+		<pid>1</pid>
+		<title>Second category</title>
+		<description>This is the second category</description>
+		<parent>123</parent>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>1</uid>
+		<pid>1</pid>
+		<title>First foo record</title>
+		<main_category>124</main_category>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>2</uid>
+		<pid>1</pid>
+		<title>Second foo record</title>
+		<main_category>124</main_category>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>3</uid>
+		<pid>1</pid>
+		<title>Third foo record</title>
+		<main_category>124</main_category>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>4</uid>
+		<pid>1</pid>
+		<title>4th foo record</title>
+		<main_category>124</main_category>
+	</tx_fakeextension_domain_model_foo>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>10</uid>
+		<pid>1</pid>
+		<title>First bar record</title>
+		<main_category>125</main_category>
+		<mm_assignments>2</mm_assignments>
+		<inline_relation_parent_foo>1</inline_relation_parent_foo>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>11</uid>
+		<pid>1</pid>
+		<title>Second bar record</title>
+		<main_category>125</main_category>
+		<mm_assignments>0</mm_assignments>
+		<inline_relation_parent_foo>2</inline_relation_parent_foo>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_domain_model_bar>
+		<uid>12</uid>
+		<pid>1</pid>
+		<title>Third bar record</title>
+		<main_category>125</main_category>
+		<mm_assignments>0</mm_assignments>
+		<inline_relation_parent_foo>2</inline_relation_parent_foo>
+	</tx_fakeextension_domain_model_bar>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>3</uid_local>
+		<uid_foreign>10</uid_foreign>
+		<sorting>1</sorting>
+		<sorting_foreign>1</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+
+	<tx_fakeextension_foo_bar_mm>
+		<uid_local>4</uid_local>
+		<uid_foreign>10</uid_foreign>
+		<sorting>2</sorting>
+		<sorting_foreign>2</sorting_foreign>
+	</tx_fakeextension_foo_bar_mm>
+</dataset>

--- a/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_one_to_one_relations.xml
+++ b/Tests/Integration/ContentObject/Fixtures/solr_relation_can_resolve_one_to_one_relations.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>1</uid>
+		<is_siteroot>1</is_siteroot>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>Root of Testpage testone.site aka integration_tree_one</title>
+	</pages>
+
+	<sys_category>
+		<uid>123</uid>
+		<pid>1</pid>
+		<title>Main category</title>
+		<description>This is the main category</description>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<sys_category>
+		<uid>124</uid>
+		<pid>1</pid>
+		<title>Second category</title>
+		<description>This is the second category</description>
+		<parent>123</parent>
+		<sys_language_uid>0</sys_language_uid>
+	</sys_category>
+
+	<tx_fakeextension_domain_model_foo>
+		<uid>1</uid>
+		<pid>1</pid>
+		<title>First foo record</title>
+		<main_category>124</main_category>
+	</tx_fakeextension_domain_model_foo>
+</dataset>

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -17,8 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
-use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -29,37 +28,302 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 class RelationTest extends IntegrationTest
 {
     /**
-     * @test
+     * @param string $fixtureName
      *
+     * @test
      * @dataProvider fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn
      */
-    public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn($fixtureName)
+    public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn(string $fixtureName): void
     {
         $this->importDataSetFromFixture($fixtureName);
-        /* @var TypoScriptFrontendController|MockObject $tsfe */
-        $GLOBALS['TSFE'] = $tsfe = $this->createMock(TypoScriptFrontendController::class);
-        $tsfe->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-        /* @var ContentObjectRenderer $contentObjectRendererMock */
-        $contentObjectRendererMock = $this->getMockBuilder(ContentObjectRenderer::class)->setConstructorArgs([$GLOBALS['TSFE']])->getMock();
-        $contentObjectRendererMock->currentRecord = 'pages:7';
-
-        /* @var Relation $solrRelation */
-        $solrRelation = GeneralUtility::makeInstance(Relation::class, $contentObjectRendererMock);
+        $solrRelation = $this->getSolrRelation('pages', 7);
         $actual = $solrRelation->render(['localField' => 'categories']);
 
         self::assertSame('Some Category', $actual, 'Can not fallback to table "pages" on non existent column configuration in TCA for table "pages_language_overlay".');
     }
 
     /**
-     * canGetRelatedItemsUsingOriginalUidFromPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn
+     * Data provider for "canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn"
      *
-     * @return array
+     * @return \Traversable
      */
-    public function fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn(): array
+    public function fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn(): \Traversable
     {
-        return [
-            ['solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml'],
-            ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml'],
+        yield 'Can fallback to pages if no TCA for local field'
+            => ['solr_relation_can_fallback_to_pages_table_if_no_tca_for_local_field.xml'];
+        yield 'Can get related items using original uid if overlay has no TCA'
+            => ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.xml'];
+    }
+
+    /**
+     * @param string $expected
+     * @param array $config
+     *
+     * @test
+     * @dataProvider canResolveOneToOneRelationDataProvider
+     */
+    public function canResolveOneToOneRelation(string $expected, array $config): void
+    {
+        $this->importExtTablesDefinition('fake_extension.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('TCA/tx_fakeextension_domain_model_foo.php'));
+        $this->importDataSetFromFixture('solr_relation_can_resolve_one_to_one_relations.xml');
+
+        $solrRelation = $this->getSolrRelation('tx_fakeextension_domain_model_foo', 1);
+        self::assertEquals($expected, $solrRelation->render($config));
+    }
+
+    /**
+     * Data provider for "canResolveOneToOneRelation"
+     *
+     * @return \Traversable
+     */
+    public function canResolveOneToOneRelationDataProvider(): \Traversable
+    {
+        yield 'Can resolve title of 1:1 relation' => [
+            'Second category',
+            ['localField' => 'main_category'],
         ];
+
+        yield 'Can resolve description field of 1:1 relation' => [
+            'This is the second category',
+            ['localField' => 'main_category', 'foreignLabelField' => 'description'],
+        ];
+
+        yield 'Can resolve uid of 1:1 relation' => [
+            '124',
+            ['localField' => 'main_category', 'foreignLabelField' => 'uid'],
+        ];
+
+        yield 'Can resolve uid of parent in 1:1 relation' => [
+            '123',
+            ['localField' => 'main_category', 'foreignLabelField' => 'parent.uid'],
+        ];
+
+        yield 'Can resolve title of parent in 1:1 relation' => [
+            'Main category',
+            ['localField' => 'main_category', 'foreignLabelField' => 'parent'],
+        ];
+
+        yield 'Can resolve title of 1:1 relation and apply stdWrap' => [
+            'pre:Second category:post',
+            ['localField' => 'main_category', 'wrap' => 'pre:|:post'],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $table
+     * @param int $recordUid
+     * @param array $config
+     *
+     * @test
+     * @dataProvider canResolveMToNRelationDataProvider
+     */
+    public function canResolveMToNRelation(string $expected, string $table, int $recordUid, array $config): void
+    {
+        $this->importExtTablesDefinition('fake_extension.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('TCA/tx_fakeextension_domain_model_foo.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('TCA/tx_fakeextension_domain_model_bar.php'));
+        $this->importDataSetFromFixture('solr_relation_can_resolve_m_to_n_relations.xml');
+
+        $solrRelation = $this->getSolrRelation($table, $recordUid);
+        $result = $solrRelation->render($config);
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for "canResolveMToNRelation"
+     *
+     * @return \Traversable
+     */
+    public function canResolveMToNRelationDataProvider(): \Traversable
+    {
+        yield 'Can resolve title of m:n relation and apply stdWrap' => [
+            'pre:First bar record:post',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments', 'wrap' => 'pre:|:post'],
+        ];
+
+        yield 'Can resolve title of m:n relation' => [
+            'First bar record',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments'],
+        ];
+
+        yield 'Can resolve title of relation\'s main category in m:n relation' => [
+            'Second category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category'],
+        ];
+
+        yield 'Can resolve explicitly configured title of relation\'s main category in m:n relation' => [
+            'Second category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category.title'],
+        ];
+
+        yield 'Can resolve title of parent category of relation\'s main category in m:n relation' => [
+            'Main category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category.title.parent'],
+        ];
+
+        yield 'Can resolve description of parent category of relation\'s main category in m:n relation' => [
+            'This is the main category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category.title.parent.description'],
+        ];
+
+        yield 'Can resolve title of m:n relation, with 2 items' => [
+            'Second bar record, First bar record',
+            'tx_fakeextension_domain_model_foo',
+            2,
+            ['localField' => 'mm_assignments'],
+        ];
+
+        yield 'Can resolve titles of the main categories of the related records in m:n relation' => [
+            serialize(['Third category', 'Second category']),
+            'tx_fakeextension_domain_model_foo',
+            2,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
+        ];
+
+        yield 'Can resolve titles of the main categories of the related records in m:n relation and keep duplicates' => [
+            serialize(['Third category', 'Second category', 'Second category']),
+            'tx_fakeextension_domain_model_foo',
+            3,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
+        ];
+
+        yield 'Can resolve titles of the main categories of the related records in m:n relation and remove duplicates' => [
+            serialize(['Third category', 'Second category']),
+            'tx_fakeextension_domain_model_foo',
+            3,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1, 'removeDuplicateValues' => 1],
+        ];
+
+        yield 'Can resolve uids of m:n relation, with 2 items' => [
+            '11, 10',
+            'tx_fakeextension_domain_model_foo',
+            2,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'uid'],
+        ];
+
+        yield 'Can resolve uids of m:n relation for multi value field, with 2 items' => [
+            serialize(['11', '10']),
+            'tx_fakeextension_domain_model_foo',
+            2,
+            ['localField' => 'mm_assignments', 'foreignLabelField' => 'uid', 'multiValue' => 1],
+        ];
+
+        yield 'Can resolve title of bidirectional m:n relation' => [
+            'Third foo record',
+            'tx_fakeextension_domain_model_bar',
+            12,
+            ['localField' => 'mm_assignments'],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $table
+     * @param int $recordUid
+     * @param array $config
+     *
+     * @test
+     * @dataProvider canResolveOneToNRelationDataProvider
+     */
+    public function canResolveOneToNRelation(string $expected, string $table, int $recordUid, array $config): void
+    {
+        $this->importExtTablesDefinition('fake_extension.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('TCA/tx_fakeextension_domain_model_foo.php'));
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_bar'] = include($this->getFixturePathByName('TCA/tx_fakeextension_domain_model_bar.php'));
+        $this->importDataSetFromFixture('solr_relation_can_resolve_one_to_n_relations.xml');
+
+        $solrRelation = $this->getSolrRelation($table, $recordUid);
+        $result = $solrRelation->render($config);
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for "canResolveOneToNRelation"
+     *
+     * @return \Traversable
+     */
+    public function canResolveOneToNRelationDataProvider(): \Traversable
+    {
+        yield 'Can resolve title of single 1:n relation' => [
+            'First bar record',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations'],
+        ];
+
+        yield 'Can resolve titles of 1:n relation' => [
+            'Second bar record, Third bar record',
+            'tx_fakeextension_domain_model_foo',
+            2,
+            ['localField' => 'inline_relations'],
+        ];
+
+        yield 'Can resolve titles of related records 1:n relation' => [
+            'Third foo record, 4th foo record',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.title', 'multiValue' => 0],
+        ];
+
+        yield 'Can resolve uids of related records 1:n relation' => [
+            '3, 4',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.uid', 'multiValue' => 0],
+        ];
+
+        yield 'Can resolve related categories of related records 1:n relation' => [
+            'Second category, Second category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.main_category', 'multiValue' => 0],
+        ];
+
+        yield 'Can resolve related categories of related records 1:n relation (multi value)' => [
+            serialize(['Second category', 'Second category']),
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.main_category', 'multiValue' => 1],
+        ];
+
+        yield 'Can resolve related categories of related records 1:n relation and remove duplicates' => [
+            'Second category',
+            'tx_fakeextension_domain_model_foo',
+            1,
+            ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.main_category', 'removeDuplicateValues' => 1],
+        ];
+    }
+
+    /**
+     * Prepares and returns the Relation to test
+     *
+     * @param string $table
+     * @param int $uid
+     * @return Relation
+     */
+    protected function getSolrRelation(string $table, int $uid): Relation
+    {
+        $tsfeMock = $this->createMock(TypoScriptFrontendController::class);
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class, $tsfeMock);
+        $contentObjectRenderer->start(
+            BackendUtility::getRecord($table, $uid),
+            $table
+        );
+
+        return GeneralUtility::makeInstance(Relation::class, $contentObjectRenderer);
     }
 }


### PR DESCRIPTION
This changeset fixes issues with the resolution of values in SOLR_RELATION, fixed is the resolution of:
- foreignLabelFields (2nd level+)
- multiple values in m:n relations
- nested m:n relations
- nested multi values

Additionally the missing stdWrap functionality on values from mm relations is added.

Integration tests are added to ensure the right behaviour of SOLR_RELATION.

# How to test

Test scenarios are added in `RelationTest`

For manual testing:
-  Create a table A with an 1:m relation to table B
-  In table B create an n:m relation to table C
-  Configure indexing for table A with a multi value field that should contain all relations to table C
- Index the records
- Relations must be resolved correctly

Resolves: #3152
Resolves: #3408

