### PR TITLE
[BUGFIX] Exception on search plugin if no Solr connection is configured

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -101,6 +101,10 @@ class SearchController extends AbstractBaseController
      */
     public function resultsAction(): ResponseInterface
     {
+        if ($this->searchService === null) {
+            return $this->handleSolrUnavailable();
+        }
+
         try {
             $arguments = $this->request->getArguments();
             $pageId = $this->typoScriptFrontendController->getRequestedId();
@@ -148,6 +152,10 @@ class SearchController extends AbstractBaseController
      */
     public function formAction(): ResponseInterface
     {
+        if ($this->searchService === null) {
+            return $this->handleSolrUnavailable();
+        }
+
         $values = [
             'search' => $this->searchService->getSearch(),
             'additionalFilters' => $this->getAdditionalFilters(),
@@ -192,6 +200,10 @@ class SearchController extends AbstractBaseController
      */
     public function detailAction(string $documentId = ''): ResponseInterface
     {
+        if ($this->searchService === null) {
+            return $this->handleSolrUnavailable();
+        }
+
         try {
             $document = $this->searchService->getDocumentById($documentId);
             $this->view->assign('document', $document);


### PR DESCRIPTION
# What this pr does
To prevent fatal errors (null pointer exception) we are forwarding to action solrNotAvailable  if the property SearchService is not set.


# How to test

Fixes: #3426

---

- [x] port/cherry-pick to release-11.5.x See: #3498
