### PR TITLE
[FEATURE:P:11.5] Add new option manualSortOrderDelimiter for facets

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
@@ -152,7 +152,8 @@ abstract class AbstractFacetParser implements FacetParserInterface
         if (!isset($facetConfiguration['manualSortOrder'])) {
             return $facet;
         }
-        $fields = GeneralUtility::trimExplode(',', $facetConfiguration['manualSortOrder']);
+        $delimiter = trim($facetConfiguration['manualSortOrderDelimiter'] ?? ',');
+        $fields = GeneralUtility::trimExplode($delimiter, $facetConfiguration['manualSortOrder']);
         // @extensionScannerIgnoreLine
         $sortedOptions = $facet->getOptions()->getManualSortedCopy($fields);
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1151,6 +1151,17 @@ Using `faceting.facets.[facetName].manualSortOrder = Travel, Health` will result
     + Culture (179)
     + Automobile (99)
 
+faceting.facets.[facetName].manualSortOrderDelimiter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].manualSortOrderDelimiter
+:Since: 11.5
+:Default: ,
+
+Define an alternative delimiter instead of the default comma (`,`) for the manualSortOrder option.
+This is especially useful if the `,` is part of a facet option value.
+
 faceting.facets.[facetName].minimumCount
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Use the option `faceting.facets.[facetName].manualSortOrderDelimiter` to define an alternative delimiter used for manual sorting facets.

Resolves: #3483
Ports: #3493