### PR TITLE
[FEATURE] Add arm64-platform support (e.g. for Apple Silicon processors) to docker-image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
         with:
           context: .
           file: ./Docker/SolrServer/Dockerfile
-          platforms: ${{ env.DOCKER_IMAGE_TAGS }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAGS }}
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,18 @@ jobs:
     outputs:
       matrix: ${{ steps.collect_build_matrix.outputs.matrix }}
     steps:
-      # Workaround for issue with actions/checkout@v2 wrong PR commit checkout: See https://github.com/actions/checkout/issues/299#issuecomment-677674415
+      # Workaround for issue with actions/checkout@v2+ wrong PR commit checkout: See https://github.com/actions/checkout/issues/299#issuecomment-677674415
       -
         name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
         if: github.event_name == 'push'
-        uses: actions/checkout@v2
-      # End: Workaround for issue with actions/checkout@v2 wrong PR commit checkout
+        uses: actions/checkout@v3
+      # End: Workaround for issue with actions/checkout@v2+ wrong PR commit checkout
       -
         name: "Resolve target branch of pull request."
         if: github.event_name == 'pull_request'
@@ -71,10 +71,10 @@ jobs:
           >&2 echo -e "Non-stable releases can not be published to TER. The tag 11.5.0-beta-1 is invalid for TER."
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Docker/SolrServer/Dockerfile
@@ -90,7 +90,7 @@ jobs:
           ./Build/Test/cibuild_docker.sh
       -
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: solrci-image
           path: /tmp/solrci-image.tar
@@ -111,21 +111,21 @@ jobs:
 
     name: TYPO3 ${{ matrix.TYPO3 }} on PHP ${{ matrix.PHP }}
     steps:
-      # Workaround for issue with actions/checkout@v2 wrong PR commit checkout: See https://github.com/actions/checkout/issues/299#issuecomment-677674415
+      # Workaround for issue with actions/checkout@v2+ wrong PR commit checkout: See https://github.com/actions/checkout/issues/299#issuecomment-677674415
       -
         name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
         if: github.event_name == 'push'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      # End: Workaround for issue with actions/checkout@v2 wrong PR commit checkout
+      # End: Workaround for issue with actions/checkout@v2+ wrong PR commit checkout
       -
         name: Mount RAMFS
         run: |
@@ -136,10 +136,10 @@ jobs:
             && sudo chown 8983:8983 ${{ env.CI_BUILD_DIRECTORY }}/data-solr
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Download solrci-image from "ci_bootstrapping" job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: solrci-image
           path: /tmp
@@ -175,11 +175,11 @@ jobs:
           export CI_BUILD_CACHE_KEY=${{ runner.os }}-PHP:${{ matrix.PHP }}-TYPO3:$TYPO3_VERSION@$CURRENT_TYPO3_VERSION_REFERNCE-SOLARIUM:$CURRENT_SOLARIUM_VERSION-"CI_CACHE_VERSION:"$CI_CACHE_VERSION
           echo "COMPOSER_GLOBAL_REQUEREMENTS=$(composer config home)" >> $GITHUB_ENV
           echo "CI_BUILD_CACHE_KEY=$CI_BUILD_CACHE_KEY" >> $GITHUB_ENV
-          echo "The key for actions/cache@v2 is \"$CI_BUILD_CACHE_KEY\""
+          echo "The key for actions/cache@v3 is \"$CI_BUILD_CACHE_KEY\""
       -
         name: Restore ci build caches
         id: restore_ci_build_caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ env.CI_BUILD_DIRECTORY }}/Web
@@ -217,7 +217,7 @@ jobs:
             ${{ env.CI_BUILD_DIRECTORY }}/data-mysql \
             ${{ env.CI_BUILD_DIRECTORY }}/data-solr
 
-  publish:
+  publish-typo3-ter:
     name: Publish new version to TER
     needs: tests
     if: startsWith(github.ref, 'refs/tags/')
@@ -227,7 +227,7 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -
@@ -269,3 +269,114 @@ jobs:
             exit 13
           fi
           php ~/.composer/vendor/bin/tailor ter:publish --comment "$TER_COMMENT" "$RELEASE_VERSION"
+
+  publish-docker-hub:
+    name: Publish docker-image to docker-hub
+    needs: tests
+    if: |
+      (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        startsWith(github.ref, 'refs/tags/')
+      )
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PLATFORMS:  "linux/amd64,linux/arm64"
+      DOCKER_IMAGE_NAME: "${{ secrets.DOCKERHUB_USERNAME }}/ext-solr"
+      # is overriden below
+      DOCKER_IMAGE_TAGS: ""
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      #
+      # git-branch : main
+      # image-tag  : typo3solr/ext-solr:latest
+      #
+      # git-branch : release-11.5.x
+      # image-tag  : release-11.5.x typo3solr/ext-solr:release-11.5.x
+      #
+      -
+        name: Export docker-image tag(s) for main and release-* git-branches
+        if: startsWith(github.ref, 'refs/heads/')
+        run: |
+          TAGS="${DOCKER_IMAGE_NAME}:${GITHUB_REF_NAME//main/latest}"
+
+          echo "DOCKER_IMAGE_TAGS=${TAGS}" | tee -a $GITHUB_ENV
+      #
+      # git-tag    : 11.5.1
+      # image-tags : typo3solr/ext-solr:11.5.1,typo3solr/ext-solr:11.5,typo3solr/ext-solr:11
+      #
+      # git-tag    : 11.2.1
+      # image-tags : typo3solr/ext-solr:11.2.1,typo3solr/ext-solr:11.2
+      #
+      # git-tag    : 10.0.5
+      # image-tags : typo3solr/ext-solr:10.0.5,typo3solr/ext-solr:10.0,typo3solr/ext-solr:10
+      #
+      -
+        name: Export docker-image tag(s) for release git-tags
+        if: ( startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') )
+        run: |
+          # image-tag: typo3solr/ext-solr:11.5.1
+          TAGS="${DOCKER_IMAGE_NAME}:${GITHUB_REF_NAME}"
+          # image-tag: typo3solr/ext-solr:11.5
+          TAGS="${DOCKER_IMAGE_NAME}:${GITHUB_REF_NAME%.*}${TAGS+,$TAGS}"
+
+          VERSION_MAJOR_ONLY="${GITHUB_REF_NAME%%.*}"
+          VERSION_MAJOR_MINOR="${GITHUB_REF_NAME%.*}"
+          VERSION_LASTEST=$(git tag -l --sort -version:refname | grep -E "^${VERSION_MAJOR_ONLY}\\." | head -n1)
+
+          if [ "${VERSION_LASTEST%.*}" = "${VERSION_MAJOR_MINOR}" ]; then
+            # image-tag: typo3solr/ext-solr:11
+            TAGS="${DOCKER_IMAGE_NAME}:${VERSION_MAJOR_ONLY}${TAGS+,$TAGS}"
+          fi
+
+          echo "DOCKER_IMAGE_TAGS=${TAGS}" | tee -a $GITHUB_ENV
+      #
+      # git-tag    : 11.5.0-rc-3
+      # image-tag  : typo3solr/ext-solr:11.5.x-dev
+      #
+      -
+        name: Export docker-image tag(s) for pre-release git-tags
+        if: ( startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') )
+        run: |
+          # ie: typo3solr/ext-solr:11.5.x-dev
+          TAGS="${DOCKER_IMAGE_NAME}:${GITHUB_REF_NAME%.*}.x-dev"
+
+          echo "DOCKER_IMAGE_TAGS=${TAGS}" | tee -a $GITHUB_ENV
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download solrci-image from "ci_bootstrapping" job
+        uses: actions/download-artifact@v3
+        with:
+          name: solrci-image
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/solrci-image.tar
+          docker image ls -a
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Docker/SolrServer/Dockerfile
+          platforms: ${{ env.DOCKER_IMAGE_TAGS }}
+          push: true
+          tags: ${{ env.DOCKER_IMAGE_TAGS }}
+      -
+        name: Inspect all images
+        run: |
+          docker image inspect ${DOCKER_IMAGE_TAGS//,/ }


### PR DESCRIPTION
# What this PR does

This PR adds arm64-platform support (e.g. for Apple Silicon processors) to `typo3solr/ext-solr` docker-image. Therefore several changes were neccessary:

- Update all required github-actions in .github/workflow/ci.yml
- Add a new `publish-docker-hub` job to the pipeline
  - Reuse the cached `solrci-image` image artifact from the `test`-job for `linux/amd64` (Intel & Co.) platforms
  - Build `typo3solr/ext-solr` image with the additional `linux/arm64` (Apple Silicon) platform
  - I tried my best to guess which (kind of) git-tag and -branch corresponds to which docker-image tag in your current docker-hub build setup
    - The current git-tag/-branch to docker-image tag mapping is:
      ```markdown
      | git-branch or -tag | docker image-tag(s) |
      |--------------------|---------------------|
      | main               | latest              |
      | release-11.5.x     | release-11.5.x      |
      | release-11.2.x     | release-11.2.x      |
      | release-11.0.x     | release-11.0.x      |
      | release-10.0.x     | release-10.0.x      |
      | 11.5.1             | 11.5.1, 11.5, 11    |(†)
      | 11.2.1             | 11.2.1, 11.2        |(†)
      | 10.0.1             | 10.0.1, 10.0, 10    |(†)
      | 11.5.0-rc-1        | 11.5.x-dev          |
      | 11.2.0-alpha-1     | 11.2.x-dev          |
      | 11.0.0-beta-1      | 11.0.x-dev          |
      ```
      **(†)** git-tags without pre-release suffix produce three docker image-tags, if they represent the latest release of its MAJOR version, otherwise they produce only two docker-image tags.
- Rename the `publish`-job to `publish-typo3-ter`, to avoid confusion, with the new `publish-docker-hub` job.

## New GitHub Action environment-variables and secrets

- [ ] two new secrets are needed:
   ```yaml
  DOCKERHUB_USERNAME : "typo3solr"
  DOCKERHUB_TOKEN    : "DOCKERHUB_PERSONAL_ACCESS_TOKEN"
  ```
- [ ] three new environment-variables
   ```yaml
  DOCKER_PLATFORMS  : "linux/amd64,linux/arm64"
  DOCKER_IMAGE_NAME : "${{ secrets.DOCKERHUB_USERNAME }}/ext-solr"
  # This one is overridden automatically, based upon branch or tag, see above
  DOCKER_IMAGE_TAGS : ""
   ```

# How to test

Good question? I tried to test it with https://github.com/nektos/act#readme on Apple Silicon M2 Max and Mac OS Ventura 13.2.1. This brought me surprisingly far, but in the end I had no luck, as the `cibuild_docker.sh` always fails in the `assertDataPathIsCreatedByApacheSolr` function. This is still confusing to me, as this does not seem to be related with this PR at all.

Hope we can finish this (or another) solution together?

Cheers,
Stephan

------------------

As soon as everything ist running, this PR …
Fixes: #2891 
