### PR TITLE
[BUGFIX] 3507 Added missing initialPagesAdditionalWhereClause 

### DIFF
--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -145,7 +145,7 @@ class PagesRepository extends AbstractRepository
             return $this->transientVariableCache->get($cacheIdentifier);
         }
 
-        $pageIdsList = $this->getTreeList($rootPageId, 9999, 0, 'deleted = 0');
+        $pageIdsList = $this->getTreeList($rootPageId, 9999, 0, 'deleted = 0 ' . $initialPagesAdditionalWhereClause);
         $pageIds = GeneralUtility::intExplode(',', $pageIdsList);
 
         if (!empty($initialPagesAdditionalWhereClause)) {

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -149,7 +149,6 @@ class PagesRepository extends AbstractRepository
         $pageIdsList = $this->getTreeList($rootPageId, 9999, 0, $permClause);
         $pageIds = GeneralUtility::intExplode(',', $pageIdsList);
 
-
         if (!empty($initialPagesAdditionalWhereClause)) {
             $pageIds = $this->filterPageIdsByAdditionalWhereClause($pageIds, $initialPagesAdditionalWhereClause);
         }

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -145,11 +145,13 @@ class PagesRepository extends AbstractRepository
             return $this->transientVariableCache->get($cacheIdentifier);
         }
 
-        $pageIdsList = $this->getTreeList($rootPageId, 9999, 0, 'deleted = 0 ' . $initialPagesAdditionalWhereClause);
+        $permClause = empty($initialPagesAdditionalWhereClause) ? 'deleted = 0' : ('deleted = 0 AND ' . $initialPagesAdditionalWhereClause);
+        $pageIdsList = $this->getTreeList($rootPageId, 9999, 0, $permClause);
         $pageIds = GeneralUtility::intExplode(',', $pageIdsList);
 
+
         if (!empty($initialPagesAdditionalWhereClause)) {
-            $pageIds = $this->filterPageIdsByInitialPagesAdditionalWhereClause($pageIds, $initialPagesAdditionalWhereClause);
+            $pageIds = $this->filterPageIdsByAdditionalWhereClause($pageIds, $initialPagesAdditionalWhereClause);
         }
 
         $this->transientVariableCache->set($cacheIdentifier, $pageIds);
@@ -157,12 +159,13 @@ class PagesRepository extends AbstractRepository
     }
 
     /**
-     * This method retrieves the pages ids from the current tree level a calls getPages recursive,
-     * when the maxDepth has not been reached.
+     * This method applies the $initialPagesAdditionalWhereClause filter on pages
+     * returned by $this->getTreeList() in order to it apply it on descendants of a
+     * given page
      *
      * @throws DBALException
      */
-    protected function filterPageIdsByInitialPagesAdditionalWhereClause(
+    protected function filterPageIdsByAdditionalWhereClause(
         array $pageIds,
         string $initialPagesAdditionalWhereClause
     ): array {

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -167,7 +167,6 @@ ID's that shouldn't be processed at all.
 If not configured the initializing the Index Queue will only consider records with the flag deleted = 0,
 otherwise the initialPagesAdditionalWhereClause will be appended to the deleted = 0.
 
-
 .. code-block:: typoscript
 
     // Filter away pages that are "spacer" and have no_search, hidden and nav_hide set to zero

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -164,6 +164,9 @@ A WHERE clause that is used when initializing the Index Queue, limiting pages th
 This filter is applied **prior** to the plugin.tx_solr.index.queue.[indexConfig].additionalWhereClause
 filter and hence provides an even stronger filter mechanism - since it can be used to filter away page
 ID's that shouldn't be processed at all.
+If not configured the initializing the Index Queue will only consider records with the flag deleted = 0,
+otherwise the initialPagesAdditionalWhereClause will be appended to the deleted = 0.
+
 
 .. code-block:: typoscript
 


### PR DESCRIPTION
Added missing initialPagesAdditionalWhereClause  this->getTreeList to permClause

# What this pr does

Re-adds initialPagesAdditionalWhereClause as condition to permClause in call to $this->getTreeList

# How to test

Have some hidden pages with subpages. Configure 
plugin.tx_solr.index.queue.pages.initialPagesAdditionalWhereClause = hidden = 0
Observe hidden pages and subpages under the hidden pages are not added to the
queue if queue is flushed pages re-added under "Index Queue" 

Fixes: #3507 
