### PR TITLE
[BUGFIX] Respect indexingPriority in QueueItemRepository

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -192,6 +192,7 @@ class QueueItemRepository extends AbstractRepository
      * @param int $rootPageId The uid of the rootPage
      * @param int $changedTime The forced change time that should be used for updating
      * @param string $indexingConfiguration The name of the related indexConfiguration
+     * @param int $indexingPriority
      * @return int affected rows
      *
      * @throws DBALException|\Doctrine\DBAL\DBALException
@@ -201,12 +202,14 @@ class QueueItemRepository extends AbstractRepository
         int $itemUid,
         int $rootPageId,
         int $changedTime,
-        string $indexingConfiguration = ''
+        string $indexingConfiguration = '',
+        int $indexingPriority = 0
     ): int {
         $queryBuilder = $this->getQueryBuilder();
         $queryBuilder
             ->update($this->table)
             ->set('changed', $changedTime)
+            ->set('indexing_priority', $indexingPriority)
             ->andWhere(
                 /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
@@ -233,6 +236,7 @@ class QueueItemRepository extends AbstractRepository
      * @param int $rootPageId
      * @param int $changedTime
      * @param string $indexingConfiguration The item's indexing configuration to use. Optional, overwrites existing / determined configuration.
+     * @param int $indexingPriority
      * @return int the number of inserted rows, which is typically 1
      *
      * @throws DBALException|\Doctrine\DBAL\DBALException
@@ -242,7 +246,8 @@ class QueueItemRepository extends AbstractRepository
         int $itemUid,
         int $rootPageId,
         int $changedTime,
-        string $indexingConfiguration
+        string $indexingConfiguration,
+        int $indexingPriority = 0
     ): int {
         $queryBuilder = $this->getQueryBuilder();
         return (int)$queryBuilder
@@ -254,6 +259,7 @@ class QueueItemRepository extends AbstractRepository
                 'changed' => $changedTime,
                 'errors' => '',
                 'indexing_configuration' => $indexingConfiguration,
+                'indexing_priority' => $indexingPriority,
             ])
             ->execute();
     }

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -214,14 +214,15 @@ class Queue
             if ($indexingConfiguration === null) {
                 continue;
             }
+            $indexingPriority = $solrConfiguration->getIndexQueueIndexingPriorityByConfigurationName($indexingConfiguration);
             $itemInQueueForRootPage = $this->containsItemWithRootPageId($itemType, $itemUid, $rootPageId);
             if ($itemInQueueForRootPage) {
                 // update changed time if that item is in the queue already
                 $changedTime = ($forcedChangeTime > 0) ? $forcedChangeTime : $this->getItemChangedTime($itemType, $itemUid);
-                $updatedRows = $this->queueItemRepository->updateExistingItemByItemTypeAndItemUidAndRootPageId($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration);
+                $updatedRows = $this->queueItemRepository->updateExistingItemByItemTypeAndItemUidAndRootPageId($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration, $indexingPriority);
             } else {
                 // add the item since it's not in the queue yet
-                $updatedRows = $this->addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId);
+                $updatedRows = $this->addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId, $indexingPriority);
             }
 
             $updateCount += $updatedRows;
@@ -325,6 +326,7 @@ class Queue
      * @param string $indexingConfiguration The item's indexing configuration to use.
      *      Optional, overwrites existing / determined configuration.
      * @param int $rootPageId
+     * @param int $indexingPriority
      * @return int
      * @throws DBALDriverException
      * @throws DBALException|\Doctrine\DBAL\DBALException
@@ -333,7 +335,8 @@ class Queue
         string $itemType,
         $itemUid,
         string $indexingConfiguration,
-        int $rootPageId
+        int $rootPageId,
+        int $indexingPriority = 0
     ): int {
         $additionalRecordFields = '';
         if ($itemType === 'pages') {
@@ -348,7 +351,7 @@ class Queue
 
         $changedTime = $this->getItemChangedTime($itemType, $itemUid);
 
-        return $this->queueItemRepository->add($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration);
+        return $this->queueItemRepository->add($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration, $indexingPriority);
     }
 
     /**

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -704,6 +704,21 @@ class TypoScriptConfiguration
     }
 
     /**
+    * Retrieves indexingPriority when configured or 0.
+    *
+    * plugin.tx_solr.index.queue.<configurationName>.indexingPriority
+    *
+    * @param string $configurationName
+    * @param int $defaultIfEmpty
+    * @return int
+    */
+    public function getIndexQueueIndexingPriorityByConfigurationName(string $configurationName, int $defaultIfEmpty = 0)
+    {
+        $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.indexingPriority';
+        return (int)$this->getValueByPathOrDefaultValue($path, $defaultIfEmpty);
+    }
+
+    /**
      * Returns the _LOCAL_LANG configuration from the TypoScript.
      *
      * plugin.tx_solr._LOCAL_LANG.


### PR DESCRIPTION
# What this pr does

Fixes https://github.com/TYPO3-Solr/ext-solr/issues/3492 by reading and saving the `indexingPriority` attribute when using the QueueItemRepository

# How to test

1. Set an `indexingPriority` to an existing queue (e.g. `plugin.tx_solr.index.queue.news.indexingPriority = 50`)
2. Create a new item of the corresponding type (e.g. `news`) and save the record
3. Open the `tx_solr_indexqueue_item` table. The queued item will get an indexingPriority of `50`

Fixes: #3492

---

### Maintainers notes:

#### Wanted ports:

- [x] release-11.5.x #3556
- [x] release-11.2.x #3557 
- [x] release-11.0.x (ELTS) #3558 