### PR TITLE
[BUGFIX] Use correct property when creating Node (context has to be s…

### DIFF
--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -57,7 +57,7 @@ class Node extends Endpoint
             'collection' => null,
             'core' => basename($path),
             'leader' => false,
-	];
+        ];
 
         parent::__construct($options);
         $this->setAuthentication($username, $password);

--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -48,24 +48,16 @@ class Node extends Endpoint
         ?string $username = null,
         ?string $password = null
     ) {
-        $path = (string)$path;
-        $elements = explode('/', trim($path, '/'));
-        $coreName = (string)array_pop($elements);
-        // Remove API version
-        array_pop($elements);
-
-        // The path should always have the same format!
-        $path = trim(implode('/', $elements), '/');
-
         $options = [
             'scheme' => $scheme,
             'host' => $host,
             'port' => $port,
-            'path' => '/' . $path,
+            'context' => dirname($path),
+            'path' => '/',
             'collection' => null,
-            'core' => $coreName,
+            'core' => basename($path),
             'leader' => false,
-        ];
+	];
 
         parent::__construct($options);
         $this->setAuthentication($username, $password);

--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -147,6 +147,7 @@ class Node extends Endpoint
             'port' => $this->getPort(),
             'scheme' => $this->getScheme(),
             'path' => $this->getPath(),
+            'context' => $this->getContext(),
             'core' => $this->getCore(),
         ];
     }

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -158,8 +158,8 @@ class SolrConnectionTest extends UnitTest
     public function coreBasePathDataProvider(): array
     {
         return [
-            ['path' => '/solr/bla', 'expectedPath' => ''],
-            ['path' => '/somewherelese/solr/corename', 'expectedCoreBasePath' => '/somewherelese'],
+            ['path' => '/solr/bla', 'expectedPath' => 'solr'],
+            ['path' => '/somewherelese/solr/corename', 'expectedCoreBasePath' => 'somewherelese/solr'],
         ];
     }
 
@@ -174,7 +174,7 @@ class SolrConnectionTest extends UnitTest
         );
         $writeNode = $readNode;
         $solrService = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);
-        self::assertSame($expectedCoreBasePath, $solrService->getReadService()->getPrimaryEndpoint()->getPath());
+        self::assertSame($expectedCoreBasePath, $solrService->getReadService()->getPrimaryEndpoint()->getContext());
     }
 
     /**
@@ -183,7 +183,7 @@ class SolrConnectionTest extends UnitTest
     public function toStringContainsAllSegments()
     {
         $readNode = Node::fromArray(
-            ['host' => 'localhost', 'port' => 8080, 'path' => '/core_de/', 'scheme' => 'http', 'username' => '', 'password' => '']
+            ['host' => 'localhost', 'port' => 8080, 'path' => '/solr/core_de/', 'scheme' => 'http', 'username' => '', 'password' => '']
         );
         $writeNode = $readNode;
         $solrService = $this->getSolrConnectionWithDummyConstructorArgs($readNode, $writeNode);


### PR DESCRIPTION
…et instead of path)

# What this pr does

Settings the path when creating makes no sense as a 'context' property exists.

# How to test

Log in to TYPO3 backend and check the solr connection status (should be green).

Fixes: #3043
