### PR TITLE
[BUGFIX] Fix handling of non existing pages on deletions

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\GarbageCollectorPostProcessor;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -106,7 +107,13 @@ abstract class AbstractStrategy
         // record can be indexed for multiple sites
         $indexQueueItems = $this->queue->getItems($table, $uid);
         foreach ($indexQueueItems as $indexQueueItem) {
-            $site = $indexQueueItem->getSite();
+            try {
+                $site = $indexQueueItem->getSite();
+            } catch (InvalidArgumentException $e) {
+                $this->queue->deleteItem($indexQueueItem->getType(), $indexQueueItem->getIndexQueueUid());
+                continue;
+            }
+
             $enableCommitsSetting = $site->getSolrConfiguration()->getEnableCommits();
             $siteHash = $site->getSiteHash();
             // a site can have multiple connections (cores / languages)

--- a/Classes/Domain/Index/Queue/RecordMonitor/Exception/RootPageRecordNotFoundException.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Exception/RootPageRecordNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception;
+
+use ApacheSolrForTypo3\Solr\Exception;
+
+/**
+ * Exception that is thrown if the record of the root page couldn't be found
+ */
+class RootPageRecordNotFoundException extends Exception
+{
+}

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception\RootPageRecordNotFoundException;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Page\Rootline;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
-use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -79,7 +79,7 @@ class RootPageResolver implements SingletonInterface
      * @param int $uid
      * @return array
      * @throws DBALDriverException
-     * @throws InvalidArgumentException
+     * @throws RootPageRecordNotFoundException
      * @throws Throwable
      */
     public function getResponsibleRootPageIds(string $table, int $uid): array
@@ -101,7 +101,7 @@ class RootPageResolver implements SingletonInterface
      *
      * @param int $pageId Page ID
      * @return bool TRUE if the page is marked as root page, FALSE otherwise
-     * @throws InvalidArgumentException
+     * @throws RootPageRecordNotFoundException
      */
     public function getIsRootPageId(int $pageId): bool
     {
@@ -126,7 +126,7 @@ class RootPageResolver implements SingletonInterface
         if (empty($page)) {
             // @todo: 1636120156 See \ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper\PageIndexerTest::phpProcessDoesNotDieIfPageIsNotAvailable()
             //        Do we need an exception here or is it sufficient to just return false?
-            throw new InvalidArgumentException(
+            throw new RootPageRecordNotFoundException(
                 'The page for the given page ID \'' . $pageId
                 . '\' could not be found in the database and can therefore not be used as site root page.',
                 1487171426
@@ -196,7 +196,7 @@ class RootPageResolver implements SingletonInterface
      * @param int $uid
      * @return array
      * @throws DBALDriverException
-     * @throws InvalidArgumentException
+     * @throws RootPageRecordNotFoundException
      * @throws Throwable
      */
     protected function buildResponsibleRootPageIds(string $table, int $uid): array

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -79,6 +79,7 @@ class RootPageResolver implements SingletonInterface
      * @param int $uid
      * @return array
      * @throws DBALDriverException
+     * @throws InvalidArgumentException
      * @throws Throwable
      */
     public function getResponsibleRootPageIds(string $table, int $uid): array
@@ -100,6 +101,7 @@ class RootPageResolver implements SingletonInterface
      *
      * @param int $pageId Page ID
      * @return bool TRUE if the page is marked as root page, FALSE otherwise
+     * @throws InvalidArgumentException
      */
     public function getIsRootPageId(int $pageId): bool
     {
@@ -121,7 +123,9 @@ class RootPageResolver implements SingletonInterface
         }
 
         $page = $this->getPageRecordByPageId($pageId);
-        if (empty($page)) { // @todo: 1636120156 See \ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper\PageIndexerTest::phpProcessDoesNotDieIfPageIsNotAvailable()
+        if (empty($page)) {
+            // @todo: 1636120156 See \ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper\PageIndexerTest::phpProcessDoesNotDieIfPageIsNotAvailable()
+            //        Do we need an exception here or is it sufficient to just return false?
             throw new InvalidArgumentException(
                 'The page for the given page ID \'' . $pageId
                 . '\' could not be found in the database and can therefore not be used as site root page.',
@@ -192,6 +196,7 @@ class RootPageResolver implements SingletonInterface
      * @param int $uid
      * @return array
      * @throws DBALDriverException
+     * @throws InvalidArgumentException
      * @throws Throwable
      */
     protected function buildResponsibleRootPageIds(string $table, int $uid): array

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception\RootPageRecordNotFoundException;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
@@ -31,7 +32,6 @@ use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception as DBALException;
-use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
@@ -215,7 +215,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
             } else {
                 $pid = $updatedFields['pid'] ?? $this->getValidatedPid('pages', $uid);
             }
-        } catch (Throwable $e) {
+        } catch (RootPageRecordNotFoundException $e) {
             $pid = null;
         }
 
@@ -400,7 +400,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
     {
         try {
             $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($recordTable, $recordUid);
-        } catch (InvalidArgumentException $e) {
+        } catch (RootPageRecordNotFoundException $e) {
             $rootPageIds = [];
         }
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueInitializationService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception\RootPageRecordNotFoundException;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
@@ -31,7 +32,6 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception as DBALException;
-use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -196,7 +196,7 @@ class Queue
         $updateCount = 0;
         try {
             $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($itemType, $itemUid);
-        } catch (InvalidArgumentException $e) {
+        } catch (RootPageRecordNotFoundException $e) {
             $this->deleteItem($itemType, $itemUid);
             return 0;
         }

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -31,6 +31,7 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception as DBALException;
+use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -193,7 +194,13 @@ class Queue
     protected function updateOrAddItemForAllRelatedRootPages(string $itemType, $itemUid, int $forcedChangeTime): int
     {
         $updateCount = 0;
-        $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($itemType, $itemUid);
+        try {
+            $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($itemType, $itemUid);
+        } catch (InvalidArgumentException $e) {
+            $this->deleteItem($itemType, $itemUid);
+            return 0;
+        }
+
         foreach ($rootPageIds as $rootPageId) {
             $skipInvalidRootPage = $rootPageId === 0;
             if ($skipInvalidRootPage) {

--- a/Tests/Integration/Fixtures/can_handle_missing_page_on_deletion.xml
+++ b/Tests/Integration/Fixtures/can_handle_missing_page_on_deletion.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>123</uid>
+		<pid>1</pid>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+		<deleted>1</deleted>
+		<title>Already deleted page</title>
+	</pages>
+
+	<tt_content>
+		<uid>321</uid>
+		<pid>123</pid>
+		<bodytext>content element on an already deleted page 123</bodytext>
+		<colPos>0</colPos>
+	</tt_content>
+
+	<tt_content>
+		<uid>432</uid>
+		<pid>234</pid>
+		<bodytext>content element on missing page 234</bodytext>
+		<colPos>0</colPos>
+	</tt_content>
+
+	<tx_solr_indexqueue_item>
+		<uid>123</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<item_uid>123</item_uid>
+		<indexing_configuration>pages</indexing_configuration>
+		<has_indexing_properties>0</has_indexing_properties>
+		<indexing_priority>0</indexing_priority>
+		<changed>1449151778</changed>
+		<indexed>1</indexed>
+		<errors></errors>
+		<pages_mountidentifier></pages_mountidentifier>
+	</tx_solr_indexqueue_item>
+
+	<tx_solr_indexqueue_item>
+		<uid>234</uid>
+		<root>1</root>
+		<item_type>pages</item_type>
+		<item_uid>234</item_uid>
+		<indexing_configuration>pages</indexing_configuration>
+		<has_indexing_properties>0</has_indexing_properties>
+		<indexing_priority>0</indexing_priority>
+		<changed>1449151778</changed>
+		<indexed>1</indexed>
+		<errors></errors>
+		<pages_mountidentifier></pages_mountidentifier>
+	</tx_solr_indexqueue_item>
+</dataset>

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -71,7 +71,6 @@ class QueueTest extends IntegrationTest
     public function preFilledQueueContainsRootPageAfterInitialize()
     {
         $this->importDataSetFromFixture('can_clear_queue_after_initialize.xml');
-        $itemCount = $this->indexQueue->getAllItemsCount();
 
         $this->assertItemsInQueue(1);
         self::assertFalse($this->indexQueue->containsItem('pages', 1));
@@ -125,7 +124,6 @@ class QueueTest extends IntegrationTest
         $this->assertEmptyQueue();
 
         // record does not exist in fixture
-        $this->expectException(\InvalidArgumentException::class);
         $this->indexQueue->updateItem('pages', 5);
 
         // queue should still be empty

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -15,11 +15,11 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\RecordMonitor\Helper;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception\RootPageRecordNotFoundException;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -127,7 +127,7 @@ class RootPageResolverTest extends UnitTest
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
             ->onlyMethods(['getPageRecordByPageId'])->getMock();
         $this->rootPageResolver->expects(self::once())->method('getPageRecordByPageId')->willReturn([]);
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RootPageRecordNotFoundException::class);
         $this->rootPageResolver->getIsRootPageId(42);
     }
 


### PR DESCRIPTION
# What this pr does

If a records page or the site root is not available exceptions will occur during garbage collection. This commit improves
the handling of missing pages to fix this issue.

# How to test

Try to delete a record without a proper page tree connection via DataHandler, e.g. use a deleted site root or a deleted record
storage.

Fixes: #3500 
