### PR TITLE
[BUGFIX] Fixes 'typed property must not be accessed before initializa…

### DIFF
--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -49,7 +49,7 @@ class Search
      *
      * @var Query|null
      */
-    protected ?Query $query;
+    protected ?Query $query = null;
 
     /**
      * The search response


### PR DESCRIPTION
Using PHP8.0 and no initial query defined in plugin configuration the frontend threw the following error:

503
Oops, an error occurred!
Typed property ApacheSolrForTypo3\Solr\Search::$query must not be accessed before initialization

Initializing the $query-Property with null resolves this Problem.

---

### Maintainers comments:

Todos:

- [x] port into release-11.5.x