### PR TITLE
[TASK] Use PCOV for coverage instead of xDebug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.PHP }}
-          coverage: xdebug
+          coverage: pcov
           tools: composer:2.1.14
       -
         name: Resolve CI build cache key


### PR DESCRIPTION
PCOV is faster as xDebug for coverage.
We are using coverage currently for Scrutinizer.
Later other static analyse tools will benefit as well.

Fixes: #3526