### PR TITLE
[BUGFIX] Use correct eval for site TCA

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -50,7 +50,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
     'label' => 'Port',
     'config' => [
         'type' => 'input',
-        'eval' => 'required',
+        'required' => true,
         'size' => 5,
         'default' => 8983,
     ],


### PR DESCRIPTION
Instead of using 

```php
'eval' => 'required',
```

use 

```php
'required' => true,
```
