### PR TITLE
[TASK:BP:11.5] Handle Solr connection exception

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -24,7 +24,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 use RuntimeException;
-use Solarium\Exception\HttpException;
 use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
@@ -136,9 +135,8 @@ class IndexService
         if ($enableCommitsSetting && count($itemsToIndex) > 0) {
             $solrServers = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionsBySite($this->site);
             foreach ($solrServers as $solrServer) {
-                try {
-                    $solrServer->getWriteService()->commit(false, false);
-                } catch (HttpException $e) {
+                $response = $solrServer->getWriteService()->commit(false, false);
+                if ($response->getHttpStatus() !== 200) {
                     $errors++;
                 }
             }

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -35,7 +35,6 @@ use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception as DBALException;
 use InvalidArgumentException;
 use RuntimeException;
-use Solarium\Exception\HttpException;
 use Throwable;
 use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
@@ -197,13 +196,9 @@ class Indexer extends AbstractIndexer
         $documents = $this->processDocuments($item, $documents);
         $documents = self::preAddModifyDocuments($item, $language, $documents);
 
-        try {
-            $response = $this->solr->getWriteService()->addDocuments($documents);
-            if ($response->getHttpStatus() == 200) {
-                $itemIndexed = true;
-            }
-        } catch (HttpException $e) {
-            $response = new ResponseAdapter($e->getBody(), 500, $e->getStatusMessage());
+        $response = $this->solr->getWriteService()->addDocuments($documents);
+        if ($response->getHttpStatus() === 200) {
+            $itemIndexed = true;
         }
 
         $this->log($item, $documents, $response);

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -397,7 +397,12 @@ abstract class AbstractSolrService
      */
     protected function executeRequest(Request $request): ResponseAdapter
     {
-        $result = $this->client->executeRequest($request);
+        try {
+            $result = $this->client->executeRequest($request);
+        } catch (HttpException $e) {
+            return new ResponseAdapter($e->getMessage(), $e->getCode(), $e->getStatusMessage());
+        }
+
         return new ResponseAdapter($result->getBody(), $result->getStatusCode(), $result->getStatusMessage());
     }
 

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\GarbageRemover;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\AbstractStrategy;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
+use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use Traversable;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\AccessibleProxyTrait;
+
+/**
+ * Abstract strategy tests
+ */
+abstract class AbstractStrategyTest extends UnitTest
+{
+    /**
+     * @var AbstractStrategy|AccessibleProxyTrait $subject
+     */
+    protected AbstractStrategy $subject;
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
+    /**
+     * @param int $status
+     * @param bool $commit
+     *
+     * @test
+     * @dataProvider canDeleteRecordInAllSolrConnectionsDataProvider
+     */
+    public function canDeleteRecordInAllSolrConnections(int $status, bool $commit): void
+    {
+        $query = 'type:tx_fakeextension_foo AND uid:123 AND siteHash:#siteHash#';
+        $response = new ResponseAdapter(
+            '',
+            $status,
+            'msg' . $status,
+        );
+
+        $writeServiceMock = $this->createMock(SolrWriteService::class);
+        $writeServiceMock
+            ->expects(self::once())
+            ->method('deleteByQuery')
+            ->with($query)
+            ->willReturn($response);
+
+        $writeServiceMock
+            ->expects((($status === 200 && $commit) ? self::once() : self::never()))
+            ->method('commit');
+
+        $writeServiceMock
+            ->expects(($status !== 200 ? self::once() : self::never()))
+            ->method('getCorePath')
+            ->willReturn('core_en');
+
+        $connectionMock = $this->createMock(SolrConnection::class);
+        $connectionMock
+            ->expects(self::atLeastOnce())
+            ->method('getWriteService')
+            ->willReturn($writeServiceMock);
+
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
+        GeneralUtility::addInstance(SolrLogManager::class, $solrLogManagerMock);
+        if ($status !== 200) {
+            $solrLogManagerMock
+                ->expects(self::once())
+                ->method('log')
+                ->with(
+                    SolrLogManager::ERROR,
+                    'Couldn\'t delete index document',
+                    [
+                        'status' => $status,
+                        'msg' => 'msg' . $status,
+                        'core' => 'core_en',
+                        'query' => $query,
+                    ]
+                );
+        } else {
+            $solrLogManagerMock
+                ->expects(self::never())
+                ->method('log');
+        }
+
+        $this->subject->_call(
+            'deleteRecordInAllSolrConnections',
+            'tx_fakeextension_foo',
+            123,
+            [$connectionMock],
+            '#siteHash#',
+            $commit
+        );
+    }
+
+    /**
+     * Data provider for canDeleteRecordInAllSolrConnectionsDataProvider
+     * @return Traversable
+     */
+    public function canDeleteRecordInAllSolrConnectionsDataProvider(): Traversable
+    {
+        yield 'can delete and commit' => [
+            'status' => 200,
+            'commit' => true,
+        ];
+
+        yield 'can delete and skip commit' => [
+            'status' => 200,
+            'commit' => false,
+        ];
+
+        yield 'can log failed request' => [
+            'status' => 500,
+            'commit' => true,
+        ];
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/PageStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/PageStrategyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\GarbageRemover;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\PageStrategy;
+
+/**
+ * PageStrategy tests
+ */
+class PageStrategyTest extends AbstractStrategyTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = $this->getAccessibleMock(
+            PageStrategy::class,
+            null,
+            [],
+            '',
+            false
+        );
+    }
+}

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/RecordStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/RecordStrategyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\GarbageRemover;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\RecordStrategy;
+
+/**
+ * RecordStrategy tests
+ */
+class RecordStrategyTest extends AbstractStrategyTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = $this->getAccessibleMock(
+            RecordStrategy::class,
+            null,
+            [],
+            '',
+            false
+        );
+    }
+}


### PR DESCRIPTION
# What this pr does

Solr requests may fail due to server errors or faulty queries, thrown exceptions or just an invalid status code indicate such errors.

This commit ensures that exceptions are handled and a valid response with a meaningful status code is returned. Handling is centralized in SolrService so that other components just have to deal with the status code.

Additionally the GarbageCollection is considering this status and is logging missing index update.

# How to test

- Configure an indexing configuration e.g. for news
- Simulate invalid Solr responses
- Try to hide an indexed record in TYPO3 backend

Record update shouldn't fail, but a log entry should be in place.

Resolves: #2903

