### PR TITLE
[TASK] Rename misnamed util function getExceptionTime to getExecution…

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -191,7 +191,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
             return;
         }
 
-        $this->indexQueue->updateItem('pages', $pid, Util::getExceptionTime());
+        $this->indexQueue->updateItem('pages', $pid, Util::getExecutionTime());
     }
 
     /**

--- a/Classes/System/Records/Queue/EventQueueItemRepository.php
+++ b/Classes/System/Records/Queue/EventQueueItemRepository.php
@@ -50,7 +50,7 @@ class EventQueueItemRepository extends AbstractRepository implements SingletonIn
         $queryBuilder
             ->insert($this->table)
             ->values([
-                'tstamp' => Util::getExceptionTime(),
+                'tstamp' => Util::getExecutionTime(),
                 'event' => $serializedEvent,
 
             ])

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -191,7 +191,7 @@ class Util
      * @return int
      * @throws AspectNotFoundException
      */
-    public static function getExceptionTime(): int
+    public static function getExecutionTime(): int
     {
         $context = GeneralUtility::makeInstance(Context::class);
         return (int)$context->getPropertyFromAspect('date', 'timestamp');


### PR DESCRIPTION
# What this pr does

Rename misnamed util function `getExceptionTime` to `getExecutionTime`


In older versions, the function was named `getExectionTime` and was then renamed to `getExceptionTime`, presumably via rector