### PR TITLE
[FEATURE] Make statistics more dynamic

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -133,10 +133,10 @@ class InfoModuleController extends AbstractModuleController
         );
         $statisticsConfig = $frameWorkConfiguration['plugin.']['tx_solr.']['statistics.'] ?? [];
 
-        $topHitsLimit = (int) ($statisticsConfig['topHits.']['limit'] ?? 5);
-        $noHitsLimit = (int) ($statisticsConfig['noHits.']['limit'] ?? 5);
+        $topHitsLimit = (int)($statisticsConfig['topHits.']['limit'] ?? 5);
+        $noHitsLimit = (int)($statisticsConfig['noHits.']['limit'] ?? 5);
 
-        $queriesDays = (int) ($statisticsConfig['queries.']['days'] ?? 30);
+        $queriesDays = (int)($statisticsConfig['queries.']['days'] ?? 30);
 
         $siteRootPageId = $this->selectedSite->getRootPageId();
         /* @var StatisticsRepository $statisticsRepository */
@@ -146,7 +146,7 @@ class InfoModuleController extends AbstractModuleController
             'top_search_phrases',
             $statisticsRepository->getTopKeyWordsWithHits(
                 $siteRootPageId,
-                (int) ($statisticsConfig['topHits.']['days'] ?? 30),
+                (int)($statisticsConfig['topHits.']['days'] ?? 30),
                 $topHitsLimit
             )
         );
@@ -154,7 +154,7 @@ class InfoModuleController extends AbstractModuleController
             'top_search_phrases_without_hits',
             $statisticsRepository->getTopKeyWordsWithoutHits(
                 $siteRootPageId,
-                (int) ($statisticsConfig['noHits.']['days'] ?? 30),
+                (int)($statisticsConfig['noHits.']['days'] ?? 30),
                 $noHitsLimit
             )
         );
@@ -163,7 +163,7 @@ class InfoModuleController extends AbstractModuleController
             $statisticsRepository->getSearchStatistics(
                 $siteRootPageId,
                 $queriesDays,
-                (int) ($statisticsConfig['queries.']['limit'] ?? 100)
+                (int)($statisticsConfig['queries.']['limit'] ?? 100)
             )
         );
 

--- a/Configuration/TypoScript/Examples/EverythingOn/setup.typoscript
+++ b/Configuration/TypoScript/Examples/EverythingOn/setup.typoscript
@@ -24,8 +24,22 @@ plugin.tx_solr {
 		variants = 1
 	}
 
-	statistics = 1
-	statistics.anonymizeIP = 1
+  statistics = 1
+  statistics {
+    anonymizeIP = 1
+    topHits {
+      days = 30
+      limit = 5
+    }
+    noHits {
+      days = 30
+      limit = 5
+    }
+    queries {
+      days = 30
+      limit = 100
+    }
+  }
 
 	suggest = 1
 

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -43,3 +43,63 @@ Adds debug data to the columns `time_total`, `time_preparation` and `time_proces
 from the result of the search query.
 
 **Note**: Enabling addDebugData can have performance impact since debugMode is appended to queries.
+
+statistics.topHits.days
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.topHits.days
+:Since: 12.0
+:Default: 30
+
+Number of days to read out the search top hits.
+
+statistics.topHits.limit
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.topHits.limit
+:Since: 12.0
+:Default: 5
+
+Number of records to read out the search top hits.
+
+statistics.noHits.days
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.noHits.days
+:Since: 12.0
+:Default: 30
+
+Number of days to read out non-search hits.
+
+statistics.noHits.limit
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.noHits.limit
+:Since: 12.0
+:Default: 5
+
+Number of records to read out non-search hits.
+
+statistics.queries.days
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.queries.days
+:Since: 12.0
+:Default: 30
+
+Number of days to read out search queries.
+
+statistics.queries.limit
+-----------------------
+
+:Type: Integer
+:TS Path: plugin.tx_solr.statistics.queries.limit
+:Since: 12.0
+:Default: 100
+
+Number of records to read out search queries.

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -55,7 +55,7 @@ statistics.topHits.days
 Number of days to read out the search top hits.
 
 statistics.topHits.limit
------------------------
+------------------------
 
 :Type: Integer
 :TS Path: plugin.tx_solr.statistics.topHits.limit

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -95,7 +95,7 @@ statistics.queries.days
 Number of days to read out search queries.
 
 statistics.queries.limit
------------------------
+------------------------
 
 :Type: Integer
 :TS Path: plugin.tx_solr.statistics.queries.limit

--- a/Documentation/Configuration/Reference/TxSolrStatistics.rst
+++ b/Documentation/Configuration/Reference/TxSolrStatistics.rst
@@ -65,7 +65,7 @@ statistics.topHits.limit
 Number of records to read out the search top hits.
 
 statistics.noHits.days
------------------------
+----------------------
 
 :Type: Integer
 :TS Path: plugin.tx_solr.statistics.noHits.days

--- a/Resources/Private/Language/cs.locallang.xlf
+++ b/Resources/Private/Language/cs.locallang.xlf
@@ -445,12 +445,12 @@
 				<target>Nenalezeny žádné záznamy. Povolili jste 'plugin.tx_solr.statistics = 1' v konfiguraci typoscriptu vašeho webu?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>Top 5 vyhledaných frází</target>
+				<source>Top %d Search Phrases</source>
+				<target>Top %d vyhledaných frází</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>Top 5 vyhledávacích frází bez hitů</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>Top %d vyhledávacích frází bez hitů</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/es.locallang.xlf
+++ b/Resources/Private/Language/es.locallang.xlf
@@ -443,12 +443,12 @@
 				<target>No se han encontrado registros. ¿Ha habilitado &apos;plugin.tx_solr.statistics = 1&apos; en la configuración de typoscript de su sitio?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>Las 5 principales frases de búsqueda</target>
+				<source>Top %d Search Phrases</source>
+				<target>Las %d principales frases de búsqueda</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>Las 5 principales frases de búsqueda sin resultados</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>Las %d principales frases de búsqueda sin resultados</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -451,12 +451,12 @@
 				<target>No records found. Did you enabled 'plugin.tx_solr.statistics = 1' in the typoscript configuration of your site?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>Top 5 Search Phrases</target>
+				<source>Top %d Search Phrases</source>
+				<target>Top %d Search Phrases</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>Top 5 Search Phrases Without Hits</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>Top %d Search Phrases Without Hits</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/ja.locallang.xlf
+++ b/Resources/Private/Language/ja.locallang.xlf
@@ -440,12 +440,12 @@
 				<target>レコードが見つかりません。サイトのタイポスクリプト構成設定で「plugin.tx_solr.statistics = 1」を有効化しましたか?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>トップ 5 検索フレーズ</target>
+				<source>Top %d Search Phrases</source>
+				<target>トップ %d 検索フレーズ</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>該当の無いトップ 5 検索フレーズ</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>該当の無いトップ %d 検索フレーズ</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/ko.locallang.xlf
+++ b/Resources/Private/Language/ko.locallang.xlf
@@ -440,12 +440,12 @@
 				<target>기록이 없습니다. 사이트의  타이포스크립트 구성에서  &apos;plugin.tx_solr.statistics = 1&apos;을 활성화시켰습니까?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>Top 5 검색 구문</target>
+				<source>Top %d Search Phrases</source>
+				<target>Top %d 검색 구문</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>Top 5 검색 구문(Hit 없음)</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>Top %d 검색 구문(Hit 없음)</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -365,10 +365,10 @@
 				<source>No records found. Did you enabled 'plugin.tx_solr.statistics = 1' in the typoscript configuration of your site?</source>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
+				<source>Top %d Search Phrases</source>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
+				<source>Top %d Search Phrases Without Hits</source>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Language/pt.locallang.xlf
+++ b/Resources/Private/Language/pt.locallang.xlf
@@ -443,12 +443,12 @@
 				<target>Nenhum registro encontrado. Você ativou "plugin.tx_solr.statistics = 1" na configuração typoscript do seu site?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
-				<source>Top 5 Search Phrases</source>
-				<target>5 principais frases pesquisadas</target>
+				<source>Top %d Search Phrases</source>
+				<target>%d principais frases pesquisadas</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
-				<source>Top 5 Search Phrases Without Hits</source>
-				<target>5 principais frases pesquisadas sem resultados</target>
+				<source>Top %d Search Phrases Without Hits</source>
+				<target>%d principais frases pesquisadas sem resultados</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>

--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -131,7 +131,9 @@
         <div class="row">
             <div class="col-md-12">
                 <h2>
-                    <f:translate key="solr.backend.search_statistics_module.top_search_phrases"/>
+									<f:format.printf arguments="{0: '{topHitsLimit}'}">
+										<f:translate key="solr.backend.search_statistics_module.top_search_phrases"/>
+									</f:format.printf>
                 </h2>
 
                 <ul>
@@ -151,7 +153,9 @@
         <div class="row section-with-header">
             <div class="col-md-12">
                 <h2>
-                    <f:translate key="solr.backend.search_statistics_module.top_search_phrases_without_hits"/>
+									<f:format.printf arguments="{0: '{noHitsLimit}'}">
+										<f:translate key="solr.backend.search_statistics_module.top_search_phrases_without_hits"/>
+									</f:format.printf>
                 </h2>
 
                 <ul>


### PR DESCRIPTION
# What this pr does

The statistics are hard-coded so far. It is now defined in Typoscript. If no values are defined, the previous values are set as the default value in the code to prevent a breaking change.

# How to test

Simply add TypoScript and look at the statistics in the backend info module.

# Hint

The documentation is adapted if everything fits in terms of content and the variable naming is also good enough.


Fixes: #3534
