### PR TITLE
[BUGFIX:BP:11.2] Use plugin namespace as label for flexforms

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -165,7 +165,7 @@ class FlexFormUserFunctions
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
         $namespaces = [];
         foreach ($extensionConfiguration->getAvailablePluginNamespaces() as $namespace) {
-            $label = $namespace === 'tx_solr' ? 'Default' : '';
+            $label = $namespace === 'tx_solr' ? 'Default' : $namespace;
             $namespaces[$namespace] = [$label, $namespace];
         }
         $parentInformation['items'] = $namespaces;


### PR DESCRIPTION
Backport of https://github.com/TYPO3-Solr/ext-solr/pull/3549

---

When you configure additional pluginnamespaces via extension configuration, the dropdown in the plugin flexform shows _Default_ followed by empty entries.


Extension Configuration to reproduce this:
```php
$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr']['pluginNamespaces'] => 'search,sitesearch,newssearch,eventsearch'
```

The `view.pluginNamespace` DropDown shows up with the folowing Field:
```html
<select class="form-select form-control-adapt">
    <option value="tx_solr" selected="selected">Default</option>
    <option value="search"></option>
    <option value="sitesearch"></option>
    <option value="newssearch"></option>
    <option value="eventsearch"></option>
</select>
```
It is hard to select an plugin namespace with empty labels.

The user function that returns the entries creates the labels with  
`$label = $namespace === 'tx_solr' ? 'Default' : ''`:

https://github.com/TYPO3-Solr/ext-solr/blob/d09505848b337969f4977f78478d933092eb41c1/Classes/System/UserFunctions/FlexFormUserFunctions.php#L189-L198


This pull requests uses the namespace instead of an empty string for the label:  
`$label = $namespace === 'tx_solr' ? 'Default' : $namespace`

