### PR TITLE
[BUGFIX:BP:11.0] Respect indexingPriority in QueueItemRepository

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -173,14 +173,22 @@ class QueueItemRepository extends AbstractRepository
      * @param string $indexingConfiguration The name of the related indexConfiguration
      * @param int $rootPageId The uid of the rootPage
      * @param int $changedTime The forced change time that should be used for updating
+     * @param int $indexingPriority
      * @return int affected rows
      */
-    public function updateExistingItemByItemTypeAndItemUidAndRootPageId(string $itemType, int $itemUid, int $rootPageId, int $changedTime, string $indexingConfiguration = '') : int
-    {
+    public function updateExistingItemByItemTypeAndItemUidAndRootPageId(
+        string $itemType,
+        int $itemUid,
+        int $rootPageId,
+        int $changedTime,
+        string $indexingConfiguration = '',
+        int $indexingPriority = 0
+    ): int {
         $queryBuilder = $this->getQueryBuilder();
         $queryBuilder
             ->update($this->table)
             ->set('changed', $changedTime)
+            ->set('indexing_priority', $indexingPriority)
             ->andWhere(
                 $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
                 $queryBuilder->expr()->eq('item_uid', $itemUid),
@@ -204,10 +212,17 @@ class QueueItemRepository extends AbstractRepository
      * @param int $rootPageId
      * @param int $changedTime
      * @param string $indexingConfiguration The item's indexing configuration to use. Optional, overwrites existing / determined configuration.
+     * @param int $indexingPriority
      * @return int the number of inserted rows, which is typically 1
      */
-    public function add(string $itemType, int $itemUid, int $rootPageId, int $changedTime, string $indexingConfiguration) : int
-    {
+    public function add(
+        string $itemType,
+        int $itemUid,
+        int $rootPageId,
+        int $changedTime,
+        string $indexingConfiguration,
+        int $indexingPriority = 0
+    ): int {
         $queryBuilder = $this->getQueryBuilder();
         return $queryBuilder
             ->insert($this->table)
@@ -217,7 +232,8 @@ class QueueItemRepository extends AbstractRepository
                 'item_uid' => $itemUid,
                 'changed' => $changedTime,
                 'errors' => '',
-                'indexing_configuration' => $indexingConfiguration
+                'indexing_configuration' => $indexingConfiguration,
+                'indexing_priority' => $indexingPriority,
             ])
             ->execute();
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -197,14 +197,15 @@ class Queue
 
             $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($rootPageId);
             $indexingConfiguration = $this->recordService->getIndexingConfigurationName($itemType, $itemUid, $solrConfiguration);
+            $indexingPriority = $solrConfiguration->getIndexQueueIndexingPriorityByConfigurationName($indexingConfiguration);
             $itemInQueueForRootPage = $this->containsItemWithRootPageId($itemType, $itemUid, $rootPageId);
             if ($itemInQueueForRootPage) {
                 // update changed time if that item is in the queue already
                 $changedTime = ($forcedChangeTime > 0) ? $forcedChangeTime : $this->getItemChangedTime($itemType, $itemUid);
-                $updatedRows = $this->queueItemRepository->updateExistingItemByItemTypeAndItemUidAndRootPageId($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration);
+                $updatedRows = $this->queueItemRepository->updateExistingItemByItemTypeAndItemUidAndRootPageId($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration, $indexingPriority);
             } else {
                 // add the item since it's not in the queue yet
-                $updatedRows = $this->addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId);
+                $updatedRows = $this->addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId, $indexingPriority);
             }
 
             $updateCount += $updatedRows;
@@ -299,10 +300,16 @@ class Queue
      * @param string $indexingConfiguration The item's indexing configuration to use.
      *      Optional, overwrites existing / determined configuration.
      * @param $rootPageId
+     * @param int $indexingPriority
      * @return int
      */
-    private function addNewItem($itemType, $itemUid, $indexingConfiguration, $rootPageId)
-    {
+    private function addNewItem(
+        $itemType,
+        $itemUid,
+        $indexingConfiguration,
+        $rootPageId,
+        int $indexingPriority = 0
+    ): int {
         $additionalRecordFields = '';
         if ($itemType === 'pages') {
             $additionalRecordFields = ', doktype, uid';
@@ -316,7 +323,7 @@ class Queue
 
         $changedTime = $this->getItemChangedTime($itemType, $itemUid);
 
-        return $this->queueItemRepository->add($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration);
+        return $this->queueItemRepository->add($itemType, $itemUid, $rootPageId, $changedTime, $indexingConfiguration, $indexingPriority);
     }
 
     /**

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -654,6 +654,21 @@ class TypoScriptConfiguration
     }
 
     /**
+    * Retrieves indexingPriority when configured or 0.
+    *
+    * plugin.tx_solr.index.queue.<configurationName>.indexingPriority
+    *
+    * @param string $configurationName
+    * @param int $defaultIfEmpty
+    * @return int
+    */
+    public function getIndexQueueIndexingPriorityByConfigurationName(string $configurationName, int $defaultIfEmpty = 0): int
+    {
+        $path = 'plugin.tx_solr.index.queue.' . $configurationName . '.indexingPriority';
+        return (int)$this->getValueByPathOrDefaultValue($path, $defaultIfEmpty);
+    }
+
+    /**
      * Returns the _LOCAL_LANG configuration from the TypoScript.
      *
      * plugin.tx_solr._LOCAL_LANG.

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     }
   },
   "config": {
+    "allow-plugins": true,
     "vendor-dir": ".Build/vendor",
     "bin-dir": ".Build/bin"
   },


### PR DESCRIPTION
Backport of #3509

----

# What this pr does

Fixes https://github.com/TYPO3-Solr/ext-solr/issues/3492 by reading and saving the `indexingPriority` attribute when using the QueueItemRepository

# How to test

1. Set an `indexingPriority` to an existing queue (e.g. `plugin.tx_solr.index.queue.news.indexingPriority = 50`)
2. Create a new item of the corresponding type (e.g. `news`) and save the record
3. Open the `tx_solr_indexqueue_item` table. The queued item will get an indexingPriority of `50`

Fixes: #3492
