### PR TITLE
[BUGFIX] Retry Uri Building after exception

### DIFF
--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -27,6 +27,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use ApacheSolrForTypo3\Solr\Utility\ParameterSortingUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -277,11 +278,26 @@ class SearchUriBuilder
         } else {
             self::$missCount++;
             $this->uriBuilder->reset()->setTargetPageUid($pageUid);
-            $uriCacheTemplate = $this->uriBuilder->setArguments($structure)->build();
+            try {
+                $uriCacheTemplate = $this->uriBuilder->setArguments($structure)->build();
 
-            /** @var UrlHelper $urlHelper */
-            $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $uriCacheTemplate);
-            self::$preCompiledLinks[$hash] = (string)$urlHelper;
+                /** @var UrlHelper $urlHelper */
+                $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $uriCacheTemplate);
+                self::$preCompiledLinks[$hash] = (string)$urlHelper;
+            } catch (InvalidParameterException $exception) {
+                // the placeholders may result in an exception when route enhancers with requirements are active
+                // In this case, try to build the URL with original arguments
+                $hash = md5($pageUid . json_encode($arguments));
+                if (isset(self::$preCompiledLinks[$hash])) {
+                    self::$hitCount++;
+                    $uriCacheTemplate = self::$preCompiledLinks[$hash];
+                } else {
+                    $uriCacheTemplate = $this->uriBuilder->setArguments($arguments)->build();
+                    /** @var UrlHelper $urlHelper */
+                    $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $uriCacheTemplate);
+                    self::$preCompiledLinks[$hash] = (string)$urlHelper;
+                }
+            }
         }
 
         $keys = array_map(static function ($value) {

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -465,6 +466,72 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
             ->willReturn($this->extBaseUriBuilderMock);
         $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
         $this->extBaseUriBuilderMock->expects(self::once())->method('build')->willReturn($linkBuilderResult);
+        $this->searchUrlBuilder->injectRoutingService($routingServiceMock);
+        $uri = $this->searchUrlBuilder->getResultPageUri($previousRequest, 0);
+        self::assertEquals($linkBuilderResult, $uri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriErrorsResultInNonMappedProcessing(): void
+    {
+        $configuration = Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'));
+        $routingServiceMock = $this->createMock(RoutingService::class);
+        $routingServiceMock->expects(self::any())
+            ->method('fetchEnhancerByPageUid')
+            ->willReturn($configuration['routeEnhancers']['example']);
+        $queryParameters = [
+            'tx_solr' => [
+                'filter' => [
+                    'type:pages',
+                    'color:green',
+                    'color:red',
+                    'color:yellow',
+                    'taste:matcha',
+                    'taste:sour',
+                    'product:candy',
+                    'product:sweets',
+                    'quantity:20',
+                ],
+            ],
+        ];
+        $subsitutedQueryParameters = [
+            'tx_solr' => [
+                'filter' => [
+                    '###tx_solr:filter:0:type###',
+                    '###tx_solr:filter:1:color###',
+                    '###tx_solr:filter:2:color###',
+                    '###tx_solr:filter:3:color###',
+                    '###tx_solr:filter:4:taste###',
+                    '###tx_solr:filter:5:taste###',
+                    '###tx_solr:filter:6:product###',
+                    '###tx_solr:filter:7:product###',
+                    '###tx_solr:filter:8:quantity###',
+                ],
+            ],
+        ];
+        $linkBuilderResult = '/index.php?id=42&color=' . urlencode('green,red,yellow') .
+            '&taste=' . urlencode('matcha,sour') .
+            '&product=' . urlencode('candy,sweets') .
+            '&' . urlencode('tx_solr[filter][0]') . '=' . urlencode('quantity:20');
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
+        $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(42);
+
+        $previousRequest =  new SearchRequest($queryParameters, 42, 0, $configurationMock);
+        $this->extBaseUriBuilderMock->expects(self::any())->method('setArguments')
+            ->withConsecutive([$subsitutedQueryParameters], [$queryParameters])
+            ->willReturn($this->extBaseUriBuilderMock);
+        $this->extBaseUriBuilderMock->expects(self::once())->method('reset')->with()->willReturn($this->extBaseUriBuilderMock);
+        $buildCounter = 0;
+        $this->extBaseUriBuilderMock->expects(self::exactly(2))->method('build')
+            ->willReturnCallback(function () use ($linkBuilderResult, &$buildCounter) {
+                if (++$buildCounter === 1) {
+                    throw new InvalidParameterException('First call fails, should reprocess with regular arguments');
+                }
+                return $linkBuilderResult;
+            });
         $this->searchUrlBuilder->injectRoutingService($routingServiceMock);
         $uri = $this->searchUrlBuilder->getResultPageUri($previousRequest, 0);
         self::assertEquals($linkBuilderResult, $uri);


### PR DESCRIPTION
# What this pr does

When there are route enhancers defined for a page containing the Solr search plugin, e.g. to realize pretty URLs for the search term, filters or pagination, there are issues with the URI caching that utilizes placeholders. Placeholders usually do not get replaced, leading to the issue described in #2984.

This PR implements a solution for route enhancers that define `requirements` in their parameters. The requirements are checked against the placeholders, leading to an exception. This exception is caught and it will then proceed the URI building with the original arguments instead of the placeholder arguments.

Fixes: #2984

# How to test

## Scenario 1: Speaking URL for search term

See https://github.com/TYPO3-Solr/ext-solr/issues/2984

## Scenario 2: Speaking URLs for pagination

1. Set up the following route enhancer (set the page containing the Solr list plugin in `limitToPages`):
```yaml
routeEnhancers:
  SolrPagination:
    type: Plugin
    namespace: 'tx_solr'
    routePath: '/{page}'
    defaults:
      page: 0
    requirements:
      page: '\d+'
    limitToPages: [1]
```
2. Clear TYPO3 cache
3. Open the Solr list plugin (e.g. https://mysite.dev/search)
4. The pagination links should be pretty (e.g. https://mysite.dev/search/1, https://mysite.dev/search/2)

