### PR TITLE
[BUGFIX] Add named array keys to items for Index Queue

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -173,7 +173,11 @@ class IndexingConfigurationSelectorField
                 $labelTableName = ' (' . $tableName . ')';
             }
 
-            $selectorItems[] = [$configurationName . $labelTableName, $configurationName, $icon];
+            $selectorItems[] = [
+                'label' => $configurationName . $labelTableName,
+                'value' => $configurationName,
+                'icon' => $icon,
+            ];
         }
 
         return $selectorItems;


### PR DESCRIPTION
# What this pr does

Show icon, value and label again in Index Queue module.

# How to test

Open Index Queue module. You only see the checkboxes of the indexes, but no label, icon or value. This patch solves this issue

# Change in TYPO3

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html