### PR TITLE
Implement solr variable provider

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -173,7 +173,11 @@ class IndexingConfigurationSelectorField
                 $labelTableName = ' (' . $tableName . ')';
             }
 
-            $selectorItems[] = [$configurationName . $labelTableName, $configurationName, $icon];
+            $selectorItems[] = [
+                'label' => $configurationName . $labelTableName,
+                'value' => $configurationName,
+                'icon' => $icon,
+            ];
         }
 
         return $selectorItems;

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -30,6 +30,7 @@ use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -95,6 +96,7 @@ abstract class AbstractBaseController extends ActionController
         $this->configurationManager = $configurationManager;
         // @extensionScannerIgnoreLine
         $this->contentObjectRenderer = $this->configurationManager->getContentObject();
+        $this->arguments = GeneralUtility::makeInstance(Arguments::class);
     }
 
     /**

--- a/Classes/Mvc/Variable/SolrVariableProvider.php
+++ b/Classes/Mvc/Variable/SolrVariableProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Mvc\Variable;
+
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+
+/**
+ * Extended version of the StandardVariableProvider
+ * We added searchResultsSet and TypoScriptConfiguration to variables which would be
+ * transferred to each render/section/layout
+ */
+class SolrVariableProvider extends StandardVariableProvider
+{
+    /**
+     * @param array|\ArrayAccess $variables
+     */
+    public function getScopeCopy($variables): VariableProviderInterface
+    {
+        if (!array_key_exists('settings', $variables) && array_key_exists('settings', $this->variables)) {
+            $variables['settings'] = $this->variables['settings'];
+        }
+        if (!array_key_exists('searchResultSet', $variables) && array_key_exists('searchResultSet', $this->variables)) {
+            $variables['searchResultSet'] = $this->variables['searchResultSet'];
+        }
+        if (!array_key_exists('typoScriptConfiguration', $variables) && array_key_exists('typoScriptConfiguration', $this->variables)) {
+            $variables['typoScriptConfiguration'] = $this->variables['typoScriptConfiguration'];
+        }
+
+        $className = get_class($this);
+
+        return new $className($variables);
+    }
+}

--- a/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
@@ -31,16 +31,11 @@ use InvalidArgumentException;
 abstract class AbstractSolrFrontendTagBasedViewHelper extends AbstractSolrTagBasedViewHelper
 {
     /**
-     * @var SolrControllerContext|null
-     */
-    protected ?SolrControllerContext $controllerContext = null;
-
-    /**
      * @return TypoScriptConfiguration
      */
     protected function getTypoScriptConfiguration(): TypoScriptConfiguration
     {
-        return $this->getControllerContext()->getTypoScriptConfiguration();
+        return $this->renderingContext->getVariableProvider()->get('typoScriptConfiguration');
     }
 
     /**
@@ -48,24 +43,6 @@ abstract class AbstractSolrFrontendTagBasedViewHelper extends AbstractSolrTagBas
      */
     protected function getSearchResultSet(): ?SearchResultSet
     {
-        return $this->getControllerContext()->getSearchResultSet();
-    }
-
-    /**
-     * @return SolrControllerContext
-     * @throws InvalidArgumentException
-     */
-    protected function getControllerContext(): SolrControllerContext
-    {
-        $controllerContext = null;
-        if (method_exists($this->renderingContext, 'getControllerContext')) {
-            $controllerContext = $this->renderingContext->getControllerContext();
-        }
-
-        if (!$controllerContext instanceof SolrControllerContext) {
-            throw new InvalidArgumentException('No valid SolrControllerContext found', 1512998673);
-        }
-
-        return $controllerContext;
+        return $this->renderingContext->getVariableProvider()->get('searchResultSet');
     }
 }

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -74,15 +74,17 @@ class TranslateViewHelper extends AbstractViewHelper
             $arguments['languageKey'],
             $arguments['alternativeLanguageKeys']
         );
+
         if ($result === null && isset($arguments['default'])) {
-            $result = $arguments['default'];
-            $result = self::replaceTranslationPrefixesWithAtWithStringMarker($result);
+            $result = self::replaceTranslationPrefixesWithAtWithStringMarker(
+                (string)($arguments['default'] ?? '')
+            );
             if (is_array($arguments['arguments'])) {
                 $result = vsprintf($result, $arguments['arguments']);
             }
         }
 
-        return (string)$result;
+        return $result ?? '';
     }
 
     /**
@@ -93,8 +95,6 @@ class TranslateViewHelper extends AbstractViewHelper
      * @param array|null $arguments Arguments to be replaced in the resulting string
      * @param string|null $languageKey Language key to use for this translation
      * @param string[]|null $alternativeLanguageKeys Alternative language keys if no translation does exist
-     *
-     * @return string|null
      */
     public static function translateAndReplaceMarkers(
         string $id,
@@ -102,7 +102,7 @@ class TranslateViewHelper extends AbstractViewHelper
         ?array $arguments = null,
         ?string $languageKey = null,
         ?array $alternativeLanguageKeys = null
-    ): ?string {
+    ): string {
         $result = LocalizationUtility::translate(
             $id,
             $extensionName,
@@ -110,10 +110,12 @@ class TranslateViewHelper extends AbstractViewHelper
             $languageKey,
             $alternativeLanguageKeys
         );
-        $result = self::replaceTranslationPrefixesWithAtWithStringMarker($result);
+
+        $result = self::replaceTranslationPrefixesWithAtWithStringMarker($result ?? '');
         if (is_array($arguments)) {
             $result = vsprintf($result, $arguments);
         }
+
         return $result;
     }
 
@@ -135,22 +137,19 @@ class TranslateViewHelper extends AbstractViewHelper
         TemplateCompiler $compiler
     ) {
         return sprintf(
-            '\\%1$s::translateAndReplaceMarkers(%2$s[\'key\'] ?? %2$s[\'id\'], %2$s[\'extensionName\'] ?? $renderingContext->getControllerContext()->getRequest()->getControllerExtensionName(), %2$s[\'arguments\'], %2$s[\'languageKey\'], %2$s[\'alternativeLanguageKeys\']) ?? %2$s[\'default\'] ?? %3$s()',
+            '\\%1$s::translateAndReplaceMarkers(%2$s[\'key\'] ?? %2$s[\'id\'], %2$s[\'extensionName\'] ?? $renderingContext->getRequest()->getControllerExtensionName(), %2$s[\'arguments\'], %2$s[\'languageKey\'], %2$s[\'alternativeLanguageKeys\']) ?? %2$s[\'default\'] ?? %3$s()',
             static::class,
             $argumentsName,
             $closureName
         );
     }
 
-    /**
-     * @param mixed $result
-     * @return mixed
-     */
-    protected static function replaceTranslationPrefixesWithAtWithStringMarker($result)
+    protected static function replaceTranslationPrefixesWithAtWithStringMarker(string $result): string
     {
-        if (str_contains((string)$result, '@')) {
-            $result = preg_replace('~\"?@[a-zA-Z]*\"?~', '%s', $result);
+        if (str_contains($result, '@')) {
+            $result = (string)preg_replace('~\"?@[a-zA-Z]*\"?~', '%s', $result);
         }
+
         return $result;
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,6 +7,19 @@ services:
     resource: '../Classes/*'
     exclude: '../Classes/Eid/*'
 
+  controller:
+    namespace: ApacheSolrForTypo3\Solr\Controller\
+    resource: '../Classes/Controller/*'
+    public: true
+    autowire: true
+    shared: false
+
+  viewhelper:
+    namespace: ApacheSolrForTypo3\Solr\ViewHelpers\
+    resource: '../Classes/ViewHelpers/*'
+    public: true
+    autowire: true
+
   backend_controller:
     namespace: ApacheSolrForTypo3\Solr\Controller\Backend\Search\
     resource: '../Classes/Controller/Backend/Search/*'


### PR DESCRIPTION
# What this pr does

As Extbase ControllerContext has been removed, we need a new method to transfer all EXT:solr related variables through all layouts, partials and templates without assigning them for each ViewHelper again ans again.
We implemented our own SolrVariableProvider, which extends Extbase StandardVariableProvider with "searchResultSet" and "typoScriptConfiguration".

# TYPO3 ChangeLog

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95139-ExtbaseControllerContext.html