### PR TITLE
[BUGFIX] Mark query modifiers as public in Services.yaml

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetPackage.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetPackage.php
@@ -24,13 +24,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 abstract class AbstractFacetPackage
 {
-    /**
-     * @return string
-     */
     abstract public function getParserClassName(): string;
 
     /**
-     * @return FacetParserInterface
      * @throws InvalidFacetPackageException
      */
     public function getParser(): FacetParserInterface
@@ -39,12 +35,10 @@ abstract class AbstractFacetPackage
         if (!$parser instanceof FacetParserInterface) {
             throw new InvalidFacetPackageException('Invalid parser for package ' . __CLASS__);
         }
+
         return $parser;
     }
 
-    /**
-     * @return string
-     */
     public function getUrlDecoderClassName(): string
     {
         return DefaultUrlDecoder::class;
@@ -52,7 +46,6 @@ abstract class AbstractFacetPackage
 
     /**
      * @throws InvalidUrlDecoderException
-     * @return FacetUrlDecoderInterface
      */
     public function getUrlDecoder(): FacetUrlDecoderInterface
     {
@@ -60,12 +53,10 @@ abstract class AbstractFacetPackage
         if (!$urlDecoder instanceof FacetUrlDecoderInterface) {
             throw new InvalidUrlDecoderException('Invalid url-decoder for package ' . __CLASS__);
         }
+
         return $urlDecoder;
     }
 
-    /**
-     * @return string
-     */
     public function getQueryBuilderClassName(): string
     {
         return DefaultFacetQueryBuilder::class;
@@ -73,14 +64,14 @@ abstract class AbstractFacetPackage
 
     /**
      * @throws InvalidQueryBuilderException
-     * @return FacetQueryBuilderInterface
      */
     public function getQueryBuilder(): FacetQueryBuilderInterface
     {
-        $urlDecoder = GeneralUtility::makeInstance($this->getQueryBuilderClassName());
-        if (!$urlDecoder instanceof FacetQueryBuilderInterface) {
+        $facetQueryBuilder = GeneralUtility::makeInstance($this->getQueryBuilderClassName());
+        if (!$facetQueryBuilder instanceof FacetQueryBuilderInterface) {
             throw new InvalidQueryBuilderException('Invalid query-builder for package ' . __CLASS__);
         }
-        return $urlDecoder;
+
+        return $facetQueryBuilder;
     }
 }

--- a/Classes/Query/Modifier/Elevation.php
+++ b/Classes/Query/Modifier/Elevation.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Enables query elevation
@@ -28,18 +27,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Elevation implements Modifier
 {
-    /**
-     * @var QueryBuilder
-     */
-    protected $queryBuilder;
+    protected QueryBuilder $queryBuilder;
 
-    /**
-     * Elevation constructor.
-     * @param QueryBuilder|null $builder
-     */
-    public function __construct(QueryBuilder $builder = null)
+    public function __construct(QueryBuilder $queryBuilder)
     {
-        $this->queryBuilder = $builder ?? GeneralUtility::makeInstance(QueryBuilder::class);
+        $this->queryBuilder = $queryBuilder;
     }
 
     /**

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use InvalidArgumentException;
 
 /**
  * Modifies a query to add faceting parameters
@@ -39,28 +38,16 @@ use InvalidArgumentException;
  */
 class Faceting implements Modifier, SearchRequestAware
 {
-    /**
-     * @var FacetRegistry
-     */
     protected FacetRegistry $facetRegistry;
 
-    /**
-     * @var SearchRequest|null
-     */
     protected ?SearchRequest $searchRequest = null;
 
-    /**
-     * @param FacetRegistry $facetRegistry
-     */
     public function __construct(FacetRegistry $facetRegistry)
     {
         $this->facetRegistry = $facetRegistry;
     }
 
-    /**
-     * @param SearchRequest $searchRequest
-     */
-    public function setSearchRequest(SearchRequest $searchRequest)
+    public function setSearchRequest(SearchRequest $searchRequest): void
     {
         $this->searchRequest = $searchRequest;
     }
@@ -79,6 +66,10 @@ class Faceting implements Modifier, SearchRequestAware
     public function modifyQuery(Query $query): Query
     {
         $typoScriptConfiguration = $this->searchRequest->getContextTypoScriptConfiguration();
+        if ($typoScriptConfiguration instanceof TypoScriptConfiguration) {
+            return $query;
+        }
+
         $faceting = FacetingBuilder::fromTypoScriptConfiguration($typoScriptConfiguration);
 
         $allFacets = $typoScriptConfiguration->getSearchFacetingFacets();
@@ -104,29 +95,22 @@ class Faceting implements Modifier, SearchRequestAware
     /**
      * Delegates the parameter building to specialized functions depending on
      * the type of facet to add.
-     * @param $allFacets
-     * @param TypoScriptConfiguration $typoScriptConfiguration
-     * @return array
+     *
      * @throws InvalidFacetPackageException
      * @throws InvalidQueryBuilderException
      */
-    protected function buildFacetingParameters($allFacets, TypoScriptConfiguration $typoScriptConfiguration): array
+    protected function buildFacetingParameters(array $allFacets, TypoScriptConfiguration $typoScriptConfiguration): array
     {
         $facetParameters = [];
-
         foreach ($allFacets as $facetName => $facetConfiguration) {
             $facetName = substr($facetName, 0, -1);
             $type = $facetConfiguration['type'] ?? 'options';
             $facetParameterBuilder = $this->facetRegistry->getPackage($type)->getQueryBuilder();
 
-            if (is_null($facetParameterBuilder)) {
-                throw new InvalidArgumentException('No query build configured for facet ' . htmlspecialchars($facetName));
-            }
-
-            $facetParameters = array_merge_recursive($facetParameters, $facetParameterBuilder->build($facetName, $typoScriptConfiguration));
+            $facetParameters[] = $facetParameterBuilder->build($facetName, $typoScriptConfiguration);
         }
 
-        return $facetParameters;
+        return array_merge_recursive(...$facetParameters);
     }
 
     /**
@@ -173,7 +157,11 @@ class Faceting implements Modifier, SearchRequestAware
     protected function getFilterTag(array $facetConfiguration, bool $keepAllFacetsOnSelection): string
     {
         $tag = '';
-        if (($facetConfiguration['keepAllOptionsOnSelection'] ?? null) == 1 || ($facetConfiguration['addFieldAsTag'] ?? null) == 1 || $keepAllFacetsOnSelection) {
+        if (
+            (int)($facetConfiguration['keepAllOptionsOnSelection'] ?? 0) === 1
+            || (int)($facetConfiguration['addFieldAsTag'] ?? 0) === 1
+            || $keepAllFacetsOnSelection
+        ) {
             $tag = '{!tag=' . addslashes($facetConfiguration['field']) . '}';
         }
 
@@ -183,10 +171,6 @@ class Faceting implements Modifier, SearchRequestAware
     /**
      * This method is used to build the filter parts of the query.
      *
-     * @param array $facetConfiguration
-     * @param string $facetName
-     * @param array $filterValues
-     * @return array
      * @throws InvalidFacetPackageException
      * @throws InvalidUrlDecoderException
      */
@@ -196,10 +180,6 @@ class Faceting implements Modifier, SearchRequestAware
 
         $type = $facetConfiguration['type'] ?? 'options';
         $filterEncoder = $this->facetRegistry->getPackage($type)->getUrlDecoder();
-
-        if (is_null($filterEncoder)) {
-            throw new InvalidArgumentException('No encoder configured for facet ' . htmlspecialchars($facetName));
-        }
 
         foreach ($filterValues as $filterValue) {
             $filterOptions = isset($facetConfiguration['type']) ? ($facetConfiguration[$facetConfiguration['type'] . '.'] ?? null) : null;
@@ -216,10 +196,6 @@ class Faceting implements Modifier, SearchRequestAware
 
     /**
      * Groups facet values by facet name.
-     *
-     * @param array $resultParameters
-     * @param array $allFacets
-     * @return array
      */
     protected function getFiltersByFacetName(array $resultParameters, array $allFacets): array
     {
@@ -233,16 +209,22 @@ class Faceting implements Modifier, SearchRequestAware
         // filters for a certain facet/field
         // $filtersByFacetName look like ['name' =>  ['value1', 'value2'], 'fieldname2' => ['foo']]
         $filtersByFacetName = [];
-        if ($this->searchRequest->getContextTypoScriptConfiguration()->getSearchFacetingUrlParameterStyle() === UrlFacetContainer::PARAMETER_STYLE_ASSOC) {
+        if (
+            ($typoScriptConfiguration = $this->searchRequest->getContextTypoScriptConfiguration())
+            && $typoScriptConfiguration instanceof TypoScriptConfiguration
+            && $typoScriptConfiguration->getSearchFacetingUrlParameterStyle() === UrlFacetContainer::PARAMETER_STYLE_ASSOC
+        ) {
             $filters = array_keys($filters);
         }
+
         foreach ($filters as $filter) {
             if (!str_contains($filter, ':')) {
                 continue;
             }
+
             // only split by the first colon to allow using colons in the filter value itself
-            list($filterFacetName, $filterValue) = explode(':', $filter, 2);
-            if (in_array($filterFacetName, $configuredFacets)) {
+            [$filterFacetName, $filterValue] = explode(':', $filter, 2);
+            if (in_array($filterFacetName, $configuredFacets, true)) {
                 $filtersByFacetName[$filterFacetName][] = $filterValue;
             }
         }
@@ -253,7 +235,6 @@ class Faceting implements Modifier, SearchRequestAware
     /**
      * Gets the facets as configured through TypoScript
      *
-     * @param array $allFacets
      * @return array An array of facet names as specified in TypoScript
      */
     protected function getFacetNamesWithConfiguredField(array $allFacets): array

--- a/Classes/Query/Modifier/Statistics.php
+++ b/Classes/Query/Modifier/Statistics.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Enables tracking of detailed statistics
@@ -28,18 +27,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Statistics implements Modifier
 {
-    /**
-     * @var QueryBuilder
-     */
-    protected $queryBuilder;
+    protected QueryBuilder $queryBuilder;
 
-    /**
-     * Elevation constructor.
-     * @param QueryBuilder|null $builder
-     */
-    public function __construct(QueryBuilder $builder = null)
+    public function __construct(QueryBuilder $queryBuilder)
     {
-        $this->queryBuilder = $builder ?? GeneralUtility::makeInstance(QueryBuilder::class);
+        $this->queryBuilder = $queryBuilder;
     }
 
     /**

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -101,7 +101,7 @@ class TranslateViewHelper extends AbstractViewHelper
         string $extensionName = 'solr',
         ?array $arguments = null,
         ?string $languageKey = null,
-        array $alternativeLanguageKeys = []
+        ?array $alternativeLanguageKeys = []
     ): string {
         $result = LocalizationUtility::translate(
             $id,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,12 +20,22 @@ services:
     public: true
     autowire: true
 
+  query_modifier:
+    namespace: ApacheSolrForTypo3\Solr\Query\Modifier\
+    resource: '../Classes/Query/Modifier/*'
+    public: true
+    autowire: true
+
   backend_controller:
     namespace: ApacheSolrForTypo3\Solr\Controller\Backend\Search\
     resource: '../Classes/Controller/Backend/Search/*'
     public: true
     autowire: true
     tags: ['backend.controller']
+
+  ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder:
+    public: true
+    autowire: true
 
   # BE modules, plugins
   ApacheSolrForTypo3\Solr\Backend\SettingsPreviewOnPlugins:


### PR DESCRIPTION
# What this pr does

Query Modifiers are called with GeneralUtility::makeInstance. That's why we have to mark them as public in Services.yaml.
Further it removes superflous annotations and adds checks against null in SearchUriBuilder, AbstractFacetPackage and TranslateViewHelper.