### PR TITLE
[BUGFIX] Replace ControllerContext

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -63,7 +63,7 @@ abstract class AbstractBaseController extends ActionController
     private ?SolrConfigurationManager $solrConfigurationManager = null;
 
     /**
-     * The configuration is private if you need it please get it from the controllerContext.
+     * The configuration is private if you need it please get it from the SolrVariableProvider of RenderingContext.
      *
      * @var TypoScriptConfiguration|null
      */

--- a/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
@@ -20,7 +20,6 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use InvalidArgumentException;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -31,9 +30,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 abstract class AbstractSolrFrontendViewHelper extends AbstractSolrViewHelper
 {
-    /**
-     * @return TypoScriptConfiguration|null
-     */
     protected function getTypoScriptConfiguration(): ?TypoScriptConfiguration
     {
         return $this->renderingContext->getVariableProvider()->get('typoScriptConfiguration');
@@ -48,13 +44,12 @@ abstract class AbstractSolrFrontendViewHelper extends AbstractSolrViewHelper
     }
 
     /**
-     * @param RenderingContextInterface $renderingContext
      * @return SearchResultSet|GroupItem|null
      */
     protected static function getUsedSearchResultSetFromRenderingContext(
         RenderingContextInterface $renderingContext
     ) {
         return $renderingContext->getVariableProvider()->get('resultSet')
-            ?? $renderingContext->getControllerContext()->getSearchResultSet();
+            ?? $renderingContext->getVariableProvider()->get('searchResultSet');
     }
 }

--- a/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
@@ -23,6 +23,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
@@ -36,40 +38,28 @@ abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
 {
     use CompileWithRenderStatic;
 
-    /**
-     * @var SearchUriBuilder
-     */
     protected static SearchUriBuilder $searchUriBuilder;
 
-    /**
-     * @param SearchUriBuilder $searchUriBuilder
-     */
-    public function injectSearchUriBuilder(SearchUriBuilder $searchUriBuilder)
+    public function injectSearchUriBuilder(SearchUriBuilder $searchUriBuilder): void
     {
         self::$searchUriBuilder = $searchUriBuilder;
     }
 
-    /**
-     * @param RenderingContextInterface|null $renderingContext
-     * @return SearchUriBuilder
-     */
     protected static function getSearchUriBuilder(RenderingContextInterface $renderingContext = null): SearchUriBuilder
     {
         if (!isset(self::$searchUriBuilder)) {
             self::$searchUriBuilder = GeneralUtility::makeInstance(SearchUriBuilder::class);
         }
 
-        if ($renderingContext && method_exists($renderingContext, 'getControllerContext')) {
-            self::$searchUriBuilder->injectUriBuilder($renderingContext->getControllerContext()->getUriBuilder());
+        if ($renderingContext instanceof RenderingContext) {
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $uriBuilder->reset()->setRequest($renderingContext->getRequest());
+            self::$searchUriBuilder->injectUriBuilder($uriBuilder);
         }
 
         return self::$searchUriBuilder;
     }
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     * @return SearchRequest|null
-     */
     protected static function getUsedSearchRequestFromRenderingContext(RenderingContextInterface $renderingContext): ?SearchRequest
     {
         $resultSet = static::getUsedSearchResultSetFromRenderingContext($renderingContext);


### PR DESCRIPTION
# What this pr does

As extbase ControllerContext has been removed with TYPO3 12, we have replaced ControllerContext in various
ViewHelper classes.

Relates: #3376