### PR TITLE
[BUGFIX:BP:11.5] Sanitize frequent and last searches output

### DIFF
--- a/Resources/Private/Partials/Search/FrequentlySearched.html
+++ b/Resources/Private/Partials/Search/FrequentlySearched.html
@@ -19,7 +19,7 @@
 			<ul class="list-group list-group-flush collapse show" id="frequendSearches">
 				<f:for each="{frequentSearches}" as="searchedForInfo">
 					<li class="list-group-item {searchedForInfo.class}">
-						<a href="{s:uri.search.startNewSearch(queryString: searchedForInfo.q)}" class="solr-ajaxified">{searchedForInfo.q}</a>
+						<a href="{s:uri.search.startNewSearch(queryString: searchedForInfo.q)}" class="solr-ajaxified"><f:format.htmlentities>{searchedForInfo.q}</f:format.htmlentities></a>
 					</li>
 				</f:for>
 			</ul>

--- a/Resources/Private/Partials/Search/LastSearches.html
+++ b/Resources/Private/Partials/Search/LastSearches.html
@@ -20,7 +20,7 @@
 			<ul class="list-group collapse show" id="lastSearches">
 				<f:for each="{lastSearches}" as="searchedFor">
 					<li class="list-group-item">
-						<a href="{s:uri.search.startNewSearch(queryString: searchedFor)}" class="solr-ajaxified">{searchedFor}</a>
+						<a href="{s:uri.search.startNewSearch(queryString: searchedFor)}" class="solr-ajaxified"><f:format.htmlentities>{searchedFor}</f:format.htmlentities></a>
 					</li>
 				</f:for>
 			</ul>


### PR DESCRIPTION
Backport of https://github.com/TYPO3-Solr/ext-solr/pull/3590

---

# What this pr does

Wraps output of frequent searches and last searches in format.htmlentities, to prevent XSS. In rare scenarios there might be issues with unsanitized output of frequent searches and/or last searches, this issues are now solved.

The StatisticsWriterProcessor is already sanitizing the stored terms, but as it's possible to use any custom table it should be ensured the data is sanitized.

If last searches is activated and configured for global mode, there might be issues too. Though it's required that the prepared query delivers result documents, as EXT:solr will only store the terms if results are found, the output should be sanitized too.

Please add a description here

# How to test

As it required special configurations and index contents to reproduce the issues, the easiest way is to place simulated data in `tx_solr_statistics` and `tx_solr_last_searches`.  If last searches and frequent searches (global mode) are activated a sanitized string should be visible.

Ports: #3590
Resolves: #3589

