### PR TITLE
[BUGFIX] Avoid getSolrConfiguration() on null

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -201,15 +201,20 @@ class Queue
             return 0;
         }
 
+        /* @var SiteRepository $siteRepository */
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         foreach ($rootPageIds as $rootPageId) {
             $skipInvalidRootPage = $rootPageId === 0;
             if ($skipInvalidRootPage) {
                 continue;
             }
 
-            /* @var SiteRepository $siteRepository */
-            $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-            $solrConfiguration = $siteRepository->getSiteByRootPageId($rootPageId)->getSolrConfiguration();
+            $site = $siteRepository->getSiteByRootPageId($rootPageId);
+            if ($site === null) {
+                continue;
+            }
+
+            $solrConfiguration = $site->getSolrConfiguration();
             $indexingConfiguration = $this->recordService->getIndexingConfigurationName($itemType, $itemUid, $solrConfiguration);
             if ($indexingConfiguration === null) {
                 continue;


### PR DESCRIPTION
Fixes: #3597

---

## Maintainers comment:

Ports: 
- [x] release-11.5.x
- ~[ ] release-11.2.x(ELTS?)~ not using the Site object
- ~[ ] release-11.0.x(ELTS?)~  not using the Site object