### PR TITLE
[TASK:BP:11.2] Disable sql handler

### DIFF
--- a/Resources/Private/Solr/configsets/ext_solr_11_2_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_2_0/conf/solrconfig.xml
@@ -363,6 +363,7 @@
 		</arr>
 	</requestHandler>
 
+	<requestHandler name="/sql" class="solr.NotFoundRequestHandler"/>
 
 	<searchComponent
 		name="clusteringComponent"


### PR DESCRIPTION
Backport of #3602 

---------

# What this pr does

The SQL handler is not used by EXT:solr and is only available if SolrCloud is used. But as there is a vulnerability we are explicitly deactivating this handler, as adviced in CVE-2022-39135.

# How to test

SQL handler is not used by  EXT:solr, so just check if core can be loaded after applying the changes. 

Resolves: #3414
