### PR TITLE
[BUGFIX] Avoid PHP 8 warning when page indexing fails

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -292,6 +292,7 @@ class PageIndexer extends AbstractFrontendHelper implements SingletonInterface
                 $this->responseData['documentsSentToSolr'][] = (array)$document;
             }
         } catch (Throwable $e) {
+            $this->responseData['pageIndexed'] = false;
             if ($configuration->getLoggingExceptions()) {
                 $this->logger->log(
                     SolrLogManager::ERROR,


### PR DESCRIPTION
# What this pr does

Set variable `$this->responseData['pageIndexed'] = false` try/catch to make it available for further processing

# How to test

See detailed information in related issue

Fixes: #3605 
