### PR TITLE
[BUGFIX] Do not list cores twice in Index Inspector

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -97,9 +97,14 @@ class InfoModuleController extends AbstractModuleController
             return;
         }
 
+        $alreadyListedConnections = [];
         foreach ($connections as $connection) {
             $coreAdmin = $connection->getAdminService();
             $coreUrl = (string)$coreAdmin;
+            if (in_array($coreUrl, $alreadyListedConnections)) {
+                continue;
+            }
+            $alreadyListedConnections[] = $coreUrl;
 
             if ($coreAdmin->ping()) {
                 $connectedHosts[] = $coreUrl;
@@ -218,8 +223,17 @@ class InfoModuleController extends AbstractModuleController
     {
         $solrCoreConnections = $this->solrConnectionManager->getConnectionsBySite($this->selectedSite);
         $documentsByCoreAndType = [];
+        $alreadyListedCores = [];
         foreach ($solrCoreConnections as $languageId => $solrCoreConnection) {
             $coreAdmin = $solrCoreConnection->getAdminService();
+
+            // Do not list cores twice when multiple languages use the same core
+            $url = (string)$coreAdmin;
+            if (in_array($url, $alreadyListedCores)) {
+                continue;
+            }
+            $alreadyListedCores[] = $url;
+
             $documents = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId($this->selectedPageUID, $languageId);
 
             $documentsByType = [];


### PR DESCRIPTION
In info module cores and connections are listed only once.

# How to test

Use one core for multiple languages => see info module

Fixes: #3616

---

Maintaners comments:
Port into:
- [x] release-11.5.x
