### PR TITLE
[TASK] Use stable testing framework v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     needs: ci_bootstrapping
-    continue-on-error: ${{ contains(matrix.TYPO3, '-dev') }}
+    continue-on-error: true
     strategy:
       matrix: ${{fromJson(needs.ci_bootstrapping.outputs.matrix)}}
     env:

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -126,7 +126,7 @@ class RepositoryTest extends SetUpUnitTestCase
         $solrConnectionManager->expects(self::any())->method('getConnectionByPageId')->willReturn($solrConnectionMock);
         $mockedSingletons = [ConnectionManager::class => $solrConnectionManager];
 
-        $search = $this->getAccessibleMock(Search::class, ['search', 'getResultDocumentsEscaped'], [], '', false);
+        $search = $this->getAccessibleMock(Search::class, ['search'], [], '', false);
 
         GeneralUtility::resetSingletonInstances($mockedSingletons);
 
@@ -144,7 +144,7 @@ class RepositoryTest extends SetUpUnitTestCase
         $queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
 
         /* @var Repository $apacheSolrDocumentRepository */
-        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getQueryForPage', 'getSearch'], [null, null, $queryBuilderMock]);
+        $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getSearch'], [null, null, $queryBuilderMock]);
         $apacheSolrDocumentRepository->expects(self::once())->method('getSearch')->willReturn($search);
         $queryMock = $this->getDumbMock(Query::class);
         $queryBuilderMock->expects(self::any())->method('buildPageQuery')->willReturn($queryMock);

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "phpunit/phpunit": "^9.5",
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "~0.7.1",
-    "typo3/testing-framework": "dev-7-composerinstaller5-fix"
+    "typo3/testing-framework": "^7.0"
   },
   "replace": {
     "apache-solr-for-typo3/solrfluid": "*",


### PR DESCRIPTION
This change updates the TYPO3 testing framework to v7.0.1, which is compatible with TYPO3 v11 and v12.