### PR TITLE
[BUGFIX] make CE search form in backend editable again

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use function str_starts_with;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -209,7 +210,8 @@ class FlexFormUserFunctions
             return null;
         }
 
-        $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
+        /** @var ConfigurationManagerInterface $configurationManager */
+        $configurationManager = GeneralUtility::makeInstance(ObjectManager::class)->get(ConfigurationManagerInterface::class);
         $typoScript = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 
         return GeneralUtility::makeInstance(TypoScriptConfiguration::class, $typoScript);


### PR DESCRIPTION
Especially on TYPO3 10 the userfunction to load the flex form configuration produced an error.

This implements `TYPO3\CMS\Extbase\Object->get()` - deprecated by TYPO3 12:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.4/Deprecation-90803-DeprecationOfObjectManagergetInExtbaseContext.html

# Technical details

`FlexFormUserFunctions` does not implement the extbase controller and thereby does not have dependency injection.
With missing dependency injection the instantiation of the `Interface::class` by `GeneralUtility::makeInstance(ConfigurationManagerInterface::class)` fails with:
`Cannot instantiate interface TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface`

The solution to instantiate an object of `ConfigurationManager::class` is not feasible here - there are different implementations of `ConfigurationManagerInterface::class` for the frontend and backend.

So we are falling back to the solution provided in `GeneralUtility::makeInstance()`:
https://github.com/TYPO3/typo3/blob/808ef61a53bc1e7ef65b715c13727b0f2d086c24/typo3/sysext/core/Classes/Utility/GeneralUtility.php#L3441-L3445
> You may want to use \TYPO3\CMS\Extbase\Object\ObjectManager::get() if you
> want TYPO3 to take care about injecting dependencies of the class to be 
> created. Therefore create an instance of ObjectManager via
> GeneralUtility::makeInstance() first and call its get() method to get
> the instance of a specific class.

# Further reading on extbase and dependency injection

- https://www.derhansen.de/2022/10/problem-with-all-extbase-plugins-during-typo3-11-update.html
- https://github.com/FluidTYPO3/vhs/pull/1368#issuecomment-327141164


# How to test

This is reproducible by multiple users.

Fixes: #3622

---

Maintaners comments:

Todos: 

- [x] Rebase and change target into release-11.5.x

Port into:
- [ ] release-11.2.x