### PR TITLE
[BUGFIX] Fixes multiple sortings

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -62,9 +62,8 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
     protected function parseSortingIntoObjects(SearchResultSet $resultSet): SearchResultSet
     {
         $configuration = $resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration();
+        $activeSortings = $resultSet->getUsedSearchRequest()->getSeperatedSortings();
         $hasSorting = $resultSet->getUsedSearchRequest()->getHasSorting();
-        $activeSortingName = $resultSet->getUsedSearchRequest()->getSortingName();
-        $activeSortingDirection = $resultSet->getUsedSearchRequest()->getSortingDirection();
 
         // no configuration available
         if (!isset($configuration)) {
@@ -82,9 +81,9 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
 
             // when we have an active sorting in the request we compare the sortingName and mark is as active and
             // use the direction from the request
-            if ($hasSorting && $activeSortingName == $sortingName) {
+            if ($hasSorting && array_key_exists($sortingName, $activeSortings)) {
                 $selected = true;
-                $direction = $activeSortingDirection;
+                $direction = $activeSortings[$sortingName];
             }
 
             $field = $sortingOptions['field'];

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * The searchRequest is used to act as an api to the arguments that have been passed
@@ -262,6 +263,22 @@ class SearchRequest
     public function getHasFacetValue(string $facetName, mixed $facetValue): bool
     {
         return $this->activeFacetContainer->hasFacetValue($facetName, $facetValue);
+    }
+
+    /**
+     * Returns all sortings in the sorting string e.g. ['title' => 'asc', 'relevance' => 'desc']
+     */
+    public function getSeperatedSortings(): array
+    {
+        $parsedSortings = [];
+        $explodedSortings = GeneralUtility::trimExplode(',', $this->getSorting(), true);
+
+        foreach ($explodedSortings as $sorting) {
+            $sortingSeperated = explode(' ', $sorting);
+            $parsedSortings[$sortingSeperated[0]] = $sortingSeperated[1];
+        }
+
+        return $parsedSortings;
     }
 
     public function getHasSorting(): bool

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -1062,6 +1062,9 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $usedSearchRequest->expects(self::any())->method('getHasSorting')->willReturn(true);
         $usedSearchRequest->expects(self::any())->method('getSortingName')->willReturn('title');
         $usedSearchRequest->expects(self::any())->method('getSortingDirection')->willReturn('desc');
+        $usedSearchRequest->expects(self::any())->method('getSeperatedSortings')->willReturn(
+            ['title' => 'desc', 'relevance' => 'asc']
+        );
 
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);


### PR DESCRIPTION
# What this pr does

Enables to resolve a solr response when multiple sortings are passed as argument.

# How to test

1. Configure multiple sorting options (see attached img)
2. Pass multiple sorting options to the searchrequest (see attached img)


## Images

![Bildschirmfoto vom 2023-05-10 16-48-54](https://github.com/TYPO3-Solr/ext-solr/assets/89908559/6794c864-2ce3-4be5-8278-4efde86daee2)
![Bildschirmfoto vom 2023-05-10 16-51-01](https://github.com/TYPO3-Solr/ext-solr/assets/89908559/37b27ff3-f041-479c-b284-1ad4b35cfc52)

Fixes: #3627
