### PR TITLE
[TASK] Remove unused tx_solr_cache DB tables

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -84,34 +84,6 @@ CREATE TABLE tx_solr_indexqueue_indexing_property (
 	KEY item_id (item_id)
 ) ENGINE=InnoDB;
 
-
-#
-# Table structure for table 'tx_solr_cache'
-#
-
-CREATE TABLE tx_solr_cache (
-	id int(11) unsigned NOT NULL auto_increment,
-	identifier varchar(250) DEFAULT '' NOT NULL,
-	crdate int(11) unsigned DEFAULT '0' NOT NULL,
-	content mediumblob,
-	lifetime int(11) unsigned DEFAULT '0' NOT NULL,
-	PRIMARY KEY (id),
-	KEY cache_id (identifier)
-) ENGINE=InnoDB;
-
-
-#
-# Table structure for table 'tx_solr_cache_tags'
-#
-CREATE TABLE tx_solr_cache_tags (
-	id int(11) unsigned NOT NULL auto_increment,
-	identifier varchar(250) DEFAULT '' NOT NULL,
-	tag varchar(250) DEFAULT '' NOT NULL,
-	PRIMARY KEY (id),
-	KEY cache_id (identifier),
-	KEY cache_tag (tag)
-) ENGINE=InnoDB;
-
 #
 # Table structure for table 'tx_solr_eventqueue_item'
 #


### PR DESCRIPTION
# What this pr does

There are SQL CREATE TABLE definitions for tx_solr_cache and tx_solr_cache_tags.

These tables have been added back then when TYPO3 did not always create cache tables.

However, since TYPO3 v9, these tables have been renamed and are automatically created, so the SQL definition can be removed.

The SQL tables are not referenced anywhere in the current source code.

# How to test

Re-install the extension, drop the tables and see if everything still works.

Fixes: #3636 