### PR TITLE
[TASK] Integrate phpstan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 /.dockerignore export-ignore
 /.gitattributes export-ignore
 /.scrutinizer.yml export-ignore
-/.travis.yml export-ignore
 /.styleci.yml export-ignore
 /Dockerfile export-ignore
 /CONTRIBUTING.md export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,6 @@ jobs:
             ${{ env.CI_BUILD_DIRECTORY }}/bin
             ${{ env.CI_BUILD_DIRECTORY }}/vendor
             ${{ env.COMPOSER_GLOBAL_REQUEREMENTS }}
-            composer.json
-            composer.lock
           key: ${{ env.CI_BUILD_CACHE_KEY }}
       -
         name: CI-Bootstrap

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,7 @@ filter:
 
 tools:
   php_cpd:
-    enabled: true
+    enabled: false
 
   # we do this on GitHub-Actions via typo3/coding-standards
   php_code_sniffer:
@@ -19,45 +19,11 @@ tools:
     enabled: false
 
   php_mess_detector:
-    enabled: true
-    config:
-      controversial_rules:
-        superglobals: false
+    enabled: false
 
   php_pdepend:
-    enabled: true
-
-  php_analyzer:
-    enabled: true
-    dependency_paths:
-      - 'Resources/Private/Php/*'
+    enabled: false
 
   external_code_coverage:
     runs: 2
     timeout: 2400
-
-checks:
-  php:
-    excluded_dependencies:
-      - typo3/cms-install
-    avoid_superglobals: false
-
-build_failure_conditions:
-  - 'patches.label("Doc Comments").count > 10'
-  - 'patches.label("Spacing").count > 15'
-  - 'issues.label("coding-style").count > 10'
-  - 'issues.severity(>= MAJOR).count > 260'
-  - 'project.metric("scrutinizer.quality", < 8)'
-  - 'project.metric_change("scrutinizer.test_coverage", < -0.10)'
-
-
-build:
-  environment:
-    php:
-      # We want to test with the smallest supported TYPO3 PHP version
-      version: 8.1
-  nodes:
-    analysis:
-      tests:
-        override:
-          - php-scrutinizer-run

--- a/Build/Test/cibuild.sh
+++ b/Build/Test/cibuild.sh
@@ -71,6 +71,15 @@ else
   fi
 fi
 
+echo -e "\n\n"
+echo "Run PHPStan analysis"
+if ! composer tests:phpstan
+then
+  EXIT_CODE=7
+  echo "Error during running the PHPStan analysis, please check and fix them."
+  echo "Tip for working on them: "
+  echo "  TYPO3_VERSION="${TYPO3_VERSION}" composer tests:setup && composer tests:phpstan"
+fi
 
 echo -e "\n\n"
 echo "Run unit tests"

--- a/Build/Test/phpstan-constants.php
+++ b/Build/Test/phpstan-constants.php
@@ -1,0 +1,5 @@
+<?php
+
+// testing-framework defines this, used in various tests.
+define('ORIGINAL_ROOT', dirname(__FILE__, 2) . '/');
+define('LF', "\n");

--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -18,3 +18,6 @@ parameters:
 
   ignoreErrors:
     - '#^Variable \$_EXTKEY might not be defined\.#'
+    - '#^Method .*\\QueryBuilder::buildSuggestQuery\(\) should return .*\\SuggestQuery but returns .*\\Search\\Query\\Query\|null.#'
+    - '#^Method .*\\QueryBuilder::use.*FromTypoScript\(\) should return .*\\QueryBuilder but returns .*\\AbstractQueryBuilder.#'
+    - '#^Access to protected property .*\\PageRepository::\$where_groupAccess.#'

--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+  - ../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+  level: 3
+  treatPhpDocTypesAsCertain: false
+
+  bootstrapFiles:
+    - phpstan-constants.php
+
+  paths:
+    - %currentWorkingDirectory%/Classes
+    - %currentWorkingDirectory%/Tests
+
+  ignoreErrors:
+    - '#^Variable \$_EXTKEY might not be defined\.#'

--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
 
   universalObjectCratesClasses:
     - ApacheSolrForTypo3\Solr\System\Solr\Document\Document
+    - ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult
 
   paths:
     - %currentWorkingDirectory%/Classes

--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -8,6 +8,9 @@ parameters:
   bootstrapFiles:
     - phpstan-constants.php
 
+  universalObjectCratesClasses:
+    - ApacheSolrForTypo3\Solr\System\Solr\Document\Document
+
   paths:
     - %currentWorkingDirectory%/Classes
     - %currentWorkingDirectory%/Tests

--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -80,7 +80,7 @@ class Rootline
             $rawRootlineElements = explode(self::ELEMENT_DELIMITER, $accessRootline);
             foreach ($rawRootlineElements as $rawRootlineElement) {
                 try {
-                    $this->push(GeneralUtility::makeInstance(RootlineElement::class, /** @scrutinizer ignore-type */ $rawRootlineElement));
+                    $this->push(GeneralUtility::makeInstance(RootlineElement::class, $rawRootlineElement));
                 } catch (RootlineElementFormatException) {
                     // just ignore the faulty element for now, might log this later
                 }
@@ -144,7 +144,6 @@ class Rootline
             ) {
                 $accessRootline->push(GeneralUtility::makeInstance(
                     RootlineElement::class,
-                    /** @scrutinizer ignore-type */
                     $pageRecord['uid'] . RootlineElement::PAGE_ID_GROUP_DELIMITER . $pageRecord['fe_group']
                 ));
             }
@@ -158,7 +157,6 @@ class Rootline
         if ($currentPageRecord['fe_group']) {
             $accessRootline->push(GeneralUtility::makeInstance(
                 RootlineElement::class,
-                /** @scrutinizer ignore-type */
                 $currentPageRecord['uid'] . RootlineElement::PAGE_ID_GROUP_DELIMITER . $currentPageRecord['fe_group']
             ));
         }

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -205,12 +205,9 @@ class ConnectionManager implements SingletonInterface
      */
     protected function buildNoConnectionException(string $message): NoSolrConnectionFoundException
     {
-        /* @var NoSolrConnectionFoundException $noSolrConnectionException */
         return GeneralUtility::makeInstance(
             NoSolrConnectionFoundException::class,
-            /** @scrutinizer ignore-type */
             $message,
-            /** @scrutinizer ignore-type */
             1575396474
         );
     }

--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -95,11 +95,8 @@ class Classification extends AbstractContentObject
             $className = $class['class'];
             $classifications[] = GeneralUtility::makeInstance(
                 ClassificationItem::class,
-                /** @scrutinizer ignore-type */
                 $matchPatterns,
-                /** @scrutinizer ignore-type */
                 $unMatchPatters,
-                /** @scrutinizer ignore-type */
                 $className
             );
         }

--- a/Classes/ContentObject/Content.php
+++ b/Classes/ContentObject/Content.php
@@ -39,7 +39,6 @@ class Content extends AbstractContentObject
     {
         $contentExtractor = GeneralUtility::makeInstance(
             HtmlContentExtractor::class,
-            /** @scrutinizer ignore-type */
             $this->getRawContent($this->cObj, $conf)
         );
 

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -371,7 +371,7 @@ class Relation extends AbstractContentObject
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($foreignTable);
         $queryBuilder->select('*')
             ->from($foreignTable)
-            ->where(/** @scrutinizer ignore-type */ $queryBuilder->expr()->in('uid', $uids));
+            ->where($queryBuilder->expr()->in('uid', $uids));
         if (isset($this->configuration['additionalWhereClause'])) {
             $queryBuilder->andWhere($this->configuration['additionalWhereClause']);
         }

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -166,9 +166,7 @@ abstract class AbstractBaseController extends ActionController
 
             $this->searchService = GeneralUtility::makeInstance(
                 SearchResultSetService::class,
-                /** @scrutinizer ignore-type */
                 $this->typoScriptConfiguration,
-                /** @scrutinizer ignore-type */
                 $search
             );
         } catch (NoSolrConnectionFoundException) {

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -179,7 +179,7 @@ abstract class AbstractBaseController extends ActionController
     protected function getSearchRequestBuilder(): SearchRequestBuilder
     {
         if ($this->searchRequestBuilder === null) {
-            $this->searchRequestBuilder = GeneralUtility::makeInstance(SearchRequestBuilder::class, /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
+            $this->searchRequestBuilder = GeneralUtility::makeInstance(SearchRequestBuilder::class, $this->typoScriptConfiguration);
         }
 
         return $this->searchRequestBuilder;
@@ -192,7 +192,7 @@ abstract class AbstractBaseController extends ActionController
     {
         if ($this->typoScriptConfiguration->getLoggingExceptions()) {
             /* @var SolrLogManager $logger */
-            $logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
             $logger->log(SolrLogManager::ERROR, 'Solr server is not available');
         }
     }

--- a/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
+++ b/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
@@ -147,7 +147,7 @@ class CoreOptimizationModuleController extends AbstractModuleController
 
         $coreAdmin = $this->selectedSolrCoreConnection->getAdminService();
         foreach ($fileLines as $baseWord => $synonyms) {
-            if (!isset($baseWord) || empty($synonyms)) {
+            if (empty($synonyms)) {
                 continue;
             }
             $this->deleteExistingSynonym($overrideExisting, $deleteSynonymsBefore, $baseWord);

--- a/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
+++ b/Classes/Controller/Backend/Search/CoreOptimizationModuleController.php
@@ -147,7 +147,7 @@ class CoreOptimizationModuleController extends AbstractModuleController
 
         $coreAdmin = $this->selectedSolrCoreConnection->getAdminService();
         foreach ($fileLines as $baseWord => $synonyms) {
-            if (empty($synonyms)) {
+            if (empty($baseWord) || empty($synonyms)) {
                 continue;
             }
             $this->deleteExistingSynonym($overrideExisting, $deleteSynonymsBefore, $baseWord);

--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -86,7 +86,7 @@ class IndexQueueModuleController extends AbstractModuleController
      */
     protected function getIndexQueueInitializationSelector(): string
     {
-        $selector = GeneralUtility::makeInstance(IndexingConfigurationSelectorField::class, /** @scrutinizer ignore-type */ $this->selectedSite);
+        $selector = GeneralUtility::makeInstance(IndexingConfigurationSelectorField::class, $this->selectedSite);
         $selector->setFormElementName('tx_solr-index-queue-initialization');
 
         return $selector->render();
@@ -229,7 +229,7 @@ class IndexQueueModuleController extends AbstractModuleController
     public function doIndexingRunAction(): ResponseInterface
     {
         /* @var IndexService $indexService */
-        $indexService = GeneralUtility::makeInstance(IndexService::class, /** @scrutinizer ignore-type */ $this->selectedSite);
+        $indexService = GeneralUtility::makeInstance(IndexService::class, $this->selectedSite);
         $indexWithoutErrors = $indexService->indexItems(1);
 
         $label = 'solr.backend.index_queue_module.flashmessage.success.index_manual';

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -30,18 +30,16 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Fluid\View\TemplateView;
+use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
  * Class SearchController
  *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
+ * @property AbstractTemplateView $view {@link AbstractTemplateView} is used in this scope. Line required by PhpStan.
  */
 class SearchController extends AbstractBaseController
 {
-    protected $view;
-
     /**
      * Provide search query in extbase arguments.
      */

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -55,11 +55,8 @@ class SuggestController extends AbstractBaseController
             /* @var SuggestService $suggestService */
             $suggestService = GeneralUtility::makeInstance(
                 SuggestService::class,
-                /** @scrutinizer ignore-type */
                 $this->typoScriptFrontendController,
-                /** @scrutinizer ignore-type */
                 $this->searchService,
-                /** @scrutinizer ignore-type */
                 $this->typoScriptConfiguration
             );
 

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -60,7 +60,7 @@ class IndexService
         $this->site = $site;
         $this->indexQueue = $queue ?? GeneralUtility::makeInstance(Queue::class);
         $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     public function setContextTask(IndexQueueWorkerTask $contextTask): void
@@ -195,7 +195,7 @@ class IndexService
         $indexerClass = $configuration->getIndexQueueIndexerByConfigurationName($indexingConfigurationName);
         $indexerConfiguration = $configuration->getIndexQueueIndexerConfigurationByConfigurationName($indexingConfigurationName);
 
-        $indexer = GeneralUtility::makeInstance($indexerClass, /** @scrutinizer ignore-type */ $indexerConfiguration);
+        $indexer = GeneralUtility::makeInstance($indexerClass, $indexerConfiguration);
         if (!($indexer instanceof Indexer)) {
             throw new RuntimeException(
                 'The indexer class "' . $indexerClass . '" for indexing configuration "' . $indexingConfigurationName . '" is not a valid indexer. Must be a subclass of ApacheSolrForTypo3\Solr\IndexQueue\Indexer.',

--- a/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
+++ b/Classes/Domain/Index/PageIndexer/Helper/UriBuilder/AbstractUriStrategy.php
@@ -37,7 +37,7 @@ abstract class AbstractUriStrategy
     public function __construct(
         SolrLogManager $logger = null
     ) {
-        $this->logger = $logger ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $logger ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     protected function applyTypoScriptOverridesOnIndexingUrl(UrlHelper $urlHelper, array $overrideConfiguration = []): UrlHelper

--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -125,7 +125,7 @@ abstract class AbstractStrategy
             $response = $solr->getWriteService()->deleteByQuery($query);
 
             if ($response->getHttpStatus() !== 200) {
-                $logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+                $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
                 $logger->log(
                     SolrLogManager::ERROR,
                     'Couldn\'t delete index document',

--- a/Classes/Domain/Index/Queue/IndexQueueIndexingPropertyRepository.php
+++ b/Classes/Domain/Index/Queue/IndexQueueIndexingPropertyRepository.php
@@ -38,12 +38,10 @@ class IndexQueueIndexingPropertyRepository extends AbstractRepository
         return $queryBuilder
             ->delete($this->table)
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq(
                     'root',
                     $queryBuilder->createNamedParameter($rootPid, PDO::PARAM_INT)
                 ),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq(
                     'item_id',
                     $queryBuilder->createNamedParameter($indexQueueUid, PDO::PARAM_INT)
@@ -71,7 +69,6 @@ class IndexQueueIndexingPropertyRepository extends AbstractRepository
             ->select('property_key', 'property_value')
             ->from($this->table)
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq(
                     'item_id',
                     $queryBuilder->createNamedParameter($indexQueueUid, PDO::PARAM_INT)

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -43,7 +43,6 @@ class QueueItemRepository extends AbstractRepository
     {
         $this->logger = $logManager ?? GeneralUtility::makeInstance(
             SolrLogManager::class,
-            /** @scrutinizer ignore-type */
             __CLASS__
         );
     }
@@ -60,11 +59,9 @@ class QueueItemRepository extends AbstractRepository
             ->select('uid', 'indexed')
             ->from($this->table)
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('root', $rootPageId)
             )
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->neq('indexed', 0)
             )
             ->orderBy('indexed', 'DESC')
@@ -85,7 +82,6 @@ class QueueItemRepository extends AbstractRepository
             ->select('uid', 'item_type', 'item_uid', 'errors')
             ->from($this->table)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter('')),
                 $queryBuilder->expr()->eq('root', $site->getRootPageId())
             )->executeQuery()
@@ -110,7 +106,6 @@ class QueueItemRepository extends AbstractRepository
         $queryBuilder = $this->getQueryBuilder();
         return $this->getPreparedFlushErrorQuery($queryBuilder)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('root', $site->getRootPageId())
             )
             ->executeStatement();
@@ -124,7 +119,6 @@ class QueueItemRepository extends AbstractRepository
         $queryBuilder = $this->getQueryBuilder();
         return $this->getPreparedFlushErrorQuery($queryBuilder)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('uid', $item->getIndexQueueUid())
             )
             ->executeStatement();
@@ -139,7 +133,6 @@ class QueueItemRepository extends AbstractRepository
             ->update($this->table)
             ->set('errors', '')
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->notLike('errors', $queryBuilder->createNamedParameter(''))
             );
     }
@@ -161,11 +154,8 @@ class QueueItemRepository extends AbstractRepository
             ->set('changed', $changedTime)
             ->set('indexing_priority', $indexingPriority)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('item_uid', $itemUid),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('root', $rootPageId)
             );
 
@@ -250,7 +240,6 @@ class QueueItemRepository extends AbstractRepository
             ->add('select', $queryBuilder->expr()->max('tstamp', 'changed_time'))
             ->from('tt_content')
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('pid', $pageUid)
             )
             ->executeQuery()
@@ -279,7 +268,6 @@ class QueueItemRepository extends AbstractRepository
                 ->add('select', $queryBuilder->expr()->max($timeStampField, 'changed_time'))
                 ->from($itemType)
                 ->orWhere(
-                    /** @scrutinizer ignore-type */
                     $queryBuilder->expr()->eq('uid', $itemUid),
                     $queryBuilder->expr()->eq($translationOriginalPointerField, $itemUid)
                 )
@@ -297,9 +285,7 @@ class QueueItemRepository extends AbstractRepository
         $queryBuilder = $this->getQueryBuilder();
         return $queryBuilder->count('uid')->from($this->table)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($itemType)),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('item_uid', $itemUid)
             );
     }
@@ -325,7 +311,7 @@ class QueueItemRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilderForContainsMethods($itemType, $itemUid);
         return (bool)$queryBuilder
-            ->andWhere(/** @scrutinizer ignore-type */ $queryBuilder->expr()->eq('root', $rootPageId))
+            ->andWhere($queryBuilder->expr()->eq('root', $rootPageId))
             ->executeQuery()
             ->fetchOne();
     }
@@ -339,7 +325,7 @@ class QueueItemRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilderForContainsMethods($itemType, $itemUid);
         return (bool)$queryBuilder
-            ->andWhere(/** @scrutinizer ignore-type */ $queryBuilder->expr()->gt('indexed', 0))
+            ->andWhere($queryBuilder->expr()->gt('indexed', 0))
             ->executeQuery()
             ->fetchOne();
     }
@@ -426,14 +412,12 @@ class QueueItemRepository extends AbstractRepository
     ): QueryBuilder {
         if (!empty($rootPageIds)) {
             $queryBuilderForDeletingItems->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilderForDeletingItems->expr()->in('root', $rootPageIds)
             );
         }
 
         if (!empty($indexQueueConfigurationList)) {
             $queryBuilderForDeletingItems->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilderForDeletingItems->expr()->in(
                     'indexing_configuration',
                     $queryBuilderForDeletingItems->createNamedParameter($indexQueueConfigurationList)
@@ -443,7 +427,6 @@ class QueueItemRepository extends AbstractRepository
 
         if (!empty($itemTypeList)) {
             $queryBuilderForDeletingItems->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilderForDeletingItems->expr()->in(
                     'item_type',
                     $queryBuilderForDeletingItems->createNamedParameter($itemTypeList)
@@ -453,7 +436,6 @@ class QueueItemRepository extends AbstractRepository
 
         if (!empty($itemUids)) {
             $queryBuilderForDeletingItems->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilderForDeletingItems->expr()->in('item_uid', $itemUids)
             );
         }
@@ -549,7 +531,7 @@ class QueueItemRepository extends AbstractRepository
             return null;
         }
 
-        return GeneralUtility::makeInstance(Item::class, /** @scrutinizer ignore-type */ $indexQueueItemRecord);
+        return GeneralUtility::makeInstance(Item::class, $indexQueueItemRecord);
     }
 
     /**

--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -442,7 +442,6 @@ class QueueItemRepository extends AbstractRepository
 
         if (!empty($uids)) {
             $queryBuilderForDeletingItems->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilderForDeletingItems->expr()->in('uid', $uids)
             );
         }
@@ -523,7 +522,7 @@ class QueueItemRepository extends AbstractRepository
         $indexQueueItemRecord = $queryBuilder
             ->select('*')
             ->from($this->table)
-            ->where(/** @scrutinizer ignore-type */ $queryBuilder->expr()->eq('uid', $uid))
+            ->where($queryBuilder->expr()->eq('uid', $uid))
             ->executeQuery()
             ->fetchAssociative();
 
@@ -545,7 +544,6 @@ class QueueItemRepository extends AbstractRepository
     {
         $queryBuilder = $this->getQueryBuilder();
         $compositeExpression = $queryBuilder->expr()->and(
-            /** @scrutinizer ignore-type */
             $queryBuilder->expr()->eq('item_type', $queryBuilder->getConnection()->quote($itemType, PDO::PARAM_STR)),
             $queryBuilder->expr()->eq('item_uid', $itemUid)
         );
@@ -611,13 +609,9 @@ class QueueItemRepository extends AbstractRepository
             ->select('*')
             ->from($this->table)
             ->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('root', $site->getRootPageId()),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->gt('changed', 'indexed'),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->lte('changed', time()),
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('errors', $queryBuilder->createNamedParameter(''))
             )
             ->orderBy('indexing_priority', 'DESC')
@@ -697,7 +691,7 @@ class QueueItemRepository extends AbstractRepository
             $resultsFromRecordTable = $queryBuilderForRecordTable
                 ->select('*')
                 ->from($table)
-                ->where(/** @scrutinizer ignore-type */ $queryBuilderForRecordTable->expr()->in('uid', $uidList))
+                ->where($queryBuilderForRecordTable->expr()->in('uid', $uidList))
                 ->executeQuery();
             $records = [];
             while ($record = $resultsFromRecordTable->fetchAssociative()) {
@@ -739,9 +733,7 @@ class QueueItemRepository extends AbstractRepository
             if (isset($tableRecords[$indexQueueItemRecord['item_type']][$indexQueueItemRecord['item_uid']])) {
                 $indexQueueItems[] = GeneralUtility::makeInstance(
                     Item::class,
-                    /** @scrutinizer ignore-type */
                     $indexQueueItemRecord,
-                    /** @scrutinizer ignore-type */
                     $tableRecords[$indexQueueItemRecord['item_type']][$indexQueueItemRecord['item_uid']]
                 );
             } else {
@@ -882,7 +874,6 @@ class QueueItemRepository extends AbstractRepository
         return $queryBuilder
             ->update($this->table)
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($itemUid, PDO::PARAM_INT))
             )
             ->set(

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -124,7 +124,7 @@ class ConfigurationAwareRecordService
         int $recordUid,
         string $recordWhereClause = ''
     ): array {
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
         $cacheId = md5('ConfigurationAwareRecordService' . ':' . 'getRecordIfIndexConfigurationIsValid' . ':' . $recordTable . ':' . $recordUid . ':' . $recordWhereClause);
 
         $row = $cache->get($cacheId);

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
@@ -62,7 +62,7 @@ class MountPagesUpdater
         }
 
         /* @var Rootline $rootLine */
-        $rootLine = GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $rootLineArray);
+        $rootLine = GeneralUtility::makeInstance(Rootline::class, $rootLineArray);
         $rootLineParentPageIds = array_map('intval', $rootLine->getParentPageIds());
         $destinationMountProperties = $this->pagesRepository->findMountPointPropertiesByPageIdOrByRootLineParentPageIds($currentPageUid, $rootLineParentPageIds);
 

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -51,7 +51,7 @@ class RootPageResolver implements SingletonInterface
         TwoLevelCache $twoLevelCache = null
     ) {
         $this->recordService = $recordService ?? GeneralUtility::makeInstance(ConfigurationAwareRecordService::class);
-        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
+        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
         $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
     }
 

--- a/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
@@ -54,13 +54,11 @@ class QueueStatisticsRepository extends AbstractRepository
             ->add('select', $queryBuilder->expr()->count('*', 'count'), true)
             ->from($this->table)
             ->where(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('root', $queryBuilder->createNamedParameter($rootPid, PDO::PARAM_INT))
             )->groupBy('pending', 'failed');
 
         if (!empty($indexingConfigurationName)) {
             $queryBuilder->andWhere(
-                /** @scrutinizer ignore-type */
                 $queryBuilder->expr()->eq('indexing_configuration', $queryBuilder->createNamedParameter($indexingConfigurationName))
             );
         }

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -119,7 +119,6 @@ class DataUpdateHandler extends AbstractUpdateHandler
         $this->dataHandler = $dataHandler;
         $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(
             SolrLogManager::class,
-            /** @scrutinizer ignore-type */
             __CLASS__
         );
     }

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -186,7 +186,7 @@ class Builder
      */
     protected function getExtractorForPageContent(string $pageContent): Typo3PageContentExtractor
     {
-        return GeneralUtility::makeInstance(Typo3PageContentExtractor::class, /** @scrutinizer ignore-type */ $pageContent);
+        return GeneralUtility::makeInstance(Typo3PageContentExtractor::class, $pageContent);
     }
 
     /**

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -77,7 +77,7 @@ class Builder
         $variantId = $this->variantIdBuilder->buildFromTypeAndUid('pages', $page->id);
         $document->setField('variantId', $variantId);
 
-        $document->setField('typeNum', $page->type);
+        $document->setField('typeNum', (int)$page->getPageArguments()->getPageType());
         $document->setField('created', $pageRecord['crdate']);
         $document->setField('changed', $pageRecord['SYS_LASTCHANGED']);
 
@@ -161,7 +161,7 @@ class Builder
      */
     protected function getPageDocumentId(TypoScriptFrontendController $frontendController, string $accessGroups, string $mountPointParameter): string
     {
-        return Util::getPageDocumentId($frontendController->id, $frontendController->type, Util::getLanguageUid(), $accessGroups, $mountPointParameter);
+        return Util::getPageDocumentId($frontendController->id, (int)$frontendController->getPageArguments()->getPageType(), Util::getLanguageUid(), $accessGroups, $mountPointParameter);
     }
 
     /**

--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -53,8 +53,8 @@ class Repository implements SingletonInterface
         QueryBuilder $queryBuilder = null
     ) {
         $this->typoScriptConfiguration = $typoScriptConfiguration ?? Util::getSolrConfiguration();
-        $this->documentEscapeService = $documentEscapeService ?? GeneralUtility::makeInstance(DocumentEscapeService::class, /** @scrutinizer ignore-type */ $typoScriptConfiguration);
-        $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
+        $this->documentEscapeService = $documentEscapeService ?? GeneralUtility::makeInstance(DocumentEscapeService::class, $typoScriptConfiguration);
+        $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, $this->typoScriptConfiguration);
     }
 
     /**
@@ -119,7 +119,6 @@ class Repository implements SingletonInterface
      */
     protected function initializeSearch(int $pageId, int $languageId = 0): void
     {
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $solrConnection = $connectionManager->getConnectionByPageId($pageId, $languageId);
 
@@ -131,6 +130,6 @@ class Repository implements SingletonInterface
      */
     protected function getSearch(SolrConnection $solrConnection): Search
     {
-        return  GeneralUtility::makeInstance(Search::class, /** @scrutinizer ignore-type */ $solrConnection);
+        return  GeneralUtility::makeInstance(Search::class, $solrConnection);
     }
 }

--- a/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
+++ b/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
@@ -39,7 +39,7 @@ class SiteHighlighterUrlModifier
         $searchWords = GeneralUtility::trimExplode(' ', $searchWords, true);
 
         /* @var UrlHelper $urlHelper */
-        $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, /** @scrutinizer ignore-type */ $url)
+        $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $url)
             ->withQueryParameter('sword_list', $searchWords);
 
         if ($addNoCache) {

--- a/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesWriterProcessor.php
@@ -60,7 +60,6 @@ class LastSearchesWriterProcessor implements SearchResultSetProcessor
     {
         return GeneralUtility::makeInstance(
             LastSearchesService::class,
-            /** @scrutinizer ignore-type */
             $resultSet->getUsedSearchRequest()->getContextTypoScriptConfiguration()
         );
     }

--- a/Classes/Domain/Search/Query/AbstractQueryBuilder.php
+++ b/Classes/Domain/Search/Query/AbstractQueryBuilder.php
@@ -33,25 +33,24 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Sortings;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Spellchecking;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\TrigramPhraseFields;
 use Closure;
-use Solarium\QueryType\Select\Query\Query as SolariumQuery;
 
 /**
  * The AbstractQueryBuilder contains all logic to initialize solr queries independent of TYPO3.
  */
 abstract class AbstractQueryBuilder
 {
-    protected SolariumQuery|SearchQuery|SuggestQuery|null $queryToBuild;
+    protected Query|SearchQuery|SuggestQuery|null $queryToBuild;
 
     /**
      * @return static
      */
-    public function startFrom(SolariumQuery $query): self
+    public function startFrom(Query $query): self
     {
         $this->queryToBuild = $query;
         return $this;
     }
 
-    public function getQuery(): SolariumQuery
+    public function getQuery(): Query
     {
         return $this->queryToBuild;
     }
@@ -418,6 +417,8 @@ abstract class AbstractQueryBuilder
         return $trigramPhraseFields->build($this);
     }
 
+    abstract public function useBoostQueriesFromTypoScript(): self;
+
     abstract public function useInitialQueryFromTypoScript(): self;
 
     abstract public function useTieParameterFromTypoScript(): self;
@@ -433,4 +434,12 @@ abstract class AbstractQueryBuilder
     abstract public function useBigramPhraseFieldsFromTypoScript(): self;
 
     abstract public function useTrigramPhraseFieldsFromTypoScript(): self;
+
+    abstract public function useReturnFieldsFromTypoScript(): self;
+
+    abstract public function useQueryFieldsFromTypoScript(): self;
+
+    abstract public function useFiltersFromTypoScript(): self;
+
+    abstract public function useHighlightingFromTypoScript(): self;
 }

--- a/Classes/Domain/Search/Query/AbstractQueryBuilder.php
+++ b/Classes/Domain/Search/Query/AbstractQueryBuilder.php
@@ -42,6 +42,9 @@ abstract class AbstractQueryBuilder
 {
     protected SolariumQuery|SearchQuery|SuggestQuery|null $queryToBuild;
 
+    /**
+     * @return static
+     */
     public function startFrom(SolariumQuery $query): self
     {
         $this->queryToBuild = $query;
@@ -256,6 +259,7 @@ abstract class AbstractQueryBuilder
 
     /**
      * Can be used to use a specific filter string in the solr query.
+     * @return static
      */
     public function useFilter(string $filterString, string $filterName = ''): self
     {

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -66,7 +66,7 @@ class QueryBuilder extends AbstractQueryBuilder
         SiteHashService $siteHashService = null,
     ) {
         $this->typoScriptConfiguration = $configuration ?? Util::getSolrConfiguration();
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->siteHashService = $siteHashService ?? GeneralUtility::makeInstance(SiteHashService::class);
     }
 
@@ -486,6 +486,6 @@ class QueryBuilder extends AbstractQueryBuilder
 
     protected function getSuggestQueryInstance(string $rawQuery): SuggestQuery
     {
-        return GeneralUtility::makeInstance(SuggestQuery::class, /** @scrutinizer ignore-type */ $rawQuery, /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
+        return GeneralUtility::makeInstance(SuggestQuery::class, $rawQuery, $this->typoScriptConfiguration);
     }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
@@ -37,7 +37,7 @@ abstract class AbstractFacetItemCollection extends AbstractCollection
         return $this;
     }
 
-    public function getByValue(string $value): ?AbstractFacetItem
+    public function getByValue(string $value): AbstractFacetItem|AbstractCollection|AbstractFacetItemCollection|null
     {
         return $this->data[$value] ?? null;
     }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
+use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 
 /**
  * Collection for facet options.
@@ -44,7 +45,7 @@ class OptionCollection extends AbstractFacetItemCollection
     /**
      * Returns {@link AbstractFacetItemCollection} or {@link OptionCollection} for filtered prefix
      */
-    public function getByLowercaseLabelPrefix(string $filteredPrefix): AbstractFacetItemCollection|OptionCollection
+    public function getByLowercaseLabelPrefix(string $filteredPrefix): AbstractCollection|AbstractFacetItemCollection|OptionCollection
     {
         return $this->getFilteredCopy(function (Option $option) use ($filteredPrefix) {
             $filteredPrefixLength = mb_strlen($filteredPrefix);
@@ -61,7 +62,6 @@ class OptionCollection extends AbstractFacetItemCollection
     {
         $prefixes = [];
         foreach ($this->data as $option) {
-            /* @var Option $option */
             $prefix = mb_substr($option->getLabel(), 0, $length);
             $prefixes[$prefix] = $prefix;
         }

--- a/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
@@ -34,7 +34,7 @@ class SearchResultBuilder
     public function fromApacheSolrDocument(Document $originalDocument): SearchResult
     {
         $searchResultClassName = $this->getResultClassName();
-        $result = GeneralUtility::makeInstance($searchResultClassName, /** @scrutinizer ignore-type */ $originalDocument->getFields() ?? []);
+        $result = GeneralUtility::makeInstance($searchResultClassName, $originalDocument->getFields() ?? []);
 
         if (!$result instanceof SearchResult) {
             throw new InvalidArgumentException('Could not create result object with class: ' . $searchResultClassName, 1470037679);

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -73,9 +73,9 @@ class SearchResultSetService
     ) {
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->searchResultBuilder = $resultBuilder ?? GeneralUtility::makeInstance(SearchResultBuilder::class);
-        $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, /** @scrutinizer ignore-type */ $configuration, /** @scrutinizer ignore-type */ $solrLogManager);
+        $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, $configuration, $solrLogManager);
     }
 
     public function getIsSolrAvailable(bool $useCache = true): bool
@@ -186,7 +186,7 @@ class SearchResultSetService
     protected function getParsedSearchResults(SearchResultSet $resultSet): void
     {
         /* @var ResultParserRegistry $parserRegistry */
-        $parserRegistry = GeneralUtility::makeInstance(ResultParserRegistry::class, /** @scrutinizer ignore-type */ $this->typoScriptConfiguration);
+        $parserRegistry = GeneralUtility::makeInstance(ResultParserRegistry::class, $this->typoScriptConfiguration);
         $useRawDocuments = (bool)$this->typoScriptConfiguration->getValueByPathOrDefaultValue('plugin.tx_solr.features.useRawDocuments', false);
         $parserRegistry->getParser($resultSet)->parse($resultSet, $useRawDocuments);
     }

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -164,9 +164,7 @@ class SearchResultSetService
         /* @var VariantsProcessor $variantsProcessor */
         $variantsProcessor = GeneralUtility::makeInstance(
             VariantsProcessor::class,
-            /** @scrutinizer ignore-type */
             $this->typoScriptConfiguration,
-            /** @scrutinizer ignore-type */
             $this->searchResultBuilder
         );
         $variantsProcessor->process($resultSet);

--- a/Classes/Domain/Search/ResultSet/Sorting/Sorting.php
+++ b/Classes/Domain/Search/ResultSet/Sorting/Sorting.php
@@ -44,7 +44,7 @@ class Sorting
     protected bool $isResetOption = false;
 
     public function __construct(
-        SearchResultSet $resultSet,
+        public readonly SearchResultSet $resultSet,
         string $name,
         string $field,
         string $direction,

--- a/Classes/Domain/Search/SearchRequestBuilder.php
+++ b/Classes/Domain/Search/SearchRequestBuilder.php
@@ -135,13 +135,9 @@ class SearchRequestBuilder
     {
         return GeneralUtility::makeInstance(
             SearchRequest::class,
-            /** @scrutinizer ignore-type */
             $requestArguments,
-            /** @scrutinizer ignore-type */
             $pageId,
-            /** @scrutinizer ignore-type */
             $languageId,
-            /** @scrutinizer ignore-type */
             $this->typoScriptConfiguration
         );
     }

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -63,7 +63,6 @@ class SuggestService
         $this->typoScriptConfiguration = $typoScriptConfiguration;
         $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(
             QueryBuilder::class,
-            /** @scrutinizer ignore-type */
             $typoScriptConfiguration
         );
     }

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -150,7 +150,7 @@ class SuggestService
         $pageId = $this->tsfe->getRequestedId();
         $languageId = Util::getLanguageUid();
         $solr = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($pageId, $languageId);
-        $search = GeneralUtility::makeInstance(Search::class, /** @scrutinizer ignore-type */ $solr);
+        $search = GeneralUtility::makeInstance(Search::class, $solr);
         $response = $search->search($suggestQuery, 0, 0);
 
         $rawResponse = $response->getRawResponse();

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -198,11 +198,8 @@ class SearchUriBuilder
         $request = GeneralUtility::makeInstance(
             SearchRequest::class,
             [],
-            /** @scrutinizer ignore-type */
             $contextPageUid,
-            /** @scrutinizer ignore-type */
             $contextSystemLanguage,
-            /** @scrutinizer ignore-type */
             $contextConfiguration
         );
         $arguments = $request->setRawQueryString($queryString)->getAsArray();

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -93,9 +93,7 @@ class Site implements SiteInterface
             /* @var NoSolrConnectionFoundException $noSolrConnectionException */
             $noSolrConnectionException = GeneralUtility::makeInstance(
                 NoSolrConnectionFoundException::class,
-                /** @scrutinizer ignore-type */
                 'Could not find a Solr connection for root page [' . $this->getRootPageId() . '] and language [' . $language . '].',
-                /** @scrutinizer ignore-type */
                 1552491117
             );
             $noSolrConnectionException->setRootPageId($this->getRootPageId());

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -262,23 +262,14 @@ class SiteRepository
 
         return GeneralUtility::makeInstance(
             Site::class,
-            /** @scrutinizer ignore-type */
             $solrConfiguration,
-            /** @scrutinizer ignore-type */
             $rootPageRecord,
-            /** @scrutinizer ignore-type */
             $domain,
-            /** @scrutinizer ignore-type */
             $siteHash,
-            /** @scrutinizer ignore-type */
             $pageRepository,
-            /** @scrutinizer ignore-type */
             $defaultLanguage,
-            /** @scrutinizer ignore-type */
             $availableLanguageIds,
-            /** @scrutinizer ignore-type */
             $solrConnectionConfigurations,
-            /** @scrutinizer ignore-type */
             $typo3Site
         );
     }

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -63,7 +63,7 @@ class SiteRepository
         FrontendEnvironment $frontendEnvironment = null
     ) {
         $this->rootPageResolver = $rootPageResolver ?? GeneralUtility::makeInstance(RootPageResolver::class);
-        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */'runtime');
+        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
         $this->registry = $registry ?? GeneralUtility::makeInstance(Registry::class);
         $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
         $this->extensionConfiguration = $extensionConfiguration ?? GeneralUtility::makeInstance(ExtensionConfiguration::class);

--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -118,6 +118,6 @@ class FrontendGroupsModifier
         if ($pageIndexerRequestHandler->getRequest()->getParameter('accessRootline')) {
             $stringAccessRootline = $pageIndexerRequestHandler->getRequest()->getParameter('accessRootline');
         }
-        return GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $stringAccessRootline);
+        return GeneralUtility::makeInstance(Rootline::class, $stringAccessRootline);
     }
 }

--- a/Classes/FrontendEnvironment.php
+++ b/Classes/FrontendEnvironment.php
@@ -48,7 +48,6 @@ class FrontendEnvironment implements SingletonInterface
         ?int $language = 0,
         ?int $rootPageId = null,
     ): TypoScriptConfiguration {
-        /* @var TypoScript $typoScript */
         $typoScript = GeneralUtility::makeInstance(TypoScript::class);
         return $typoScript->getConfigurationFromPageId($pageId, $path, $language, $rootPageId);
     }

--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -70,7 +70,7 @@ class TypoScript implements SingletonInterface
         }
 
         /* @var TwoLevelCache $cache */
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'tx_solr_configuration');
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'tx_solr_configuration');
         $configurationArray = $cache->get($cacheId);
 
         if (!empty($configurationArray)) {

--- a/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/AbstractFrontendHelper.php
@@ -65,7 +65,7 @@ abstract class AbstractFrontendHelper implements FrontendHelper, SingletonInterf
     ): void {
         $this->request = $request;
         $this->response = $response;
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
 
         if ($request->getParameter('loggingEnabled')) {
             $this->logger->log(

--- a/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
+++ b/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
@@ -97,7 +97,7 @@ class AuthorizationService extends AbstractAuthenticationService
         $accessRootline = $requestHandler->getRequest()->getParameter('accessRootline');
 
         if ($user['username'] == self::SOLR_INDEXER_USERNAME && !empty($accessRootline)) {
-            $accessRootline = GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $accessRootline);
+            $accessRootline = GeneralUtility::makeInstance(Rootline::class, $accessRootline);
             $groups = $accessRootline->getGroups();
 
             foreach ($groups as $groupId) {

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -98,7 +98,7 @@ class PageIndexer extends AbstractFrontendHelper
             $stringAccessRootline = $this->request->getParameter('accessRootline');
         }
 
-        return GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ $stringAccessRootline);
+        return GeneralUtility::makeInstance(Rootline::class, $stringAccessRootline);
     }
 
     /**
@@ -223,7 +223,7 @@ class PageIndexer extends AbstractFrontendHelper
             $solrConnection = $this->getSolrConnection($indexQueueItem);
 
             /* @var Typo3PageIndexer $indexer */
-            $indexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, /** @scrutinizer ignore-type */ $this->page);
+            $indexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $this->page);
             $indexer->setSolrConnection($solrConnection);
             $indexer->setPageAccessRootline($this->getAccessRootline());
             $indexer->setPageUrl($this->generatePageUrl());

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -123,6 +123,7 @@ class UserGroupDetector extends AbstractFrontendHelper implements
         PageRepository $parentObject
     ) {
         $disableGroupAccessCheck = true;
+        // @todo: Check if reseting "where_groupAccess" really wanted. Most probably the core aspect 'frontend.user' must be used instead.
         $parentObject->where_groupAccess = ''; // just to be on the safe side
     }
 

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -74,7 +74,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
         QueueItemRepository $queueItemRepository = null,
         PagesRepository $pagesRepository = null
     ) {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');
         $this->queueItemRepository = $queueItemRepository ?? GeneralUtility::makeInstance(QueueItemRepository::class);

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -276,7 +276,7 @@ class Page extends AbstractInitializer
 
         foreach ($mountPageItems as $mountPageItemRecord) {
             /* @var Item $mountPageItem */
-            $mountPageItem = GeneralUtility::makeInstance(Item::class, /** @scrutinizer ignore-type */ $mountPageItemRecord);
+            $mountPageItem = GeneralUtility::makeInstance(Item::class, $mountPageItemRecord);
             $mountPageItem->setIndexingProperty('mountPageSource', $mountPage['mountPageSource']);
             $mountPageItem->setIndexingProperty('mountPageDestination', $mountPage['mountPageDestination']);
             $mountPageItem->setIndexingProperty('isMountedPage', '1');

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -384,7 +384,7 @@ class PageIndexer extends Indexer
             if (is_null($contentAccessGroup)) {
                 $contentAccessGroups = $this->getAccessGroupsFromContent($item, $language);
             }
-            $element = GeneralUtility::makeInstance(RootlineElement::class, /** @scrutinizer ignore-type */ 'c:' . implode(',', $contentAccessGroups));
+            $element = GeneralUtility::makeInstance(RootlineElement::class, 'c:' . implode(',', $contentAccessGroups));
             $accessRootline->push($element);
 
             $accessRootlineCache[$accessRootlineCacheEntryId] = $accessRootline;

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -95,7 +95,7 @@ class PageIndexerRequest
         $this->requestId = uniqid();
         $this->timeout = (float)ini_get('default_socket_timeout');
 
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->extensionConfiguration = $extensionConfiguration ?? GeneralUtility::makeInstance(ExtensionConfiguration::class);
         $this->requestFactory = $requestFactory ?? GeneralUtility::makeInstance(RequestFactory::class);
 

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -343,6 +343,7 @@ class PageIndexerRequest
      */
     protected function getUrl(string $url, array $headers, float $timeout): ResponseInterface
     {
+        $options = [];
         try {
             $options = $this->buildGuzzleOptions($headers, $timeout);
             $response = $this->requestFactory->request($url, 'GET', $options);
@@ -352,7 +353,6 @@ class PageIndexerRequest
                 $options['auth']['password'] = '*****';
             }
             // Log with INFO severity because this is what configured for Testing & Development contexts
-            /* @noinspection PhpUndefinedVariableInspection */
             $this->logger->log(
                 LogLevel::INFO,
                 sprintf(

--- a/Classes/IndexQueue/PageIndexerRequestHandler.php
+++ b/Classes/IndexQueue/PageIndexerRequestHandler.php
@@ -52,7 +52,7 @@ class PageIndexerRequestHandler implements SingletonInterface
     public function __construct(string $jsonEncodedParameters = null)
     {
         $this->dispatcher = GeneralUtility::makeInstance(Dispatcher::class);
-        $this->request = GeneralUtility::makeInstance(PageIndexerRequest::class, /** @scrutinizer ignore-type */ $jsonEncodedParameters);
+        $this->request = GeneralUtility::makeInstance(PageIndexerRequest::class, $jsonEncodedParameters);
         $this->response = GeneralUtility::makeInstance(PageIndexerResponse::class);
         $this->response->setRequestId($this->request->getRequestId());
     }

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -63,12 +63,12 @@ class Queue
         QueueInitializationService $queueInitializationService = null,
         FrontendEnvironment $frontendEnvironment = null
     ) {
-        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
         $this->rootPageResolver = $rootPageResolver ?? GeneralUtility::makeInstance(RootPageResolver::class);
         $this->recordService = $recordService ?? GeneralUtility::makeInstance(ConfigurationAwareRecordService::class);
         $this->queueItemRepository = $queueItemRepository ?? GeneralUtility::makeInstance(QueueItemRepository::class);
         $this->queueStatisticsRepository = $queueStatisticsRepository ??  GeneralUtility::makeInstance(QueueStatisticsRepository::class);
-        $this->queueInitializationService = $queueInitializationService ?? GeneralUtility::makeInstance(QueueInitializationService::class, /** @scrutinizer ignore-type */ $this);
+        $this->queueInitializationService = $queueInitializationService ?? GeneralUtility::makeInstance(QueueInitializationService::class, $this);
         $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
     }
 
@@ -289,7 +289,7 @@ class Queue
         int|string $itemUid,
         string $additionalRecordFields,
     ): ?array {
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
         $cacheId = md5('Queue' . ':' . 'getRecordCached' . ':' . $itemType . ':' . $itemUid . ':' . 'pid' . $additionalRecordFields);
 
         $record = $cache->get($cacheId);

--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -88,7 +88,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
             return $handler->handle($request);
         }
 
-        /* @var SiteRouteResult $routeResult */
+        /** @var SiteRouteResult $routeResult */
         $routeResult = $this->getRoutingService()
             ->getSiteMatcher()
             ->matchRequest($request);

--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -290,7 +290,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
             );
             if (empty($items)) {
                 $this->logger
-                    ->/** @scrutinizer ignore-call */
+                    ->
                     error(
                         vsprintf(
                             'Could not determine page for slug "%1$s" and language "%2$s". Given path "%3$s"',
@@ -304,7 +304,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
                 $scan = false;
             } elseif (empty($path)) {
                 $this->logger
-                    ->/** @scrutinizer ignore-call */
+                    ->
                     error(
                         vsprintf(
                             'Could not resolve page by path "%1$s" and language "%2$s".',

--- a/Classes/Query/Modifier/Elevation.php
+++ b/Classes/Query/Modifier/Elevation.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
-use Solarium\QueryType\Select\Query\Query as SolariumSelectQuery;
 
 /**
  * Enables query elevation
@@ -40,7 +39,7 @@ class Elevation implements Modifier
      *
      * @param Query $query The query to modify
      */
-    public function modifyQuery(Query $query): Query|SolariumSelectQuery
+    public function modifyQuery(Query $query): Query
     {
         return $this->queryBuilder
             ->startFrom($query)

--- a/Classes/Query/Modifier/Modifier.php
+++ b/Classes/Query/Modifier/Modifier.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
-use Solarium\QueryType\Select\Query\Query as SolariumSelectQuery;
 
 /**
  * QueryModifier interface, allows to modify search queries
@@ -31,7 +30,7 @@ interface Modifier
      * Modifies the given query and returns the modified query as result
      *
      * @param Query $query The query to modify
-     * @return Query|SolariumSelectQuery The modified query
+     * @return Query The modified query
      */
-    public function modifyQuery(Query $query): Query|SolariumSelectQuery;
+    public function modifyQuery(Query $query): Query;
 }

--- a/Classes/Query/Modifier/Statistics.php
+++ b/Classes/Query/Modifier/Statistics.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Query\Modifier;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
-use Solarium\QueryType\Select\Query\Query as SolariumSelectQuery;
 
 /**
  * Enables tracking of detailed statistics
@@ -39,9 +38,9 @@ class Statistics implements Modifier
      * Enables the query's debug mode to get more detailed information.
      *
      * @param Query $query The query to modify
-     * @return Query|SolariumSelectQuery The modified query with enabled debugging mode
+     * @return Query The modified query with enabled debugging mode
      */
-    public function modifyQuery(Query $query): Query|SolariumSelectQuery
+    public function modifyQuery(Query $query): Query
     {
         return $this->queryBuilder->startFrom($query)->useDebug(true)->getQuery();
     }

--- a/Classes/Report/AccessFilterPluginInstalledStatus.php
+++ b/Classes/Report/AccessFilterPluginInstalledStatus.php
@@ -97,13 +97,9 @@ class AccessFilterPluginInstalledStatus extends AbstractSolrStatus
         $report = $this->getRenderedReport('AccessFilterPluginInstalledStatusNotInstalled.html', $variables);
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'Access Filter Plugin',
-            /** @scrutinizer ignore-type */
             'Not Installed',
-            /** @scrutinizer ignore-type */
             $report,
-            /** @scrutinizer ignore-type */
             ContextualFeedbackSeverity::WARNING
         );
     }
@@ -123,13 +119,9 @@ class AccessFilterPluginInstalledStatus extends AbstractSolrStatus
 
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'Access Filter Plugin',
-            /** @scrutinizer ignore-type */
             'Outdated',
-            /** @scrutinizer ignore-type */
             $report,
-            /** @scrutinizer ignore-type */
             ContextualFeedbackSeverity::WARNING
         );
     }

--- a/Classes/Report/AllowUrlFOpenStatus.php
+++ b/Classes/Report/AllowUrlFOpenStatus.php
@@ -50,13 +50,9 @@ class AllowUrlFOpenStatus extends AbstractSolrStatus
 
         $reports[] = GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'allow_url_fopen',
-            /** @scrutinizer ignore-type */
             $value,
-            /** @scrutinizer ignore-type */
             $message,
-            /** @scrutinizer ignore-type */
             $severity
         );
 

--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -65,13 +65,9 @@ class SchemaStatus extends AbstractSolrStatus
                 $pingFailedMsg = 'Could not ping solr server, can not check version ' . $url;
                 $status = GeneralUtility::makeInstance(
                     Status::class,
-                    /** @scrutinizer ignore-type */
                     'Apache Solr Version',
-                    /** @scrutinizer ignore-type */
                     'Not accessible',
-                    /** @scrutinizer ignore-type */
                     $pingFailedMsg,
-                    /** @scrutinizer ignore-type */
                     ContextualFeedbackSeverity::ERROR
                 );
                 $reports[] = $status;
@@ -84,13 +80,9 @@ class SchemaStatus extends AbstractSolrStatus
                 $report = $this->getRenderedReport('SchemaStatus.html', $variables);
                 $status = GeneralUtility::makeInstance(
                     Status::class,
-                    /** @scrutinizer ignore-type */
                     'Schema Version',
-                    /** @scrutinizer ignore-type */
                     'Unsupported Schema',
-                    /** @scrutinizer ignore-type */
                     $report,
-                    /** @scrutinizer ignore-type */
                     ContextualFeedbackSeverity::WARNING
                 );
                 $reports[] = $status;

--- a/Classes/Report/SiteHandlingStatus.php
+++ b/Classes/Report/SiteHandlingStatus.php
@@ -72,13 +72,9 @@ class SiteHandlingStatus extends AbstractSolrStatus
             if (!($site instanceof Site)) {
                 $reports[] = GeneralUtility::makeInstance(
                     Status::class,
-                    /** @scrutinizer ignore-type */
                     self::TITLE_SITE_HANDLING_CONFIGURATION,
-                    /** @scrutinizer ignore-type */
                     'Something went wrong',
-                    /** @scrutinizer ignore-type */
                     vsprintf('The configured Site "%s" is not TYPO3 managed site. Please refer to TYPO3 site management docs and configure the site properly.', [$site->getLabel()]),
-                    /** @scrutinizer ignore-type */
                     ContextualFeedbackSeverity::ERROR
                 );
                 continue;
@@ -119,13 +115,9 @@ class SiteHandlingStatus extends AbstractSolrStatus
         /* @var Status $status */
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             sprintf('Site Identifier: "%s"', $ypo3Site->getIdentifier()),
-            /** @scrutinizer ignore-type */
             '',
-            /** @scrutinizer ignore-type */
             $renderedReport,
-            /** @scrutinizer ignore-type */
             $globalPassedStateForThisSite ? ContextualFeedbackSeverity::OK : ContextualFeedbackSeverity::ERROR
         );
     }

--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -62,13 +62,9 @@ class SolrConfigStatus extends AbstractSolrStatus
                 $report = $this->getRenderedReport('SolrConfigStatus.html', $variables);
                 $status = GeneralUtility::makeInstance(
                     Status::class,
-                    /** @scrutinizer ignore-type */
                     'Solrconfig Version',
-                    /** @scrutinizer ignore-type */
                     'Unsupported solrconfig.xml',
-                    /** @scrutinizer ignore-type */
                     $report,
-                    /** @scrutinizer ignore-type */
                     ContextualFeedbackSeverity::WARNING
                 );
 

--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -98,13 +98,9 @@ class SolrConfigurationStatus extends AbstractSolrStatus
         $report = $this->getRenderedReport('RootPageFlagStatus.html');
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'Sites',
-            /** @scrutinizer ignore-type */
             'No sites found',
-            /** @scrutinizer ignore-type */
             $report,
-            /** @scrutinizer ignore-type */
             ContextualFeedbackSeverity::ERROR
         );
     }
@@ -127,13 +123,9 @@ class SolrConfigurationStatus extends AbstractSolrStatus
         $report = $this->getRenderedReport('SolrConfigurationStatusIndexing.html', ['pages' => $rootPagesWithIndexingOff]);
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'Page Indexing',
-            /** @scrutinizer ignore-type */
             'Indexing is disabled',
-            /** @scrutinizer ignore-type */
             $report,
-            /** @scrutinizer ignore-type */
             ContextualFeedbackSeverity::WARNING
         );
     }

--- a/Classes/Report/SolrStatus.php
+++ b/Classes/Report/SolrStatus.php
@@ -128,13 +128,9 @@ class SolrStatus extends AbstractSolrStatus
         $report = $this->getRenderedReport('SolrStatus.html', $variables);
         return GeneralUtility::makeInstance(
             Status::class,
-            /** @scrutinizer ignore-type */
             'Apache Solr',
-            /** @scrutinizer ignore-type */
             '',
-            /** @scrutinizer ignore-type */
             $report,
-            /** @scrutinizer ignore-type */
             $this->responseStatus
         );
     }

--- a/Classes/Report/SolrVersionStatus.php
+++ b/Classes/Report/SolrVersionStatus.php
@@ -81,13 +81,9 @@ class SolrVersionStatus extends AbstractSolrStatus
             $report = $this->getRenderedReport('SolrVersionStatus.html', $variables);
             $status = GeneralUtility::makeInstance(
                 Status::class,
-                /** @scrutinizer ignore-type */
                 'Apache Solr Version',
-                /** @scrutinizer ignore-type */
                 'Outdated, Unsupported',
-                /** @scrutinizer ignore-type */
                 $report,
-                /** @scrutinizer ignore-type */
                 ContextualFeedbackSeverity::ERROR
             );
 

--- a/Classes/Report/SolrVersionStatus.php
+++ b/Classes/Report/SolrVersionStatus.php
@@ -56,13 +56,9 @@ class SolrVersionStatus extends AbstractSolrStatus
                 $pingFailedMsg = 'Could not ping solr server, can not check version ' . $url;
                 $status = GeneralUtility::makeInstance(
                     Status::class,
-                    /** @scrutinizer ignore-type */
                     'Apache Solr Version',
-                    /** @scrutinizer ignore-type */
                     'Not accessible',
-                    /** @scrutinizer ignore-type */
                     $pingFailedMsg,
-                    /** @scrutinizer ignore-type */
                     ContextualFeedbackSeverity::ERROR
                 );
                 $reports[] = $status;

--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -283,7 +283,7 @@ class RoutingService implements LoggerAwareInterface
 
         if (!isset($queryParams[$this->getPluginNamespace()])) {
             $this->logger
-                ->/** @scrutinizer ignore-call */
+                ->
                 error('Mask error: Query parameters has no entry for namespace ' . $this->getPluginNamespace());
             return $queryParams;
         }
@@ -291,14 +291,14 @@ class RoutingService implements LoggerAwareInterface
         if (!isset($queryParams[$this->getPluginNamespace()]['filter']) ||
             empty($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
-                ->/** @scrutinizer ignore-call */
+                ->
                 info('Mask info: Query parameters has no filter in namespace ' . $this->getPluginNamespace());
             return $queryParams;
         }
 
         if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
-                ->/** @scrutinizer ignore-call */
+                ->
                 warning('Mask info: Filter within the Query parameters is not an array');
             return $queryParams;
         }
@@ -313,7 +313,7 @@ class RoutingService implements LoggerAwareInterface
             $keep = false;
             if (isset($queryParameterMap[$facetName]) &&
                 isset($newQueryParams[$queryParameterMap[$facetName]])) {
-                $this->logger->/** @scrutinizer ignore-call */error(
+                $this->logger->error(
                     'Mask error: Facet "' . $facetName . '" as "' . $queryParameterMap[$facetName] .
                     '" already in query!'
                 );
@@ -465,7 +465,7 @@ class RoutingService implements LoggerAwareInterface
 
         if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
-                ->/** @scrutinizer ignore-call */
+                ->
                 warning('Mask info: Filter within the Query parameters is not an array');
             return $queryParams;
         }
@@ -549,7 +549,7 @@ class RoutingService implements LoggerAwareInterface
 
         if (!is_array($queryParams[$this->getPluginNamespace()]['filter'])) {
             $this->logger
-                ->/** @scrutinizer ignore-call */
+                ->
                 warning('Inflate query: Expected filter to be an array. Replace it with an array structure!');
             $queryParams[$this->getPluginNamespace()]['filter'] = [];
         }

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -70,7 +70,6 @@ class Search
         $this->solr = $solrConnection;
 
         if (is_null($solrConnection)) {
-            /* @var ConnectionManager $connectionManager */
             $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
             $this->solr = $connectionManager->getConnectionByPageId(($GLOBALS['TSFE']->id ?? 0), Util::getLanguageUid());
         }

--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -85,9 +85,7 @@ class ConfigurationManager implements SingletonInterface
     ): TypoScriptConfiguration {
         return GeneralUtility::makeInstance(
             TypoScriptConfiguration::class,
-            /** @scrutinizer ignore-type */
             $configurationArray,
-            /** @scrutinizer ignore-type */
             $contextPageId
         );
     }

--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -36,7 +36,7 @@ class ConfigurationPageResolver
 
     public function __construct(?TwoLevelCache $twoLevelCache = null, ?SystemTemplateRepository $systemTemplateRepository = null)
     {
-        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
+        $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
         $this->systemTemplateRepository = $systemTemplateRepository ?? GeneralUtility::makeInstance(SystemTemplateRepository::class);
     }
 

--- a/Classes/System/Data/AbstractCollection.php
+++ b/Classes/System/Data/AbstractCollection.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\System\Data;
 
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\Group;
 use ArrayAccess;
 use ArrayIterator;
 use Closure;
@@ -30,7 +32,7 @@ use Traversable;
 abstract class AbstractCollection implements IteratorAggregate, Countable, ArrayAccess
 {
     /**
-     * @var AbstractCollection[]
+     * @var AbstractFacetItem[]|Group[]
      */
     protected array $data = [];
 

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -42,7 +42,7 @@ class PagesRepository extends AbstractRepository
 
     public function __construct(TwoLevelCache $transientVariableCache = null)
     {
-        $this->transientVariableCache = $transientVariableCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
+        $this->transientVariableCache = $transientVariableCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
     }
 
     /**

--- a/Classes/System/Solr/ResponseAdapter.php
+++ b/Classes/System/Solr/ResponseAdapter.php
@@ -41,13 +41,14 @@ use stdClass;
  * @property stdClass|null $debug
  * @property stdClass|null $lucene
  * @property string $file
+ * @property bool $expanded
  * @property array $file_metadata
  *
  * Luke response
  *
  * @property stdClass $index
  * @property stdClass $fields
- * @property stdClass $$plugins
+ * @property stdClass $plugins
  */
 class ResponseAdapter implements Countable
 {

--- a/Classes/System/Solr/ResponseAdapter.php
+++ b/Classes/System/Solr/ResponseAdapter.php
@@ -32,22 +32,22 @@ use stdClass;
  *
  * Search response
  *
- * @property stdClass|null facet_counts
- * @property stdClass|null facets
- * @property stdClass|null spellcheck
- * @property stdClass|null response
- * @property stdClass|null responseHeader
- * @property stdClass|null highlighting
- * @property stdClass|null debug
- * @property stdClass|null lucene
- * @property string file
- * @property array file_metadata
+ * @property stdClass|null $facet_counts
+ * @property stdClass|null $facets
+ * @property stdClass|null $spellcheck
+ * @property stdClass|null $response
+ * @property stdClass|null $responseHeader
+ * @property stdClass|null $highlighting
+ * @property stdClass|null $debug
+ * @property stdClass|null $lucene
+ * @property string $file
+ * @property array $file_metadata
  *
  * Luke response
  *
- * @property stdClass index
- * @property stdClass fields
- * @property stdClass $plugins
+ * @property stdClass $index
+ * @property stdClass $fields
+ * @property stdClass $$plugins
  */
 class ResponseAdapter implements Countable
 {

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -46,7 +46,7 @@ abstract class AbstractSolrService
     {
         $this->client = $client;
         $this->configuration = $typoScriptConfiguration ?? Util::getSolrConfiguration();
-        $this->logger = $logManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->logger = $logManager ?? GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     /**

--- a/Classes/System/Solr/Service/SolrReadService.php
+++ b/Classes/System/Solr/Service/SolrReadService.php
@@ -94,7 +94,6 @@ class SolrReadService extends AbstractSolrService
     /**
      * This method handles a failed Solr request and maps it to a meaningful exception.
      *
-     * @return ResponseAdapter $response
      * @throws SolrCommunicationException
      */
     protected function handleErrorResponse(ResponseAdapter $response): void

--- a/Classes/System/Util/ArrayAccessor.php
+++ b/Classes/System/Util/ArrayAccessor.php
@@ -178,7 +178,7 @@ class ArrayAccessor
                 if (empty($currentElement)) {
                     unset($currentElement);
                 }
-            } else {
+            } elseif (isset($currentElement) && isset($currentElement[$pathSegment])) {
                 $currentElement = &$currentElement[$pathSegment];
             }
         }

--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -67,7 +67,7 @@ abstract class AbstractSolrTask extends AbstractTask
             $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
             $this->site = $siteRepository->getSiteByRootPageId((int)$this->rootPageId);
         } catch (InvalidArgumentException) {
-            $logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
             $logger->log(SolrLogManager::ERROR, 'Scheduler task tried to get invalid site');
         }
 

--- a/Classes/Task/EventQueueWorkerTask.php
+++ b/Classes/Task/EventQueueWorkerTask.php
@@ -156,7 +156,7 @@ final class EventQueueWorkerTask extends AbstractTask
      */
     protected function getSolrLogManager(): SolrLogManager
     {
-        return  GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        return  GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
     }
 
     /**

--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -177,7 +177,7 @@ class IndexQueueWorkerTask extends AbstractSolrTask implements ProgressProviderI
      */
     protected function getInitializedIndexService(Site $site): IndexService
     {
-        $indexService = GeneralUtility::makeInstance(IndexService::class, /** @scrutinizer ignore-type */ $site);
+        $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
         $indexService->setContextTask($this);
         return $indexService;
     }

--- a/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
@@ -50,7 +50,7 @@ class IndexQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFiel
      * items to index per run when adding or editing a task.
      *
      * @param array $taskInfo reference to the array containing the info used in the add/edit form
-     * @param AbstractTask $task when editing, reference to the current task object. Null when adding.
+     * @param IndexQueueWorkerTask $task when editing, reference to the current task object. Null when adding.
      * @param SchedulerModuleController $schedulerModule Reference to the calling object (Scheduler's BE module)
      * @return array Array containing all the information pertaining to the additional fields
      *                    The array is multidimensional, keyed to the task class name and each field's id
@@ -64,7 +64,6 @@ class IndexQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFiel
         $task,
         SchedulerModuleController $schedulerModule
     ): array {
-        /* @var IndexQueueWorkerTask $task */
         $additionalFields = [];
         $siteSelectorField = GeneralUtility::makeInstance(SiteSelectorField::class);
 
@@ -146,9 +145,7 @@ class IndexQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFiel
      * class matches.
      *
      * @param array $submittedData array containing the data submitted by the user
-     * @param AbstractTask|AbstractSolrTask|IndexQueueWorkerTask $task reference to the current task object
-     *
-     * @noinspection PhpDocSignatureInspection
+     * @param IndexQueueWorkerTask $task reference to the current task object
      */
     public function saveAdditionalFields(
         array $submittedData,

--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\Backend\CoreSelectorField;
 use ApacheSolrForTypo3\Solr\Backend\SiteSelectorField;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use Doctrine\DBAL\Exception as DBALException;
 use LogicException;
 use Throwable;
@@ -55,7 +54,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
     /**
      * Scheduler task
      */
-    protected ?AbstractTask $task = null;
+    protected ?OptimizeIndexTask $task = null;
 
     /**
      * Scheduler Module
@@ -89,10 +88,9 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
      */
     protected function initialize(
         SchedulerModuleController $schedulerModule,
-        AbstractTask $task = null,
+        OptimizeIndexTask $task = null,
         array $taskInfo = []
     ): void {
-        /* @var ReIndexTask $task */
         $this->task = $task;
         $this->schedulerModule = $schedulerModule;
         $this->taskInformation = $taskInfo;
@@ -109,14 +107,13 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
      * or editing a task.
      *
      * @param array $taskInfo reference to the array containing the info used in the add/edit form
-     * @param AbstractTask $task when editing, reference to the current task object. Null when adding.
+     * @param OptimizeIndexTask $task when editing, reference to the current task object. Null when adding.
      * @param SchedulerModuleController $schedulerModule reference to the calling object (Scheduler's BE module)
      * @return array Array containing all the information pertaining to the additional fields
      *                        The array is multidimensional, keyed to the task class name and each field's id
      *                        For each field it provides an associative sub-array with the following:
      *
      * @throws BackendFormException
-     * @throws NoSolrConnectionFoundException
      * @throws Throwable
      *
      * @noinspection PhpParameterByRefIsNotUsedAsReferenceInspection
@@ -157,7 +154,6 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
      * Returns the selector HTML element with available cores.
      *
      * @throws BackendFormException
-     * @throws NoSolrConnectionFoundException
      */
     protected function getCoreSelectorMarkup(): string
     {
@@ -170,8 +166,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
         /* @var CoreSelectorField $selectorField */
         $selectorField = GeneralUtility::makeInstance(CoreSelectorField::class, $this->site);
         $selectorField->setFormElementName('tx_scheduler[cores]');
-        /* @noinspection PhpPossiblePolymorphicInvocationInspection */
-        $selectorField->setSelectedValues($this->task->/** @scrutinizer ignore-call */getCoresToOptimizeIndex());
+        $selectorField->setSelectedValues($this->task->getCoresToOptimizeIndex());
         return $selectorField->render();
     }
 
@@ -215,26 +210,23 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
      * class matches.
      *
      * @param array $submittedData array containing the data submitted by the user
-     * @param AbstractTask $task reference to the current task object
+     * @param OptimizeIndexTask $task reference to the current task object
      */
     public function saveAdditionalFields(
         array $submittedData,
-        AbstractTask $task
+        OptimizeIndexTask|AbstractTask $task
     ): void {
-        /* @var OptimizeIndexTask $task */
         if (!$this->isTaskInstanceofOptimizeIndexTask($task)) {
             return;
         }
 
-        $task->/** @scrutinizer ignore-call */
-            setRootPageId((int)$submittedData['site']);
+        $task->setRootPageId((int)$submittedData['site']);
 
         $cores = [];
         if (!empty($submittedData['cores'])) {
             $cores = $submittedData['cores'];
         }
-        $task->/** @scrutinizer ignore-call */
-        setCoresToOptimizeIndex($cores);
+        $task->setCoresToOptimizeIndex($cores);
     }
 
     protected function getPageRenderer(): ?PageRenderer

--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -168,7 +168,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
         }
 
         /* @var CoreSelectorField $selectorField */
-        $selectorField = GeneralUtility::makeInstance(CoreSelectorField::class, /** @scrutinizer ignore-type */ $this->site);
+        $selectorField = GeneralUtility::makeInstance(CoreSelectorField::class, $this->site);
         $selectorField->setFormElementName('tx_scheduler[cores]');
         /* @noinspection PhpPossiblePolymorphicInvocationInspection */
         $selectorField->setSelectedValues($this->task->/** @scrutinizer ignore-call */getCoresToOptimizeIndex());

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -149,7 +149,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
             return $selectorMarkup;
         }
 
-        $selectorField = GeneralUtility::makeInstance(IndexingConfigurationSelectorField::class, /** @scrutinizer ignore-type */ $this->site);
+        $selectorField = GeneralUtility::makeInstance(IndexingConfigurationSelectorField::class, $this->site);
 
         $selectorField->setFormElementName('tx_scheduler[indexingConfigurations]');
         $selectorField->setSelectedValues($this->task->getIndexingConfigurationsToReIndex());

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -44,7 +44,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
     /**
      * Scheduler task
      */
-    protected ?AbstractSolrTask $task;
+    protected ?ReIndexTask $task;
 
     protected ?SchedulerModuleController $schedulerModule = null;
 
@@ -69,7 +69,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
      */
     protected function initialize(
         array $taskInfo,
-        ?AbstractSolrTask $task,
+        ?ReIndexTask $task,
         SchedulerModuleController $schedulerModule
     ): void {
         /* ReIndexTask @var $task  */
@@ -89,7 +89,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
      * or editing a task.
      *
      * @param array $taskInfo reference to the array containing the info used in the add/edit form
-     * @param AbstractSolrTask $task when editing, reference to the current task object. Null when adding.
+     * @param ReIndexTask $task when editing, reference to the current task object. Null when adding.
      * @param SchedulerModuleController $schedulerModule reference to the calling object (Scheduler's BE module)
      *
      * @return array Array containing all the information pertaining to the additional fields
@@ -191,13 +191,12 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
      * class matches.
      *
      * @param array $submittedData array containing the data submitted by the user
-     * @param AbstractTask $task reference to the current task object
+     * @param ReIndexTask $task reference to the current task object
      */
     public function saveAdditionalFields(
         array $submittedData,
-        AbstractTask $task
+        ReIndexTask|AbstractTask $task
     ): void {
-        /* @var ReIndexTask $task */
         if (!$this->isTaskInstanceofReIndexTask($task)) {
             return;
         }

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -59,7 +59,7 @@ class Typo3PageContentExtractor extends HtmlContentExtractor
 
         $indexableContent = $this->excludeContentByClass($indexableContent);
         if (empty($indexableContent) && $this->getConfiguration()->getLoggingIndexingMissingTypo3SearchMarkers()) {
-            $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+            $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
             $this->logger->log(SolrLogManager::WARNING, 'No TYPO3SEARCH markers found.');
         }
 

--- a/Classes/Typo3PageIndexer.php
+++ b/Classes/Typo3PageIndexer.php
@@ -124,7 +124,7 @@ class Typo3PageIndexer
             }
         }
 
-        $this->pageAccessRootline = GeneralUtility::makeInstance(Rootline::class, /** @scrutinizer ignore-type */ '');
+        $this->pageAccessRootline = GeneralUtility::makeInstance(Rootline::class, '');
     }
 
     public function setIndexQueueItem(Item $indexQueueItem): void

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -82,7 +82,6 @@ class Util
         int $uid,
         string $additionalIdParameters = '',
     ): string {
-        /* @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByPageId($rootPageId);
         $siteHash = $site->getSiteHash();

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
 /**
@@ -30,6 +31,8 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  *
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
+ *
+ * @property RenderingContext $renderingContext
  */
 class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
 {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total Downloads](http://poser.pugx.org/apache-solr-for-typo3/solr/downloads)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 [![Monthly Downloads](https://poser.pugx.org/apache-solr-for-typo3/solr/d/monthly)](https://packagist.org/packages/apache-solr-for-typo3/solr)
 [![Build Status](https://github.com/TYPO3-Solr/ext-solr/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/TYPO3-Solr/ext-solr/actions?query=branch:main)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/?branch=main)
+
 [![Code Coverage](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/badges/coverage.png?b=main)](https://scrutinizer-ci.com/g/TYPO3-Solr/ext-solr/?branch=main)
 
 # Apache Solr for TYPO3 CMS

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -68,7 +68,6 @@ class ConnectionManagerTest extends IntegrationTest
         $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/connection_basic.csv');
 
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         foreach ([0, 1, 2] as $languageID) {
@@ -116,7 +115,6 @@ class ConnectionManagerTest extends IntegrationTest
         $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/connection_basic.csv');
 
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         foreach ([0, 1, 2] as $languageID) {
@@ -170,7 +168,6 @@ class ConnectionManagerTest extends IntegrationTest
         $this->setupNotFullyConfiguredSite();
 
         $this->expectException(NoSolrConnectionFoundException::class);
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $connectionManager->getConnectionByRootPageId(3);
 
@@ -197,7 +194,6 @@ class ConnectionManagerTest extends IntegrationTest
         $this->setupNotFullyConfiguredSite();
 
         $this->expectException(NoSolrConnectionFoundException::class);
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $connectionManager->getConnectionByPageId(31);
     }
@@ -226,7 +222,6 @@ class ConnectionManagerTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/connection_for_mounted_page.csv');
 
-        /* @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         $solrService = $connectionManager->getConnectionByPageId(24, 0, '24-14');

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -301,6 +301,8 @@ class RelationTest extends IntegrationTest
             $table,
             $requestMock
         );
-        return $contentObjectRenderer->getContentObject(Relation::CONTENT_OBJECT_NAME);
+        /** @var Relation $relation */
+        $relation = $contentObjectRenderer->getContentObject(Relation::CONTENT_OBJECT_NAME);
+        return $relation;
     }
 }

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -81,15 +81,12 @@ class IndexServiceTest extends IntegrationTest
 
         $this->addToIndexQueue('tx_fakeextension_domain_model_bar', 111);
 
-        /* @var CliEnvironment $cliEnvironment */
         $cliEnvironment = GeneralUtility::makeInstance(CliEnvironment::class);
         $cliEnvironment->backup();
         $cliEnvironment->initialize(Environment::getPublicPath() . '/');
 
-        /* @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getFirstAvailableSite();
-        /* @var IndexService $indexService */
         $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
 
         // run the indexer

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -63,7 +63,6 @@ class QueueItemRepositoryTest extends IntegrationTest
     public function deleteItemDeletesItemForEverySite()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         self::assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
         $queueItemRepository->deleteItem('pages', 1);
@@ -77,7 +76,6 @@ class QueueItemRepositoryTest extends IntegrationTest
     public function canDeleteItemByPassingTypeOnly()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         self::assertSame(6, $queueItemRepository->count(), 'Unexpected amount of items in the index queue');
         $queueItemRepository->deleteItem('pages');
@@ -91,7 +89,6 @@ class QueueItemRepositoryTest extends IntegrationTest
     public function canCountItems()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         self::assertSame(6, $queueItemRepository->countItems(), 'Unexpected amount of items counted when no filter was passed');
         self::assertSame(3, $queueItemRepository->countItems([], ['pages']), 'Unexpected amount of counted pages');
@@ -105,7 +102,6 @@ class QueueItemRepositoryTest extends IntegrationTest
     public function canFindItems()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         $items = $queueItemRepository->findItems([], ['pages']);
 
@@ -122,12 +118,10 @@ class QueueItemRepositoryTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_keep_indexing_properties.csv');
 
-        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
 
         $currentSite = $siteRepository->getSiteByPageId(4711);
 
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
         $queueItemRepository->add('pages', 4711, 1, 2, 'news_pages');
         $queueItemRepository->add('pages', 4711, 1, 2, 'product_pages');
@@ -163,7 +157,6 @@ class QueueItemRepositoryTest extends IntegrationTest
     public function canFlushErrorByItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_error_by_item.csv');
-        /* @var QueueItemRepository $queueItemRepository */
         $queueItemRepository = GeneralUtility::makeInstance(QueueItemRepository::class);
 
         $item = $queueItemRepository->findItemByUid(4714);

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -36,7 +36,6 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTest
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexPages([1, 2, 3, 4, 5]);
 
-        /* @var Repository $apacheSolrDocumentRepository */
         $this->apacheSolrDocumentRepository = GeneralUtility::makeInstance(Repository::class);
     }
 

--- a/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -21,10 +21,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class LastSearchesRepositoryTest extends IntegrationTest
 {
-    /**
-     * @var LastSearchesRepository
-     */
-    protected $lastSearchesRepository;
+    protected LastSearchesRepository $lastSearchesRepository;
 
     protected function setUp(): void
     {
@@ -36,7 +33,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
     /**
      * @test
      */
-    public function canFindAllKeywords()
+    public function canFindAllKeywords(): void
     {
         $actual = $this->lastSearchesRepository->findAllKeywords();
         self::assertSame(['4', '3', '2', '1', '0'], $actual);
@@ -45,7 +42,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
     /**
      * @test
      */
-    public function addWillInsertNewRowIfLastSearchesLimitIsNotExceeded()
+    public function addWillInsertNewRowIfLastSearchesLimitIsNotExceeded(): void
     {
         $this->lastSearchesRepository->add('5', 6);
 
@@ -56,7 +53,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
     /**
      * @test
      */
-    public function addWillUpdateOldestRowIfLastSearchesLimitIsExceeded()
+    public function addWillUpdateOldestRowIfLastSearchesLimitIsExceeded(): void
     {
         $this->lastSearchesRepository->add('5', 5);
 
@@ -67,7 +64,7 @@ class LastSearchesRepositoryTest extends IntegrationTest
     /**
      * @test
      */
-    public function lastUpdatedRowIsOnFirstPosition()
+    public function lastUpdatedRowIsOnFirstPosition(): void
     {
         $this->lastSearchesRepository->add('1', 5);
 

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -70,10 +70,10 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $facet */
+        /** @var OptionsFacet $facet */
         $facet = $searchResultSet->getFacets()->getByPosition(0);
 
-        /* @var Option $option1 */ // @extensionScannerIgnoreLine
+        /** @var Option $option1 */ // @extensionScannerIgnoreLine
         $option1 = $facet->getOptions()->getByPosition(0);
         self::assertSame('Pages', $option1->getLabel(), 'Rendering instructions have not been applied on the facet options');
     }
@@ -108,7 +108,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $facet */
+        /** @var OptionsFacet $facet */
         $facet = $searchResultSet->getFacets()->getByPosition(0);
         self::assertSame('MY TYPE WITH SPECIAL RENDERING', $facet->getLabel(), 'Rendering instructions have not been applied on the facet options');
     }
@@ -138,7 +138,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
     {
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
 
-        /* @var SearchRequest|MockObject $usedSearchRequestMock */
+        /** @var SearchRequest|MockObject $usedSearchRequestMock */
         $usedSearchRequestMock = $searchResultSet->getUsedSearchRequest();
         $usedSearchRequestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
         $usedSearchRequestMock->expects(self::any())->method('getActiveFacetNames')->willReturn([]);

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -49,7 +49,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetDocumentById()
+    public function canGetDocumentById(): void
     {
         // trigger a search
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
@@ -73,7 +73,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetVariants()
+    public function canGetVariants(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_searchResultSet.csv');
@@ -121,7 +121,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetCaseSensitiveVariants()
+    public function canGetCaseSensitiveVariants(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_searchResultSet.csv');
@@ -153,7 +153,6 @@ class SearchResultSetServiceTest extends IntegrationTest
         self::assertSame(3, count($searchResults), 'There should be three results at all');
 
         // We assume that the first result has 6 variants.
-        /** @var SearchResult $firstResult */
         $firstResult = $searchResults[0];
         self::assertSame(2, count($firstResult->getVariants()));
         self::assertSame('Jane Doe', $firstResult->getAuthor());
@@ -161,7 +160,6 @@ class SearchResultSetServiceTest extends IntegrationTest
         self::assertSame('Jane Doe', $firstResult->getVariantFieldValue());
 
         // We assume that the second result has 5 variants.
-        /** @var SearchResult $secondResult */
         $secondResult = $searchResults[1];
         self::assertSame(5, count($secondResult->getVariants()));
         self::assertSame('John Doe', $secondResult->getAuthor());
@@ -191,7 +189,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetZeroResultsWithVariantsOnEmptyIndex()
+    public function canGetZeroResultsWithVariantsOnEmptyIndex(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_searchResultSet.csv');
@@ -215,7 +213,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function cantGetHiddenElementWithoutPermissions()
+    public function cantGetHiddenElementWithoutPermissions(): void
     {
         $this->importFrontendRestrictedPageScenario();
 
@@ -231,7 +229,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canGetHiddenElementWithPermissions()
+    public function canGetHiddenElementWithPermissions(): void
     {
         $this->importFrontendRestrictedPageScenario();
 
@@ -247,7 +245,7 @@ class SearchResultSetServiceTest extends IntegrationTest
     /**
      * Imports a simple page with user restricted content
      */
-    protected function importFrontendRestrictedPageScenario()
+    protected function importFrontendRestrictedPageScenario(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/fe_user_page.csv');
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -64,7 +64,6 @@ class SearchResultSetServiceTest extends IntegrationTest
         $typoScriptConfiguration = Util::getSolrConfiguration();
 
         $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
-        /* @var SearchResultSetService $searchResultsSetService */
         $searchResultsSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
         $document = $searchResultsSetService->getDocumentById('002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0');
 
@@ -154,7 +153,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         self::assertSame(3, count($searchResults), 'There should be three results at all');
 
         // We assume that the first result has 6 variants.
-        /* @var SearchResult $firstResult */
+        /** @var SearchResult $firstResult */
         $firstResult = $searchResults[0];
         self::assertSame(2, count($firstResult->getVariants()));
         self::assertSame('Jane Doe', $firstResult->getAuthor());
@@ -162,7 +161,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         self::assertSame('Jane Doe', $firstResult->getVariantFieldValue());
 
         // We assume that the second result has 5 variants.
-        /* @var SearchResult $secondResult */
+        /** @var SearchResult $secondResult */
         $secondResult = $searchResults[1];
         self::assertSame(5, count($secondResult->getVariants()));
         self::assertSame('John Doe', $secondResult->getAuthor());

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -39,9 +39,6 @@ use TYPO3\CMS\Scheduler\Scheduler;
  */
 class GarbageCollectorTest extends IntegrationTest
 {
-    /**
-     * @var array
-     */
     protected array $coreExtensionsToLoad = [
         'extensionmanager',
         'scheduler',
@@ -870,6 +867,7 @@ class GarbageCollectorTest extends IntegrationTest
 
     protected function addToQueueAndIndexRecord(string $table, int $uid): bool
     {
+        $result = false;
         // write an index queue item
         $updatedItems = $this->indexQueue->updateItem($table, $uid);
 
@@ -892,10 +890,7 @@ class GarbageCollectorTest extends IntegrationTest
      */
     protected function processEventQueue(): void
     {
-        /** @var EventQueueWorkerTask $task */
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-
-        /** @var Scheduler $scheduler */
         $scheduler = GeneralUtility::makeInstance(Scheduler::class);
         $scheduler->executeTask($task);
     }

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -44,9 +44,6 @@ use TYPO3\TestingFramework\Core\Exception as TestingFrameworkCoreException;
  */
 class RecordMonitorTest extends IntegrationTest
 {
-    /**
-     * @var array
-     */
     protected array $coreExtensionsToLoad = [
         'extensionmanager',
         'scheduler',
@@ -140,9 +137,6 @@ class RecordMonitorTest extends IntegrationTest
         self::assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
     }
 
-    /**
-     * @param int $amount
-     */
     protected function assertEventQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->eventQueue->count();
@@ -177,8 +171,7 @@ class RecordMonitorTest extends IntegrationTest
             'version',
             'pages',
             1,
-            ['action' => 'swap'],
-            $this->dataHandler
+            ['action' => 'swap']
         );
 
         $output = trim(ob_get_contents());

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -65,9 +65,6 @@ abstract class IntegrationTest extends FunctionalTestCase
         'core_dk',
     ];
 
-    /**
-     * @var array
-     */
     protected array $configurationToUseInTestInstance = [
        'SYS' =>  [
            'exceptionalErrors' =>  E_WARNING | E_RECOVERABLE_ERROR | E_DEPRECATED | E_USER_DEPRECATED,

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -18,13 +18,13 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Solr\Service;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ExtractingQuery;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Psr18Adapter;
-use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -35,20 +35,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrWriteServiceTest extends IntegrationTest
 {
-    /**
-     * @var SolrWriteService
-     */
-    protected $solrWriteService;
+    protected SolrWriteService|MockObject $solrWriteService;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         // @todo: Drop manual initialization of solr Connection and use provided EXT:Solr API.
-        $psr7Client = GeneralUtility::getContainer()->get(ClientInterface::class);
-        $requestFactory = GeneralUtility::getContainer()->get(RequestFactoryInterface::class);
-        $streamFactory = GeneralUtility::getContainer()->get(StreamFactoryInterface::class);
-        /* @var EventDispatcher $eventDispatcher */
+        $psr7Client = $this->get(ClientInterface::class);
+        $requestFactory = $this->get(RequestFactoryInterface::class);
+        $streamFactory = $this->get(StreamFactoryInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $adapter = new Psr18Adapter(
             $psr7Client,
@@ -67,10 +63,9 @@ class SolrWriteServiceTest extends IntegrationTest
     /**
      * @test
      */
-    public function canExtractByQuery()
+    public function canExtractByQuery(): void
     {
         $testFilePath = __DIR__ . '/Fixtures/testpdf.pdf';
-        /* @var ExtractingQuery $extractQuery */
         $extractQuery = GeneralUtility::makeInstance(ExtractingQuery::class, $testFilePath);
         $extractQuery->setExtractOnly(true);
         $response = $this->solrWriteService->extractByQuery($extractQuery);

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -37,15 +37,8 @@ class EventQueueWorkerTaskTest extends IntegrationTest
         'scheduler',
     ];
 
-    /**
-     * @var EventQueueItemRepository
-     */
-    protected $eventQueue;
-
-    /**
-     * @var Queue
-     */
-    protected $indexQueue;
+    protected EventQueueItemRepository $eventQueue;
+    protected Queue $indexQueue;
 
     protected function setUp(): void
     {
@@ -54,7 +47,6 @@ class EventQueueWorkerTaskTest extends IntegrationTest
         $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
         $this->eventQueue = GeneralUtility::makeInstance(EventQueueItemRepository::class);
 
-        /** @var ExtensionConfiguration $task */
         $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class);
         $extConf->set('solr', ['monitoringType' => 1]);
     }
@@ -85,10 +77,7 @@ class EventQueueWorkerTaskTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_erroneous_event_queue_items.csv');
 
-        /** @var EventQueueWorkerTask $task */
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-
-        /** @var Scheduler $scheduler */
         $scheduler = GeneralUtility::makeInstance(Scheduler::class);
         $scheduler->executeTask($task);
 

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -38,19 +38,9 @@ class ReIndexTaskTest extends IntegrationTest
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 
-    /**
-     * @var ReIndexTask
-     */
-    protected $task;
+    protected ReIndexTask $task;
+    protected Queue $indexQueue;
 
-    /**
-     * @var Queue
-     */
-    protected $indexQueue;
-
-    /**
-     * @var array
-     */
     protected array $coreExtensionsToLoad = [
         'scheduler',
     ];

--- a/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
+++ b/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
@@ -72,7 +72,7 @@ class SettingsPreviewOnPluginsTest extends SetUpUnitTestCase
         array $record = [],
     ): PageContentPreviewRenderingEvent {
         /* @var PageLayoutContext|MockObject $pageLayoutContextMock */
-        $pageLayoutContextMock =  $this->getDumbMock(PageLayoutContext::class);
+        $pageLayoutContextMock =  $this->createMock(PageLayoutContext::class);
         return new PageContentPreviewRenderingEvent(
             $table,
             $record,

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -30,7 +30,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use UnexpectedValueException;
 
@@ -73,12 +72,12 @@ class ConnectionManagerTest extends SetUpUnitTestCase
      */
     protected function setUp(): void
     {
-        $TSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $TSFE = $this->createMock(TypoScriptFrontendController::class);
         $GLOBALS['TSFE'] = $TSFE;
 
-        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
-        $this->pageRepositoryMock = $this->getDumbMock(PagesRepository::class);
-        $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
+        $this->logManagerMock = $this->createMock(SolrLogManager::class);
+        $this->pageRepositoryMock = $this->createMock(PagesRepository::class);
+        $this->siteRepositoryMock = $this->createMock(SiteRepository::class);
 
         $this->configurationManager = new ConfigurationManager();
         $this->connectionManager = $this->getMockBuilder(ConnectionManager::class)
@@ -124,16 +123,10 @@ class ConnectionManagerTest extends SetUpUnitTestCase
             function ($readNode, $writeNode) use ($self) {
                 $readNode = Node::fromArray($readNode);
                 $writeNode = Node::fromArray($writeNode);
-                /* @var TypoScriptConfiguration $typoScriptConfigurationMock */
-                $typoScriptConfigurationMock = $self->getDumbMock(TypoScriptConfiguration::class);
-                /* @var SynonymParser $synonymsParserMock */
-                $synonymsParserMock = $self->getDumbMock(SynonymParser::class);
-                /* @var StopWordParser $stopWordParserMock */
-                $stopWordParserMock = $self->getDumbMock(StopWordParser::class);
-                /* @var SchemaParser $schemaParserMock */
-                $schemaParserMock = $self->getDumbMock(SchemaParser::class);
-                /* @var EventDispatcher $eventDispatcher */
-                $eventDispatcher = $self->getDumbMock(EventDispatcher::class);
+                $typoScriptConfigurationMock = $self->createMock(TypoScriptConfiguration::class);
+                $synonymsParserMock = $self->createMock(SynonymParser::class);
+                $stopWordParserMock = $self->createMock(StopWordParser::class);
+                $schemaParserMock = $self->createMock(SchemaParser::class);
 
                 return new SolrConnection(
                     $readNode,
@@ -143,10 +136,10 @@ class ConnectionManagerTest extends SetUpUnitTestCase
                     $stopWordParserMock,
                     $schemaParserMock,
                     $self->logManagerMock,
-                    $this->getDumbMock(ClientInterface::class),
-                    $this->getDumbMock(RequestFactoryInterface::class),
-                    $this->getDumbMock(StreamFactoryInterface::class),
-                    $this->getDumbMock(EventDispatcherInterface::class)
+                    $this->createMock(ClientInterface::class),
+                    $this->createMock(RequestFactoryInterface::class),
+                    $this->createMock(StreamFactoryInterface::class),
+                    $this->createMock(EventDispatcherInterface::class)
                 );
             }
         );

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -26,6 +26,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\StopWordParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -40,32 +41,11 @@ use UnexpectedValueException;
  */
 class ConnectionManagerTest extends SetUpUnitTestCase
 {
-    /**
-     * Connection manager
-     *
-     * @var ConnectionManager
-     */
-    protected $connectionManager;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $logManagerMock;
-
-    /**
-     * @var PagesRepository
-     */
-    protected $pageRepositoryMock;
-
-    /**
-     * @var SiteRepository
-     */
-    protected $siteRepositoryMock;
-
-    /**
-     * @var ConfigurationManager
-     */
-    protected $configurationManager;
+    protected ConnectionManager|MockObject $connectionManager;
+    protected SolrLogManager|MockObject $logManagerMock;
+    protected PagesRepository|MockObject $pageRepositoryMock;
+    protected SiteRepository|MockObject $siteRepositoryMock;
+    protected ConfigurationManager $configurationManager;
 
     /**
      * Set up the connection manager test
@@ -92,8 +72,6 @@ class ConnectionManagerTest extends SetUpUnitTestCase
 
     /**
      * Provides data for the connection test
-     *
-     * @return array
      */
     public function connectDataProvider(): array
     {
@@ -108,15 +86,8 @@ class ConnectionManagerTest extends SetUpUnitTestCase
      *
      * @dataProvider connectDataProvider
      * @test
-     *
-     * @param string $host
-     * @param string $port
-     * @param string $path
-     * @param string $scheme
-     * @param bool $expectsException
-     * @param string $expectedConnectionString
      */
-    public function canConnect($host, $port, $path, $scheme, $expectsException, $expectedConnectionString)
+    public function canConnect(string $host, string|int $port, string $path, string $scheme, bool $expectsException, ?string $expectedConnectionString): void
     {
         $self = $this;
         $this->connectionManager->expects(self::once())->method('getSolrConnectionForNodes')->willReturnCallback(

--- a/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
+++ b/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
@@ -47,9 +47,6 @@ abstract class AbstractModuleController extends SetUpUnitTestCase
 
     /**
      * Initializes the concrete backend module controller
-     *
-     * @param string $concreteModuleControllerClass
-     * @param array $mockMethods
      */
     protected function setUpConcreteModuleController(
         string $concreteModuleControllerClass,

--- a/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
+++ b/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
@@ -55,17 +55,17 @@ abstract class AbstractModuleController extends SetUpUnitTestCase
         string $concreteModuleControllerClass,
         array $mockMethods = ['addFlashMessage']
     ): void {
-        $this->selectedSiteMock = $this->getDumbMock(Site::class);
+        $this->selectedSiteMock = $this->createMock(Site::class);
         $this->controller = $this->getMockBuilder($concreteModuleControllerClass)
             ->setConstructorArgs(
                 [
-                    'moduleTemplateFactory' => $this->getDumbMock(ModuleTemplateFactory::class),
-                    'iconFactory' => $this->getDumbMock(IconFactory::class),
-                    'moduleDataStorageService' => $this->getDumbMock(ModuleDataStorageService::class),
-                    'siteRepository' => $this->getDumbMock(SiteRepository::class),
-                    'siteFinder' => $this->getDumbMock(SiteFinder::class),
-                    'solrConnectionManager' => $this->connectionManagerMock = $this->getDumbMock(ConnectionManager::class),
-                    'indexQueue' => $this->getDumbMock(Queue::class),
+                    'moduleTemplateFactory' => $this->createMock(ModuleTemplateFactory::class),
+                    'iconFactory' => $this->createMock(IconFactory::class),
+                    'moduleDataStorageService' => $this->createMock(ModuleDataStorageService::class),
+                    'siteRepository' => $this->createMock(SiteRepository::class),
+                    'siteFinder' => $this->createMock(SiteFinder::class),
+                    'solrConnectionManager' => $this->connectionManagerMock = $this->createMock(ConnectionManager::class),
+                    'indexQueue' => $this->createMock(Queue::class),
                 ]
             )
             ->onlyMethods($mockMethods)

--- a/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
+++ b/Tests/Unit/Controller/Backend/Search/AbstractModuleController.php
@@ -35,15 +35,8 @@ abstract class AbstractModuleController extends SetUpUnitTestCase
      */
     protected $controller;
 
-    /**
-     * @var Site|MockObject
-     */
-    protected $selectedSiteMock;
-
-    /**
-     * @var ConnectionManager|MockObject
-     */
-    protected $connectionManagerMock;
+    protected Site|MockObject $selectedSiteMock;
+    protected ConnectionManager|MockObject $connectionManagerMock;
 
     /**
      * Initializes the concrete backend module controller
@@ -53,7 +46,8 @@ abstract class AbstractModuleController extends SetUpUnitTestCase
         array $mockMethods = ['addFlashMessage']
     ): void {
         $this->selectedSiteMock = $this->createMock(Site::class);
-        $this->controller = $this->getMockBuilder($concreteModuleControllerClass)
+        /** @var ModuleController|MockObject $subject */
+        $subject = $this->getMockBuilder($concreteModuleControllerClass)
             ->setConstructorArgs(
                 [
                     'moduleTemplateFactory' => $this->createMock(ModuleTemplateFactory::class),
@@ -73,7 +67,8 @@ abstract class AbstractModuleController extends SetUpUnitTestCase
         $uriBuilderMock->expects(self::any())
             ->method('uriFor')
             ->willReturn('index');
-        $this->controller->injectUriBuilder($uriBuilderMock);
-        $this->controller->setSelectedSite($this->selectedSiteMock);
+        $subject->injectUriBuilder($uriBuilderMock);
+        $subject->setSelectedSite($this->selectedSiteMock);
+        $this->controller = $subject;
     }
 }

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -46,15 +46,15 @@ class IndexAdministrationModuleControllerTest extends AbstractModuleController
      */
     public function testReloadIndexConfigurationAction()
     {
-        $responseMock = $this->getDumbMock(ResponseAdapter::class);
+        $responseMock = $this->createMock(ResponseAdapter::class);
         $responseMock->expects(self::once())->method('getHttpStatus')->willReturn(200);
 
-        $writeEndpointMock = $this->getDumbMock(Endpoint::class);
-        $adminServiceMock = $this->getDumbMock(SolrAdminService::class);
+        $writeEndpointMock = $this->createMock(Endpoint::class);
+        $adminServiceMock = $this->createMock(SolrAdminService::class);
         $adminServiceMock->expects(self::once())->method('reloadCore')->willReturn($responseMock);
         $adminServiceMock->expects(self::once())->method('getPrimaryEndpoint')->willReturn($writeEndpointMock);
 
-        $solrConnection = $this->getDumbMock(SolrConnection::class);
+        $solrConnection = $this->createMock(SolrConnection::class);
         $solrConnection->expects(self::once())->method('getAdminService')->willReturn($adminServiceMock);
 
         $fakeConnections = [$solrConnection];

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
 
-use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Controller\Backend\Search\IndexAdministrationModuleController;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
@@ -31,9 +30,9 @@ use Solarium\Core\Client\Endpoint;
 class IndexAdministrationModuleControllerTest extends AbstractModuleController
 {
     /**
-     * @var ConnectionManager|MockObject
+     * @var IndexAdministrationModuleController|MockObject
      */
-    protected $connectionManagerMock;
+    protected $controller;
 
     protected function setUp(): void
     {
@@ -44,7 +43,7 @@ class IndexAdministrationModuleControllerTest extends AbstractModuleController
     /**
      * @test
      */
-    public function testReloadIndexConfigurationAction()
+    public function testReloadIndexConfigurationAction(): void
     {
         $responseMock = $this->createMock(ResponseAdapter::class);
         $responseMock->expects(self::once())->method('getHttpStatus')->willReturn(200);

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Controller\Backend\Search;
 
 use ApacheSolrForTypo3\Solr\Controller\Backend\Search\IndexQueueModuleController;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for IndexQueueModuleController
@@ -25,10 +26,12 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
  */
 class IndexQueueModuleControllerTest extends AbstractModuleController
 {
+    protected Queue|MockObject $indexQueueMock;
+
     /**
-     * @var Queue
+     * @var IndexQueueModuleController|MockObject
      */
-    protected $indexQueueMock;
+    protected $controller;
 
     protected function setUp(): void
     {
@@ -44,11 +47,7 @@ class IndexQueueModuleControllerTest extends AbstractModuleController
         parent::setUp();
     }
 
-    /**
-     * @param string $type
-     * @param int $uid
-     */
-    protected function assertQueueUpdateIsTriggeredFor($type, $uid)
+    protected function assertQueueUpdateIsTriggeredFor(string $type, int $uid): void
     {
         $this->indexQueueMock->expects(self::once())->method('updateOrAddItemForAllRelatedRootPages')->with($type, $uid)->willReturn(1);
     }
@@ -56,16 +55,16 @@ class IndexQueueModuleControllerTest extends AbstractModuleController
     /**
      * @test
      */
-    public function requeueDocumentActionIsTriggeringReIndexOnIndexQueue()
+    public function requeueDocumentActionIsTriggeringReIndexOnIndexQueue(): void
     {
         $this->assertQueueUpdateIsTriggeredFor('pages', 4711);
-        $this->controller->requeueDocumentAction('pages', 4711, 1, 0);
+        $this->controller->requeueDocumentAction('pages', 4711);
     }
 
     /**
      * @test
      */
-    public function hookIsTriggeredWhenRegistered()
+    public function hookIsTriggeredWhenRegistered(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'][] = IndexQueueTestUpdateHandler::class;
 
@@ -76,7 +75,7 @@ class IndexQueueModuleControllerTest extends AbstractModuleController
         $this->indexQueueMock->expects(self::once())->method('getHookImplementation')->with(IndexQueueTestUpdateHandler::class)->willReturn($testHandlerMock);
 
         $this->assertQueueUpdateIsTriggeredFor('tx_solr_file', 88);
-        $this->controller->requeueDocumentAction('tx_solr_file', 88, 1, 0);
+        $this->controller->requeueDocumentAction('tx_solr_file', 88);
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'] = [];
     }

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -69,7 +69,7 @@ class IndexQueueModuleControllerTest extends AbstractModuleController
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem'][] = IndexQueueTestUpdateHandler::class;
 
-        $testHandlerMock = $this->getDumbMock(IndexQueueTestUpdateHandler::class);
+        $testHandlerMock = $this->createMock(IndexQueueTestUpdateHandler::class);
         $testHandlerMock->expects(self::once())->method('postProcessIndexQueueUpdateItem');
 
         $this->indexQueueMock->expects(self::once())->method('updateOrAddItemForAllRelatedRootPages')->willReturn(0);

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -33,25 +33,10 @@ use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
  */
 class IndexServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var Site|MockObject
-     */
-    protected $siteMock;
-
-    /**
-     * @var Queue
-     */
-    protected $queueMock;
-
-    /**
-     * @var EventDispatcher|MockObject
-     */
+    protected Site|MockObject $siteMock;
+    protected Queue|MockObject $queueMock;
     protected EventDispatcher|MockObject $eventDispatcherMock;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $logManagerMock;
+    protected SolrLogManager|MockObject $logManagerMock;
 
     protected function setUp(): void
     {
@@ -70,7 +55,7 @@ class IndexServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function eventsAreTriggered()
+    public function eventsAreTriggered(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock = $this->getMockBuilder(Site::class)
@@ -99,7 +84,7 @@ class IndexServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testConfigurationIsNotFetchedWhenProgressIsCalculated()
+    public function testConfigurationIsNotFetchedWhenProgressIsCalculated(): void
     {
         $this->siteMock->expects(self::never())->method('getSolrConfiguration');
 
@@ -119,7 +104,7 @@ class IndexServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testServerHostIsRestoredInCaseOfAnException()
+    public function testServerHostIsRestoredInCaseOfAnException(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock = $this->getMockBuilder(Site::class)
@@ -162,7 +147,7 @@ class IndexServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testDomainIsUsedFromSiteObject()
+    public function testDomainIsUsedFromSiteObject(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
@@ -192,9 +177,9 @@ class IndexServiceTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param $fakeItems
+     * @param array $fakeItems
      */
-    protected function fakeQueueItemContent($fakeItems)
+    protected function fakeQueueItemContent(array $fakeItems): void
     {
         $this->queueMock
             ->expects(self::once())
@@ -202,10 +187,7 @@ class IndexServiceTest extends SetUpUnitTestCase
             ->willReturn($fakeItems);
     }
 
-    /**
-     * @param int $amount
-     */
-    protected function assertEventsWillBeDispatched(int $amount = 0)
+    protected function assertEventsWillBeDispatched(int $amount = 0): void
     {
         $this->eventDispatcherMock->expects(self::exactly($amount))
             ->method('dispatch')

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -55,15 +55,15 @@ class IndexServiceTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->siteMock = $this->getDumbMock(Site::class);
-        $this->queueMock = $this->getDumbMock(Queue::class);
+        $this->siteMock = $this->createMock(Site::class);
+        $this->queueMock = $this->createMock(Queue::class);
         $this->eventDispatcherMock = $this->getMockBuilder(EventDispatcher::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['dispatch'])
             ->getMock();
         $this->eventDispatcherMock->method('dispatch')
             ->willReturnArgument(0);
-        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $this->logManagerMock = $this->createMock(SolrLogManager::class);
         parent::setUp();
     }
 
@@ -72,7 +72,7 @@ class IndexServiceTest extends SetUpUnitTestCase
      */
     public function eventsAreTriggered()
     {
-        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock = $this->getMockBuilder(Site::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSolrConfiguration'])
@@ -86,8 +86,8 @@ class IndexServiceTest extends SetUpUnitTestCase
             ->getMock();
 
         // we fake an index queue with two items
-        $item1 = $this->getDumbMock(Item::class);
-        $item2 = $this->getDumbMock(Item::class);
+        $item1 = $this->createMock(Item::class);
+        $item2 = $this->createMock(Item::class);
         $fakeItems = [$item1, $item2];
         $this->fakeQueueItemContent($fakeItems);
 
@@ -103,7 +103,7 @@ class IndexServiceTest extends SetUpUnitTestCase
     {
         $this->siteMock->expects(self::never())->method('getSolrConfiguration');
 
-        $statisticMock = $this->getDumbMock(QueueStatistic::class);
+        $statisticMock = $this->createMock(QueueStatistic::class);
         $statisticMock->expects(self::once())->method('getSuccessPercentage')->willReturn(50.0);
         $this->queueMock->expects(self::once())->method('getStatisticsBySite')->willReturn($statisticMock);
 
@@ -121,7 +121,7 @@ class IndexServiceTest extends SetUpUnitTestCase
      */
     public function testServerHostIsRestoredInCaseOfAnException()
     {
-        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock = $this->getMockBuilder(Site::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSolrConfiguration', 'getDomain'])
@@ -147,10 +147,10 @@ class IndexServiceTest extends SetUpUnitTestCase
         $indexService->expects(self::exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
 
         // we fake an index queue with two items
-        $item1 = $this->getDumbMock(Item::class);
+        $item1 = $this->createMock(Item::class);
         $item1->expects(self::any())->method('getSite')->willReturn($this->siteMock);
         $item1->expects(self::any())->method('getIndexingConfigurationName')->willReturn('fake_table');
-        $item2 = $this->getDumbMock(Item::class);
+        $item2 = $this->createMock(Item::class);
         $item2->expects(self::any())->method('getIndexingConfigurationName')->willReturn('fake_table');
 
         $fakeItems = [$item1, $item2];
@@ -164,7 +164,7 @@ class IndexServiceTest extends SetUpUnitTestCase
      */
     public function testDomainIsUsedFromSiteObject()
     {
-        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
         $this->siteMock->expects(self::any())->method('getDomain')->willReturn('www.indextest.local');
 
@@ -174,15 +174,15 @@ class IndexServiceTest extends SetUpUnitTestCase
             ->onlyMethods(['getIndexerByItem'])
             ->getMock();
 
-        $indexerMock = $this->getDumbMock(Indexer::class);
+        $indexerMock = $this->createMock(Indexer::class);
         $indexerMock->expects(self::exactly(2))->method('index')->willReturn(true);
         $indexService->expects(self::exactly(2))->method('getIndexerByItem')->willReturn($indexerMock);
 
         // we fake an index queue with two items
-        $item1 = $this->getDumbMock(Item::class);
+        $item1 = $this->createMock(Item::class);
         $item1->expects(self::any())->method('getSite')->willReturn($this->siteMock);
         $item1->expects(self::any())->method('getIndexingConfigurationName')->willReturn('fake_table');
-        $item2 = $this->getDumbMock(Item::class);
+        $item2 = $this->createMock(Item::class);
         $item2->expects(self::any())->method('getIndexingConfigurationName')->willReturn('fake_table');
 
         $fakeItems = [$item1, $item2];

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
@@ -23,15 +23,13 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
     public function testPageIndexingUriFromPageItemAndLanguageId()
     {
         $pageRecord = ['uid' => 55];
-        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock = $this->createMock(Item::class);
         $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
         $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
-        /* @var SolrLogManager $loggerMock */
-        $loggerMock = $this->getDumbMock(SolrLogManager::class);
+        $loggerMock = $this->createMock(SolrLogManager::class);
 
-        /** @var TYPO3SiteStrategy $typo3SiteStrategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo');
     }
@@ -42,15 +40,13 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
     public function canOverrideHost()
     {
         $pageRecord = ['uid' => 55];
-        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock = $this->createMock(Item::class);
         $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
         $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
-        /* @var SolrLogManager $loggerMock */
-        $loggerMock = $this->getDumbMock(SolrLogManager::class);
+        $loggerMock = $this->createMock(SolrLogManager::class);
 
-        /** @var TYPO3SiteStrategy $strategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $uri = $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo', ['frontendDataHelper.' => ['host' => 'www.secondsite.de']]);
         self::assertSame('http://www.secondsite.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
@@ -62,15 +58,13 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
     public function canOverrideScheme()
     {
         $pageRecord = ['uid' => 55];
-        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock = $this->createMock(Item::class);
         $itemMock->expects(self::any())->method('getRecord')->willReturn($pageRecord);
         $itemMock->expects(self::any())->method('getRecordUid')->willReturn(55);
         $siteFinderMock = $this->getSiteFinderMock($pageRecord);
 
-        /* @var SolrLogManager $loggerMock */
-        $loggerMock = $this->getDumbMock(SolrLogManager::class);
+        $loggerMock = $this->createMock(SolrLogManager::class);
 
-        /** @var TYPO3SiteStrategy $strategy */
         $typo3SiteStrategy = GeneralUtility::makeInstance(TYPO3SiteStrategy::class, $loggerMock, $siteFinderMock);
         $uri = $typo3SiteStrategy->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo', ['frontendDataHelper.' => ['scheme' => 'https']]);
         self::assertSame('https://www.site.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
@@ -81,18 +75,17 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
      */
     protected function getSiteFinderMock($pageRecord = []): SiteFinder
     {
-        $uriMock = $this->getDumbMock(UriInterface::class);
+        $uriMock = $this->createMock(UriInterface::class);
         $uriMock->expects(self::any())->method('__toString')->willReturn('http://www.site.de/en/test');
 
-        $routerMock = $this->getDumbMock(RouterInterface::class);
+        $routerMock = $this->createMock(RouterInterface::class);
         $routerMock->expects(self::once())->method('generateUri')->with($pageRecord, ['_language' => 2, 'MP' => 'foo'])
             ->willReturn($uriMock);
 
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::once())->method('getRouter')->willReturn($routerMock);
 
-        /** @var SiteFinder $siteFinderMock */
-        $siteFinderMock = $this->getDumbMock(SiteFinder::class);
+        $siteFinderMock = $this->createMock(SiteFinder::class);
         $siteFinderMock->expects(self::once())->method('getSiteByPageId')->willReturn($siteMock);
         return $siteFinderMock;
     }

--- a/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/Helper/UriBuilder/TYPO3SiteStrategyTest.php
@@ -12,15 +12,12 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * Class SolrSiteStrategyTest
- */
 class TYPO3SiteStrategyTest extends SetUpUnitTestCase
 {
     /**
      * @test
      */
-    public function testPageIndexingUriFromPageItemAndLanguageId()
+    public function testPageIndexingUriFromPageItemAndLanguageId(): void
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->createMock(Item::class);
@@ -37,7 +34,7 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canOverrideHost()
+    public function canOverrideHost(): void
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->createMock(Item::class);
@@ -55,7 +52,7 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canOverrideScheme()
+    public function canOverrideScheme(): void
     {
         $pageRecord = ['uid' => 55];
         $itemMock = $this->createMock(Item::class);
@@ -70,10 +67,7 @@ class TYPO3SiteStrategyTest extends SetUpUnitTestCase
         self::assertSame('https://www.site.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
     }
 
-    /**
-     * @return array
-     */
-    protected function getSiteFinderMock($pageRecord = []): SiteFinder
+    protected function getSiteFinderMock(array $pageRecord = []): SiteFinder
     {
         $uriMock = $this->createMock(UriInterface::class);
         $uriMock->expects(self::any())->method('__toString')->willReturn('http://www.site.de/en/test');

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
@@ -22,17 +22,14 @@ use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\AccessibleProxyTrait;
+use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 
 /**
  * Abstract strategy tests
  */
 abstract class AbstractStrategyTest extends SetUpUnitTestCase
 {
-    /**
-     * @var AbstractStrategy|AccessibleProxyTrait $subject
-     */
-    protected AbstractStrategy $subject;
+    protected AbstractStrategy|AccessibleObjectInterface $subject;
 
     protected function tearDown(): void
     {
@@ -41,9 +38,6 @@ abstract class AbstractStrategyTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param int $status
-     * @param bool $commit
-     *
      * @test
      * @dataProvider canDeleteRecordInAllSolrConnectionsDataProvider
      */

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTest.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
-use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\AccessibleProxyTrait;
 
@@ -113,9 +112,8 @@ abstract class AbstractStrategyTest extends SetUpUnitTestCase
 
     /**
      * Data provider for canDeleteRecordInAllSolrConnectionsDataProvider
-     * @return Traversable
      */
-    public function canDeleteRecordInAllSolrConnectionsDataProvider(): Traversable
+    public function canDeleteRecordInAllSolrConnectionsDataProvider(): \Generator
     {
         yield 'can delete and commit' => [
             'status' => 200,

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -20,7 +20,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -32,8 +31,7 @@ class QueueInitializerServiceTest extends SetUpUnitTestCase
      */
     public function allIndexConfigurationsAreUsedWhenWildcardIsPassed()
     {
-        $queueMock = $this->getDumbMock(Queue::class);
-        /* @var QueueInitializationService|MockObject $service */
+        $queueMock = $this->createMock(Queue::class);
         $service = $this->getMockBuilder(QueueInitializationService::class)->onlyMethods(['executeInitializer'])->setConstructorArgs([$queueMock])->getMock();
 
         $fakeTs = [
@@ -65,7 +63,7 @@ class QueueInitializerServiceTest extends SetUpUnitTestCase
 
         $fakeConfiguration = new TypoScriptConfiguration($fakeTs);
 
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
 
         $service

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -20,7 +20,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -48,9 +47,8 @@ class RootPageResolverTest extends SetUpUnitTestCase
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
 
-        $this->recordServiceMock = $this->getDumbMock(ConfigurationAwareRecordService::class);
+        $this->recordServiceMock = $this->createMock(ConfigurationAwareRecordService::class);
 
-        /* @var RootPageResolver $rootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
             ->onlyMethods(['getIsRootPageId', 'getAlternativeSiteRootPagesIds', 'getRootPageIdByTableAndUid', 'getRecordPageId', 'getPageRecordByPageId'])->getMock();
@@ -96,7 +94,6 @@ class RootPageResolverTest extends SetUpUnitTestCase
      */
     public function getIsRootPageIdWithPageIdZero()
     {
-        /* @var RootPageResolver|MockObject $rootPageResolver */
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
             ->onlyMethods([])
@@ -133,7 +130,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
 
     protected function fakeDisabledCache()
     {
-        $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
+        $this->cacheMock = $this->createMock(TwoLevelCache::class);
         $this->cacheMock->method('get')->willReturn(false);
     }
 }

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -20,26 +20,16 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class RootPageResolverTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TwoLevelCache
-     */
-    protected $cacheMock;
-
-    /**
-     * @var ConfigurationAwareRecordService
-     */
-    protected $recordServiceMock;
-
-    /**
-     * @var RootPageResolver
-     */
-    protected $rootPageResolver;
+    protected TwoLevelCache|MockObject $cacheMock;
+    protected ConfigurationAwareRecordService|MockObject $recordServiceMock;
+    protected RootPageResolver|MockObject $rootPageResolver;
 
     protected function setUp(): void
     {
@@ -58,7 +48,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences()
+    public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences(): void
     {
         $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
         $this->rootPageResolver->expects(self::once())->method('getRecordPageId')->willReturn(111);
@@ -75,7 +65,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot()
+    public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot(): void
     {
         $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
         $this->rootPageResolver->expects(self::once())->method('getRecordPageId')->willReturn(111);
@@ -92,7 +82,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getIsRootPageIdWithPageIdZero()
+    public function getIsRootPageIdWithPageIdZero(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
@@ -105,7 +95,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getIsRootPageWithPageIdMinusOne()
+    public function getIsRootPageWithPageIdMinusOne(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
@@ -118,7 +108,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getIsRootPageIdWithUnknownPageId()
+    public function getIsRootPageIdWithUnknownPageId(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
             ->setConstructorArgs([$this->recordServiceMock, $this->cacheMock])
@@ -128,7 +118,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         $this->rootPageResolver->getIsRootPageId(42);
     }
 
-    protected function fakeDisabledCache()
+    protected function fakeDisabledCache(): void
     {
         $this->cacheMock = $this->createMock(TwoLevelCache::class);
         $this->cacheMock->method('get')->willReturn(false);

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -29,7 +29,6 @@ class QueueStatisticTest extends SetUpUnitTestCase
      */
     public function canGetFailedPercentage()
     {
-        /* @var QueueStatistic $statistic */
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
         $statistic->setFailedCount(2);
         $statistic->setSuccessCount(1);
@@ -45,7 +44,6 @@ class QueueStatisticTest extends SetUpUnitTestCase
      */
     public function canGetZeroPercentagesWhenEmpty()
     {
-        /* @var QueueStatistic $statistic */
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
         self::assertSame(0.0, $statistic->getFailedPercentage(), 'Can not zero percent for empty');
     }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -30,6 +30,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class DelayedProcessingEventListenerTest extends SetUpEventListener
 {
     /**
+     * @var DelayedProcessingEventListener
+     */
+    protected AbstractBaseEventListener $listener;
+
+    /**
      * @test
      */
     public function canHandleEvents(): void
@@ -86,20 +91,13 @@ class DelayedProcessingEventListenerTest extends SetUpEventListener
         $this->listener->__invoke($event);
     }
 
-    /**
-     * Init listener
-     *
-     * @return AbstractBaseEventListener
-     */
-    protected function initListener(): AbstractBaseEventListener
+    protected function initListener(): DelayedProcessingEventListener
     {
         return new DelayedProcessingEventListener($this->extensionConfigurationMock, $this->eventDispatcherMock);
     }
 
     /**
      * Returns the current monitoring type
-     *
-     * @return int
      */
     protected function getMonitoringType(): int
     {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\EventListener\Events;
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEventInterface;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
@@ -26,6 +25,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 abstract class SetUpProcessingFinishedEvent extends SetUpUnitTestCase
 {
+    protected const EVENT_CLASS = 'stdClass';
     /**
      * @test
      */
@@ -33,7 +33,6 @@ abstract class SetUpProcessingFinishedEvent extends SetUpUnitTestCase
     {
         $processedEvent = new RecordUpdatedEvent(123, 'tx_foo_bar');
 
-        /** @var ProcessingFinishedEventInterface $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass($processedEvent);
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -27,6 +27,11 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdate
 class NoProcessingEventListenerTest extends SetUpEventListener
 {
     /**
+     * @var NoProcessingEventListener
+     */
+    protected AbstractBaseEventListener $listener;
+
+    /**
      * @test
      */
     public function canHandleEvents(): void
@@ -56,20 +61,13 @@ class NoProcessingEventListenerTest extends SetUpEventListener
         self::assertFalse($event->isPropagationStopped());
     }
 
-    /**
-     * Init listener
-     *
-     * @return AbstractBaseEventListener
-     */
-    protected function initListener(): AbstractBaseEventListener
+    protected function initListener(): NoProcessingEventListener
     {
         return new NoProcessingEventListener($this->extensionConfigurationMock, $this->eventDispatcherMock);
     }
 
     /**
      * Returns the current monitoring type
-     *
-     * @return int
      */
     protected function getMonitoringType(): int
     {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
@@ -31,20 +31,9 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
 {
     private const MONITORING_TYPES_TO_TEST = [0, 1, 2, 99];
 
-    /**
-     * @var AbstractBaseEventListener
-     */
-    protected $listener;
-
-    /**
-     * @var MockObject|ExtensionConfiguration
-     */
-    protected $extensionConfigurationMock;
-
-    /**
-     * @var MockObject|EventDispatcherInterface
-     */
-    protected $eventDispatcherMock;
+    protected AbstractBaseEventListener $listener;
+    protected MockObject|ExtensionConfiguration $extensionConfigurationMock;
+    protected MockObject|EventDispatcherInterface $eventDispatcherMock;
 
     protected function setUp(): void
     {
@@ -62,8 +51,6 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
 
     /**
      * Init listener
-     *
-     * @return AbstractBaseEventListener
      */
     abstract protected function initListener(): AbstractBaseEventListener;
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -32,7 +32,7 @@ class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
      */
     public function canInitAndReturnFields(): void
     {
-        $event = new ContentElementDeletedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
+        $event = new ContentElementDeletedEvent(123);
         self::assertEmpty($event->getFields());
     }
 
@@ -41,7 +41,7 @@ class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
      */
     public function canForceTable(): void
     {
-        $event = new ContentElementDeletedEvent(123, 'tx_foo_bar');
+        $event = new ContentElementDeletedEvent(123);
         self::assertEquals('tt_content', $event->getTable());
     }
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -32,7 +32,7 @@ class PageMovedEventTest extends SetUpDataUpdateEvent
      */
     public function canInitAndReturnFields(): void
     {
-        $event = new PageMovedEvent(123, static::EVENT_TEST_TABLE, ['hidden' => 1]);
+        $event = new PageMovedEvent(123);
         self::assertEmpty($event->getFields());
     }
 
@@ -41,7 +41,7 @@ class PageMovedEventTest extends SetUpDataUpdateEvent
      */
     public function canForceTable(): void
     {
-        $event = new PageMovedEvent(123, 'tx_foo_bar');
+        $event = new PageMovedEvent(123);
         self::assertEquals('pages', $event->getTable());
     }
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
@@ -27,12 +27,14 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
 {
+    protected const EVENT_CLASS = AbstractDataUpdateEvent::class;
+    protected const EVENT_TEST_TABLE = 'tx_foo_bar';
+
     /**
      * @test
      */
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, static::EVENT_TEST_TABLE);
 
@@ -52,7 +54,6 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
      */
     public function canInitAndReturnFields(): void
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, static::EVENT_TEST_TABLE, $fields = ['hidden' => 1]);
 
@@ -80,12 +81,10 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
      */
     public function canIndicateContentElementUpdate(): void
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
         self::assertFalse($event->isContentElementUpdate());
 
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tt_content');
         self::assertTrue($event->isContentElementUpdate());
@@ -97,7 +96,6 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
     public function canMarkAndIndicateStoppedProcessing(): void
     {
         $eventClass = static::EVENT_CLASS;
-        /** @var AbstractDataUpdateEvent $event */
         $event = new $eventClass(123, 'tx_foo_bar');
 
         self::assertFalse($event->isPropagationStopped());
@@ -112,7 +110,6 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
      */
     public function canMarkAndIndicateForcedProcessing(): void
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'tx_foo_bar');
 
@@ -135,7 +132,6 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
             'l10n_diffsource' => 'dummy l10n_diffsource',
         ];
 
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
         $event = new $eventClass(123, 'pages', $fields);
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
 {
     /**
-     * @return SetUpDataUpdateEvent
      * @test
      */
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
@@ -65,8 +64,8 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
      */
     public function canIndicatePageUpdate(): void
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
+        /** @var AbstractDataUpdateEvent $event */
         $event = new $eventClass(123, 'tx_foo_bar');
         self::assertFalse($event->isPageUpdate());
 
@@ -97,8 +96,8 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
      */
     public function canMarkAndIndicateStoppedProcessing(): void
     {
-        /** @var AbstractDataUpdateEvent $event */
         $eventClass = static::EVENT_CLASS;
+        /** @var AbstractDataUpdateEvent $event */
         $event = new $eventClass(123, 'tx_foo_bar');
 
         self::assertFalse($event->isPropagationStopped());

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -44,25 +44,10 @@ class BuilderTest extends SetUpUnitTestCase
         'abstract' => null,
     ];
 
-    /**
-     * @var IdBuilder
-     */
-    protected $variantIdBuilderMock;
-
-    /**
-     * @var Site
-     */
-    protected $siteMock;
-
-    /**
-     * @var Typo3PageContentExtractor
-     */
-    protected $typo3PageExtractorMock;
-
-    /**
-     * @var Builder
-     */
-    protected $documentBuilder;
+    protected IdBuilder|MockObject $variantIdBuilderMock;
+    protected Site|MockObject $siteMock;
+    protected Typo3PageContentExtractor|MockObject $typo3PageExtractorMock;
+    protected Builder|MockObject $documentBuilder;
 
     protected function setUp(): void
     {
@@ -82,9 +67,8 @@ class BuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canBuildApacheSolrDocumentFromEmptyPage()
+    public function canBuildApacheSolrDocumentFromEmptyPage(): void
     {
-        /* @var MockObject|TypoScriptFrontendController $fakePage */
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
@@ -103,9 +87,8 @@ class BuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetKeywordsForApacheSolrDocument()
+    public function canSetKeywordsForApacheSolrDocument(): void
     {
-        /* @var MockObject|TypoScriptFrontendController $fakePage */
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
@@ -123,9 +106,8 @@ class BuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetEndtimeForApacheSolrDocument()
+    public function canSetEndtimeForApacheSolrDocument(): void
     {
-        /* @var MockObject|TypoScriptFrontendController $fakePage */
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
@@ -143,9 +125,8 @@ class BuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetTagFieldsForApacheSolrDocument()
+    public function canSetTagFieldsForApacheSolrDocument(): void
     {
-        /* @var MockObject|TypoScriptFrontendController $fakePage */
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
         $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
@@ -163,7 +144,7 @@ class BuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canBuildFromRecord()
+    public function canBuildFromRecord(): void
     {
         $fakeRecord = ['uid' => 4711, 'pid' => 88, 'type' => 'news'];
         $type = 'news';
@@ -187,26 +168,17 @@ class BuilderTest extends SetUpUnitTestCase
         self::assertSame('EXT:solr', $document->appKey, 'appKey field was not set as expected');
     }
 
-    /**
-     * @param string $documentId
-     */
-    protected function fakePageDocumentId($documentId)
+    protected function fakePageDocumentId(string $documentId): void
     {
         $this->documentBuilder->expects(self::once())->method('getPageDocumentId')->willReturn($documentId);
     }
 
-    /**
-     * @param string $documentId
-     */
-    protected function fakeDocumentId($documentId)
+    protected function fakeDocumentId(string $documentId): void
     {
         $this->documentBuilder->expects(self::once())->method('getDocumentId')->willReturn($documentId);
     }
 
-    /**
-     * @param array $tagContent
-     */
-    protected function fakeTagContent($tagContent = [])
+    protected function fakeTagContent($tagContent = []): void
     {
         $this->typo3PageExtractorMock->expects(self::once())->method('getTagContent')->willReturn($tagContent);
     }

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -66,12 +66,10 @@ class BuilderTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        /** @var $variantIdBuilderMock */
-        $this->variantIdBuilderMock = $this->getDumbMock(IdBuilder::class);
-        $this->siteMock = $this->getDumbMock(Site::class);
-        $this->typo3PageExtractorMock = $this->getDumbMock(Typo3PageContentExtractor::class);
+        $this->variantIdBuilderMock = $this->createMock(IdBuilder::class);
+        $this->siteMock = $this->createMock(Site::class);
+        $this->typo3PageExtractorMock = $this->createMock(Typo3PageContentExtractor::class);
 
-        /* @var Builder $documentBuilder */
         $this->documentBuilder = $this->getMockBuilder(Builder::class)->setConstructorArgs([$this->variantIdBuilderMock ])->onlyMethods(
             ['getExtractorForPageContent', 'getSiteByPageId', 'getPageDocumentId', 'getDocumentId']
         )->getMock();
@@ -87,8 +85,8 @@ class BuilderTest extends SetUpUnitTestCase
     public function canBuildApacheSolrDocumentFromEmptyPage()
     {
         /* @var MockObject|TypoScriptFrontendController $fakePage */
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
-        $fakeRootLine = $this->getDumbMock(Rootline::class);
+        $fakePage = $this->createMock(TypoScriptFrontendController::class);
+        $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
@@ -108,8 +106,8 @@ class BuilderTest extends SetUpUnitTestCase
     public function canSetKeywordsForApacheSolrDocument()
     {
         /* @var MockObject|TypoScriptFrontendController $fakePage */
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
-        $fakeRootLine = $this->getDumbMock(Rootline::class);
+        $fakePage = $this->createMock(TypoScriptFrontendController::class);
+        $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
@@ -128,8 +126,8 @@ class BuilderTest extends SetUpUnitTestCase
     public function canSetEndtimeForApacheSolrDocument()
     {
         /* @var MockObject|TypoScriptFrontendController $fakePage */
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
-        $fakeRootLine = $this->getDumbMock(Rootline::class);
+        $fakePage = $this->createMock(TypoScriptFrontendController::class);
+        $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');
@@ -148,8 +146,8 @@ class BuilderTest extends SetUpUnitTestCase
     public function canSetTagFieldsForApacheSolrDocument()
     {
         /* @var MockObject|TypoScriptFrontendController $fakePage */
-        $fakePage = $this->getDumbMock(TypoScriptFrontendController::class);
-        $fakeRootLine = $this->getDumbMock(Rootline::class);
+        $fakePage = $this->createMock(TypoScriptFrontendController::class);
+        $fakeRootLine = $this->createMock(Rootline::class);
         $fakeRootLine->expects(self::once())->method('getGroups')->willReturn([1]);
 
         $this->fakePageDocumentId('siteHash/pages/4711');

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -78,7 +78,6 @@ class RepositoryTest extends SetUpUnitTestCase
     public function findByPageIdAndByLanguageIdThrowsInvalidArgumentExceptionIfPageIdIsNotSet()
     {
         $this->expectException(TypeError::class);
-        /* @var Repository $apacheSolrDocumentRepository */
         $apacheSolrDocumentRepository = GeneralUtility::makeInstance(Repository::class);
         $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(null, 3);
     }
@@ -89,7 +88,6 @@ class RepositoryTest extends SetUpUnitTestCase
     public function findByPageIdAndByLanguageIdThrowsInvalidArgumentExceptionIfLanguageIdIsNotInteger()
     {
         $this->expectException(TypeError::class);
-        /* @var Repository $apacheSolrDocumentRepository */
         $apacheSolrDocumentRepository = GeneralUtility::makeInstance(Repository::class);
         $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(1, 'Abc');
     }
@@ -99,7 +97,6 @@ class RepositoryTest extends SetUpUnitTestCase
      */
     public function findByPageIdAndByLanguageIdReturnsEmptyCollectionIfConnectionToSolrServerCanNotBeEstablished()
     {
-        /* @var Repository $apacheSolrDocumentRepository */
         $apacheSolrDocumentRepository = $this->getAccessibleMock(
             Repository::class,
             ['initializeSearch'],
@@ -121,7 +118,7 @@ class RepositoryTest extends SetUpUnitTestCase
      */
     public function findByPageIdAndByLanguageIdReturnsResultFromSearch()
     {
-        $solrConnectionMock = $this->getDumbMock(SolrConnection::class);
+        $solrConnectionMock = $this->createMock(SolrConnection::class);
         $solrConnectionManager = $this->getAccessibleMock(ConnectionManager::class, ['getConnectionByPageId'], [], '', false);
         $solrConnectionManager->expects(self::any())->method('getConnectionByPageId')->willReturn($solrConnectionMock);
         $mockedSingletons = [ConnectionManager::class => $solrConnectionManager];
@@ -137,16 +134,15 @@ class RepositoryTest extends SetUpUnitTestCase
         $parsedData->response = new \stdClass();
         // @extensionScannerIgnoreLine
         $parsedData->response->docs = $testDocuments;
-        $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeResponse = $this->createMock(ResponseAdapter::class);
         $fakeResponse->expects(self::once())->method('getParsedData')->willReturn($parsedData);
         $search->expects(self::any())->method('search')->willReturn($fakeResponse);
 
-        $queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
 
-        /* @var Repository $apacheSolrDocumentRepository */
         $apacheSolrDocumentRepository = $this->getAccessibleMock(Repository::class, ['getSearch'], [null, null, $queryBuilderMock]);
         $apacheSolrDocumentRepository->expects(self::once())->method('getSearch')->willReturn($search);
-        $queryMock = $this->getDumbMock(Query::class);
+        $queryMock = $this->createMock(Query::class);
         $queryBuilderMock->expects(self::any())->method('buildPageQuery')->willReturn($queryMock);
         $actualApacheSolrDocumentCollection = $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(777, 0);
 

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -52,16 +52,16 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
+        $this->tsfeMock = $this->createMock(TypoScriptFrontendController::class);
         $this->tsfeMock->tmpl = new \stdClass();
         $this->tsfeMock->tmpl->rootLine = [
             0 => [
                 'uid' => 4711,
             ],
         ];
-        $this->statisticsRepositoryMock = $this->getDumbMock(StatisticsRepository::class);
-        $this->cacheMock = $this->getDumbMock(AbstractFrontend::class);
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->statisticsRepositoryMock = $this->createMock(StatisticsRepository::class);
+        $this->cacheMock = $this->createMock(AbstractFrontend::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
 
         $this->frequentSearchesService = new class ($this->configurationMock, $this->cacheMock, $this->tsfeMock, $this->statisticsRepositoryMock) extends FrequentSearchesService {
             //            protected function getCacheIdentifier(array $frequentSearchConfiguration) : string {

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -25,30 +25,11 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class FrequentSearchesServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var FrequentSearchesService
-     */
-    protected $frequentSearchesService;
-
-    /**
-     * @var TypoScriptFrontendController
-     */
-    protected $tsfeMock;
-
-    /**
-     * @var AbstractFrontend
-     */
-    protected $cacheMock;
-
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var StatisticsRepository|MockObject
-     */
-    protected $statisticsRepositoryMock;
+    protected FrequentSearchesService|MockObject $frequentSearchesService;
+    protected TypoScriptFrontendController|MockObject $tsfeMock;
+    protected AbstractFrontend|MockObject $cacheMock;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected StatisticsRepository|MockObject $statisticsRepositoryMock;
 
     protected function setUp(): void
     {
@@ -83,7 +64,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function cachedResultIsUsedWhenIdentifierIsPresent()
+    public function cachedResultIsUsedWhenIdentifierIsPresent(): void
     {
         $fakeConfiguration = [];
         $expectedCacheIdentifier = 'frequentSearchesTags_' . md5(serialize($fakeConfiguration));
@@ -98,7 +79,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function databaseResultIsUsedWhenNoCachedResultIsPresent()
+    public function databaseResultIsUsedWhenNoCachedResultIsPresent(): void
     {
         $fakeConfiguration = [
             'select.' => [
@@ -129,17 +110,13 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
         self::assertSame($frequentTerms, ['my search' => 22], 'Could not retrieve frequent search terms');
     }
 
-    /**
-     * @param string $identifier
-     * @param array $value
-     */
-    public function fakeCacheResult($identifier, $value)
+    public function fakeCacheResult(string $identifier, array $value): void
     {
         $this->cacheMock->expects(self::once())->method('has')->with($identifier)->willReturn(true);
         $this->cacheMock->expects(self::once())->method('get')->willReturn($value);
     }
 
-    public function fakeIdentifierNotInCache()
+    public function fakeIdentifierNotInCache(): void
     {
         $this->cacheMock->expects(self::once())->method('has')->willReturn(false);
     }

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\Frontend\AbstractFrontend;
+use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class FrequentSearchesServiceTest extends SetUpUnitTestCase
@@ -34,7 +35,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
     protected function setUp(): void
     {
         $this->tsfeMock = $this->createMock(TypoScriptFrontendController::class);
-        $this->tsfeMock->tmpl = new \stdClass();
+        $this->tsfeMock->tmpl = $this->createMock(TemplateService::class);
         $this->tsfeMock->tmpl->rootLine = [
             0 => [
                 'uid' => 4711,

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -17,13 +17,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\LastSearches;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class LastSearchesRepositoryTest extends SetUpUnitTestCase
 {
-    /**
-     * @var LastSearchesRepository
-     */
-    protected $lastSearchesRepositoryMock;
+    protected LastSearchesRepository|MockObject $lastSearchesRepositoryMock;
 
     protected function setUp(): void
     {
@@ -36,7 +34,7 @@ class LastSearchesRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function findAllKeywordsWillDecoteKeywordsAsHTMLEntities()
+    public function findAllKeywordsWillDecoteKeywordsAsHTMLEntities(): void
     {
         $givenKeywords = [
             ['keywords' => 'test'],

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
@@ -20,28 +20,14 @@ use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class LastSearchesServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var LastSearchesService
-     */
-    protected $lastSearchesService;
-
-    /**
-     * @var FrontendUserSession
-     */
-    protected $sessionMock;
-
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var LastSearchesRepository
-     */
-    protected $lastSearchesRepositoryMock;
+    protected LastSearchesService|MockObject $lastSearchesService;
+    protected FrontendUserSession|MockObject $sessionMock;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected LastSearchesRepository|MockObject $lastSearchesRepositoryMock;
 
     protected function setUp(): void
     {
@@ -65,7 +51,7 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetLastSearchesFromSessionInUserMode()
+    public function canGetLastSearchesFromSessionInUserMode(): void
     {
         $fakedLastSearchesInSession = ['first search', 'second search'];
 
@@ -84,7 +70,7 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetLastSearchesFromDatabaseInGlobalMode()
+    public function canGetLastSearchesFromDatabaseInGlobalMode(): void
     {
         $fakedLastSearchesFromRepository = [
             'test',
@@ -101,23 +87,17 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
         self::assertSame($fakedLastSearchesFromRepository, $lastSearches, 'Did not get last searches from database');
     }
 
-    /**
-     * @param string $mode
-     */
-    protected function fakeLastSearchMode($mode)
+    protected function fakeLastSearchMode(string $mode): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchLastSearchesMode')->willReturn($mode);
     }
 
-    /**
-     * @param int $limit
-     */
-    protected function fakeLastSearchLimit($limit)
+    protected function fakeLastSearchLimit(int $limit): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchLastSearchesLimit')->willReturn($limit);
     }
 
-    protected function assertRepositoryWillNeverBeCalled()
+    protected function assertRepositoryWillNeverBeCalled(): void
     {
         $this->lastSearchesRepositoryMock->expects(self::never())->method('findAllKeywords');
     }

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
@@ -45,8 +45,8 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->sessionMock = $this->getDumbMock(FrontendUserSession::class);
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->sessionMock = $this->createMock(FrontendUserSession::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
 
         $this->lastSearchesRepositoryMock = $this->getMockBuilder(LastSearchesRepository::class)
             ->onlyMethods(['getLastSearchesResultSet', 'findAllKeywords'])

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -68,10 +68,12 @@ class QueryBuilderTest extends SetUpUnitTestCase
         return $request->getParams();
     }
 
-    protected function getInitializedTestSearchQuery(string $queryString = '', TypoScriptConfiguration $fakeConfiguration = null): SearchQuery
+    protected function getInitializedTestSearchQuery(string $queryString = '', TypoScriptConfiguration $fakeConfiguration = null): Query
     {
         $builder = new QueryBuilder($fakeConfiguration, $this->loggerMock, $this->siteHashServiceMock);
-        return $builder->buildSearchQuery($queryString);
+        /** @var Query $query */
+        $query = $builder->buildSearchQuery($queryString);
+        return $query;
     }
 
     /**
@@ -951,6 +953,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
 
+        $query->__toString();
         $queryToString = (string)$query;
         self::assertSame('test', $queryToString, 'Could not convert query to string');
     }

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -47,25 +47,10 @@ use function str_starts_with;
  */
 class QueryBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TypoScriptConfiguration|MockObject
-     */
-    protected $configurationMock;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $loggerMock;
-
-    /**
-     * @var SiteHashService
-     */
-    protected $siteHashServiceMock;
-
-    /**
-     * @var QueryBuilder
-     */
-    protected $builder;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected SolrLogManager|MockObject $loggerMock;
+    protected SiteHashService|MockObject $siteHashServiceMock;
+    protected QueryBuilder|MockObject $builder;
 
     protected function setUp(): void
     {
@@ -76,11 +61,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @param Query $searchQuery
-     * @return array
-     */
-    protected function getAllQueryParameters(Query $searchQuery)
+    protected function getAllQueryParameters(Query $searchQuery): array
     {
         $requestBuilder = new RequestBuilder();
         $request = $requestBuilder->build($searchQuery);
@@ -96,16 +77,16 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchQueryPassesQueryString()
+    public function buildSearchQueryPassesQueryString(): void
     {
         $query = $this->builder->buildSearchQuery('one');
-        self::assertSame('one', (string)$query, 'Query has unexpected value, when casted to string');
+        self::assertSame('one', (string)$query->getQuery(), 'Query has unexpected value, when casted to string');
     }
 
     /**
      * @test
      */
-    public function buildSearchQueryPassesDefaultPerPage()
+    public function buildSearchQueryPassesDefaultPerPage(): void
     {
         $query = $this->builder->buildSearchQuery('one');
         self::assertSame(10, $query->getRows(), 'Query was not created with default perPage value');
@@ -114,7 +95,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchQueryPassesCustomPerPage()
+    public function buildSearchQueryPassesCustomPerPage(): void
     {
         $query = $this->builder->buildSearchQuery('one', 22);
         self::assertSame(22, $query->getRows(), 'Query was not created with default perPage value');
@@ -123,7 +104,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchQueryInitializesQueryFieldsFromConfiguration()
+    public function buildSearchQueryInitializesQueryFieldsFromConfiguration(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
         $query = $this->builder->buildSearchQuery('foo');
@@ -133,7 +114,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchQueryInitializesTrigramPhraseFields()
+    public function buildSearchQueryInitializesTrigramPhraseFields(): void
     {
         $this->configurationMock->expects(self::once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);
 
@@ -145,7 +126,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchIsSettingWildCardQueryOnInitializeWithEmptyQuery()
+    public function buildSearchIsSettingWildCardQueryOnInitializeWithEmptyQuery(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchInitializeWithEmptyQuery')->willReturn(true);
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
@@ -155,7 +136,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchIsSettingWildCardQueryOnInitializeWithAllowEmptyQuery()
+    public function buildSearchIsSettingWildCardQueryOnInitializeWithAllowEmptyQuery(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryAllowEmptyQuery')->willReturn(true);
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
@@ -165,7 +146,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchIsSettingQuerystringForConfiguredInitialQuery()
+    public function buildSearchIsSettingQuerystringForConfiguredInitialQuery(): void
     {
         $this->configurationMock->expects(self::exactly(2))->method('getSearchInitializeWithQuery')->willReturn('myinitialsearch');
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
@@ -175,7 +156,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchIsSettingConfiguredAdditionalFilters()
+    public function buildSearchIsSettingConfiguredAdditionalFilters(): void
     {
         $this->configurationMock->expects(self::any())->method('getSearchQueryFilterConfiguration')->willReturn(['noPage' => '-type:pages']);
         $query = $this->builder->buildSearchQuery('applies configured filters');
@@ -189,7 +170,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function buildSearchIsSettingNoAlternativeQueryByDefault()
+    public function buildSearchIsSettingNoAlternativeQueryByDefault(): void
     {
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
         self::assertArrayNotHasKey('q.alt', $this->getAllQueryParameters($query), 'The alterativeQuery is not null when nothing was set');
@@ -198,7 +179,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canEnableHighlighting()
+    public function canEnableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $highlighting = new Highlighting();
@@ -213,7 +194,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canDisableHighlighting()
+    public function canDisableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $highlighting = new Highlighting();
@@ -233,7 +214,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetHighlightingFieldList()
+    public function canSetHighlightingFieldList(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
@@ -254,7 +235,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canPassCustomWrapForHighlighting()
+    public function canPassCustomWrapForHighlighting(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
@@ -275,7 +256,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed()
+    public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
@@ -300,7 +281,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canUseFastVectorHighlighting()
+    public function canUseFastVectorHighlighting(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -320,7 +301,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18()
+    public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -340,7 +321,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetQueryString()
+    public function canSetQueryString(): void
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');
         self::assertSame('i like solr', $query->getQuery(), 'Can not set and get query string');
@@ -349,7 +330,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetPage()
+    public function canSetPage(): void
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');
         $query->setStart(10);
@@ -360,7 +341,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function noFiltersAreSetAfterInitialization()
+    public function noFiltersAreSetAfterInitialization(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
@@ -370,7 +351,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function addsCorrectAccessFilterForAnonymousUser()
+    public function addsCorrectAccessFilterForAnonymousUser(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
@@ -382,7 +363,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function grantsAccessToGroupZeroIfNoGroupsProvided()
+    public function grantsAccessToGroupZeroIfNoGroupsProvided(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
@@ -394,7 +375,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function grantsAccessToGroupZeroIfZeroNotProvided()
+    public function grantsAccessToGroupZeroIfZeroNotProvided(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
@@ -406,7 +387,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function filtersDuplicateAccessGroups()
+    public function filtersDuplicateAccessGroups(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
@@ -418,7 +399,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function allowsOnlyOneAccessFilter()
+    public function allowsOnlyOneAccessFilter(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryBuilder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
@@ -435,7 +416,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function groupingIsNotActiveAfterInitialization()
+    public function groupingIsNotActiveAfterInitialization(): void
     {
         $query = $this->getInitializedTestSearchQuery();
 
@@ -475,7 +456,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
      * @test
      * @depends settingGroupingTrueActivatesGrouping
      */
-    public function settingGroupingFalseDeactivatesGrouping(SearchQuery $query)
+    public function settingGroupingFalseDeactivatesGrouping(SearchQuery $query): void
     {
         $grouping = new Grouping(false);
         $query = $this->builder->startFrom($query)->useGrouping($grouping)->getQuery();
@@ -491,7 +472,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetNumberOfGroups()
+    public function canSetNumberOfGroups(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
         $query->getGrouping()->setNumberOfGroups(true);
@@ -501,7 +482,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canAddGroupField()
+    public function canAddGroupField(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
         self::assertSame([], $query->getGrouping()->getFields(), 'Unexpected default state of groupFields');
@@ -512,7 +493,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetGroupSorting()
+    public function canGetGroupSorting(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
         self::assertNull($query->getGrouping()->getSort(), 'By default getGroupSortings should return an empty array');
@@ -527,7 +508,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetNumberOfResultsByGroup()
+    public function canSetNumberOfResultsByGroup(): void
     {
         $query = $this->getInitializedTestSearchQuery('group test');
         $grouping = new Grouping(true);
@@ -543,7 +524,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canAddGroupQuery()
+    public function canAddGroupQuery(): void
     {
         $query = $this->getInitializedTestSearchQuery('group test');
         $initialGroupQueries = $query->getGrouping()->getQueries();
@@ -555,7 +536,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetQueryFieldsAsStringWhenPassedFromConfiguration()
+    public function canGetQueryFieldsAsStringWhenPassedFromConfiguration(): void
     {
         $input = 'content^10, title^5';
         $fakeConfigurationArray = [];
@@ -571,7 +552,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReturnEmptyStringAsQueryFieldStringWhenNothingWasPassed()
+    public function canReturnEmptyStringAsQueryFieldStringWhenNothingWasPassed(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -586,7 +567,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetMinimumMatch()
+    public function canSetMinimumMatch(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
@@ -605,7 +586,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetBoostFunction()
+    public function canSetBoostFunction(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
@@ -626,7 +607,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetBoostQuery()
+    public function canSetBoostQuery(): void
     {
         $query = $this->getInitializedTestSearchQuery();
         $queryParameters = $this->getAllQueryParameters($query);
@@ -643,7 +624,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReturnFieldListWhenConfigurationWithReturnFieldsWasPassed()
+    public function canReturnFieldListWhenConfigurationWithReturnFieldsWasPassed(): void
     {
         $input = 'abstract, price';
         $fakeConfigurationArray = [];
@@ -657,7 +638,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReturnDefaultFieldListWhenNoConfigurationWasPassed()
+    public function canReturnDefaultFieldListWhenNoConfigurationWasPassed(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -669,7 +650,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canAddReturnField()
+    public function canAddReturnField(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -684,7 +665,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canRemoveReturnField()
+    public function canRemoveReturnField(): void
     {
         $fakeConfigurationArray = [];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
@@ -700,7 +681,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canEnableFaceting()
+    public function canEnableFaceting(): void
     {
         /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -69,9 +69,9 @@ class QueryBuilderTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->loggerMock = $this->getDumbMock(SolrLogManager::class);
-        $this->siteHashServiceMock = $this->getDumbMock(SiteHashService::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->loggerMock = $this->createMock(SolrLogManager::class);
+        $this->siteHashServiceMock = $this->createMock(SiteHashService::class);
         $this->builder = new QueryBuilder($this->configurationMock, $this->loggerMock, $this->siteHashServiceMock);
         parent::setUp();
     }
@@ -87,11 +87,6 @@ class QueryBuilderTest extends SetUpUnitTestCase
         return $request->getParams();
     }
 
-    /**
-     * @param string $queryString
-     * @param TypoScriptConfiguration|null $fakeConfiguration
-     * @return SearchQuery
-     */
     protected function getInitializedTestSearchQuery(string $queryString = '', TypoScriptConfiguration $fakeConfiguration = null): SearchQuery
     {
         $builder = new QueryBuilder($fakeConfiguration, $this->loggerMock, $this->siteHashServiceMock);
@@ -205,7 +200,6 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function canEnableHighlighting()
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
         $highlighting = new Highlighting();
         $highlighting->setIsEnabled(true);
@@ -221,7 +215,6 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function canDisableHighlighting()
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
         $highlighting = new Highlighting();
         $highlighting->setIsEnabled(true);
@@ -852,7 +845,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     public function noSiteHashFilterIsSetWhenWildcardIsPassed()
     {
         /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => '*']);
         $this->siteHashServiceMock->expects(self::once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('*');
 
@@ -871,7 +864,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
     public function filterIsAddedWhenAllowedSiteIsPassed()
     {
         /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => 'site1.local']);
 
         $this->siteHashServiceMock->expects(self::once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('site1.local');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -33,7 +33,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
     public function canAddAndRetrieveFacetByKey()
     {
         $facetCollection = new FacetCollection();
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
@@ -50,7 +50,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
     public function canAddAndRetrieveFacetByPosition()
     {
         $facetCollection = new FacetCollection();
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
@@ -67,7 +67,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
     public function canRetrieveFacetOfCollectionCopyByKey()
     {
         $facetCollection = new FacetCollection();
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);
@@ -85,7 +85,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
     public function canRetrieveFacetOfCollectionCopyByPosition()
     {
         $facetCollection = new FacetCollection();
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'top']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -32,13 +32,9 @@ class FacetRegistryTest extends SetUpUnitTestCase
 {
     /**
      * Initialize a RendererRegistry and mock createRendererInstance()
-     *
-     * @param array $createsPackageInstances
-     * @return MockObject|FacetRegistry
      */
-    protected function getTestFacetPackageRegistry(array $createsPackageInstances = [])
+    protected function getTestFacetPackageRegistry(array $createsPackageInstances = []): MockObject|FacetRegistry
     {
-        /** @var $facetRegistry MockObject|FacetRegistry */
         $facetRegistry = $this->getMockBuilder(FacetRegistry::class)
             ->onlyMethods(['createInstance'])
             ->getMock();
@@ -55,7 +51,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function registeredPackageClassCanBeRetrievedByType()
+    public function registeredPackageClassCanBeRetrievedByType(): void
     {
         $facetType = 'myType';
         $packageObject = new TestPackage();
@@ -70,7 +66,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function registerParserClassThrowsExceptionIfClassDoesNotExist()
+    public function registerParserClassThrowsExceptionIfClassDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1462883324);
@@ -81,7 +77,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function registerParserClassThrowsExceptionIfClassDoesNotImplementFacetPackageInterface()
+    public function registerParserClassThrowsExceptionIfClassDoesNotImplementFacetPackageInterface(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1462883325);
@@ -93,7 +89,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function registerReturnsDefaultPackageForUnknownFacetType()
+    public function registerReturnsDefaultPackageForUnknownFacetType(): void
     {
         $optionsFacetPackage = new OptionsPackage();
         $facetParserRegistry = $this->getTestFacetPackageRegistry([[OptionsPackage::class, $optionsFacetPackage]]);
@@ -103,7 +99,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canRegisterDifferentDefaultPackage()
+    public function canRegisterDifferentDefaultPackage(): void
     {
         $packageObject = new TestPackage();
         $packageClass = get_class($packageObject);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -183,7 +183,6 @@ class HierarchyFacetParserTest extends SetUpFacetParser
             $facetConfiguration
         );
 
-        /* @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
         self::assertFalse($facet->getIsUsed());

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -160,7 +160,9 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         );
         $facet = $parser->parse($searchResultSet, 'categoryHierarchyByTitle', $facetConfiguration);
 
-        self::assertSame(1, $facet->getAllFacetItems()->getByValue($optionValue)->getChildNodes()->count(), 'Selected facet-option with slash in title/name breaks the Hierarchical facets.');
+        /** @var Node $facetOption */
+        $facetOption = $facet->getAllFacetItems()->getByValue($optionValue);
+        self::assertSame(1, $facetOption->getChildNodes()->count(), 'Selected facet-option with slash in title/name breaks the Hierarchical facets.');
     }
 
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -31,7 +31,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
     /**
      * @test
      */
-    public function facetIsCreated()
+    public function facetIsCreated(): void
     {
         $facetConfiguration = [
             'pageHierarchy.' => [
@@ -60,10 +60,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         self::assertSame('14', $firstNode->getKey());
     }
 
-    /**
-     * @return array
-     */
-    public function dataProviderForDeepMoreThen10DoesNotBreakHierarchyFacet()
+    public function dataProviderForDeepMoreThen10DoesNotBreakHierarchyFacet(): array
     {
         return [
             'sortByCount' => [
@@ -146,6 +143,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
 
         /* @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
+        /** @var HierarchyFacet $facet */
         $facet = $parser->parse($searchResultSet, 'categoryHierarchyByTitle', $facetConfiguration);
         // HierarchyFacetParser::getActiveFacetValuesFromRequest() must be aware about slashes in path segments
         self::assertSame(5, $facet->getAllFacetItems()->count(), 'Selected facet option is wrong parsed. The slash in Title leads to new facet option.');
@@ -168,7 +166,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
     /**
      * @test
      */
-    public function facetIsNotActive()
+    public function facetIsNotActive(): void
     {
         $facetConfiguration = [
             'pageHierarchy.' => [
@@ -191,7 +189,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
     /**
      * @test
      */
-    public function facetIsActive()
+    public function facetIsActive(): void
     {
         $facetConfiguration = [
             'pageHierarchy.' => [
@@ -209,8 +207,10 @@ class HierarchyFacetParserTest extends SetUpFacetParser
 
         /* @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
+        /** @var HierarchyFacet $facet */
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
 
+        /** @var HierarchyFacet $selectedFacetByUrl */
         $selectedFacetByUrl = $facet->getChildNodes()->getByPosition(0)->getChildNodes()->getByPosition(0);
         self::assertTrue($facet->getIsUsed());
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -31,11 +31,11 @@ class NodeTest extends SetUpUnitTestCase
      */
     public function canGetHasParentNode()
     {
-        $facetMock = $this->getDumbMock(HierarchyFacet::class);
+        $facetMock = $this->createMock(HierarchyFacet::class);
         $node = new Node($facetMock);
         self::assertFalse($node->getHasParentNode(), 'Node with unassigned parent node should not indicate that a parent node was assigned');
 
-        $facetMock = $this->getDumbMock(HierarchyFacet::class);
+        $facetMock = $this->createMock(HierarchyFacet::class);
         $parentNode = new Node($facetMock);
         $node = new Node($facetMock, $parentNode);
         self::assertTrue($node->getHasParentNode(), 'Node with assigned parent node should indicate that');
@@ -47,7 +47,7 @@ class NodeTest extends SetUpUnitTestCase
      */
     public function canGetHasChildNodeSelectedReturnFalseWhenNoChildNodeWasAssigned()
     {
-        $facetMock = $this->getDumbMock(HierarchyFacet::class);
+        $facetMock = $this->createMock(HierarchyFacet::class);
         $node = new Node($facetMock);
 
         self::assertFalse($node->getHasChildNodeSelected(), 'Node without childnodes should not indicate that it as a selected child node');
@@ -58,7 +58,7 @@ class NodeTest extends SetUpUnitTestCase
      */
     public function canGetHasChildNodeSelectedReturnFalseWhenNoSelectedChildNodeWasAssigned()
     {
-        $facetMock = $this->getDumbMock(HierarchyFacet::class);
+        $facetMock = $this->createMock(HierarchyFacet::class);
         $node = new Node($facetMock);
 
         $childNode = new Node($facetMock, $node);
@@ -72,7 +72,7 @@ class NodeTest extends SetUpUnitTestCase
      */
     public function canGetHasChildNodeSelectedReturnTrueWhenSelectedChildNodeWasAssigned()
     {
-        $facetMock = $this->getDumbMock(HierarchyFacet::class);
+        $facetMock = $this->createMock(HierarchyFacet::class);
         $node = new Node($facetMock);
 
         $selectedChildNode = new Node($facetMock, $node, '', '', '', 0, true);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -39,7 +39,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetManualSortedCopy()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
 
         $red = new Option($facet, 'Rubin Red', 'red', 9);
@@ -63,7 +63,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetLabelPrefixes()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
 
         $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
@@ -88,7 +88,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetByLowercaseLabelPrefix()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
 
         $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
@@ -117,7 +117,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetByLowercaseLabelPrefixWithMultiByteCharacter()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new OptionsFacet($searchResultSetMock, 'authors', 'authors_s');
 
         $ben = new Option($facet, 'Ben', 'ben', 14);
@@ -136,7 +136,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetByValueAfterManualSorting()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new OptionsFacet($searchResultSetMock, 'colors', 'colors_s');
 
         $red = new Option($facet, 'Rubin Red', 'red', 9);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -40,7 +40,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
             'sortBy' => 'index',
             'sortDirection' => 'desc',
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );
@@ -80,7 +80,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
             'field' => 'category',
             'facetLimit' => 20,
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );
@@ -115,7 +115,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         $fakeFacetConfiguration = [
             'field' => 'category',
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );
@@ -155,7 +155,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
             'field' => 'category',
             'minimumCount' => 2,
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );
@@ -204,7 +204,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         $fakeFacetConfiguration = [
             'field' => 'category',
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );
@@ -248,7 +248,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
                 'downloads' => 'sum(downloads_intS)',
             ],
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('category')->willReturn(
             $fakeFacetConfiguration
         );

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -40,7 +40,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function canGetTitleFromOptionsFacet()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $optionsFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from options facet');
     }
@@ -50,7 +50,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function canAddOptionsToFacet()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $optionsFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         $option = new Option($optionsFacet);
 
@@ -69,7 +69,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function getDefaultPartialName()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $queryGroupFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
 
         self::assertEquals('Options', $queryGroupFacet->getPartialName());
@@ -80,7 +80,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function getCustomPartialName()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $queryGroupFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
         self::assertEquals('MyPartial', $queryGroupFacet->getPartialName());
@@ -91,7 +91,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function getType()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $myFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
         self::assertEquals('options', $myFacet->getType());
@@ -119,7 +119,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
      */
     public function getIncludeInAvailableFacets($includeInAvailableFacetsConfiguration, $expectedResult)
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $myFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['includeInAvailableFacets' => $includeInAvailableFacetsConfiguration]);
 
         self::assertSame($myFacet->getIncludeInAvailableFacets(), $expectedResult, 'Method getIncludeInAvailableFacets returns unexpected result');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -33,7 +33,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
      */
     public function canGetManualSortedCopy()
     {
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $facet = new QueryGroupFacet($searchResultSetMock, 'age', 'created');
 
         $week = new Option($facet, 'Last week', '1week', 9);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
@@ -34,16 +33,10 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
  */
 class QueryGroupFacetParserTest extends SetUpFacetParser
 {
-    /**
-     * @param string $fixtureFile
-     * @param array $facetConfiguration
-     * @param array $activeFilters
-     * @return SearchResultSet
-     */
-    protected function initializeSearchResultSetFromFakeResponse($fixtureFile, $facetConfiguration, array $activeFilters = [])
+    protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile, array $facetConfiguration, array $activeFilters = []): SearchResultSet
     {
         $fakeResponseJson = $this->getFixtureContentByName($fixtureFile);
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock = $this->createMock(SearchRequest::class);
         $fakeResponse = new ResponseAdapter($fakeResponseJson);
 
         $searchResultSet = new SearchResultSet();
@@ -100,7 +93,6 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
             'fake_solr_response_with_query_fields_facets_and_used_facet.json',
             $facetConfiguration
         );
-        /* @var QueryGroupFacetParser $parser */
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
@@ -132,7 +124,6 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
             $facetConfiguration
         );
 
-        /* @var QueryGroupFacetParser $parser */
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
@@ -164,7 +155,6 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
             $facetConfiguration,
             ['age:week']
         );
-        /* @var QueryGroupFacetParser $parser */
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
@@ -196,12 +186,10 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
             $facetConfiguration,
             ['age:week']
         );
-        /* @var QueryGroupFacetParser $parser */
         $parser = $this->getInitializedParser(QueryGroupFacetParser::class);
         /** @var QueryGroupFacet $facet */
         $facet = $parser->parse($searchResultSet, 'age', $facetConfiguration['age.']);
 
-        /** @var Option $option */ // @extensionScannerIgnoreLine
         foreach ($facet->getOptions() as $option) {
             if ($option->getValue() === 'week') {
                 self::assertTrue($option->getSelected(), 'Option ' . $option->getValue() . ' isn\'t active');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -51,7 +51,7 @@ class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
                 'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-7DAYS]'],
             ],
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
             $fakeFacetConfiguration
         );
@@ -143,7 +143,7 @@ class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
                 'month.' => ['query' => '[NOW/DAY-1MONTH TO NOW/DAY-14DAYS]'],
             ],
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
             $fakeFacetConfiguration
         );

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -45,7 +45,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
      */
     public function canGetTitleFromOptionsFacet()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $optionsFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from queryGroup facet');
     }
@@ -55,7 +55,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
      */
     public function canAddOptionsToFacet()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
         $option = new Option($queryGroupFacet);
 
@@ -74,7 +74,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
      */
     public function getDefaultPartialName()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle');
 
         self::assertEquals('Options', $queryGroupFacet->getPartialName());
@@ -85,7 +85,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
      */
     public function getCustomPartialName()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $queryGroupFacet = new QueryGroupFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['partialName' => 'MyPartial']);
 
         self::assertEquals('MyPartial', $queryGroupFacet->getPartialName());

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -36,7 +36,7 @@ class DateRangeFacetQueryBuilderTest extends SetUpUnitTestCase
             'keepAllOptionsOnSelection' => 1,
             'dateRange.' => ['start' => 'NOW/DAY-2YEAR', 'end' => 'NOW/DAY+2YEAR', 'gap' => '+1DAY'],
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
             $fakeFacetConfiguration
         );

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -36,7 +36,7 @@ class DateRangeTest extends SetUpUnitTestCase
     {
         $dateTime = new DateTime('2021-07-20 16:04:21.000000');
         $dateRangeOpenStart = new DateRange(
-            $this->getDumbMock(DateRangeFacet::class),
+            $this->createMock(DateRangeFacet::class),
             null,
             $dateTime,
             null,
@@ -47,7 +47,7 @@ class DateRangeTest extends SetUpUnitTestCase
             false
         );
         $dateRangeOpenEnd = new DateRange(
-            $this->getDumbMock(DateRangeFacet::class),
+            $this->createMock(DateRangeFacet::class),
             $dateTime,
             null,
             null,

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -30,7 +30,6 @@ class DateRangeTest extends SetUpUnitTestCase
 {
     /**
      * @test
-     * @noinspection PhpParamsInspection
      */
     public function canHandleHalfOpenDateRanges()
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\RangeBased\NumericRange;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacetParser;
@@ -31,13 +30,8 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
 {
     /**
      * Returns a basic facet configuration
-     *
-     * @param int $start
-     * @param int $end
-     * @param int $gap
-     * @return array[]
      */
-    protected function getPageIdFacetConfiguration($start = -100.0, $end = 100.0, $gap = '2'): array
+    protected function getPageIdFacetConfiguration(float|int $start = -100.0, float|int $end = 100.0, int|string $gap = '2'): array
     {
         return [
             'myPids.' => [
@@ -56,26 +50,23 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
 
     /**
      * Returns the numeric range facet
-     *
-     * @param array $facetConfiguration
-     * @param array $filters
-     * @param string $facetName
-     * @return AbstractFacet|NumericRangeFacet|null
      */
     protected function getNumericRangeFacet(
         array $facetConfiguration,
         array $filters,
         string $facetName
-    ): ?AbstractFacet {
+    ): ?NumericRangeFacet {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
             'fake_solr_response_with_numericRange_facet.json',
             $facetConfiguration,
             $filters
         );
 
-        /* @var NumericRangeFacetParser $parser */
+        /** @var NumericRangeFacetParser $parser */
         $parser = $this->getInitializedParser(NumericRangeFacetParser::class);
-        return $parser->parse($searchResultSet, $facetName, $facetConfiguration[$facetName . '.']);
+        /** @var NumericRangeFacet|null $facet */
+        $facet = $parser->parse($searchResultSet, $facetName, $facetConfiguration[$facetName . '.']);
+        return $facet;
     }
 
     /**
@@ -113,8 +104,6 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
      * Test the parsing of the active range values
      *
      * @dataProvider canParseActiveFacetValuesProvider
-     * @param int $startRequested
-     * @param int $endRequested
      * @test
      */
     public function canParseActiveFacetValues(int $startRequested, int $endRequested): void
@@ -132,8 +121,6 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
 
     /**
      * Data provider for testing the parsing of the active range values
-     *
-     * @return array
      */
     public function canParseActiveFacetValuesProvider(): array
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -36,7 +36,7 @@ class NumericRangeFacetQueryBuilderTest extends SetUpUnitTestCase
             'keepAllOptionsOnSelection' => 1,
             'numericRange.' => ['start' => 1, 'end' => 100, 'gap' => 5],
         ];
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetByName')->with('testFacet')->willReturn(
             $fakeFacetConfiguration
         );

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -39,7 +39,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
      */
     public function getRequirementsMetReturnTrueWhenNothingConfigured()
     {
-        $facet = $this->getDumbMock(OptionsFacet::class);
+        $facet = $this->createMock(OptionsFacet::class);
         $service = new RequirementsService();
         self::assertTrue($service->getAllRequirementsMet($facet), 'Facet without any requirements should met all requirements');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SetUpFacetParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SetUpFacetParser.php
@@ -28,20 +28,12 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Class QueryGroupFacetParserTest
- *
  * @author Timo Hund <timo.hund@dkd.de>
  * @author Frans Saris <frans@beech.it>
  */
 abstract class SetUpFacetParser extends SetUpUnitTestCase
 {
-    /**
-     * @param string $fixtureFile
-     * @param array $facetConfiguration
-     * @param array $activeFilters
-     * @return SearchResultSet
-     */
-    protected function initializeSearchResultSetFromFakeResponse($fixtureFile, $facetConfiguration, array $activeFilters = [])
+    protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile, array $facetConfiguration, array $activeFilters = []): SearchResultSet
     {
         $fakeResponseJson = $this->getFixtureContentByName($fixtureFile);
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
@@ -4,16 +4,15 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Test
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\NodeCollection;
 
 class TestFacet extends AbstractFacet
 {
     /**
      * The implementation of this method should return a "flatten" collection of all items.
-     *
-     * @return AbstractFacetItemCollection
      */
     public function getAllFacetItems(): AbstractFacetItemCollection
     {
-        // TODO: Implement getAllFacetItems() method.
+        return new NodeCollection();
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
@@ -8,13 +8,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 class TestParser extends AbstractFacetParser
 {
-    /**
-     * @param SearchResultSet $resultSet
-     * @param string $facetName
-     * @param array $facetConfiguration
-     * @return AbstractFacet|null
-     */
-    public function parse(SearchResultSet $resultSet, string $facetName, array $facetConfiguration)
+    public function parse(SearchResultSet $resultSet, string $facetName, array $facetConfiguration): ?AbstractFacet
     {
         return new TestFacet($resultSet, $facetName, 'testField');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -28,10 +28,8 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
 {
     /**
      * Test data for index based url parameters
-     *
-     * @var string[][][]
      */
-    protected $indexParameters = [
+    protected array $indexParameters = [
         'tx_solr' => [
             'filter' => [
                 'type:pages',
@@ -43,10 +41,8 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
     ];
     /**
      * Test data for assoc based url parameters
-     *
-     * @var string[][][]
      */
-    protected $assocParameters = [
+    protected array $assocParameters = [
         'tx_solr' => [
             'filter' => [
                 'type:pages' => 1,

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -47,7 +47,7 @@ class GroupItemTest extends SetUpUnitTestCase
             12,
             1,
             99,
-            $this->getDumbMock(SearchRequest::class)
+            $this->createMock(SearchRequest::class)
         );
         parent::setUp();
     }
@@ -99,7 +99,7 @@ class GroupItemTest extends SetUpUnitTestCase
     {
         self::assertSame(0, $this->groupItem->getSearchResults()->getCount());
 
-        $searchResult = $this->getDumbMock(SearchResult::class);
+        $searchResult = $this->createMock(SearchResult::class);
         $this->groupItem->addSearchResult($searchResult);
 
         self::assertSame(1, $this->groupItem->getSearchResults()->getCount());

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -74,7 +74,7 @@ class GroupTest extends SetUpUnitTestCase
             12,
             0,
             22.0,
-            $this->getDumbMock(SearchRequest::class)
+            $this->createMock(SearchRequest::class)
         );
         $groupItems[] = $groupItem;
 
@@ -97,7 +97,7 @@ class GroupTest extends SetUpUnitTestCase
             12,
             0,
             22.0,
-            $this->getDumbMock(SearchRequest::class)
+            $this->createMock(SearchRequest::class)
         );
         $group->addGroupItem($groupItem);
 

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Unit test case for the SearchResult.
@@ -29,15 +30,8 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class DefaultParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var DefaultResultParser
-     */
-    protected $parser;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected DefaultResultParser $parser;
 
     protected function setUp(): void
     {
@@ -49,7 +43,7 @@ class DefaultParserTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function parseWillCreateResultCollectionFromSolrResponse()
+    public function parseWillCreateResultCollectionFromSolrResponse(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
@@ -64,7 +58,7 @@ class DefaultParserTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function returnsResultSetWithResultCount()
+    public function returnsResultSetWithResultCount(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
@@ -79,7 +73,7 @@ class DefaultParserTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function parseWillSetMaximumScore()
+    public function parseWillSetMaximumScore(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
 
@@ -94,7 +88,7 @@ class DefaultParserTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canParseReturnsFalseWhenGroupingIsEnabled()
+    public function canParseReturnsFalseWhenGroupingIsEnabled(): void
     {
         $requestMock = $this->createMock(SearchRequest::class);
         $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);
@@ -108,7 +102,7 @@ class DefaultParserTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canParseReturnsTrueWhenGroupingIsDisabled()
+    public function canParseReturnsTrueWhenGroupingIsDisabled(): void
     {
         $requestMock = $this->createMock(SearchRequest::class);
         $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -41,7 +41,7 @@ class DefaultParserTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $this->parser = new DefaultResultParser();
         parent::setUp();
     }
@@ -96,9 +96,9 @@ class DefaultParserTest extends SetUpUnitTestCase
      */
     public function canParseReturnsFalseWhenGroupingIsEnabled()
     {
-        $requestMock = $this->getDumbMock(SearchRequest::class);
+        $requestMock = $this->createMock(SearchRequest::class);
         $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);
-        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet = $this->createMock(SearchResultSet::class);
         $fakeResultSet->expects(self::any())->method('getUsedSearchRequest')->willReturn($requestMock);
 
         $this->configurationMock->expects(self::once())->method('getIsSearchGroupingEnabled')->willReturn(true);
@@ -110,9 +110,9 @@ class DefaultParserTest extends SetUpUnitTestCase
      */
     public function canParseReturnsTrueWhenGroupingIsDisabled()
     {
-        $requestMock = $this->getDumbMock(SearchRequest::class);
+        $requestMock = $this->createMock(SearchRequest::class);
         $requestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($this->configurationMock);
-        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet = $this->createMock(SearchResultSet::class);
         $fakeResultSet->expects(self::any())->method('getUsedSearchRequest')->willReturn($requestMock);
 
         $this->configurationMock->expects(self::once())->method('getIsSearchGroupingEnabled')->willReturn(false);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -42,7 +42,7 @@ class ResultParserRegistryTest extends SetUpUnitTestCase
      */
     public function canRegisterAndRetrieveParserWithAHigherPriority()
     {
-        $fakeResultSet = $this->getDumbMock(SearchResultSet::class);
+        $fakeResultSet = $this->createMock(SearchResultSet::class);
         $this->registry->registerParser(TestResultParser::class, 200);
         $retrievedParser = $this->registry->getParser($fakeResultSet);
         self::assertInstanceOf(TestResultParser::class, $retrievedParser, 'Did not retrieve register custom parser with higher priority');

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -27,9 +27,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class SearchResultTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SearchResult
-     */
     protected SearchResult $searchResult;
 
     protected function setUp(): void
@@ -50,7 +47,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetId()
+    public function canGetId(): void
     {
         self::assertSame(
             '4711',
@@ -62,7 +59,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetScore()
+    public function canGetScore(): void
     {
         self::assertSame(
             0.55,
@@ -74,7 +71,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetContent()
+    public function canGetContent(): void
     {
         self::assertSame(
             'foobar',
@@ -86,7 +83,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetType()
+    public function canGetType(): void
     {
         self::assertSame(
             'pages',
@@ -98,7 +95,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetTitle()
+    public function canGetTitle(): void
     {
         self::assertSame(
             'The title',
@@ -110,7 +107,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetUrl()
+    public function canGetUrl(): void
     {
         self::assertSame(
             '://mytestdomain.com/test',
@@ -122,7 +119,7 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetIsElevated()
+    public function canGetIsElevated(): void
     {
         self::assertTrue(
             $this->searchResult->getIsElevated(),
@@ -133,9 +130,10 @@ class SearchResultTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getOnUnexistingFieldReturnsNull()
+    public function getOnUnexistingFieldReturnsNull(): void
     {
         self::assertNull(
+            /** @phpstan-ignore-next-line */
             $this->searchResult->getUnexistingField(),
             'Calling getter for unexisting field does not return null'
         );

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -135,7 +135,6 @@ class SearchResultTest extends SetUpUnitTestCase
      */
     public function getOnUnexistingFieldReturnsNull()
     {
-        /** @noinspection PhpUndefinedMethodInspection */
         self::assertNull(
             $this->searchResult->getUnexistingField(),
             'Calling getter for unexisting field does not return null'

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -51,7 +51,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteSpellCheckingModelsFromResponse()
+    public function canReconstituteSpellCheckingModelsFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck.json');
 
@@ -69,7 +69,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteFacetModelFromResponse()
+    public function canReconstituteFacetModelFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_one_fields_facet.json');
 
@@ -97,7 +97,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteJsonFacetModelFromResponse()
+    public function canReconstituteJsonFacetModelFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_jsonfacets.json');
 
@@ -133,7 +133,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteFacetModelsFromResponse()
+    public function canReconstituteFacetModelsFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -166,7 +166,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSkipOptionsMarkedAsExcludeValue()
+    public function canSkipOptionsMarkedAsExcludeValue(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -199,7 +199,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetRequirementsMetToFalseOnFacetThatMissesARequirement()
+    public function canSetRequirementsMetToFalseOnFacetThatMissesARequirement(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -242,7 +242,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetRequirementsMetToTrueOnFacetThatFullFillsARequirement()
+    public function canSetRequirementsMetToTrueOnFacetThatFullFillsARequirement(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
         $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
@@ -290,7 +290,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrder()
+    public function canGetOptionsInExpectedOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -323,7 +323,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrderWhenReversOrderIsApplied()
+    public function canGetOptionsInExpectedOrderWhenReversOrderIsApplied(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -357,7 +357,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrderWhenManualSortOrderIsApplied()
+    public function canGetOptionsInExpectedOrderWhenManualSortOrderIsApplied(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -391,7 +391,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteFacetModelsWithSameFieldNameFromResponse()
+    public function canReconstituteFacetModelsWithSameFieldNameFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -424,7 +424,6 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         // after the reconstitution they should be 1 facet present
         self::assertCount(3, $searchResultSet->getFacets());
 
-        /** @var OptionsFacet $facet */
         $facets = $searchResultSet->getFacets();
         self::assertCount(2, $facets->getByPosition(0)->getOptions());
     }

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -245,7 +245,9 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     public function canSetRequirementsMetToTrueOnFacetThatFullFillsARequirement(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 return $name == 'myType' ? ['pages'] : [];
             }
@@ -431,10 +433,12 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReconstituteUsedFacet()
+    public function canReconstituteUsedFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
             }
@@ -481,10 +485,12 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canMarkUsedOptionAsSelected()
+    public function canMarkUsedOptionAsSelected(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
             }
@@ -523,10 +529,12 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function includeIsUsedFacetsCanBeSetToFalse()
+    public function includeIsUsedFacetsCanBeSetToFalse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 return $name == 'type' ? ['tx_solr_file'] : [];
             }
@@ -560,10 +568,12 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetConfiguredFacetNotInResponseAsUnavailableFacet()
+    public function canGetConfiguredFacetNotInResponseAsUnavailableFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 return $name == 'type' ? ['pages'] : [];
             }
@@ -602,10 +612,12 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetTwoUsedFacetOptions()
+    public function canGetTwoUsedFacetOptions(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_two_used_facets.json');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetValuesByName')->willReturnCallback(
             function ($name) {
                 if ($name == 'mytitle') {
                     return ['jpeg', 'kasper"s'];
@@ -647,7 +659,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function emptyFacetsAreNotReconstitutedWhenDisabled()
+    public function emptyFacetsAreNotReconstitutedWhenDisabled(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
 
@@ -681,7 +693,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function emptyFacetIsKeptWhenNothingIsConfiguredGloballyButKeepingIsEnabledOnFacetLevel()
+    public function emptyFacetIsKeptWhenNothingIsConfiguredGloballyButKeepingIsEnabledOnFacetLevel(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
 
@@ -715,7 +727,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function includeInAvailableFacetsCanBeSetToFalse()
+    public function includeInAvailableFacetsCanBeSetToFalse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
 
@@ -745,7 +757,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function includeInAvailableFacetsCanBeSetToTrue()
+    public function includeInAvailableFacetsCanBeSetToTrue(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
 
@@ -775,7 +787,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function labelCanBeConfiguredAsAPlainText()
+    public function labelCanBeConfiguredAsAPlainText(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
 
@@ -803,7 +815,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function returnsCorrectSetUpFacetTypeForAQueryGroupFacet()
+    public function returnsCorrectSetUpFacetTypeForAQueryGroupFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -846,7 +858,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrderForQueryGroupFacet()
+    public function canGetOptionsInExpectedOrderForQueryGroupFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -893,7 +905,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrderForQueryGroupFacetWithManualSortOrder()
+    public function canGetOptionsInExpectedOrderForQueryGroupFacetWithManualSortOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -941,7 +953,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetOptionsInExpectedOrderForQueryGroupFacetWithReversOrder()
+    public function canGetOptionsInExpectedOrderForQueryGroupFacetWithReversOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -989,7 +1001,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function returnsResultSetWithConfiguredSortingOptions()
+    public function returnsResultSetWithConfiguredSortingOptions(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -1007,7 +1019,9 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
             ],
         ];
 
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getHasSorting')->willReturn(false);
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getHasSorting')->willReturn(false);
 
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
@@ -1020,7 +1034,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canReturnSortingsAndMarkedSelectedAsActive()
+    public function canReturnSortingsAndMarkedSelectedAsActive(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
 
@@ -1043,9 +1057,11 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
             ],
         ];
 
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getHasSorting')->willReturn(true);
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getSortingName')->willReturn('title');
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getSortingDirection')->willReturn('desc');
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getHasSorting')->willReturn(true);
+        $usedSearchRequest->expects(self::any())->method('getSortingName')->willReturn('title');
+        $usedSearchRequest->expects(self::any())->method('getSortingDirection')->willReturn('desc');
 
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
@@ -1055,27 +1071,20 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('desc', $searchResultSet->getSortings()->getSelected()->getDirection(), 'Selected sorting as unexpected direction');
     }
 
-    /**
-     * @param array $facetConfiguration
-     * @return array
-     */
-    protected function getConfigurationArrayFromFacetConfigurationArray($facetConfiguration)
+    protected function getConfigurationArrayFromFacetConfigurationArray(array $facetConfiguration): array
     {
         $configuration = [];
         $configuration['plugin.']['tx_solr.']['search.']['faceting.'] = $facetConfiguration;
         return $configuration;
     }
 
-    /**
-     * @param array $configuration
-     * @param $searchResultSet
-     * @return ResultSetReconstitutionProcessor
-     */
-    protected function getConfiguredReconstitutionProcessor($configuration, $searchResultSet): ResultSetReconstitutionProcessor
+    protected function getConfiguredReconstitutionProcessor(array $configuration, SearchResultSet $searchResultSet): ResultSetReconstitutionProcessor
     {
         $typoScriptConfiguration = new TypoScriptConfiguration($configuration);
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
-        $searchResultSet->getUsedSearchRequest()->expects(self::any())->method('getActiveFacetNames')->willReturn([]);
+        /** @var MockObject|SearchRequest $usedSearchRequest */
+        $usedSearchRequest = $searchResultSet->getUsedSearchRequest();
+        $usedSearchRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
+        $usedSearchRequest->expects(self::any())->method('getActiveFacetNames')->willReturn([]);
 
         $processor = new ResultSetReconstitutionProcessor();
         return $processor;

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\Option;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\ResultSetReconstitutionProcessor;
@@ -24,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
@@ -33,13 +33,10 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
 {
-    /**
-     * @param $fixtureFile
-     * @return SearchResultSet
-     */
-    protected function initializeSearchResultSetFromFakeResponse($fixtureFile)
+    protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile): SearchResultSet
     {
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        /** @var SearchRequest|MockObject $searchRequestMock */
+        $searchRequestMock = $this->createMock(SearchRequest::class);
 
         $fakeResponseJson = $this->getFixtureContentByName($fixtureFile);
         $fakeResponse = new ResponseAdapter($fakeResponseJson);
@@ -194,11 +191,8 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
 
         self::assertCount(1, $searchResultSet->getFacets());
 
-        /* @var OptionsFacet $optionFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
-        // @extensionScannerIgnoreLine
         self::assertCount(1, $optionFacet->getOptions());
-        // @extensionScannerIgnoreLine
         self::assertSame('event', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Skipping configured value not working as expected');
     }
 
@@ -317,14 +311,11 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $optionFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
 
-        /* @var Option $option1 */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
         self::assertSame('page', $option1->getValue());
 
-        /* @var Option $option2 */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
         self::assertSame('event', $option2->getValue());
     }
@@ -354,14 +345,11 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $optionFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
 
-        /* @var Option $option1 */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
         self::assertSame('event', $option1->getValue());
 
-        /* @var Option $option2 */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
         self::assertSame('page', $option2->getValue());
     }
@@ -391,14 +379,11 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $optionFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
 
-        /* @var Option $option1 */ // @extensionScannerIgnoreLine
         $option1 = $optionFacet->getOptions()->getByPosition(0);
         self::assertSame('event', $option1->getValue());
 
-        /* @var Option $option2 */ // @extensionScannerIgnoreLine
         $option2 = $optionFacet->getOptions()->getByPosition(1);
         self::assertSame('page', $option2->getValue());
     }
@@ -609,7 +594,6 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         /** @var OptionsFacet $facet1 */
         $facet1 = $facets->getByPosition(0);
 
-        /* @var Option $firstOption */ // @extensionScannerIgnoreLine
         $firstOption = $facet1->getOptions()->getByPosition(0);
         self::assertEquals('pages', $firstOption->getValue());
         self::assertEquals(5, $firstOption->getDocumentCount());
@@ -655,7 +639,6 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         /** @var OptionsFacet $facet1 */
         $facet1 = $facets->getByPosition(0);
 
-        /* @var Option $firstOption */ // @extensionScannerIgnoreLine
         $firstOption = $facet1->getOptions()->getByPosition(0);
         self::assertEquals('jpeg', $firstOption->getValue());
         self::assertEquals(1, $firstOption->getDocumentCount());
@@ -814,7 +797,6 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
 
-        /* @var OptionsFacet $facet */
         $facet = $searchResultSet->getFacets()->getByPosition(0);
         self::assertSame('My Type with special rendering', $facet->getLabel(), 'Could not get label for facet');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -23,41 +23,19 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchResultSetServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SearchResultSetService
-     */
-    protected $searchResultSetService;
-
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var Search
-     */
-    protected $searchMock;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $logManagerMock;
-
-    /**
-     * @var SearchResultBuilder
-     */
-    protected $searchResultBuilderMock;
-
-    /**
-     * @var QueryBuilder
-     */
-    protected $queryBuilderMock;
+    protected SearchResultSetService $searchResultSetService;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected Search|MockObject $searchMock;
+    protected SolrLogManager|MockObject $logManagerMock;
+    protected SearchResultBuilder|MockObject $searchResultBuilderMock;
+    protected QueryBuilder|MockObject $queryBuilderMock;
 
     protected function setUp(): void
     {
@@ -73,7 +51,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function searchIsNotTriggeredWhenEmptySearchDisabledAndEmptyQueryWasPassed()
+    public function searchIsNotTriggeredWhenEmptySearchDisabledAndEmptyQueryWasPassed(): void
     {
         $searchRequest = new SearchRequest();
         $searchRequest->setRawQueryString('');
@@ -85,7 +63,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function searchIsNotTriggeredWhenEmptyQueryWasPassedAndEmptySearchWasDisabled()
+    public function searchIsNotTriggeredWhenEmptyQueryWasPassedAndEmptySearchWasDisabled(): void
     {
         $searchRequest = new SearchRequest();
         $searchRequest->setRawQueryString('');
@@ -94,7 +72,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
         self::assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
 
-    protected function assertAllInitialSearchesAreDisabled()
+    protected function assertAllInitialSearchesAreDisabled(): void
     {
         $this->configurationMock->expects(self::any())->method('getSearchInitializeWithEmptyQuery')->willReturn(false);
         $this->configurationMock->expects(self::any())->method('getSearchShowResultsOfInitialEmptyQuery')->willReturn(false);

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -61,11 +61,11 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->logManagerMock = $this->getDumbMock(SolrLogManager::class);
-        $this->searchMock = $this->getDumbMock(Search::class);
-        $this->searchResultBuilderMock = $this->getDumbMock(SearchResultBuilder::class);
-        $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->logManagerMock = $this->createMock(SolrLogManager::class);
+        $this->searchMock = $this->createMock(Search::class);
+        $this->searchResultBuilderMock = $this->createMock(SearchResultBuilder::class);
+        $this->queryBuilderMock = $this->createMock(QueryBuilder::class);
         $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock);
         parent::setUp();
     }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -30,41 +30,19 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SearchResultSetTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var Search
-     */
-    protected $searchMock;
-
-    /**
-     * @var SearchResultSetService
-     */
-    protected $searchResultSetService;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $solrLogManagerMock;
-
-    /**
-     * @var Query
-     */
-    protected $queryMock;
-
-    /**
-     * @var EscapeService
-     */
-    protected $escapeServiceMock;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected Search|MockObject $searchMock;
+    protected SearchResultSetService|MockObject $searchResultSetService;
+    protected SolrLogManager|MockObject $solrLogManagerMock;
+    protected Query|MockObject $queryMock;
+    protected EscapeService|MockObject $escapeServiceMock;
 
     protected function setUp(): void
     {
@@ -94,10 +72,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @param $fakedRegisteredComponents
-     */
-    protected function fakeRegisteredSearchComponents(array $fakedRegisteredComponents)
+    protected function fakeRegisteredSearchComponents(array $fakedRegisteredComponents): void
     {
         $this->searchResultSetService->expects(self::once())->method('getRegisteredSearchComponents')->willReturn(
             $fakedRegisteredComponents
@@ -107,11 +82,11 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testSearchIfFiredWithInitializedQuery()
+    public function testSearchIfFiredWithInitializedQuery(): void
     {
         $this->fakeRegisteredSearchComponents([]);
 
-        // we expect the the ->search method on the Search object will be called once
+        // we expect the ->search method on the Search object will be called once
         // and we pass the response that should be returned when it was call to compare
         // later if we retrieve the expected result
         $fakeResponse = $this->createMock(ResponseAdapter::class);
@@ -128,7 +103,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
     * @test
     */
-    public function testOffsetIsPassedAsExpectedWhenSearchWasPaginated()
+    public function testOffsetIsPassedAsExpectedWhenSearchWasPaginated(): void
     {
         $this->fakeRegisteredSearchComponents([]);
 
@@ -146,7 +121,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testQueryAwareComponentGetsInitialized()
+    public function testQueryAwareComponentGetsInitialized(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchConfiguration')->willReturn([]);
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
@@ -170,7 +145,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canRegisterSearchResultSetProcessor()
+    public function canRegisterSearchResultSetProcessor(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
@@ -200,7 +175,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testAdditionalFiltersGetPassedToTheQuery()
+    public function testAdditionalFiltersGetPassedToTheQuery(): void
     {
         $this->fakeRegisteredSearchComponents([]);
         $fakeResponse = $this->createMock(ResponseAdapter::class);
@@ -224,7 +199,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testExpandedDocumentsGetAddedWhenVariantsAreConfigured()
+    public function testExpandedDocumentsGetAddedWhenVariantsAreConfigured(): void
     {
         // we fake that collapsing is enabled
         $this->configurationMock->expects(self::atLeastOnce())->method('getSearchVariants')->willReturn(true);
@@ -244,17 +219,12 @@ class SearchResultSetTest extends SetUpUnitTestCase
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         self::assertSame(1, count($resultSet->getSearchResults()), 'Unexpected amount of document');
 
-        /** @var  $fistResult SearchResult */
+        /** @var SearchResult $fistResult */
         $fistResult = $resultSet->getSearchResults()[0];
         self::assertSame(5, count($fistResult->getVariants()), 'Unexpected amount of expanded result');
     }
 
-    /**
-     * @param string $expextedQueryString
-     * @param int $expectedOffset
-     * @param ResponseAdapter $fakeResponse
-     */
-    public function assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse($expextedQueryString, $expectedOffset, ResponseAdapter $fakeResponse)
+    public function assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse(string $expextedQueryString, int $expectedOffset, ResponseAdapter $fakeResponse): void
     {
         $this->searchMock->expects(self::once())->method('search')->willReturnCallback(
             function (Query $query, $offset) use ($expextedQueryString, $expectedOffset, $fakeResponse) {

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -68,11 +68,11 @@ class SearchResultSetTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->searchMock = $this->getDumbMock(Search::class);
-        $this->solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->searchMock = $this->createMock(Search::class);
+        $this->solrLogManagerMock = $this->createMock(SolrLogManager::class);
 
-        $this->escapeServiceMock = $this->getDumbMock(EscapeService::class);
+        $this->escapeServiceMock = $this->createMock(EscapeService::class);
         $this->escapeServiceMock->expects(self::any())->method('escape')->willReturnArgument(0);
 
         $queryBuilder = new QueryBuilder(
@@ -114,7 +114,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         // we expect the the ->search method on the Search object will be called once
         // and we pass the response that should be returned when it was call to compare
         // later if we retrieve the expected result
-        $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeResponse = $this->createMock(ResponseAdapter::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my search', 0, $fakeResponse);
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
@@ -132,7 +132,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     {
         $this->fakeRegisteredSearchComponents([]);
 
-        $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeResponse = $this->createMock(ResponseAdapter::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 2. search', 50, $fakeResponse);
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
@@ -152,12 +152,12 @@ class SearchResultSetTest extends SetUpUnitTestCase
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
 
         // we expect that the initialize method of our component will be called
-        $fakeQueryAwareSpellChecker = $this->getDumbMock(SpellcheckingComponent::class);
+        $fakeQueryAwareSpellChecker = $this->createMock(SpellcheckingComponent::class);
         $fakeQueryAwareSpellChecker->expects(self::once())->method('initializeSearchComponent');
         $fakeQueryAwareSpellChecker->expects(self::once())->method('setQuery');
 
         $this->fakeRegisteredSearchComponents([$fakeQueryAwareSpellChecker]);
-        $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeResponse = $this->createMock(ResponseAdapter::class);
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('my 3. search', 0, $fakeResponse);
 
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 3. search']]);
@@ -203,7 +203,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
     public function testAdditionalFiltersGetPassedToTheQuery()
     {
         $this->fakeRegisteredSearchComponents([]);
-        $fakeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeResponse = $this->createMock(ResponseAdapter::class);
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
 

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -38,7 +38,7 @@ class SortingTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $this->resultSetMock = $this->createMock(SearchResultSet::class);
 
         $name = 'Price';
         $field = 'price_f';

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -43,8 +43,8 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->sessionMock = $this->getDumbMock(FrontendUserSession::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->sessionMock = $this->createMock(FrontendUserSession::class);
         $this->searchRequestBuilder = new SearchRequestBuilder($this->configurationMock, $this->sessionMock);
         parent::setUp();
     }

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -20,26 +20,16 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchRequestBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @var FrontendUserSession
-     */
-    protected $sessionMock;
-
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var SearchRequestBuilder
-     */
-    protected $searchRequestBuilder;
+    protected FrontendUserSession|MockObject $sessionMock;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected SearchRequestBuilder|MockObject $searchRequestBuilder;
 
     protected function setUp(): void
     {
@@ -52,7 +42,7 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testPageIsResettedWhenValidResultsPerPageValueWasPassed()
+    public function testPageIsResettedWhenValidResultsPerPageValueWasPassed(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
             ->willReturn([10, 25]);
@@ -72,7 +62,7 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testPerPageValueIsNotSetInSession()
+    public function testPerPageValueIsNotSetInSession(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
             ->willReturn([10, 25]);
@@ -82,12 +72,12 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
         $this->searchRequestBuilder->buildForSearch($requestArguments, 0, 0);
     }
 
-    private function assertPerPageInSessionWillBeChanged()
+    private function assertPerPageInSessionWillBeChanged(): void
     {
         $this->sessionMock->expects(self::once())->method('setPerPage');
     }
 
-    private function assertPerPageInSessionWillNotBeChanged()
+    private function assertPerPageInSessionWillNotBeChanged(): void
     {
         $this->sessionMock->expects(self::never())->method('setPerPage');
     }

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -382,7 +382,7 @@ class SearchRequestTest extends SetUpUnitTestCase
      */
     public function canGetContextTypoScriptConfigurationPassedOnCreation()
     {
-        $typoScriptConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $typoScriptConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $request = new SearchRequest([], 111, 4711, $typoScriptConfiguration);
 
         self::assertSame($request->getContextTypoScriptConfiguration(), $typoScriptConfiguration, 'Can get initial passed TypoScriptConfiguration');

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -68,11 +68,11 @@ class StatisticsWriterProcessorTest extends SetUpUnitTestCase
     {
         $this->statisticsRepositoryMock = $this->getMockBuilder(StatisticsRepository::class)->onlyMethods(['saveStatisticsRecord'])->getMock();
 
-        $this->siteRepositoryMock = $this->getDumbMock(SiteRepository::class);
+        $this->siteRepositoryMock = $this->createMock(SiteRepository::class);
         $this->processor = $this->getMockBuilder(StatisticsWriterProcessor::class)->setConstructorArgs([$this->statisticsRepositoryMock, $this->siteRepositoryMock])->onlyMethods(['getTSFE', 'getTime', 'getUserIp'])->getMock();
-        $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
-        $this->queryMock = $this->getDumbMock(Query::class);
+        $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->searchRequestMock = $this->createMock(SearchRequest::class);
+        $this->queryMock = $this->createMock(Query::class);
         parent::setUp();
     }
 
@@ -81,13 +81,12 @@ class StatisticsWriterProcessorTest extends SetUpUnitTestCase
      */
     public function canWriteExpectedStatisticsData()
     {
-        /* @var TypoScriptFrontendController $fakeTSFE */
-        $fakeTSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakeTSFE = $this->createMock(TypoScriptFrontendController::class);
         $fakeTSFE->id = 888;
         $fakeTime = 100;
         $fakeIP = '192.168.2.22';
 
-        $fakeSite = $this->getDumbMock(Site::class);
+        $fakeSite = $this->createMock(Site::class);
         $fakeSite->expects(self::once())->method('getRootPageId')->willReturn(4711);
         $this->siteRepositoryMock->expects(self::once())->method('getSiteByPageId')->with(888)->willReturn($fakeSite);
 
@@ -99,12 +98,11 @@ class StatisticsWriterProcessorTest extends SetUpUnitTestCase
 
         $this->queryMock->expects(self::once())->method('getQuery')->willReturn('my search');
 
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $resultSetMock->expects(self::once())->method('getUsedQuery')->willReturn($this->queryMock);
         $resultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($this->searchRequestMock);
 
-        $self = $this;
-        $this->statisticsRepositoryMock->expects(self::any())->method('saveStatisticsRecord')->willReturnCallback(function ($statisticData) use ($self) {
+        $this->statisticsRepositoryMock->expects(self::any())->method('saveStatisticsRecord')->willReturnCallback(function ($statisticData) {
             $this->assertSame('my search', $statisticData['keywords'], 'Unexpected keywords given');
             $this->assertSame('192.168.2.22', $statisticData['ip'], 'Unexpected ip given');
             $this->assertSame(4711, $statisticData['root_pid'], 'Unexpected root pid given');

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -74,12 +74,12 @@ class SuggestServiceTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->tsfeMock = $this->getDumbMock(TypoScriptFrontendController::class);
-        $this->searchResultSetServiceMock = $this->getDumbMock(SearchResultSetService::class);
-        $this->configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
-        $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
+        $this->tsfeMock = $this->createMock(TypoScriptFrontendController::class);
+        $this->searchResultSetServiceMock = $this->createMock(SearchResultSetService::class);
+        $this->configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $this->queryBuilderMock = $this->createMock(QueryBuilder::class);
 
-        $this->suggestQueryMock = $this->getDumbMock(SuggestQuery::class);
+        $this->suggestQueryMock = $this->createMock(SuggestQuery::class);
         $this->queryBuilderMock->expects(self::once())->method('buildSuggestQuery')->willReturn($this->suggestQueryMock);
 
         $this->suggestService = $this->getMockBuilder(SuggestService::class)
@@ -135,12 +135,12 @@ class SuggestServiceTest extends SetUpUnitTestCase
         $this->assertNoSearchWillBeTriggered();
         $fakeRequest = $this->getFakedSearchRequest('some');
 
-        $solrConnectionMock = $this->getDumbMock(SolrConnection::class);
+        $solrConnectionMock = $this->createMock(SolrConnection::class);
         $connectionManagerMock = $this->getAccessibleMock(ConnectionManager::class, ['getConnectionByPageId'], [], '', false);
         $connectionManagerMock->expects(self::any())->method('getConnectionByPageId')->willReturn($solrConnectionMock);
         GeneralUtility::setSingletonInstance(ConnectionManager::class, $connectionManagerMock);
 
-        $searchStub = new class ($this->getDumbMock(SolrConnection::class)) extends Search implements SingletonInterface {
+        $searchStub = new class ($this->createMock(SolrConnection::class)) extends Search implements SingletonInterface {
             public static $suggestServiceTest;
             public function search(Query $query, $offset = 0, $limit = 10): ?ResponseAdapter
             {
@@ -208,7 +208,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
             'typo' => 5,
         ]);
 
-        $fakeTopResults = $this->getDumbMock(SearchResultSet::class);
+        $fakeTopResults = $this->createMock(SearchResultSet::class);
         $fakeResultDocuments = new SearchResultCollection(
             [
                 $this->getFakedSearchResult('http://www.typo3-solr.com/a', 'pages', 'hello solr', 'my suggestions'),
@@ -237,7 +237,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
      */
     protected function getFakedSearchResult($url, $type, $title, $content)
     {
-        $result = $this->getDumbMock(SearchResult::class);
+        $result = $this->createMock(SearchResult::class);
         $result->expects(self::once())->method('getUrl')->willReturn($url);
         $result->expects(self::once())->method('getType')->willReturn($type);
         $result->expects(self::once())->method('getTitle')->willReturn($title);
@@ -257,7 +257,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
      */
     protected function getFakedSearchRequest(string $queryString): SearchRequest|MockObject
     {
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::atLeastOnce())->method('getRawUserQuery')->willReturn($queryString);
         return $fakeRequest;
     }

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -42,35 +42,12 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class SuggestServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SuggestService
-     */
-    protected $suggestService;
-
-    /**
-     * @var TypoScriptFrontendController
-     */
-    protected $tsfeMock;
-
-    /**
-     * @var SearchResultSetService
-     */
-    protected $searchResultSetServiceMock;
-
-    /**
-     * @var TypoScriptConfiguration
-     */
-    protected $configurationMock;
-
-    /**
-     * @var QueryBuilder
-     */
-    protected $queryBuilderMock;
-
-    /**
-     * @var SuggestQuery
-     */
-    protected $suggestQueryMock;
+    protected SuggestService|MockObject $suggestService;
+    protected TypoScriptFrontendController|MockObject $tsfeMock;
+    protected SearchResultSetService|MockObject $searchResultSetServiceMock;
+    protected TypoScriptConfiguration|MockObject $configurationMock;
+    protected QueryBuilder|MockObject $queryBuilderMock;
+    protected SuggestQuery|MockObject $suggestQueryMock;
 
     protected function setUp(): void
     {
@@ -89,10 +66,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @param string $queryString
-     */
-    protected function assertSuggestQueryWithQueryStringCreated($queryString)
+    protected function assertSuggestQueryWithQueryStringCreated(string $queryString): void
     {
         $this->suggestQueryMock->expects(self::any())->method('getQuery')->willReturn($queryString);
     }
@@ -100,7 +74,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetSuggestionsWithoutTopResults()
+    public function canGetSuggestionsWithoutTopResults(): void
     {
         // the query string is used as prefix but no real query string is passed.
         $this->assertSuggestQueryWithQueryStringCreated('');
@@ -130,7 +104,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canHandleInvalidSyntaxInAdditionalFilters()
+    public function canHandleInvalidSyntaxInAdditionalFilters(): void
     {
         $this->assertNoSearchWillBeTriggered();
         $fakeRequest = $this->getFakedSearchRequest('some');
@@ -141,7 +115,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         GeneralUtility::setSingletonInstance(ConnectionManager::class, $connectionManagerMock);
 
         $searchStub = new class ($this->createMock(SolrConnection::class)) extends Search implements SingletonInterface {
-            public static $suggestServiceTest;
+            public static SuggestServiceTest $suggestServiceTest;
             public function search(Query $query, $offset = 0, $limit = 10): ?ResponseAdapter
             {
                 return self::$suggestServiceTest->getMockBuilder(ResponseAdapter::class)
@@ -176,7 +150,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function emptyJsonIsReturnedWhenSolrHasNoSuggestions()
+    public function emptyJsonIsReturnedWhenSolrHasNoSuggestions(): void
     {
         $this->configurationMock->expects(self::never())->method('getSuggestShowTopResults');
         $this->assertNoSearchWillBeTriggered();
@@ -193,7 +167,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetSuggestionsWithTopResults()
+    public function canGetSuggestionsWithTopResults(): void
     {
         $this->configurationMock->expects(self::once())->method('getSuggestShowTopResults')->willReturn(true);
         $this->configurationMock->expects(self::once())->method('getSuggestNumberOfTopResults')->willReturn(2);
@@ -228,14 +202,8 @@ class SuggestServiceTest extends SetUpUnitTestCase
 
     /**
      * Builds a faked SearchResult object.
-     *
-     * @param string $url
-     * @param string $type
-     * @param string $title
-     * @param string $content
-     * @return SearchResult
      */
-    protected function getFakedSearchResult($url, $type, $title, $content)
+    protected function getFakedSearchResult(string $url, string $type, string $title, string $content): SearchResult|MockObject
     {
         $result = $this->createMock(SearchResult::class);
         $result->expects(self::once())->method('getUrl')->willReturn($url);
@@ -246,15 +214,11 @@ class SuggestServiceTest extends SetUpUnitTestCase
         return $result;
     }
 
-    protected function assertNoSearchWillBeTriggered()
+    protected function assertNoSearchWillBeTriggered(): void
     {
         $this->searchResultSetServiceMock->expects(self::never())->method('search');
     }
 
-    /**
-     * @param string $queryString
-     * @return SearchRequest|MockObject
-     */
     protected function getFakedSearchRequest(string $queryString): SearchRequest|MockObject
     {
         $fakeRequest = $this->createMock(SearchRequest::class);

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -33,26 +34,15 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
  */
 class SearchUriBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SearchUriBuilder
-     */
-    protected $searchUrlBuilder;
-
-    /**
-     * @var UriBuilder
-     */
-    protected $extBaseUriBuilderMock;
-
-    /**
-     * @var RoutingService
-     */
-    protected $routingServiceMock;
+    protected SearchUriBuilder|MockObject $searchUrlBuilder;
+    protected UriBuilder|MockObject $extBaseUriBuilderMock;
+    protected RoutingService|MockObject $routingServiceMock;
 
     protected function setUp(): void
     {
-        $this->extBaseUriBuilderMock = $this->getDumbMock(UriBuilder::class);
-        $this->routingServiceMock = $this->getDumbMock(RoutingService::class);
-        $eventDispatcherMock = $this->getDumbMock(EventDispatcher::class);
+        $this->extBaseUriBuilderMock = $this->createMock(UriBuilder::class);
+        $this->routingServiceMock = $this->createMock(RoutingService::class);
+        $eventDispatcherMock = $this->createMock(EventDispatcher::class);
         $eventDispatcherMock->expects(self::any())->method('dispatch')->willReturnArgument(0);
         $this->searchUrlBuilder = new SearchUriBuilder();
         $this->searchUrlBuilder->injectUriBuilder($this->extBaseUriBuilderMock);
@@ -65,9 +55,9 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function addFacetLinkIsCalledWithSubstitutedArguments()
+    public function addFacetLinkIsCalledWithSubstitutedArguments(): void
     {
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->willReturn([]);
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
@@ -83,7 +73,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function addFacetLinkWillAddAdditionalConfiguredArguments()
+    public function addFacetLinkWillAddAdditionalConfiguredArguments(): void
     {
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0:option###']], 'foo' => '###foo###'];
         $linkBuilderResult = '/index.php?id=1&filter=' . urlencode('###tx_solr:filter:0:option###') . '&foo=' . urlencode('###foo###');
@@ -100,8 +90,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
             ->method('build')
             ->with()
             ->willReturn($linkBuilderResult);
-        /* @var TypoScriptConfiguration $configurationMock */
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())
             ->method('getSearchPluginNamespace')
             ->willReturn('tx_solr');
@@ -137,9 +126,9 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered()
+    public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered(): void
     {
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->willReturn([]);
         $configurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(1);
@@ -163,12 +152,12 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function targetPageUidIsPassedWhenSortingIsAdded()
+    public function targetPageUidIsPassedWhenSortingIsAdded(): void
     {
         $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
         $linkBuilderResult = '/index.php?id=1&' . urlencode('tx_solr[sort]') . '=' . urlencode('###tx_solr:sort###');
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(4711);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
@@ -202,9 +191,9 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetRemoveFacetOptionUri()
+    public function canGetRemoveFacetOptionUri(): void
     {
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
@@ -231,9 +220,9 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetRemoveFacetUri()
+    public function canGetRemoveFacetUri(): void
     {
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
@@ -264,9 +253,9 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
      *
      * @test
      */
-    public function addFacetUriRemovesPreviousGroupPage()
+    public function addFacetUriRemovesPreviousGroupPage(): void
     {
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())
             ->method('getSearchPluginNamespace')
             ->willReturn('tx_solr');
@@ -303,7 +292,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetGroupPageForQueryGroup()
+    public function canSetGroupPageForQueryGroup(): void
     {
         $expectedArguments = [
             'tx_solr' => [
@@ -326,7 +315,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         ];
         $linkBuilderResult = '/index.php?' . http_build_query($givenTemplate);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(1);
 
@@ -371,10 +360,10 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function siteConfigurationModifyUriTest()
+    public function siteConfigurationModifyUriTest(): void
     {
         $configuration = Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'));
-        $routingServiceMock = $this->getDumbMock(RoutingService::class);
+        $routingServiceMock = $this->createMock(RoutingService::class);
         $routingServiceMock->expects(self::any())
             ->method('fetchEnhancerByPageUid')
             ->willReturn($configuration['routeEnhancers']['example']);
@@ -409,7 +398,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         $linkBuilderResult = '/index.php?id=42&color=' . urlencode('green,red,yellow') .
             '&taste=' . urlencode('matcha,sour') .
             '&product=' . urlencode('candy,sweets');
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(42);
 
@@ -426,10 +415,10 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function siteConfigurationModifyUriKeepUnmappedFilterTest()
+    public function siteConfigurationModifyUriKeepUnmappedFilterTest(): void
     {
         $configuration = Yaml::parse($this->getFixtureContentByName('siteConfiguration.yaml'));
-        $routingServiceMock = $this->getDumbMock(RoutingService::class);
+        $routingServiceMock = $this->createMock(RoutingService::class);
         $routingServiceMock->expects(self::any())
             ->method('fetchEnhancerByPageUid')
             ->willReturn($configuration['routeEnhancers']['example']);
@@ -467,7 +456,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
             '&taste=' . urlencode('matcha,sour') .
             '&product=' . urlencode('candy,sweets') .
             '&' . urlencode('tx_solr[filter][0]') . '=' . urlencode('quantity:20');
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::any())->method('getSearchPluginNamespace')->willReturn('tx_solr');
         $configurationMock->expects(self::once())->method('getSearchTargetPage')->willReturn(42);
 

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -58,14 +58,14 @@ class SiteHashServiceTest extends SetUpUnitTestCase
 
         $baseAMock = $this->createMock(UriInterface::class);
         $baseAMock->method('getHost')->willReturn('solrtesta.local');
-        $siteA = $this->getDumbMock(Site::class);
+        $siteA = $this->createMock(Site::class);
         $siteA->method('getBase')->willReturn($baseAMock);
         $siteA->method('getLanguages')->willReturn([$siteLanguageMock]);
         $siteA->method('getConfiguration')->willReturn($siteConfiguration);
 
         $baseBMock = $this->createMock(UriInterface::class);
         $baseBMock->method('getHost')->willReturn('solrtestb.local');
-        $siteB = $this->getDumbMock(Site::class);
+        $siteB = $this->createMock(Site::class);
         $siteB->method('getBase')->willReturn($baseBMock);
         $siteB->method('getLanguages')->willReturn([$siteLanguageMock]);
         $siteB->method('getConfiguration')->willReturn($siteConfiguration);

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -63,10 +63,10 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     protected function setUp(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
-        $this->cacheMock = $this->getDumbMock(TwoLevelCache::class);
-        $this->rootPageResolverMock = $this->getDumbMock(RootPageResolver::class);
-        $this->registryMock = $this->getDumbMock(Registry::class);
-        $this->siteFinderMock = $this->getDumbMock(SiteFinder::class);
+        $this->cacheMock = $this->createMock(TwoLevelCache::class);
+        $this->rootPageResolverMock = $this->createMock(RootPageResolver::class);
+        $this->registryMock = $this->createMock(Registry::class);
+        $this->siteFinderMock = $this->createMock(SiteFinder::class);
 
         // we mock buildSite to avoid the creation of real Site objects and pass all dependencies as mock
         $this->siteRepository = $this->getMockBuilder(SiteRepository::class)
@@ -184,7 +184,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         $this->siteRepository->expects(self::any())->method('buildSite')->willReturnCallback(
             function ($idToUse) use ($pageIds, $fakedConnectionConfiguration) {
                 if (in_array($idToUse, $pageIds)) {
-                    $site = $this->getDumbMock(Site::class);
+                    $site = $this->createMock(Site::class);
                     $site->expects($this->any())->method('getRootPageId')->willReturn(
                         $idToUse
                     );
@@ -214,14 +214,14 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     protected function getSiteMock(int $rootPageUid, array $languageUids)
     {
         /** @var CoreSite $siteMock */
-        $siteMock = $this->getDumbMock(CoreSite::class);
+        $siteMock = $this->createMock(CoreSite::class);
         $siteMock->expects(self::any())->method('getRootPageId')->willReturn($rootPageUid);
 
         $languageMocks = [];
         $defaultLanguage = null;
 
         foreach ($languageUids as $languageUid) {
-            $languageMock = $this->getDumbMock(SiteLanguage::class);
+            $languageMock = $this->createMock(SiteLanguage::class);
             $languageMock->expects(self::any())->method('getLanguageId')->willReturn($languageUid);
             $languageMocks[] = $languageMock;
         }

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -35,30 +36,11 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  */
 class SiteRepositoryTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TwoLevelCache
-     */
-    protected $cacheMock;
-
-    /**
-     * @var RootPageResolver
-     */
-    protected $rootPageResolverMock;
-
-    /**
-     * @var Registry
-     */
-    protected $registryMock;
-
-    /**
-     * @var SiteRepository
-     */
-    protected $siteRepository;
-
-    /**
-     * @var SiteFinder
-     */
-    protected $siteFinderMock;
+    protected TwoLevelCache|MockObject $cacheMock;
+    protected RootPageResolver|MockObject $rootPageResolverMock;
+    protected Registry|MockObject $registryMock;
+    protected SiteRepository|MockObject $siteRepository;
+    protected SiteFinder|MockObject $siteFinderMock;
 
     protected function setUp(): void
     {
@@ -79,7 +61,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetSiteByRootPageId()
+    public function canGetSiteByRootPageId(): void
     {
         $this->fakeEmptyCache();
 
@@ -93,7 +75,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetSiteByPageId()
+    public function canGetSiteByPageId(): void
     {
         $this->fakeEmptyCache();
         $this->fakeExistingRootPage(222, 111);
@@ -108,7 +90,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetFirstAvailableSite()
+    public function canGetFirstAvailableSite(): void
     {
         $this->fakeEmptyCache();
 
@@ -127,7 +109,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetAvailableSites()
+    public function canGetAvailableSites(): void
     {
         $this->fakeEmptyCache();
         $siteMockA = $this->getSiteMock(123, [0, 1]);
@@ -144,7 +126,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetAllLanguages()
+    public function canGetAllLanguages(): void
     {
         $this->fakeEmptyCache();
         $siteMockA = $this->getSiteMock(123, [0, 2, 5]);
@@ -165,21 +147,17 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         self::assertEquals([0, 2, 5], array_keys($connections), 'Could not get languages for site');
     }
 
-    protected function fakeEmptyCache()
+    protected function fakeEmptyCache(): void
     {
         $this->cacheMock->expects(self::any())->method('get')->willReturn(null);
     }
 
-    protected function assertCacheIsWritten()
+    protected function assertCacheIsWritten(): void
     {
         $this->cacheMock->expects(self::once())->method('set');
     }
 
-    /**
-     * @param array $pageIds
-     * @param array $fakedConnectionConfiguration
-     */
-    protected function assertThatSitesAreCreatedWithPageIds(array $pageIds, array $fakedConnectionConfiguration = [])
+    protected function assertThatSitesAreCreatedWithPageIds(array $pageIds, array $fakedConnectionConfiguration = []): void
     {
         $this->siteRepository->expects(self::any())->method('buildSite')->willReturnCallback(
             function ($idToUse) use ($pageIds, $fakedConnectionConfiguration) {
@@ -198,27 +176,20 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @param int $forPageId
-     * @param int $rootPageId
-     */
-    protected function fakeExistingRootPage($forPageId, $rootPageId)
+    protected function fakeExistingRootPage(int $forPageId, int $rootPageId): void
     {
         $this->rootPageResolverMock->expects(self::any())->method('getRootPageId')->with($forPageId)->willReturn($rootPageId);
     }
 
     /**
-     * @param int $rootPageUid
-     * @return CoreSite
+     * @param array<int, int> $languageUids
      */
-    protected function getSiteMock(int $rootPageUid, array $languageUids)
+    protected function getSiteMock(int $rootPageUid, array $languageUids): CoreSite|MockObject
     {
-        /** @var CoreSite $siteMock */
         $siteMock = $this->createMock(CoreSite::class);
         $siteMock->expects(self::any())->method('getRootPageId')->willReturn($rootPageUid);
 
         $languageMocks = [];
-        $defaultLanguage = null;
 
         foreach ($languageUids as $languageUid) {
             $languageMock = $this->createMock(SiteLanguage::class);
@@ -235,10 +206,8 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     /**
      * @param array $sitesInTYPO3
      */
-    protected function fakeSitesInTYPO3Systems(array $sitesInTYPO3)
+    protected function fakeSitesInTYPO3Systems(array $sitesInTYPO3): void
     {
-        $this->siteFinderMock->expects(self::any())->method('getAllSites')->willReturn(
-            $sitesInTYPO3
-        );
+        $this->siteFinderMock->expects(self::any())->method('getAllSites')->willReturn($sitesInTYPO3);
     }
 }

--- a/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
+++ b/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
@@ -20,14 +20,10 @@ use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TypoScriptTest extends SetUpUnitTestCase
 {
-    use ProphecyTrait;
-
     protected TypoScript|MockObject $typoScriptMock;
     protected TypoScriptConfiguration|MockObject $typoScriptConfigurationDumpMock;
 
@@ -46,15 +42,6 @@ class TypoScriptTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    protected function tearDown(): void
-    {
-        GeneralUtility::resetSingletonInstances([]);
-        unset(
-            $this->typoScriptMock
-        );
-        parent::tearDown();
-    }
-
     /**
      * @test
      */
@@ -66,16 +53,14 @@ class TypoScriptTest extends SetUpUnitTestCase
         $cacheId = md5($pageId . '|' . $path . '|' . $language);
 
         // prepare first call
-        /** @var TwoLevelCache|ObjectProphecy $twoLevelCache */
-        $twoLevelCache = $this->prophesize(TwoLevelCache::class);
+        $twoLevelCache = $this->createMock(TwoLevelCache::class);
         $twoLevelCache
-            ->get($cacheId)
-            ->shouldBeCalled()
-            ->willReturn([]);
+            ->expects(self::once())
+            ->method('get')->with($cacheId)->willReturn([]);
         $twoLevelCache
-            ->set($cacheId, [])
-            ->shouldBeCalledOnce();
-        GeneralUtility::addInstance(TwoLevelCache::class, $twoLevelCache->reveal());
+            ->expects(self::once())
+            ->method('set')->with($cacheId, []);
+        GeneralUtility::addInstance(TwoLevelCache::class, $twoLevelCache);
 
         $this->typoScriptMock
             ->method('buildConfigurationArray')

--- a/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
+++ b/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
@@ -49,7 +49,7 @@ class TypoScriptTest extends SetUpUnitTestCase
                 ]
             )->getMock();
 
-        $this->typoScriptConfigurationDumpMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->typoScriptConfigurationDumpMock = $this->createMock(TypoScriptConfiguration::class);
         parent::setUp();
     }
 

--- a/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
+++ b/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
@@ -28,15 +28,8 @@ class TypoScriptTest extends SetUpUnitTestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var TypoScript
-     */
-    protected $typoScriptMock;
-
-    /**
-     * @var TypoScriptConfiguration|MockObject
-     */
-    protected $typoScriptConfigurationDumpMock;
+    protected TypoScript|MockObject $typoScriptMock;
+    protected TypoScriptConfiguration|MockObject $typoScriptConfigurationDumpMock;
 
     protected function setUp(): void
     {
@@ -65,7 +58,7 @@ class TypoScriptTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getConfigurationFromPageIdReturnsCachedConfiguration()
+    public function getConfigurationFromPageIdReturnsCachedConfiguration(): void
     {
         $pageId = 12;
         $path = '';

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -81,7 +81,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_preProcessUHandlesRecordDeletion(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
@@ -102,7 +102,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_preProcessIgnoresDraftWorkspace(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $GLOBALS['BE_USER']->workspace = 1;
         $this->eventDispatcherMock
@@ -116,7 +116,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessHandlesPageMovement(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
@@ -138,7 +138,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessIgnoresPageMovementInDraftWorkspace(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $GLOBALS['BE_USER']->workspace = 1;
         $this->eventDispatcherMock
@@ -153,7 +153,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
      */
     public function processDatamap_preProcessFieldArrayStoresRecordData(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
         $dummyRecord = [
             'uid' => 123,
             'pid' => 1,
@@ -204,7 +204,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
     public function processDatamap_afterDatabaseOperationsTriggersRecordGarbageCheck(): void
     {
         $GLOBALS['TCA']['tx_foo_bar']['ctrl']['enablecolumns']['fe_group'] = 'fe_group';
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
         $dummyRecord = [
             'uid' => 123,
             'pid' => 1,

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -34,7 +34,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function isSerializedValueCanHandleCustomContentElements()
+    public function isSerializedValueCanHandleCustomContentElements(): void
     {
         $indexingConfiguration = [
             'topic_stringM' => 'SOLR_CLASSIFICATION',
@@ -57,7 +57,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function isSerializedValueCanHandleCustomInvalidSerializedValueDetector()
+    public function isSerializedValueCanHandleCustomInvalidSerializedValueDetector(): void
     {
         // register invalid detector
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][] = InvalidSerializedValueDetector::class;
@@ -75,7 +75,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function isSerializedValueCanHandleCustomValidSerializedValueDetector()
+    public function isSerializedValueCanHandleCustomValidSerializedValueDetector(): void
     {
         // register invalid detector
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][] = ValidSerializedValueDetector::class;
@@ -92,8 +92,8 @@ class AbstractIndexerTest extends SetUpUnitTestCase
         self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM'), 'Every value should be treated as serialized by custom detector');
         self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'csv_stringM'), 'Every value should be treated as serialized by custom detector');
         self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'categories_stringM'), 'Every value should be treated as serialized by custom detector');
-        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM', 'Every value should be treated as serialized by custom detector'));
-        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM', 'Every value should be treated as serialized by custom detector'));
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'category_stringM'), 'Every value should be treated as serialized by custom detector');
+        self::assertTrue(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM'), 'Every value should be treated as serialized by custom detector');
     }
 
     /**
@@ -101,7 +101,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
      * @test
      * @dataProvider indexingDataProvider
      */
-    public function resolveFieldValue(array $indexingConfiguration, string $solrFieldName, array $data, $expectedValue)
+    public function resolveFieldValue(array $indexingConfiguration, string $solrFieldName, array $data, $expectedValue): void
     {
         $subject = new class () extends AbstractIndexer {
         };
@@ -119,7 +119,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
         );
     }
 
-    public function indexingDataProvider()
+    public function indexingDataProvider(): \Generator
     {
         yield 'solr field defined as string' => [
             ['solrFieldName_stringS' => 'solrFieldName'],

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -105,7 +105,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
     {
         $subject = new class () extends AbstractIndexer {
         };
-        $tsfe = $this->getDumbMock(TypoScriptFrontendController::class);
+        $tsfe = $this->createMock(TypoScriptFrontendController::class);
         self::assertEquals(
             $this->callInaccessibleMethod(
                 $subject,

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -36,7 +36,6 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 use RuntimeException;
-use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use UnexpectedValueException;
 
@@ -123,10 +122,8 @@ class IndexerTest extends SetUpUnitTestCase
 
     /**
      * Data provider for "canTriggerIndexingAndIndicateIndexStatus"
-     *
-     * @return Traversable
      */
-    public function canTriggerIndexingAndIndicateIndexStatusDataProvider(): Traversable
+    public function canTriggerIndexingAndIndicateIndexStatusDataProvider(): \Generator
     {
         yield 'Item could be indexed' => [
             200,
@@ -139,14 +136,10 @@ class IndexerTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param string|AdditionalIndexQueueItemIndexer $class
-     * @param string|null $expectedException
-     * @param int $resultCount
-     *
      * @test
      * @dataProvider canGetAdditionalDocumentsDataProvider
      */
-    public function canGetAdditionalDocuments($class, ?string $expectedException, int $expectedResultCount): void
+    public function canGetAdditionalDocuments(\stdClass|string|AdditionalIndexQueueItemIndexer|null $class, ?string $expectedException, int $expectedResultCount): void
     {
         if ($class !== null) {
             if (is_object($class)) {
@@ -186,10 +179,8 @@ class IndexerTest extends SetUpUnitTestCase
 
     /**
      * Data provider for "canGetAdditionalDocuments"
-     *
-     * @return Traversable
      */
-    public function canGetAdditionalDocumentsDataProvider(): Traversable
+    public function canGetAdditionalDocumentsDataProvider(): \Generator
     {
         yield 'no AdditionalIndexQueueItemIndexer registered' => [
             null,
@@ -232,9 +223,6 @@ class IndexerTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param object|null $modifier
-     * @param string|null $expectedException
-     *
      * @test
      * @dataProvider canCallDocumentsModifierHookDataProvider
      */
@@ -260,10 +248,8 @@ class IndexerTest extends SetUpUnitTestCase
 
     /**
      * Data provider for "canCallDocumentsModifierHook"
-     *
-     * @return Traversable
      */
-    public function canCallDocumentsModifierHookDataProvider(): Traversable
+    public function canCallDocumentsModifierHookDataProvider(): \Generator
     {
         yield 'no modifier' => [null, null];
 
@@ -280,7 +266,7 @@ class IndexerTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function indexerAlwaysInitializesTSFE()
+    public function indexerAlwaysInitializesTSFE(): void
     {
         self::markTestSkipped('API has been changed, the test case must be moved, since it is still relevant.');
         /* @var Item|ObjectProphecy $item */

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -317,14 +317,6 @@ class IndexerTest extends SetUpUnitTestCase
 
     /**
      * Returns a mock builder with dump-mocked object properties.
-     *
-     * @param array $options
-     * @param PagesRepository|null $pagesRepository
-     * @param Builder|null $documentBuilder
-     * @param SolrLogManager|null $logger
-     * @param ConnectionManager|null $connectionManager
-     * @param FrontendEnvironment|null $frontendEnvironment
-     * @return MockBuilder
      */
     protected function getMockBuilderForIndexer(
         array $options = [],
@@ -336,11 +328,11 @@ class IndexerTest extends SetUpUnitTestCase
     ): MockBuilder {
         return $this->getMockBuilder(Indexer::class)->setConstructorArgs([
             $options,
-            $pagesRepository ?? $this->getDumbMock(PagesRepository::class),
-            $documentBuilder ?? $this->getDumbMock(Builder::class),
-            $logger ?? $this->getDumbMock(SolrLogManager::class),
-            $connectionManager ?? $this->getDumbMock(ConnectionManager::class),
-            $frontendEnvironment ?? $this->getDumbMock(FrontendEnvironment::class),
+            $pagesRepository ?? $this->createMock(PagesRepository::class),
+            $documentBuilder ?? $this->createMock(Builder::class),
+            $logger ?? $this->createMock(SolrLogManager::class),
+            $connectionManager ?? $this->createMock(ConnectionManager::class),
+            $frontendEnvironment ?? $this->createMock(FrontendEnvironment::class),
         ]);
     }
 }

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -90,7 +90,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
 
         /* @var MockObject|Item $queueItemMock */
-        $queueItemMock = $this->getDumbMock(Item::class);
+        $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
         $response = $requestMock->send('http://7.6.local.typo3.org/about/typo3/');
@@ -111,7 +111,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
         /* @var MockObject|Item $queueItemMock */
-        $queueItemMock = $this->getDumbMock(Item::class);
+        $queueItemMock = $this->createMock(Item::class);
 
         $requestMock->setIndexQueueItem($queueItemMock);
 
@@ -129,8 +129,8 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $fakeResponse = 'invalidJsonString!!';
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
-        $queueItemMock = $this->getDumbMock(Item::class);
         /* @var MockObject|Item $queueItemMock */
+        $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
         $this->expectException(RuntimeException::class);
@@ -161,7 +161,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
         /* @var MockObject|Item $queueItemMock */
-        $queueItemMock = $this->getDumbMock(Item::class);
+        $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
         $requestMock->send('https://7.6.local.typo3.org/about/typo3/');
@@ -173,7 +173,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
     public function authenticationHeaderIsSetWhenUsernameAndPasswordHaveBeenPassed()
     {
         /* @var MockObject|RequestFactory $requestFactoryMock */
-        $requestFactoryMock = $this->getDumbMock(RequestFactory::class);
+        $requestFactoryMock = $this->createMock(RequestFactory::class);
         $requestFactoryMock->expects(self::once())->method('request')->willReturnCallback(function ($url, $method, $options) {
             $this->assertSame(['bob', 'topsecret'], $options['auth'], 'Authentication options have not been set');
             $this->assertSame('GET', $method, 'Unexpected http method');
@@ -182,15 +182,15 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         });
 
         /* @var MockObject|SolrLogManager $solrLogManagerMock */
-        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
         /* @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
-        $extensionConfigurationMock = $this->getDumbMock(ExtensionConfiguration::class);
+        $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
 
         $testParameters = json_encode(['requestId' => '581f76be71f60']);
         $pageIndexerRequest = new PageIndexerRequest($testParameters, $solrLogManagerMock, $extensionConfigurationMock, $requestFactoryMock);
 
         /* @var MockObject|Item $queueItemMock */
-        $queueItemMock = $this->getDumbMock(Item::class);
+        $queueItemMock = $this->createMock(Item::class);
         $pageIndexerRequest->setIndexQueueItem($queueItemMock);
         $pageIndexerRequest->setAuthorizationCredentials('bob', 'topsecret');
 
@@ -220,7 +220,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $pageIndexerRequest = $this->getPageIndexerRequest();
 
         /* @var MockObject|Item $itemMock */
-        $itemMock = $this->getDumbMock(Item::class);
+        $itemMock = $this->createMock(Item::class);
         $pageIndexerRequest->setIndexQueueItem($itemMock);
         $headers = $pageIndexerRequest->getHeaders();
         self::assertContains('User-Agent: TYPO3', $headers, 'Header should contain a proper User-Agent');
@@ -234,10 +234,10 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
     protected function getPageIndexerRequest(string $jsonEncodedParameter = null, RequestFactory $requestFactory = null): PageIndexerRequest
     {
         /* @var MockObject|SolrLogManager $solrLogManagerMock */
-        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
         /* @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
-        $extensionConfigurationMock = $this->getDumbMock(ExtensionConfiguration::class);
-        $requestFactory = $requestFactory ?? $this->getDumbMock(RequestFactory::class);
+        $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+        $requestFactory = $requestFactory ?? $this->createMock(RequestFactory::class);
         return new PageIndexerRequest($jsonEncodedParameter, $solrLogManagerMock, $extensionConfigurationMock, $requestFactory);
     }
 
@@ -248,9 +248,9 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
      */
     protected function getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse): PageIndexerRequest|MockObject
     {
-        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
-        $extensionConfigurationMock = $this->getDumbMock(ExtensionConfiguration::class);
-        $requestFactoryMock = $this->getDumbMock(RequestFactory::class);
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
+        $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+        $requestFactoryMock = $this->createMock(RequestFactory::class);
         /* @var MockObject|PageIndexerRequest $requestMock */
         $requestMock = $this->getMockBuilder(PageIndexerRequest::class)
             ->onlyMethods(['getUrl'])
@@ -275,11 +275,11 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
      */
     protected function getFakedGuzzleResponse($fakeResponse): ResponseInterface
     {
-        $bodyStream = $this->getDumbMock(StreamInterface::class);
+        $bodyStream = $this->createMock(StreamInterface::class);
         $bodyStream->expects(self::any())->method('getContents')->willReturn($fakeResponse);
 
         /* @var MockObject|ResponseInterface $responseMock */
-        $responseMock = $this->getDumbMock(ResponseInterface::class);
+        $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->expects(self::any())->method('getBody')->willReturn($bodyStream);
         return $responseMock;
     }

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -74,13 +74,13 @@ class PageIndexerTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->pagesRepositoryMock = $this->getDumbMock(PagesRepository::class);
-        $this->documentBuilderMock = $this->getDumbMock(Builder::class);
-        $this->solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
-        $this->connectionManagerMock = $this->getDumbMock(ConnectionManager::class);
-        $this->pageIndexerRequestMock = $this->getDumbMock(PageIndexerRequest::class);
-        $this->uriStrategyMock = $this->getDumbMock(AbstractUriStrategy::class);
-        $this->frontendEnvironmentMock = $this->getDumbMock(FrontendEnvironment::class);
+        $this->pagesRepositoryMock = $this->createMock(PagesRepository::class);
+        $this->documentBuilderMock = $this->createMock(Builder::class);
+        $this->solrLogManagerMock = $this->createMock(SolrLogManager::class);
+        $this->connectionManagerMock = $this->createMock(ConnectionManager::class);
+        $this->pageIndexerRequestMock = $this->createMock(PageIndexerRequest::class);
+        $this->uriStrategyMock = $this->createMock(AbstractUriStrategy::class);
+        $this->frontendEnvironmentMock = $this->createMock(FrontendEnvironment::class);
         parent::setUp();
     }
 
@@ -114,7 +114,7 @@ class PageIndexerTest extends SetUpUnitTestCase
     public function testIndexPageItemIsSendingFrontendRequestsToExpectedUrls()
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::once())->method('getAllSolrConnectionConfigurations')->willReturn([
             ['rootPageUid' => 88, 'language' => 0],
         ]);
@@ -126,16 +126,16 @@ class PageIndexerTest extends SetUpUnitTestCase
         $this->uriStrategyMock->expects(self::any())->method('getPageIndexingUriFromPageItemAndLanguageId')->willReturn($testUri);
 
         /* @var Item|MockObject $item */
-        $item = $this->getDumbMock(Item::class);
+        $item = $this->createMock(Item::class);
         $item->expects(self::any())->method('getRootPageUid')->willReturn(88);
         $item->expects(self::any())->method('getRecordUid')->willReturn(4711);
         $item->expects(self::any())->method('getSite')->willReturn($siteMock);
         $item->expects(self::any())->method('getIndexingConfigurationName')->willReturn('pages');
 
-        $accessGroupResponse = $this->getDumbMock(PageIndexerResponse::class);
+        $accessGroupResponse = $this->createMock(PageIndexerResponse::class);
         $accessGroupResponse->expects(self::once())->method('getActionResult')->with('findUserGroups')->willReturn([0]);
 
-        $indexResponse = $this->getDumbMock(PageIndexerResponse::class);
+        $indexResponse = $this->createMock(PageIndexerResponse::class);
         $indexResponse->expects(self::once())->method('getActionResult')->with('indexPage')->willReturn(['pageIndexed' => 'Success']);
 
         // Two requests will be send, the first one for the access groups, the second one for the indexing itself
@@ -144,7 +144,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         );
 
         $pageIndexer = $this->getPageIndexerWithMockedDependencies([]);
-        $pageRootLineMock = $this->getDumbMock(Rootline::class);
+        $pageRootLineMock = $this->createMock(Rootline::class);
         $pageIndexer->expects(self::once())->method('getAccessRootlineByPageId')->willReturn($pageRootLineMock);
 
         $pageIndexer->index($item);

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -32,45 +32,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class PageIndexerTest extends SetUpUnitTestCase
 {
-    /**
-     * @var PageIndexer
-     */
-    protected $pageIndexer;
-
-    /**
-     * @var PagesRepository
-     */
-    protected $pagesRepositoryMock;
-
-    /**
-     * @var Builder
-     */
-    protected $documentBuilderMock;
-
-    /**
-     * @var SolrLogManager
-     */
-    protected $solrLogManagerMock;
-
-    /**
-     * @var ConnectionManager
-     */
-    protected $connectionManagerMock;
-
-    /**
-     * @var PageIndexerRequest
-     */
-    protected $pageIndexerRequestMock;
-
-    /**
-     * @var AbstractUriStrategy
-     */
-    protected $uriStrategyMock;
-
-    /**
-     * @var MockObject|FrontendEnvironment
-     */
-    protected $frontendEnvironmentMock;
+    protected PageIndexer|MockObject $pageIndexer;
+    protected PagesRepository|MockObject $pagesRepositoryMock;
+    protected Builder|MockObject $documentBuilderMock;
+    protected SolrLogManager|MockObject $solrLogManagerMock;
+    protected ConnectionManager|MockObject $connectionManagerMock;
+    protected PageIndexerRequest|MockObject $pageIndexerRequestMock;
+    protected AbstractUriStrategy|MockObject $uriStrategyMock;
+    protected MockObject|FrontendEnvironment $frontendEnvironmentMock;
 
     protected function setUp(): void
     {
@@ -84,11 +53,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @param array $options
-     * @return PageIndexer|MockObject
-     */
-    protected function getPageIndexerWithMockedDependencies(array $options = [])
+    protected function getPageIndexerWithMockedDependencies(array $options = []): PageIndexer|MockObject
     {
         $pageIndexer = $this->getMockBuilder(PageIndexer::class)
             ->setConstructorArgs(
@@ -111,7 +76,7 @@ class PageIndexerTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function testIndexPageItemIsSendingFrontendRequestsToExpectedUrls()
+    public function testIndexPageItemIsSendingFrontendRequestsToExpectedUrls(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         $siteMock = $this->createMock(Site::class);

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -55,10 +55,10 @@ class RecordMonitorTest extends SetUpUnitTestCase
         $GLOBALS['BE_USER']->workspace = 0;
         GeneralUtility::addInstance(
             ExtensionConfiguration::class,
-            $this->getDumbMock(ExtensionConfiguration::class)
+            $this->createMock(ExtensionConfiguration::class)
         );
 
-        $rootlineUtilityMock = $this->getDumbMock(RootlineUtility::class);
+        $rootlineUtilityMock = $this->createMock(RootlineUtility::class);
         $rootlineUtilityMock->method('get')->willReturn([]);
         GeneralUtility::addInstance(
             RootlineUtility::class,
@@ -113,7 +113,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfPageRecord(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
@@ -122,7 +122,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processCmdmap_postProcess('version', 'pages', 4711, ['action' => 'swap'], $dataHandlerMock);
+        $this->recordMonitor->processCmdmap_postProcess('version', 'pages', 4711, ['action' => 'swap']);
 
         self::assertTrue($dispatchedEvent instanceof VersionSwappedEvent);
         self::assertEquals('pages', $dispatchedEvent->getTable());
@@ -134,8 +134,6 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfRecord(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-
         $dispatchedEvent = null;
         $this->eventDispatcherMock
             ->expects(self::once())
@@ -143,7 +141,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processCmdmap_postProcess('version', 'tx_foo_bar', 888, ['action' => 'swap'], $dataHandlerMock);
+        $this->recordMonitor->processCmdmap_postProcess('version', 'tx_foo_bar', 888, ['action' => 'swap']);
 
         self::assertTrue($dispatchedEvent instanceof VersionSwappedEvent);
         self::assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
@@ -155,8 +153,6 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecord(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-
         $dispatchedEvent = null;
         $this->eventDispatcherMock
             ->expects(self::once())
@@ -164,7 +160,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, [], $dataHandlerMock);
+        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, []);
 
         self::assertTrue($dispatchedEvent instanceof RecordMovedEvent);
         self::assertEquals('pages', $dispatchedEvent->getTable());
@@ -176,13 +172,12 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecordInDraftWorkspace(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
         $GLOBALS['BE_USER']->workspace = 1;
 
         $this->eventDispatcherMock
             ->expects(self::never())
             ->method('dispatch');
-        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, [], $dataHandlerMock);
+        $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, []);
     }
 
     /**
@@ -190,8 +185,6 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfRecord(): void
     {
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
-
         $dispatchedEvent = null;
         $this->eventDispatcherMock
             ->expects(self::once())
@@ -199,7 +192,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processCmdmap_postProcess('move', 'tx_foo_bar', 888, [], $dataHandlerMock);
+        $this->recordMonitor->processCmdmap_postProcess('move', 'tx_foo_bar', 888, []);
 
         self::assertTrue($dispatchedEvent instanceof RecordMovedEvent);
         self::assertEquals('tx_foo_bar', $dispatchedEvent->getTable());
@@ -212,8 +205,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
      */
     public function processDatamap_afterDatabaseOperationsUsesAlreadyResolvedNextAutoIncrementValueForNewStatus(): void
     {
-        /* @var DataHandler|MockObject $dataHandlerMock */
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
 
         $dispatchedEvent = null;
         $this->eventDispatcherMock
@@ -222,7 +214,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', 4711, ['pid' => 1], $dataHandlerMock);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', 4711, ['pid' => 1]);
 
         self::assertTrue($dispatchedEvent instanceof RecordUpdatedEvent);
         self::assertEquals('tt_content', $dispatchedEvent->getTable());
@@ -236,7 +228,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
     public function processDatamap_afterDatabaseOperationsUsesNotYetResolvedNextAutoIncrementValueForNewStatus(): void
     {
         $newId = 'NEW1';
-        $dataHandlerMock = $this->getDumbMock(DataHandler::class);
+        $dataHandlerMock = $this->createMock(DataHandler::class);
         $dataHandlerMock->substNEWwithIDs[$newId] = 123;
 
         $dispatchedEvent = null;

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -36,10 +36,7 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  */
 class RecordMonitorTest extends SetUpUnitTestCase
 {
-    /**
-     * @var RecordMonitor|null
-     */
-    protected ?RecordMonitor $recordMonitor;
+    protected RecordMonitor $recordMonitor;
 
     /**
      * @var EventDispatcherInterface|MockObject
@@ -214,7 +211,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
             ->willReturnCallback(function () use (&$dispatchedEvent) {
                 $dispatchedEvent = func_get_arg(0);
             });
-        $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', 4711, ['pid' => 1]);
+        $this->recordMonitor->processDatamap_afterDatabaseOperations('new', 'tt_content', 4711, ['pid' => 1], $dataHandlerMock);
 
         self::assertTrue($dispatchedEvent instanceof RecordUpdatedEvent);
         self::assertEquals('tt_content', $dispatchedEvent->getTable());

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -136,7 +136,6 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
             $this->responseOutputHandler
         );
         $request = $this->responseOutputHandler->getRequest();
-        /* @var Uri $uri */
         $uri = $request->getUri();
 
         self::assertEquals(

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -40,14 +41,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
  */
 class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
 {
-    /**
-     * @var RoutingService
-     */
-    protected $routingServiceMock;
-
-    /**
-     * @var RequestHandlerInterface
-     */
+    protected RoutingService|MockObject $routingServiceMock;
     protected $responseOutputHandler;
 
     protected function setUp(): void
@@ -59,10 +53,7 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
 
         /* @see \TYPO3\CMS\Frontend\Tests\Unit\Middleware\PageResolverTest::setUp */
         $this->responseOutputHandler = new class () implements RequestHandlerInterface {
-            /**
-             * @var ServerRequestInterface
-             */
-            protected $request;
+            protected ServerRequestInterface $request;
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 $this->request = $request;
@@ -70,9 +61,7 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
             }
 
             /**
-             * This method is required since we wand to know how the URI changed inside
-             *
-             * @return ServerRequestInterface
+             * This method is required since we want to know how the URI changed inside
              */
             public function getRequest(): ServerRequestInterface
             {
@@ -87,7 +76,7 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
      * @test
      * @covers \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::process
      */
-    public function missingEnhancerHasNoEffectTest()
+    public function missingEnhancerHasNoEffectTest(): void
     {
         $serverRequest = new ServerRequest(
             'GET',

--- a/Tests/Unit/Query/Modifier/ElevationTest.php
+++ b/Tests/Unit/Query/Modifier/ElevationTest.php
@@ -33,7 +33,7 @@ class ElevationTest extends SetUpUnitTestCase
      */
     public function canModifyQuery()
     {
-        $query = $this->getDumbMock(Query::class);
+        $query = $this->createMock(Query::class);
 
         $queryBuilderMock = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([null, null, $this->createMock(SiteHashService::class)])

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -58,7 +58,7 @@ class FacetingTest extends SetUpUnitTestCase
         $facetRegistry = new FacetRegistry();
 
         /* @var SolrLogManager|MockObject $solrLogManagerMock */
-        $solrLogManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $solrLogManagerMock = $this->createMock(SolrLogManager::class);
 
         /* @var Query $query */
         $queryBuilder = new QueryBuilder(
@@ -110,7 +110,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
 
@@ -150,7 +150,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $queryParameter = $this->getQueryParametersFromExecutedFacetingModifier($fakeConfiguration, $fakeRequest);
@@ -188,7 +188,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
 
@@ -236,7 +236,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -283,7 +283,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -333,7 +333,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -370,7 +370,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -414,7 +414,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -455,7 +455,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -492,7 +492,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -529,7 +529,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -567,7 +567,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeArguments = ['filter' => [urlencode('type:product')]];
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -613,7 +613,7 @@ class FacetingTest extends SetUpUnitTestCase
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
         /* @var SearchRequest|MockObject $fakeRequest */
-        $fakeRequest = $this->getDumbMock(SearchRequest::class);
+        $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
 
@@ -629,20 +629,20 @@ class FacetingTest extends SetUpUnitTestCase
      */
     public function getFiltersByFacetNameCanHandleAssocUrlParameterStyle()
     {
-        $facetingModifierStub = new class ($this->getDumbMock(FacetRegistry::class)) extends Faceting {
+        $facetingModifierStub = new class ($this->createMock(FacetRegistry::class)) extends Faceting {
             public function callGetFiltersByFacetName(array $resultParameters, array $allFacets): array
             {
                 return parent::getFiltersByFacetName($resultParameters, $allFacets);
             }
         };
 
-        $typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
         $typoScriptConfigurationMock->expects(self::once())
             ->method('getSearchFacetingUrlParameterStyle')
             ->willReturn(UrlFacetContainer::PARAMETER_STYLE_ASSOC);
 
         /* @var SearchRequest|MockObject $searchRequestMock */
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock = $this->createMock(SearchRequest::class);
         $searchRequestMock->expects(self::once())
             ->method('getContextTypoScriptConfiguration')
             ->willReturn($typoScriptConfigurationMock);

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -70,10 +70,8 @@ class FacetingTest extends SetUpUnitTestCase
 
         GeneralUtility::addInstance(SiteHashService::class, $this->createMock(SiteHashService::class));
 
-        /* @var Faceting $facetModifier */
         $facetModifier = GeneralUtility::makeInstance(Faceting::class, $facetRegistry);
         $facetModifier->setSearchRequest($fakeSearchRequest);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $query = $facetModifier->modifyQuery($query);
 
         $requestBuilder = new RequestBuilder();

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrConfigurationStatus;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Reports\Status;
 
@@ -29,10 +30,7 @@ use TYPO3\CMS\Reports\Status;
  */
 class SolrConfigurationStatusTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SolrConfigurationStatus
-     */
-    protected SolrConfigurationStatus $report;
+    protected SolrConfigurationStatus|MockObject $report;
 
     protected function setUp(): void
     {
@@ -53,7 +51,7 @@ class SolrConfigurationStatusTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetEmptyResultWhenEverythingIsOK()
+    public function canGetEmptyResultWhenEverythingIsOK(): void
     {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];
 
@@ -71,7 +69,7 @@ class SolrConfigurationStatusTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetViolationWhenSolrIsEnabledButIndexingNot()
+    public function canGetViolationWhenSolrIsEnabledButIndexingNot(): void
     {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];
 

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Search\SortingComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for SortingComponent
@@ -31,20 +32,9 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class SortingComponentTest extends SetUpUnitTestCase
 {
-    /**
-     * @var Query
-     */
-    protected $query;
-
-    /**
-     * @var SearchRequest
-     */
-    protected $searchRequestMock;
-
-    /**
-     * @var SortingComponent
-     */
-    protected $sortingComponent;
+    protected Query|MockObject $query;
+    protected SearchRequest|MockObject $searchRequestMock;
+    protected SortingComponent|MockObject $sortingComponent;
 
     /**
      * SortingComponentTest constructor.
@@ -53,7 +43,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     {
         $this->query = new Query();
         $this->query->setQuery('');
-        $this->searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $this->searchRequestMock = $this->createMock(SearchRequest::class);
 
         $queryBuilder = new QueryBuilder(
             $this->createMock(TypoScriptConfiguration::class),
@@ -70,7 +60,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function sortingFromUrlIsNotAppliedWhenSortingIsDisabled()
+    public function sortingFromUrlIsNotAppliedWhenSortingIsDisabled(): void
     {
         $this->searchRequestMock->expects(self::any())->method('getArguments')->willReturn(['sort' => 'title asc']);
         $this->sortingComponent->initializeSearchComponent();
@@ -80,7 +70,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function validSortingFromUrlIsApplied()
+    public function validSortingFromUrlIsApplied(): void
     {
         $this->sortingComponent->setSearchConfiguration([
             'sorting' => 1,
@@ -100,7 +90,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function invalidSortingFromUrlIsNotApplied()
+    public function invalidSortingFromUrlIsNotApplied(): void
     {
         $this->sortingComponent->setSearchConfiguration([
             'sorting' => 1,
@@ -120,7 +110,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function sortByIsApplied()
+    public function sortByIsApplied(): void
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [
@@ -135,7 +125,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function urlSortingHasPrioriy()
+    public function urlSortingHasPrioriy(): void
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [
@@ -158,7 +148,7 @@ class SortingComponentTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function querySortingHasPriorityWhenSortingIsDisabled()
+    public function querySortingHasPriorityWhenSortingIsDisabled(): void
     {
         $this->sortingComponent->setSearchConfiguration([
             'query.' => [

--- a/Tests/Unit/Search/StatisticsComponentTest.php
+++ b/Tests/Unit/Search/StatisticsComponentTest.php
@@ -43,7 +43,7 @@ class StatisticsComponentTest extends SetUpUnitTestCase
             ],
         ]);
 
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock = $this->createMock(SearchRequest::class);
         $searchRequestMock->expects(self::once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
 
         $statisticsComponent = new StatisticsComponent();
@@ -68,7 +68,7 @@ class StatisticsComponentTest extends SetUpUnitTestCase
             ],
         ]);
 
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock = $this->createMock(SearchRequest::class);
         $searchRequestMock->expects(self::once())->method('getContextTypoScriptConfiguration')->willReturn($typoScriptConfiguration);
 
         $statisticsComponent = new StatisticsComponent();

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -43,13 +43,13 @@ class SearchTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        //        $this->solrReadServiceMock = $this->getDumbMock(SolrReadService::class);
+        //        $this->solrReadServiceMock = $this->createMock(SolrReadService::class);
         $this->solrReadServiceMock = $this->getMockBuilder(SolrReadService::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['search'])
             ->getMock();
 
-        $this->solrConnectionMock = $this->getDumbMock(SolrConnection::class);
+        $this->solrConnectionMock = $this->createMock(SolrConnection::class);
         $this->solrConnectionMock->expects(self::any())->method('getReadService')->willReturn($this->solrReadServiceMock);
         $this->search = new Search($this->solrConnectionMock);
         parent::setUp();
@@ -65,7 +65,7 @@ class SearchTest extends SetUpUnitTestCase
         $this->solrReadServiceMock->expects(self::once())->method('search')->willReturnCallback(
             function ($query) use ($limit) {
                 $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
-                return $this->getDumbMock(ResponseAdapter::class);
+                return $this->createMock(ResponseAdapter::class);
             }
         );
 
@@ -84,7 +84,7 @@ class SearchTest extends SetUpUnitTestCase
         $this->solrReadServiceMock->expects(self::once())->method('search')->willReturnCallback(
             function ($query) use ($limit) {
                 $this->assertSame($limit, $query->getRows(), 'Unexpected limit was passed');
-                return $this->getDumbMock(ResponseAdapter::class);
+                return $this->createMock(ResponseAdapter::class);
             }
         );
 

--- a/Tests/Unit/SetUpUnitTestCase.php
+++ b/Tests/Unit/SetUpUnitTestCase.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use ReflectionException;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -33,18 +32,6 @@ abstract class SetUpUnitTestCase extends UnitTestCase
     {
         date_default_timezone_set('Europe/Berlin');
         parent::setUp();
-    }
-
-    /**
-     * Returns a mock class where every behaviour is mocked, just to full fill
-     * the datatype and have the possibility to mock the behaviour.
-     *
-     * @param string $className
-     * @return MockObject
-     */
-    protected function getDumbMock(string $className): MockObject
-    {
-        return $this->createMock($className);
     }
 
     /**

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Cache;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -29,30 +30,16 @@ use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
  */
 class TwoLevelCacheTest extends SetUpUnitTestCase
 {
-    /**
-     * @var TwoLevelCache
-     */
-    protected $twoLevelCache;
+    protected TwoLevelCache $twoLevelCache;
+    protected FrontendInterface|MockObject $secondLevelCacheMock;
 
-    /**
-     * @var  FrontendInterface
-     */
-    protected $secondLevelCacheMock;
-
-    /**
-     * Prepare
-     */
     protected function setUp(): void
     {
-        $this->secondLevelCacheMock = $this->getDumbMock(FrontendInterface::class);
+        $this->secondLevelCacheMock = $this->createMock(FrontendInterface::class);
         $this->twoLevelCache = new TwoLevelCache('test', $this->secondLevelCacheMock);
         parent::setUp();
     }
 
-    /**
-     * Cleanup
-     * {@inheritDoc}
-     */
     protected function tearDown(): void
     {
         $this->twoLevelCache->flush();

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -29,7 +29,6 @@ class DebugWriterTest extends SetUpUnitTestCase
      */
     public function testDebugMessageIsWrittenForMessageFromSolr()
     {
-        /* @var DebugWriter $logWriter */
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(true);
         $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(true);
@@ -44,7 +43,6 @@ class DebugWriterTest extends SetUpUnitTestCase
      */
     public function testDebugMessageIsNotWrittenWhenDevIpMaskIsNotMatching()
     {
-        /* @var DebugWriter $logWriter */
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(false);
         $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(true);
@@ -59,7 +57,6 @@ class DebugWriterTest extends SetUpUnitTestCase
      */
     public function testDebugMessageIsNotWrittenWhenDebugOutputIsDisabled()
     {
-        /* @var DebugWriter $logWriter */
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
         $logWriter->expects(self::any())->method('getIsAllowedByDevIPMask')->willReturn(true);
         $logWriter->expects(self::any())->method('getIsdebugOutputEnabled')->willReturn(false);

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -54,7 +54,7 @@ class ConfigurationServiceTest extends SetUpUnitTestCase
                     ],
                 ],
           ];
-        $flexFormServiceMock = $this->getDumbMock(FlexFormService::class);
+        $flexFormServiceMock = $this->createMock(FlexFormService::class);
         $flexFormServiceMock->expects(self::once())->method('convertflexFormContentToArray')->willReturn($fakeFlexFormArrayData);
 
         $typoScriptConfiguration = new TypoScriptConfiguration(['plugin.' => ['tx_solr.' => []]]);

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Session;
 
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 /**
@@ -26,10 +27,7 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
  */
 class FrontendUserSessionTest extends SetUpUnitTestCase
 {
-    /**
-     * @var FrontendUserAuthentication
-     */
-    protected $feUserMock;
+    protected FrontendUserAuthentication|MockObject $feUserMock;
 
     /**
      * @var FrontendUserSession
@@ -38,7 +36,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->feUserMock = $this->getDumbMock(FrontendUserAuthentication::class);
+        $this->feUserMock = $this->createMock(FrontendUserAuthentication::class);
         $this->session = new FrontendUserSession($this->feUserMock);
         parent::setUp();
     }
@@ -46,7 +44,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getEmptyArrayWhenNoLastSearchesInSession()
+    public function getEmptyArrayWhenNoLastSearchesInSession(): void
     {
         $lastSearches = $this->session->getLastSearches();
         self::assertSame([], $lastSearches, 'Expected to get an empty lastSearches array');
@@ -55,7 +53,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function sessionDataWillBeRetrievedFromSessionForLastSearches()
+    public function sessionDataWillBeRetrievedFromSessionForLastSearches(): void
     {
         $fakeSessionData = ['foo', 'bar'];
         $this->feUserMock->expects(self::once())->method('getKey')->with('ses', 'tx_solr_lastSearches')->willReturn($fakeSessionData);
@@ -65,7 +63,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetLastSearchesInSession()
+    public function canSetLastSearchesInSession(): void
     {
         $lastSearches = ['TYPO3', 'solr'];
         $this->feUserMock->expects(self::once())->method('setKey')->with('ses', 'tx_solr_lastSearches', $lastSearches);
@@ -75,7 +73,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getHasPerPageReturnsFalseWhenNothingIsSet()
+    public function getHasPerPageReturnsFalseWhenNothingIsSet(): void
     {
         self::assertFalse($this->session->getHasPerPage(), 'Has per page should be false');
     }
@@ -83,7 +81,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getPerPageReturnsZeroWhenNothingIsSet()
+    public function getPerPageReturnsZeroWhenNothingIsSet(): void
     {
         self::assertSame(0, $this->session->getPerPage(), 'Expected to get 0 when nothing was set');
     }
@@ -91,7 +89,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getPerPageFromSessionData()
+    public function getPerPageFromSessionData(): void
     {
         $fakeSessionData = 12;
         $this->feUserMock->expects(self::once())->method('getKey')->with('ses', 'tx_solr_resultsPerPage')->willReturn($fakeSessionData);
@@ -101,7 +99,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canSetPerPageInSessionData()
+    public function canSetPerPageInSessionData(): void
     {
         $lastSearches = 45;
         $this->feUserMock->expects(self::once())->method('setKey')->with('ses', 'tx_solr_resultsPerPage', $lastSearches);

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Endpoint;
 use stdClass;
@@ -31,24 +32,13 @@ use function json_encode;
  */
 class SolrAdminServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var SolrAdminService
-     */
-    protected $adminService;
-
-    /**
-     * @var Client
-     */
-    protected $clientMock;
-
-    /**
-     * @var Endpoint
-     */
-    protected $endpointMock;
+    protected SolrAdminService|MockObject $adminService;
+    protected Client|MockObject $clientMock;
+    protected Endpoint|MockObject $endpointMock;
 
     protected function setUp(): void
     {
-        $this->endpointMock = $this->getDumbMock(Endpoint::class);
+        $this->endpointMock = $this->createMock(Endpoint::class);
         $this->endpointMock->expects(self::any())->method('getScheme')->willReturn('http');
         $this->endpointMock->expects(self::any())->method('getHost')->willReturn('localhost');
         $this->endpointMock->expects(self::any())->method('getPort')->willReturn(8983);
@@ -56,7 +46,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         $this->endpointMock->expects(self::any())->method('getCore')->willReturn('core_en');
         $this->endpointMock->expects(self::any())->method('getCoreBaseUri')->willReturn('http://localhost:8983/solr/core_en/');
 
-        $this->clientMock = $this->getDumbMock(Client::class);
+        $this->clientMock = $this->createMock(Client::class);
         $this->clientMock->expects(self::any())->method('getEndpoint')->willReturn($this->endpointMock);
         $this->adminService = $this->getMockBuilder(SolrAdminService::class)->setConstructorArgs([$this->clientMock])->onlyMethods(['_sendRawGet'])->getMock();
         parent::setUp();
@@ -64,9 +54,9 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getLukeMetaDataIsSendingRequestToExpectedUrl()
+    public function getLukeMetaDataIsSendingRequestToExpectedUrl(): void
     {
-        $fakedLukeResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakedLukeResponse = $this->createMock(ResponseAdapter::class);
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/luke?numTerms=50&wt=json&fl=%2A', $fakedLukeResponse);
         $result = $this->adminService->getLukeMetaData(50);
 
@@ -76,9 +66,9 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getPluginsInformation()
+    public function getPluginsInformation(): void
     {
-        $fakePluginsResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakePluginsResponse = $this->createMock(ResponseAdapter::class);
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/plugins?wt=json', $fakePluginsResponse);
         $result = $this->adminService->getPluginsInformation();
         self::assertSame($fakePluginsResponse, $result, 'Could not get expected result from getPluginsInformation');
@@ -87,9 +77,9 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getSystemInformation()
+    public function getSystemInformation(): void
     {
-        $fakeSystemInformationResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakeSystemInformationResponse = $this->createMock(ResponseAdapter::class);
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/system?wt=json', $fakeSystemInformationResponse);
         $result = $this->adminService->getSystemInformation();
         self::assertSame($fakeSystemInformationResponse, $result, 'Could not get expected result from getSystemInformation');
@@ -98,7 +88,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function getSolrServerVersion()
+    public function getSolrServerVersion(): void
     {
         $fakeRawResponse = new stdClass();
         $fakeRawResponse->lucene = new stdClass();
@@ -115,10 +105,10 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canGetSolrConfigNameFromFakedXmlResponse()
+    public function canGetSolrConfigNameFromFakedXmlResponse(): void
     {
         $fakeTestSchema = $this->getFixtureContentByName('solrconfig.xml');
-        $fakedSolrConfigResponse = $this->getDumbMock(ResponseAdapter::class);
+        $fakedSolrConfigResponse = $this->createMock(ResponseAdapter::class);
         $fakedSolrConfigResponse->expects(self::once())->method('getRawResponse')->willReturn($fakeTestSchema);
 
         $this->assertGetRequestIsTriggered('http://localhost:8983/solr/core_en/admin/file?file=solrconfig.xml', $fakedSolrConfigResponse);
@@ -126,11 +116,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedSchemaVersion, $this->adminService->getSolrconfigName(), 'SolrAdminService could not parse the solrconfig version as expected');
     }
 
-    /**
-     * @param string $url
-     * @param mixed $fakeResponse
-     */
-    protected function assertGetRequestIsTriggered(string $url, mixed $fakeResponse)
+    protected function assertGetRequestIsTriggered(string $url, mixed $fakeResponse): void
     {
         $this->adminService->expects(self::once())->method('_sendRawGet')->with($url)->willReturn($fakeResponse);
     }

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrInternalServerErrorException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Client\Response;
@@ -36,31 +37,16 @@ use Solarium\QueryType\Ping\Query as PingQuery;
  */
 class SolrReadServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var Request
-     */
-    protected $requestMock;
-
-    /**
-     * @var Response
-     */
-    protected $responseMock;
-
-    /**
-     * @var Client
-     */
-    protected $clientMock;
-
-    /**
-     * @var SolrReadService
-     */
+    protected Request|MockObject $requestMock;
+    protected Response|MockObject $responseMock;
+    protected Client|MockObject $clientMock;
     protected SolrReadService $service;
 
     protected function setUp(): void
     {
-        $this->responseMock = $this->getDumbMock(Response::class);
-        $this->requestMock = $this->getDumbMock(Request::class);
-        $this->clientMock = $this->getDumbMock(Client::class);
+        $this->responseMock = $this->createMock(Response::class);
+        $this->requestMock = $this->createMock(Request::class);
+        $this->clientMock = $this->createMock(Client::class);
         $this->clientMock->expects(self::any())->method('createRequest')->willReturn($this->requestMock);
         $this->clientMock->expects(self::any())->method('executeRequest')->willReturn($this->responseMock);
 
@@ -75,7 +61,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
     {
         // we fake a 200 OK response and expect that
         $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects(self::once())->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
+        $this->clientMock->expects(self::once())->method('createPing')->willReturn($this->createMock(PingQuery::class));
         $this->service->ping();
         $this->service->ping();
     }
@@ -87,7 +73,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
     {
         // we fake a 200 OK response and expect that
         $this->responseMock->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects(self::exactly(2))->method('createPing')->willReturn($this->getDumbMock(PingQuery::class));
+        $this->clientMock->expects(self::exactly(2))->method('createPing')->willReturn($this->createMock(PingQuery::class));
         $this->service->ping(false);
         $this->service->ping(false);
     }
@@ -98,7 +84,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
     public function searchMethodIsTriggeringGetRequest()
     {
         $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
+        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->createMock(Request::class));
 
         $searchQuery = new SearchQuery();
         $searchQuery->setQuery('foo');
@@ -129,7 +115,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
     public function searchThrowsExpectedExceptionForStatusCode($exceptionClass, $statusCode)
     {
         $this->responseMock->expects(self::any())->method('getStatusCode')->willReturn($statusCode);
-        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->getDumbMock(Request::class));
+        $this->clientMock->expects(self::once())->method('createRequest')->willReturn($this->createMock(Request::class));
 
         $this->clientMock->expects(self::once())->method('executeRequest')->willReturnCallback(function () use ($statusCode) {
             throw new HttpException('Solr error', $statusCode);
@@ -146,9 +132,9 @@ class SolrReadServiceTest extends SetUpUnitTestCase
      */
     protected function getDefaultSolrServiceWithMockedDependencies()
     {
-        $clientMock = $this->getDumbMock(Client::class);
-        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
-        $logManagerMock = $this->getDumbMock(SolrLogManager::class);
+        $clientMock = $this->createMock(Client::class);
+        $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
+        $logManagerMock = $this->createMock(SolrLogManager::class);
         $solrService = new SolrReadService($clientMock, $fakeConfiguration, $logManagerMock);
         return $solrService;
     }

--- a/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Response;
 use Solarium\QueryType\Update\Query\Query;
@@ -29,33 +30,18 @@ use Solarium\QueryType\Update\Result;
  */
 class SolrWriteServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var Response
-     */
-    protected $responseMock;
-
-    /**
-     * @var Result
-     */
-    protected $resultMock;
-
-    /**
-     * @var Client
-     */
-    protected $clientMock;
-
-    /**
-     * @var SolrWriteService
-     */
-    protected $service;
+    protected Response|MockObject $responseMock;
+    protected Result|MockObject $resultMock;
+    protected Client|MockObject $clientMock;
+    protected SolrWriteService $service;
 
     protected function setUp(): void
     {
-        $this->responseMock = $this->getDumbMock(Response::class);
+        $this->responseMock = $this->createMock(Response::class);
 
-        $this->resultMock = $this->getDumbMock(Result::class);
+        $this->resultMock = $this->createMock(Result::class);
         $this->resultMock->expects(self::any())->method('getResponse')->willReturn($this->responseMock);
-        $this->clientMock = $this->getDumbMock(Client::class);
+        $this->clientMock = $this->createMock(Client::class);
 
         $this->service = new SolrWriteService($this->clientMock);
         parent::setUp();
@@ -64,10 +50,10 @@ class SolrWriteServiceTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canRunOptimizeIndex()
+    public function canRunOptimizeIndex(): void
     {
         $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
-        $this->clientMock->expects(self::once())->method('createUpdate')->willReturn($this->getDumbMock(Query::class));
+        $this->clientMock->expects(self::once())->method('createUpdate')->willReturn($this->createMock(Query::class));
         $this->clientMock->expects(self::once())->method('update')->willReturn($this->resultMock);
 
         $result = $this->service->optimizeIndex();

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -66,17 +66,17 @@ class SolrConnectionTest extends SetUpUnitTestCase
     ): ?SolrConnection {
         try {
             return new SolrConnection(
-                $readNode ?? $this->getDumbMock(Node::class),
-                $writeNode ?? $this->getDumbMock(Node::class),
-                $configuration ?? $this->getDumbMock(TypoScriptConfiguration::class),
-                $synonymParser ?? $this->getDumbMock(SynonymParser::class),
-                $stopWordParser ?? $this->getDumbMock(StopWordParser::class),
-                $schemaParser ?? $this->getDumbMock(SchemaParser::class),
-                $logManager ?? $this->getDumbMock(SolrLogManager::class),
-                $psr7Client ?? $this->getDumbMock(ClientInterface::class),
-                $requestFactory ?? $this->getDumbMock(RequestFactoryInterface::class),
-                $streamFactory ?? $this->getDumbMock(StreamFactoryInterface::class),
-                $eventDispatcher ?? $this->getDumbMock(EventDispatcherInterface::class)
+                $readNode ?? $this->createMock(Node::class),
+                $writeNode ?? $this->createMock(Node::class),
+                $configuration ?? $this->createMock(TypoScriptConfiguration::class),
+                $synonymParser ?? $this->createMock(SynonymParser::class),
+                $stopWordParser ?? $this->createMock(StopWordParser::class),
+                $schemaParser ?? $this->createMock(SchemaParser::class),
+                $logManager ?? $this->createMock(SolrLogManager::class),
+                $psr7Client ?? $this->createMock(ClientInterface::class),
+                $requestFactory ?? $this->createMock(RequestFactoryInterface::class),
+                $streamFactory ?? $this->createMock(StreamFactoryInterface::class),
+                $eventDispatcher ?? $this->createMock(EventDispatcherInterface::class)
             );
         } catch (\Throwable $e) {
             // No exception will be ever happen, this is for saving up the lines in test cases.
@@ -89,10 +89,8 @@ class SolrConnectionTest extends SetUpUnitTestCase
      */
     public function authenticationIsNotTriggeredWithoutUsername()
     {
-        /* @var Endpoint $endpointMock */
-        $endpointMock = $this->getDumbMock(Endpoint::class);
-        /* @var Client $clientMock */
-        $clientMock = $this->getDumbMock(Client::class);
+        $endpointMock = $this->createMock(Endpoint::class);
+        $clientMock = $this->createMock(Client::class);
         $clientMock->expects(self::any())->method('getEndpoints')->willReturn([$endpointMock]);
 
         $readNode = Node::fromArray(
@@ -111,8 +109,8 @@ class SolrConnectionTest extends SetUpUnitTestCase
      */
     public function authenticationIsTriggeredWhenUsernameIsPassed()
     {
-        $endpointMock = $this->getDumbMock(Endpoint::class);
-        $clientMock = $this->getDumbMock(Client::class);
+        $endpointMock = $this->createMock(Endpoint::class);
+        $clientMock = $this->createMock(Client::class);
         $clientMock->expects(self::any())->method('getEndpoints')->willReturn([$endpointMock]);
 
         $readNode = Node::fromArray(
@@ -143,7 +141,7 @@ class SolrConnectionTest extends SetUpUnitTestCase
      */
     public function canGetCoreName($path, $expectedCoreName)
     {
-        $fakeConfiguration = $this->getDumbMock(TypoScriptConfiguration::class);
+        $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
         $readNode = Node::fromArray(
             ['host' => 'localhost', 'port' => 8080, 'path' => $path, 'scheme' => 'http', 'username' => '', 'password' => '']
         );

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -28,7 +28,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function whenNoFacetsAreConfiguredAllSolrFieldsShouldBeAvailableAsFilter()
     {
-        /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
 
@@ -51,7 +50,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function labelIsUsedFromFacetWhenTheFacetIsConfiguredInTypoScript()
     {
-        /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
 
@@ -79,7 +77,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function duplicateFacetLabelDoesNotMakeFieldsDisappearingInFlexForms()
     {
-        /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
         $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
@@ -113,7 +110,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function facetLabelIsShownTranslatedInBracketsSignsInFlexFormsIfTranslationIsAvailable()
     {
-        /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage', 'getTranslation'])->getMock();
         $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
@@ -163,7 +159,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function cObjectPathIsShownInBracketsSignsInFlexFormsIfcObjectIsUsed()
     {
-        /** @var FlexFormUserFunctions $flexFormUserFunctionsMock */
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getFieldNamesFromSolrMetaDataForPage', 'getConfiguredFacetsForPage'])->getMock();
         $flexFormUserFunctionsMock->expects(self::once())->method('getFieldNamesFromSolrMetaDataForPage')
@@ -193,7 +188,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function passingNullRowReturnsEmptyItems()
     {
-        /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods(['getConfiguredFacetsForPage'])->getMock();
 
@@ -217,7 +211,6 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
      */
     public function canGetExpectedSelectOptions()
     {
-        /** @var FlexFormUserFunctions $userFunc */
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
             ->onlyMethods([
                 'getAvailableTemplateFromTypoScriptConfiguration',

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -39,10 +39,10 @@ class SiteUtilityTest extends SetUpUnitTestCase
     public function canFallbackToLanguageSpecificReadProperty()
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
-        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock = $this->createMock(SiteLanguage::class);
         $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $property = SiteUtility::getConnectionProperty($siteMock, 'core', 2, 'write');
 
@@ -55,11 +55,11 @@ class SiteUtilityTest extends SetUpUnitTestCase
     public function canFallbackToGlobalPropertyWhenLanguageSpecificPropertyIsNotSet()
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
-        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock = $this->createMock(SiteLanguage::class);
         $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
         $globalConfiguration = ['solr_host_read' => 'readhost'];
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $siteMock->expects(self::any())->method('getConfiguration')->willReturn($globalConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
@@ -107,7 +107,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
      */
     public function solr_use_write_connectionSiteSettingInfluencesTheWriteConnection(string $expectedSolrHost, array $expectedSiteMockConfiguration)
     {
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getConfiguration')->willReturn($expectedSiteMockConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 0, 'write');
 
@@ -125,11 +125,11 @@ class SiteUtilityTest extends SetUpUnitTestCase
     public function canLanguageSpecificConfigurationOverwriteGlobalConfiguration()
     {
         $languageConfiguration = ['solr_host_read' => 'readhost.local.de'];
-        $languageMock = $this->getDumbMock(SiteLanguage::class);
+        $languageMock = $this->createMock(SiteLanguage::class);
         $languageMock->expects(self::any())->method('toArray')->willReturn($languageConfiguration);
 
         $globalConfiguration = ['solr_host_read' => 'readhost.global.de'];
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $siteMock->expects(self::any())->method('getConfiguration')->willReturn($globalConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, 'host', 2, 'read');
@@ -142,8 +142,8 @@ class SiteUtilityTest extends SetUpUnitTestCase
      */
     public function specifiedDefaultValueIsReturnedByGetConnectionPropertyIfPropertyIsNotDefinedInConfiguration()
     {
-        $languageMock = $this->getDumbMock(SiteLanguage::class);
-        $siteMock = $this->getDumbMock(Site::class);
+        $languageMock = $this->createMock(SiteLanguage::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getLanguageById')->willReturn($languageMock);
         $property = SiteUtility::getConnectionProperty($siteMock, 'some_property', 2, 'read', 'value-of_some_property');
 
@@ -280,7 +280,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
         string $scope,
         $expectedConfigurationValue
     ) {
-        $siteMock = $this->getDumbMock(Site::class);
+        $siteMock = $this->createMock(Site::class);
         $siteMock->expects(self::any())->method('getConfiguration')->willReturn($fakeConfiguration);
         $property = SiteUtility::getConnectionProperty($siteMock, $property, 0, $scope);
 

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -76,6 +76,7 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
             ->with(99)
             ->willReturn([$queueItem]);
 
+        /** @var array<int, mixed> $dispatchedEvents */
         $dispatchedEvents = [];
         $eventDispatcherMock
             ->expects(self::exactly(2))

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -33,10 +33,7 @@ use TYPO3\CMS\Scheduler\Scheduler;
  */
 class EventQueueWorkerTaskTest extends SetUpUnitTestCase
 {
-    /**
-     * @var EventQueueWorkerTask
-     */
-    protected $task;
+    protected EventQueueWorkerTask $task;
 
     protected function setUp(): void
     {
@@ -64,7 +61,6 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         GeneralUtility::addInstance(EventDispatcherInterface::class, $eventDispatcherMock);
 
-        /** @var RecordUpdatedEvent $event */
         $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
         $serializedEvent = serialize($event);
         /** @var RecordUpdatedEvent $unserializedEvent */
@@ -117,7 +113,6 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
         GeneralUtility::addInstance(SolrLogManager::class, $solrLogManagerMock);
 
-        /** @var RecordUpdatedEvent $event */
         $event = new RecordUpdatedEvent(123, 'tx_foo_bar');
         $serializedEvent = serialize($event);
         /** @var RecordUpdatedEvent $unserializedEvent */

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -31,7 +31,6 @@ class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
      */
     public function canGetWebRoot()
     {
-        /* @var IndexQueueWorkerTask $indexQueuerWorker */
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['execute'])
@@ -54,7 +53,6 @@ class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-        /* @var IndexQueueWorkerTask $indexQueuerWorker */
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSite'])

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -30,7 +30,6 @@ class ReIndexTaskTest extends SetUpUnitTestCase
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-        /* @var ReIndexTask $indexQueuerWorker */
         $indexQueuerWorker = $this->getMockBuilder(ReIndexTask::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSite'])

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -33,7 +33,7 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->typoScripConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->typoScripConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
         $this->typoScripConfigurationMock->expects(self::once())->method(
             'getIndexQueuePagesExcludeContentByClassArray'
         )->willReturn(['typo3-search-exclude']);

--- a/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -35,7 +35,7 @@ class IsStringViewHelperTest extends SetUpUnitTestCase
             '__elseClosures' => [function () { return 'elseResult'; }],
         ];
 
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $result = IsStringViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
         self::assertSame('thenResult', $result, 'thenClosure was not rendered');
     }
@@ -51,7 +51,7 @@ class IsStringViewHelperTest extends SetUpUnitTestCase
             '__elseClosures' => [function () { return 'elseResult'; }],
         ];
 
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $result = IsStringViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
         self::assertSame('elseResult', $result, 'elseResult was not rendered');
     }

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -64,9 +64,9 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
     public function canRenderCreateHighlightSnipped(array $input, $expectedOutput, $configuredWrap)
     {
         /* @var RenderingContextInterface|MockObject $renderingContextMock */
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
 
-        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getSearchResultsHighlightingFragmentSeparator')->willReturn(
             '###'
         );
@@ -74,7 +74,7 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
             $configuredWrap
         );
 
-        $searchRequestMock = $this->getDumbMock(SearchRequest::class);
+        $searchRequestMock = $this->createMock(SearchRequest::class);
         $searchRequestMock->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn(
             $configurationMock
         );
@@ -83,12 +83,12 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
         $fakeHighlightedContent->foo = new stdClass();
         $fakeHighlightedContent->foo->content = $input;
 
-        $searchMock = $this->getDumbMock(Search::class);
+        $searchMock = $this->createMock(Search::class);
         $searchMock->expects(self::once())->method('getHighlightedContent')->willReturn(
             $fakeHighlightedContent
         );
 
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $resultSetMock->expects(self::any())->method('getUsedSearchRequest')->willReturn(
             $searchRequestMock
         );
@@ -97,7 +97,7 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
             $searchMock
         );
 
-        $documentMock = $this->getDumbMock(SearchResult::class);
+        $documentMock = $this->createMock(SearchResult::class);
         $documentMock->expects(self::any())->method('getId')->willReturn('foo');
 
         $viewHelper = new HighlightResultViewHelper();

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -31,17 +31,17 @@ class RelevanceViewHelperTest extends SetUpUnitTestCase
      */
     public function canCalculateRelevance()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $resultSetMock->expects(self::any())->method('getMaximumScore')->willReturn(5.5);
 
-        $documentMock = $this->getDumbMock(SearchResult::class);
+        $documentMock = $this->createMock(SearchResult::class);
         $documentMock->expects(self::once())->method('getScore')->willReturn(0.55);
 
         $arguments = [
             'resultSet' => $resultSetMock,
             'document' => $documentMock,
         ];
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
 
         self::assertEquals(10.0, $score, 'Unexpected score');
@@ -52,10 +52,10 @@ class RelevanceViewHelperTest extends SetUpUnitTestCase
      */
     public function canCalculateRelevanceFromPassedMaximumScore()
     {
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
         $resultSetMock->expects(self::never())->method('getMaximumScore');
 
-        $documentMock = $this->getDumbMock(SearchResult::class);
+        $documentMock = $this->createMock(SearchResult::class);
         $documentMock->expects(self::once())->method('getScore')->willReturn(0.55);
 
         $arguments = [
@@ -63,7 +63,7 @@ class RelevanceViewHelperTest extends SetUpUnitTestCase
             'document' => $documentMock,
             'maximumScore' => 11,
         ];
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $score = RelevanceViewHelper::renderStatic($arguments, function () {}, $renderingContextMock);
 
         self::assertEquals(5.0, $score, 'Unexpected score');

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -45,7 +45,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
         GroupViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
         self::assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
 
-        /** @var  $facetCollection FacetCollection */
+        /** @var FacetCollection $facetCollection */
         $facetCollection = $variableContainer->get('areaFacets');
         self::assertEquals(2, $facetCollection->getCount());
 
@@ -71,7 +71,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
 
         self::assertTrue($variableContainer->exists('areaFacets'), 'Expected that filteredFacets has been set');
 
-        /** @var  $facetCollection FacetCollection */
+        /** @var FacetCollection $facetCollection */
         $facetCollection = $variableContainer->get('areaFacets');
         self::assertEquals(2, $facetCollection->getCount());
 

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -36,7 +36,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
         $facetCollection = $this->getTestFacetCollection();
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['facets'] = $facetCollection;
@@ -61,7 +61,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
         $facetCollection = $this->getTestFacetCollection();
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $viewHelper = $this->getMockBuilder(GroupViewHelper::class)->onlyMethods(['renderChildren'])->getMock();
@@ -85,7 +85,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
     protected function getTestFacetCollection()
     {
         $facetCollection = new FacetCollection();
-        $resultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $resultSetMock = $this->createMock(SearchResultSet::class);
 
         $colorFacet = new OptionsFacet($resultSetMock, 'color', 'color_s', '', ['groupName' => 'left']);
         $brandFacet = new OptionsFacet($resultSetMock, 'brand', 'brand_s', '', ['groupName' => 'left']);

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -33,7 +33,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
      */
     public function canMakeOnlyExpectedFacetsAvailableInStaticContext()
     {
-        $facet = $this->getDumbMock(OptionsFacet::class);
+        $facet = $this->createMock(OptionsFacet::class);
 
         $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
         $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);
@@ -49,7 +49,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
         $optionCollection->add($royalGreen);
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
@@ -69,7 +69,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
      */
     public function canMakeOnlyExpectedFacetsAvailableInStaticContextWithMultiByteCharacters()
     {
-        $facet = $this->getDumbMock(OptionsFacet::class);
+        $facet = $this->createMock(OptionsFacet::class);
 
         $ben = new Option($facet, 'Ben', 'ben', 14);
         $ole = new Option($facet, 'Øle', 'ole', 12);
@@ -79,7 +79,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
         $optionCollection->add($ole);
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -31,7 +31,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canMakeOnlyExpectedFacetsAvailableInStaticContext()
+    public function canMakeOnlyExpectedFacetsAvailableInStaticContext(): void
     {
         $facet = $this->createMock(OptionsFacet::class);
 
@@ -58,7 +58,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
         LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
         self::assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
 
-        /** @var  $optionCollection OptionCollection */
+        /** @var OptionCollection $optionCollection */
         $optionCollection = $variableContainer->get('filteredOptions');
         self::assertSame(1, $optionCollection->getCount());
         self::assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
@@ -67,7 +67,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function canMakeOnlyExpectedFacetsAvailableInStaticContextWithMultiByteCharacters()
+    public function canMakeOnlyExpectedFacetsAvailableInStaticContextWithMultiByteCharacters(): void
     {
         $facet = $this->createMock(OptionsFacet::class);
 
@@ -88,7 +88,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
         LabelFilterViewHelper::renderStatic($testArguments, function () {}, $renderingContextMock);
         self::assertTrue($variableContainer->exists('filteredOptions'), 'Expected that filteredOptions has been set');
 
-        /** @var  $optionCollection OptionCollection */
+        /** @var OptionCollection $optionCollection */
         $optionCollection = $variableContainer->get('filteredOptions');
         self::assertSame(1, $optionCollection->getCount());
         self::assertSame('Øle', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -36,7 +36,7 @@ class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
         $optionCollection = $this->getTestFacetOptionCollection();
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
@@ -55,7 +55,7 @@ class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
         $optionCollection = $this->getTestFacetOptionCollection();
 
         $variableContainer = $this->getMockBuilder(StandardVariableProvider::class)->onlyMethods(['remove'])->getMock();
-        $renderingContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
 
         $testArguments['options'] = $optionCollection;
@@ -71,7 +71,7 @@ class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
      */
     protected function getTestFacetOptionCollection(): OptionCollection
     {
-        $facet = $this->getDumbMock(OptionsFacet::class);
+        $facet = $this->createMock(OptionsFacet::class);
 
         $roseRed = new Option($facet, 'Rose Red', 'rose_red', 14);
         $blue = new Option($facet, 'Polar Blue', 'polar_blue', 12);

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -43,8 +43,8 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
 
     protected function setUp(): void
     {
-        $this->uriBuilderMock = $this->getDumbMock(UriBuilder::class);
-        $this->typoScriptConfigurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $this->uriBuilderMock = $this->createMock(UriBuilder::class);
+        $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
 
         $this->viewHelper = $this->getMockBuilder(SearchFormViewHelper::class)
             ->setConstructorArgs(
@@ -71,7 +71,7 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
         $renderingContext->setRequest($request);
         $this->viewHelper->setRenderingContext($renderingContext);
         $this->viewHelper->expects(self::any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
-        $this->viewHelper->expects(self::any())->method('getTemplateVariableContainer')->willReturn($this->getDumbMock(VariableProviderInterface::class));
+        $this->viewHelper->expects(self::any())->method('getTemplateVariableContainer')->willReturn($this->createMock(VariableProviderInterface::class));
         $this->viewHelper->expects(self::once())->method('renderChildren')->willReturn('');
         $this->viewHelper->expects(self::once())->method('getIsSiteManagedSite')->willReturn(false);
         parent::setUp();

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -31,11 +31,11 @@ class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
     {
         $facet = $this->getTestColorFacet();
 
-        $renderContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelper = new AddFacetItemViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
-        $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
+        $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -34,17 +34,17 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
      */
     public function setFacetItemWillUseUriBuilderAsExpected(): void
     {
-        $mockedPreviousFakedRequest = $this->getDumbMock(SearchRequest::class);
-        $mockedControllerRequest = $this->getDumbMock(Request::class);
+        $mockedPreviousFakedRequest = $this->createMock(SearchRequest::class);
+        $mockedControllerRequest = $this->createMock(Request::class);
 
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $searchResultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($mockedPreviousFakedRequest);
 
-        $variableProvideMock = $this->getDumbMock(StandardVariableProvider::class);
+        $variableProvideMock = $this->createMock(StandardVariableProvider::class);
         $variableProvideMock->expects(self::once())->method('get')->with('resultSet')->willReturn($searchResultSetMock);
 
         /* @var MockObject|RenderingContext $renderContextMock */
-        $renderContextMock = $this->getDumbMock(RenderingContext::class);
+        $renderContextMock = $this->createMock(RenderingContext::class);
         $renderContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableProvideMock);
         $renderContextMock->expects(self::any())->method('getRequest')->willReturn($mockedControllerRequest);
 
@@ -52,7 +52,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $viewHelper->setRenderingContext($renderContextMock);
 
         /* @var MockObject|SearchUriBuilder $searchUriBuilderMock */
-        $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
+        $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getRemoveAllFacetsUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getRemoveAllFacetsUri')->with($mockedPreviousFakedRequest);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -31,11 +31,11 @@ class RemoveFacetItemViewHelperTest extends SetUpFacetItemViewHelper
     {
         $facet = $this->getTestColorFacet();
 
-        $renderContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelper = new RemoveFacetItemViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
-        $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
+        $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getRemoveFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -32,11 +32,11 @@ class RemoveFacetViewHelperTest extends SetUpFacetItemViewHelper
     {
         $facet = $this->getTestColorFacet();
 
-        $renderContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelper = new RemoveFacetViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
-        $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
+        $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getRemoveFacetValueUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getRemoveFacetUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -31,11 +31,11 @@ class SetFacetItemViewHelperTest extends SetUpFacetItemViewHelper
     {
         $facet = $this->getTestColorFacet();
 
-        $renderContextMock = $this->getDumbMock(RenderingContextInterface::class);
+        $renderContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelper = new SetFacetItemViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
-        $searchUriBuilderMock = $this->getDumbMock(SearchUriBuilder::class);
+        $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getSetFacetValueUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getSetFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetUpFacetItemViewHelper.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetUpFacetItemViewHelper.php
@@ -44,7 +44,7 @@ abstract class SetUpFacetItemViewHelper extends SetUpUnitTestCase
     protected function getTestColorFacet()
     {
         $searchRequest = new SearchRequest();
-        $searchResultSetMock = $this->getDumbMock(SearchResultSet::class);
+        $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $searchResultSetMock->expects(self::any())->method('getUsedSearchRequest')->willReturn($searchRequest);
 
         $facet = new OptionsFacet($searchResultSetMock, 'Color', 'color');

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,9 @@
     ],
     "tests:setup": [
       "@tests:env",
-      "@composer req --prefer-source --update-with-all-dependencies typo3/cms-core:${TYPO3_VERSION}",
+      "@composer req --update-with-all-dependencies typo3/cms-core:${TYPO3_VERSION}",
+      "rm -Rf .Build/vendor/typo3/cms-core",
+      "@composer update --prefer-source typo3/cms-core",
       "@tests:restore-git"
     ],
     "tests:unit": [

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,9 @@
     "phpunit/phpunit": "^9.5",
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "~0.7.1",
-    "typo3/testing-framework": "^7.0"
+    "typo3/testing-framework": "^7.0",
+    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan-phpunit": "^1.3"
   },
   "replace": {
     "apache-solr-for-typo3/solrfluid": "*",
@@ -66,7 +68,8 @@
   "config": {
     "allow-plugins": true,
     "vendor-dir": ".Build/vendor",
-    "bin-dir": ".Build/bin"
+    "bin-dir": ".Build/bin",
+    "sort-packages": true
   },
   "scripts": {
     "post-autoload-dump": [
@@ -95,6 +98,9 @@
     "tests:integration": [
       "Composer\\Config::disableProcessTimeout",
       "phpunit --colors --config=Build/Test/IntegrationTests.xml --bootstrap=Build/Test/IntegrationTestsBootstrap.php"
+    ],
+    "tests:phpstan": [
+      "phpstan analyze -c Build/Test/phpstan.neon"
     ],
     "t3:standards:fix": [
       "php-cs-fixer fix"


### PR DESCRIPTION
# What this pr does

This change adds phpstan for static code analysis.

The current code base (especially the tests),
define wrong phpdoc comments, which is the main work to achieve in this patch.

In order to make tests / mocking behaviour easier, the phpunit extension is also installed.

For this reason, the "getDumbMock" need to be
removed for "createMock" from phpunit.

# How to test

The test can be executed like this:

* composer install --prefer-source
* composer tests:phpstan

Fixes: #3632