### PR TITLE
[TASK] Raise phpstan to level 5 and remove prophecy tests

### DIFF
--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -22,3 +22,4 @@ parameters:
     - '#^Method .*\\QueryBuilder::use.*FromTypoScript\(\) should return .*\\QueryBuilder but returns .*\\AbstractQueryBuilder.#'
     - '#^Access to protected property .*\\PageRepository::\$where_groupAccess.#'
     - '#^Unreachable statement - code above always terminates.#'
+    - '#^Parameter \#1 \$queryAlternative of method .*\\DisMax::setQueryAlternative\(\) expects string, null given.#'

--- a/Build/Test/phpstan.neon
+++ b/Build/Test/phpstan.neon
@@ -2,7 +2,7 @@ includes:
   - ../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
-  level: 3
+  level: 5
   treatPhpDocTypesAsCertain: false
 
   bootstrapFiles:
@@ -21,3 +21,4 @@ parameters:
     - '#^Method .*\\QueryBuilder::buildSuggestQuery\(\) should return .*\\SuggestQuery but returns .*\\Search\\Query\\Query\|null.#'
     - '#^Method .*\\QueryBuilder::use.*FromTypoScript\(\) should return .*\\QueryBuilder but returns .*\\AbstractQueryBuilder.#'
     - '#^Access to protected property .*\\PageRepository::\$where_groupAccess.#'
+    - '#^Unreachable statement - code above always terminates.#'

--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -127,7 +127,7 @@ class Rootline
         int $pageId,
         string $mountPointParameter = ''
     ): Rootline {
-        /* @var Rootline $accessRootline */
+        /** @var Rootline $accessRootline */
         $accessRootline = GeneralUtility::makeInstance(Rootline::class);
         $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageId, $mountPointParameter);
         try {
@@ -149,7 +149,7 @@ class Rootline
             }
         }
 
-        /* @var PageRepository $pageSelector */
+        /** @var PageRepository $pageSelector */
         $pageSelector = GeneralUtility::makeInstance(PageRepository::class);
 
         // current page

--- a/Classes/Backend/CoreSelectorField.php
+++ b/Classes/Backend/CoreSelectorField.php
@@ -161,7 +161,7 @@ class CoreSelectorField
             'fieldTSConfig' => ['noMatchingValue_label' => ''],
         ];
 
-        /* @var NodeFactory $nodeFactory */
+        /** @var NodeFactory $nodeFactory */
         $nodeFactory = GeneralUtility::makeInstance(NodeFactory::class);
         $options = [
             'renderType' => 'selectCheckBox',

--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -145,7 +145,7 @@ class IndexingConfigurationSelectorField
     protected function buildSelectorItems(array $tablesToIndex): array
     {
         $selectorItems = [];
-        /* @var IconRegistry $iconRegistry */
+        /** @var IconRegistry $iconRegistry */
         $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
         $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $defaultIcon = 'mimetypes-other-other';
@@ -189,7 +189,7 @@ class IndexingConfigurationSelectorField
             'fieldTSConfig' => ['noMatchingValue_label' => ''],
         ];
 
-        /* @var NodeFactory $nodeFactory */
+        /** @var NodeFactory $nodeFactory */
         $nodeFactory = GeneralUtility::makeInstance(NodeFactory::class);
         $options = [
             'type' => 'select', 'renderType' => 'selectCheckBox',

--- a/Classes/Backend/SettingsPreviewOnPlugins.php
+++ b/Classes/Backend/SettingsPreviewOnPlugins.php
@@ -58,7 +58,7 @@ class SettingsPreviewOnPlugins
     {
         $this->collectSummary();
 
-        /* @var StandaloneView $standaloneView */
+        /** @var StandaloneView $standaloneView */
         $standaloneView = GeneralUtility::makeInstance(StandaloneView::class);
         $standaloneView->setTemplatePathAndFilename(
             GeneralUtility::getFileAbsFileName('EXT:solr/Resources/Private/Templates/Backend/PageModule/Summary.html')

--- a/Classes/Backend/SiteSelectorField.php
+++ b/Classes/Backend/SiteSelectorField.php
@@ -54,7 +54,7 @@ class SiteSelectorField
                 $selectedAttribute = ' selected="selected"';
             }
 
-            $selector .= '<option value="' . htmlspecialchars($site->getRootPageId()) . '"' . $selectedAttribute . '>'
+            $selector .= '<option value="' . htmlspecialchars((string)$site->getRootPageId()) . '"' . $selectedAttribute . '>'
                 . htmlspecialchars($site->getLabel())
                 . '</option>';
         }

--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -67,7 +67,7 @@ class Classification extends AbstractContentObject
             $data = $this->cObj->stdWrap($data, $conf);
         }
         $classifications = $this->buildClassificationsFromConfiguration($configuredMappedClasses);
-        /* @var ClassificationService $classificationService */
+        /** @var ClassificationService $classificationService */
         $classificationService = GeneralUtility::makeInstance(ClassificationService::class);
 
         return serialize($classificationService->getMatchingClassNames((string)$data, $classifications));

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -247,7 +247,7 @@ class Relation extends AbstractContentObject
         $foreignTableLabelField = $this->resolveForeignTableLabelField($foreignTableTca);
         $localField = $this->configuration['localField'];
 
-        /* @var RelationHandler $relationHandler */
+        /** @var RelationHandler $relationHandler */
         $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
         if (!empty($localFieldTca['config']['MM'] ?? '')) {
             $relationHandler->start(
@@ -367,7 +367,7 @@ class Relation extends AbstractContentObject
      */
     protected function getRelatedRecords(string $foreignTable, int ...$uids): array
     {
-        /* @var QueryBuilder $queryBuilder */
+        /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($foreignTable);
         $queryBuilder->select('*')
             ->from($foreignTable)

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -99,7 +99,7 @@ abstract class AbstractBaseController extends ActionController
         if ($this->resetConfigurationBeforeInitialize) {
             $this->solrConfigurationManager->reset();
         }
-        /* @var TypoScriptService $typoScriptService */
+        /** @var TypoScriptService $typoScriptService */
         $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
 
         // Merge settings done by typoscript with solrConfiguration plugin.tx_solr (obsolete when part of ext:solr)
@@ -189,7 +189,7 @@ abstract class AbstractBaseController extends ActionController
     protected function logSolrUnavailable(): void
     {
         if ($this->typoScriptConfiguration->getLoggingExceptions()) {
-            /* @var SolrLogManager $logger */
+            /** @var SolrLogManager $logger */
             $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
             $logger->log(SolrLogManager::ERROR, 'Solr server is not available');
         }

--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -166,7 +166,7 @@ abstract class AbstractModuleController extends ActionController
             return;
         }
 
-        /* @var BackendUserAuthentication $beUser */
+        /** @var BackendUserAuthentication $beUser */
         $beUser = $GLOBALS['BE_USER'];
         $permissionClause = $beUser->getPagePermsClause(1);
         $pageRecord = BackendUtility::readPageAccess($this->selectedSite->getRootPageId(), $permissionClause);

--- a/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
@@ -52,7 +52,7 @@ class IndexAdministrationModuleController extends AbstractModuleController
             $solrServers = $this->solrConnectionManager->getConnectionsBySite($this->selectedSite);
             foreach ($solrServers as $solrServer) {
                 $writeService = $solrServer->getWriteService();
-                /* @var SolrConnection $solrServer */
+                /** @var SolrConnection $solrServer */
                 $writeService->deleteByQuery('siteHash:' . $siteHash);
                 $writeService->commit(false, false);
                 $affectedCores[] = $writeService->getPrimaryEndpoint()->getCore();

--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -228,7 +228,7 @@ class IndexQueueModuleController extends AbstractModuleController
      */
     public function doIndexingRunAction(): ResponseInterface
     {
-        /* @var IndexService $indexService */
+        /** @var IndexService $indexService */
         $indexService = GeneralUtility::makeInstance(IndexService::class, $this->selectedSite);
         $indexWithoutErrors = $indexService->indexItems(1);
 

--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -72,6 +72,7 @@ class InfoModuleController extends AbstractModuleController
      * Renders the details of Apache Solr documents
      *
      * @noinspection PhpUnused
+     * @throws DBALException
      */
     public function documentsDetailsAction(string $type, int $uid, int $pageId, int $languageUid): ResponseInterface
     {
@@ -90,7 +91,7 @@ class InfoModuleController extends AbstractModuleController
         $missingHosts = [];
         $invalidPaths = [];
 
-        /* @var Path $path */
+        /** @var Path $path */
         $path = GeneralUtility::makeInstance(Path::class);
         $connections = $this->solrConnectionManager->getConnectionsBySite($this->selectedSite);
 
@@ -142,7 +143,7 @@ class InfoModuleController extends AbstractModuleController
         $queriesDays = (int)($statisticsConfig['queries.']['days'] ?? 30);
 
         $siteRootPageId = $this->selectedSite->getRootPageId();
-        /* @var StatisticsRepository $statisticsRepository */
+        /** @var StatisticsRepository $statisticsRepository */
         $statisticsRepository = GeneralUtility::makeInstance(StatisticsRepository::class);
 
         $this->view->assign(
@@ -207,7 +208,7 @@ class InfoModuleController extends AbstractModuleController
             if ($coreAdmin->ping()) {
                 $lukeData = $coreAdmin->getLukeMetaData();
 
-                /* @var Registry $registry */
+                /** @var Registry $registry */
                 $registry = GeneralUtility::makeInstance(Registry::class);
                 $limit = $registry->get('tx_solr', 'luke.limit', 20000);
                 $limitNote = '';
@@ -243,6 +244,8 @@ class InfoModuleController extends AbstractModuleController
 
     /**
      * Retrieves the information for the index inspector.
+     *
+     * @throws DBALException
      */
     protected function collectIndexInspectorInfo(): void
     {

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -127,7 +127,7 @@ class SearchController extends AbstractBaseController
             $pagination = GeneralUtility::makeInstance(ResultsPagination::class, $paginator);
             $pagination->setMaxPageNumbers($this->typoScriptConfiguration->getMaxPaginatorLinks());
 
-            /* @var AfterSearchEvent $afterSearchEvent */
+            /** @var AfterSearchEvent $afterSearchEvent */
             $afterSearchEvent = $this->eventDispatcher->dispatch(
                 new AfterSearchEvent(
                     $searchResultSet,
@@ -166,7 +166,7 @@ class SearchController extends AbstractBaseController
             return $this->handleSolrUnavailable();
         }
 
-        /* @var FormEvent $formEvent */
+        /** @var FormEvent $formEvent */
         $formEvent = $this->eventDispatcher->dispatch(
             new FormEvent(
                 $this->searchService->getSearch(),
@@ -193,7 +193,7 @@ class SearchController extends AbstractBaseController
      */
     public function frequentlySearchedAction(): ResponseInterface
     {
-        /* @var SearchResultSet $searchResultSet */
+        /** @var SearchResultSet $searchResultSet */
         $searchResultSet = GeneralUtility::makeInstance(SearchResultSet::class);
 
         $pageId = $this->typoScriptFrontendController->getRequestedId();
@@ -203,7 +203,7 @@ class SearchController extends AbstractBaseController
 
         $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
 
-        /* @var AfterFrequentlySearchedEvent $afterFrequentlySearchedEvent*/
+        /** @var AfterFrequentlySearchedEvent $afterFrequentlySearchedEvent*/
         $afterFrequentlySearchedEvent = $this->eventDispatcher->dispatch(
             new AfterFrequentlySearchedEvent(
                 $searchResultSet,

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use ApacheSolrForTypo3\Solr\Util;
+use Doctrine\DBAL\Exception as DBALException;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -37,6 +38,7 @@ class SuggestController extends AbstractBaseController
      * This method creates a suggest json response that can be used in a suggest layer.
      *
      * @throws AspectNotFoundException
+     * @throws DBALException
      * @throws InvalidFacetPackageException
      * @throws NoSolrConnectionFoundException
      *
@@ -52,7 +54,7 @@ class SuggestController extends AbstractBaseController
         }
 
         try {
-            /* @var SuggestService $suggestService */
+            /** @var SuggestService $suggestService */
             $suggestService = GeneralUtility::makeInstance(
                 SuggestService::class,
                 $this->typoScriptFrontendController,

--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -94,7 +94,7 @@ abstract class AbstractStrategy
         foreach ($indexQueueItems as $indexQueueItem) {
             try {
                 $site = $indexQueueItem->getSite();
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException) {
                 $this->queue->deleteItem($indexQueueItem->getType(), $indexQueueItem->getIndexQueueUid());
                 continue;
             }
@@ -125,6 +125,7 @@ abstract class AbstractStrategy
             $response = $solr->getWriteService()->deleteByQuery($query);
 
             if ($response->getHttpStatus() !== 200) {
+                /** @var SolrLogManager $logger */
                 $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
                 $logger->log(
                     SolrLogManager::ERROR,

--- a/Classes/Domain/Index/Queue/QueueInitializationService.php
+++ b/Classes/Domain/Index/Queue/QueueInitializationService.php
@@ -73,7 +73,7 @@ class QueueInitializationService
     {
         $initializationStatesBySiteId = [];
         foreach ($sites as $site) {
-            /* @var Site $site */
+            /** @var Site $site */
             $initializationResult = $this->initializeBySiteAndIndexConfigurations($site, $indexingConfigurationNames);
             $initializationStatesBySiteId[$site->getRootPageId()] = $initializationResult;
         }
@@ -147,7 +147,7 @@ class QueueInitializationService
         array $indexConfiguration
     ): bool {
         $initializer = GeneralUtility::makeInstance($initializerClass);
-        /* @var AbstractInitializer $initializer */
+        /** @var AbstractInitializer $initializer */
         $initializer->setSite($site);
         $initializer->setType($type);
         $initializer->setIndexingConfigurationName($indexingConfigurationName);

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
@@ -61,7 +61,7 @@ class MountPagesUpdater
             return;
         }
 
-        /* @var Rootline $rootLine */
+        /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class, $rootLineArray);
         $rootLineParentPageIds = array_map('intval', $rootLine->getParentPageIds());
         $destinationMountProperties = $this->pagesRepository->findMountPointPropertiesByPageIdOrByRootLineParentPageIds($currentPageUid, $rootLineParentPageIds);
@@ -88,7 +88,7 @@ class MountPagesUpdater
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $mountingSite = $siteRepository->getSiteByPageId($mountProperties['mountPageDestination']);
 
-        /* @var Page $pageInitializer */
+        /** @var Page $pageInitializer */
         $pageInitializer = GeneralUtility::makeInstance(Page::class);
         $pageInitializer->setSite($mountingSite);
         $pageInitializer->setIndexingConfigurationName('pages');

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -79,6 +79,8 @@ class RootPageResolver implements SingletonInterface
 
     /**
      * Checks if the passed pageId is a root page.
+     *
+     * @throws RootPageRecordNotFoundException
      */
     public function getIsRootPageId(int $pageId): bool
     {
@@ -136,7 +138,7 @@ class RootPageResolver implements SingletonInterface
             return 0;
         }
 
-        /* @var Rootline $rootLine */
+        /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
 
         // frontend
@@ -146,7 +148,7 @@ class RootPageResolver implements SingletonInterface
 
         // fallback, backend
         if ($forceFallback || !$rootLine->getHasRootPage()) {
-            /* @var RootlineUtility $rootlineUtility */
+            /** @var RootlineUtility $rootlineUtility */
             $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageId, $mountPointIdentifier);
             try {
                 $rootLineArray = $rootlineUtility->get();

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -61,6 +61,7 @@ class RootPageResolver implements SingletonInterface
      * The result is cached by the caching framework.
      *
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     public function getResponsibleRootPageIds(string $table, int $uid): array
     {
@@ -163,6 +164,7 @@ class RootPageResolver implements SingletonInterface
      * if the pid is references in another site with additionalPageIds and returning those rootPageIds as well.
      *
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     protected function buildResponsibleRootPageIds(string $table, int $uid): array
     {

--- a/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
+++ b/Classes/Domain/Index/Queue/Statistic/QueueStatisticsRepository.php
@@ -75,7 +75,7 @@ class QueueStatisticsRepository extends AbstractRepository
      */
     protected function buildQueueStatisticFromResultSet(array $indexQueueStatisticResultSet): QueueStatistic
     {
-        /* @var QueueStatistic $statistic */
+        /** @var QueueStatistic $statistic */
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
         foreach ($indexQueueStatisticResultSet as $row) {
             if ($row['failed'] == 1) {

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -128,6 +128,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
      *
      * @throws DBALException
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     public function handleContentElementUpdate(int $uid, array $updatedFields = []): void
     {
@@ -164,6 +165,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
      *
      * @throws DBALException
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     public function handlePageUpdate(int $uid, array $updatedFields = []): void
     {
@@ -352,6 +354,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
      *
      * @throws DBALException
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     protected function processPageRecord(int $uid, int $pid, array $updatedFields = []): void
     {
@@ -437,6 +440,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
      * This method is used to determine the pageId that should be used to retrieve the index queue configuration.
      *
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      */
     protected function getConfigurationPageId(string $recordTable, int $recordPageId, int $recordUid): int
     {

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Exception\RootPageRecordNotFoundException;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\ProcessingFinishedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\DataUpdateEventInterface;
@@ -114,6 +115,7 @@ class ImmediateProcessingEventListener extends AbstractBaseEventListener
      *
      * @throws DBALException
      * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws RootPageRecordNotFoundException
      *
      * @noinspection PhpUnused
      */

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -55,7 +55,7 @@ class Builder
         Rootline $pageAccessRootline,
         string $mountPointParameter = '',
     ): Document {
-        /* @var Document $document */
+        /** @var Document $document */
         $document = GeneralUtility::makeInstance(Document::class);
         $site = $this->getSiteByPageId($page->id);
         $pageRecord = $page->page;
@@ -113,7 +113,7 @@ class Builder
      */
     public function fromRecord(array $itemRecord, string $type, int $rootPageUid, string $accessRootLine): Document
     {
-        /* @var Document $document */
+        /** @var Document $document */
         $document = GeneralUtility::makeInstance(Document::class);
 
         $site = $this->getSiteByPageId($rootPageUid);
@@ -158,6 +158,7 @@ class Builder
 
     /**
      * @throws AspectNotFoundException
+     * @throws DBALException
      */
     protected function getPageDocumentId(TypoScriptFrontendController $frontendController, string $accessGroups, string $mountPointParameter): string
     {

--- a/Classes/Domain/Search/ApacheSolrDocument/Repository.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Repository.php
@@ -59,6 +59,8 @@ class Repository implements SingletonInterface
 
     /**
      * Returns firs found {@link Document} for current page by given language id.
+     *
+     * @throws DBALException
      */
     public function findOneByPageIdAndByLanguageId($pageId, $languageId): Document|false
     {

--- a/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
+++ b/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
@@ -38,7 +38,7 @@ class SiteHighlighterUrlModifier
         $searchWords = str_replace('&quot;', '', $searchWords);
         $searchWords = GeneralUtility::trimExplode(' ', $searchWords, true);
 
-        /* @var UrlHelper $urlHelper */
+        /** @var UrlHelper $urlHelper */
         $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $url)
             ->withQueryParameter('sword_list', $searchWords);
 

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -38,7 +38,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
-use Solarium\QueryType\Select\Query\Query as SolariumSelectQuery;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -90,7 +89,7 @@ class QueryBuilder extends AbstractQueryBuilder
         string $rawQuery = '',
         int $resultsPerPage = 10,
         array $additionalFiltersFromRequest = []
-    ): SolariumSelectQuery {
+    ): Query {
         if ($this->typoScriptConfiguration->getLoggingQuerySearchWords()) {
             $this->logger->log(SolrLogManager::INFO, 'Received search query', [$rawQuery]);
         }
@@ -141,7 +140,7 @@ class QueryBuilder extends AbstractQueryBuilder
      *
      * @throws DBALException
      */
-    public function buildPageQuery(int $pageId): SolariumSelectQuery
+    public function buildPageQuery(int $pageId): Query
     {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByPageId($pageId);
@@ -161,7 +160,7 @@ class QueryBuilder extends AbstractQueryBuilder
      *
      * @throws DBALException
      */
-    public function buildRecordQuery(string $type, int $uid, int $pageId): SolariumSelectQuery
+    public function buildRecordQuery(string $type, int $uid, int $pageId): Query
     {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByPageId($pageId);
@@ -400,7 +399,7 @@ class QueryBuilder extends AbstractQueryBuilder
     {
         $filters = [];
 
-        /* @var PageUidToHierarchy $processor */
+        /** @var PageUidToHierarchy $processor */
         $processor = GeneralUtility::makeInstance(PageUidToHierarchy::class);
         $hierarchies = $processor->process($pageIds);
 

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
@@ -63,7 +63,7 @@ abstract class AbstractFacetItemCollection extends AbstractCollection
     /**
      * Returns the manually sorted copy of given facet items.
      */
-    public function getManualSortedCopy(array $manualSorting): AbstractFacetItemCollection
+    public function getManualSortedCopy(array $manualSorting): static
     {
         $result = clone $this;
         $copiedItems = $result->data;
@@ -84,7 +84,7 @@ abstract class AbstractFacetItemCollection extends AbstractCollection
     /**
      * Returns the manually reverse ordered copy of available facet items.
      */
-    public function getReversedOrderCopy(): AbstractFacetItemCollection
+    public function getReversedOrderCopy(): static
     {
         $result = clone $this;
         $result->data = array_reverse($result->data, true);

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
@@ -37,7 +37,6 @@ abstract class AbstractFacetParser implements FacetParserInterface
      */
     protected function getReusableContentObject(): ContentObjectRenderer
     {
-        /* @var ContentObjectRenderer $contentObject */
         if (self::$reUseAbleContentObject !== null) {
             return self::$reUseAbleContentObject;
         }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
@@ -67,9 +67,9 @@ class HierarchyFacet extends AbstractFacet
         int $count,
         bool $selected,
     ): void {
-        /* @var Node|null $parentNode */
+        /** @var Node|null $parentNode */
         $parentNode = $this->nodesByKey[$parentKey] ?? null;
-        /* @var Node $node */
+        /** @var Node $node */
         $node = GeneralUtility::makeInstance(
             Node::class,
             $this,

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
@@ -73,7 +73,7 @@ class Node extends AbstractOptionFacetItem
 
     public function getHasChildNodeSelected(): bool
     {
-        /* @var Node $childNode */
+        /** @var Node $childNode */
         foreach ($this->childNodes as $childNode) {
             if ($childNode->getSelected()) {
                 return true;

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -57,7 +57,7 @@ class OptionsFacetParser extends AbstractFacetParser
             return null;
         }
 
-        /* @var OptionsFacet $facet */
+        /** @var OptionsFacet $facet */
         $facet = GeneralUtility::makeInstance(
             OptionsFacet::class,
             $resultSet,
@@ -99,7 +99,7 @@ class OptionsFacetParser extends AbstractFacetParser
         $this->applyReverseOrder($facet, $facetConfiguration);
 
         if (isset($this->eventDispatcher)) {
-            /* @var AfterFacetParsedEvent $afterFacetParsedEvent */
+            /** @var AfterFacetParsedEvent $afterFacetParsedEvent */
             $afterFacetParsedEvent = $this->eventDispatcher
                 ->dispatch(new AfterFacetParsedEvent($facet, $facetConfiguration));
             $facet = $afterFacetParsedEvent->getFacet();

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilder.php
@@ -103,7 +103,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildLimitForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return (int)($facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit() ?? -1));
+        return (int)($facetConfiguration['facetLimit'] ?? ($configuration->getSearchFacetingFacetLimit()));
     }
 
     /**
@@ -111,7 +111,7 @@ class OptionsFacetQueryBuilder extends DefaultFacetQueryBuilder implements Facet
      */
     protected function buildMincountForJson(array $facetConfiguration, TypoScriptConfiguration $configuration): int
     {
-        return (int)($facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount() ?? 1));
+        return (int)($facetConfiguration['minimumCount'] ?? ($configuration->getSearchFacetingMinimumCount()));
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -19,7 +19,9 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRange;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRange;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\System\Solr\ParsingUtil;
@@ -48,7 +50,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
 
         $valuesFromResponse = isset($response->facet_counts->facet_ranges->{$fieldName}) ? get_object_vars($response->facet_counts->facet_ranges->{$fieldName}) : [];
 
-        /* @var NumericRangeFacet|DateRangeFacet $facet */
+        /** @var NumericRangeFacet|DateRangeFacet $facet */
         $facet = GeneralUtility::makeInstance(
             $facetClass,
             $resultSet,
@@ -91,7 +93,7 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
             $type = $facetConfiguration['type'] ?? 'numericRange';
             $gap = $facetConfiguration[$type . '.']['gap'] ?? 1;
 
-            /* @var AbstractRangeFacetItem|NumericRangeFacet|DateRangeFacet $range */
+            /** @var DateRange|NumericRange $range */
             $range = GeneralUtility::makeInstance(
                 $facetItemClass,
                 $facet,
@@ -104,7 +106,6 @@ abstract class AbstractRangeFacetParser extends AbstractFacetParser
                 $rangeCounts,
                 true
             );
-            /* @noinspection PhpParamsInspection */
             $facet->setRange($range);
         }
 

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
@@ -47,7 +47,7 @@ class DateRangeUrlDecoder implements FacetUrlDecoderInterface
     {
         [$dateRangeStart, $dateRangeEnd] = explode(self::DELIMITER, $value);
 
-        /* @var FormatService $formatService */
+        /** @var FormatService $formatService */
         $formatService = GeneralUtility::makeInstance(FormatService::class);
         $fromPart = '*';
         if ($dateRangeStart !== '') {

--- a/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
@@ -77,7 +77,7 @@ class RequirementsService
     /**
      * Returns the active item values of a facet
      *
-     * @return AbstractFacetItem[]
+     * @return string[]|int[]
      */
     protected function getSelectedItemValues(AbstractFacet $facet, string $facetNameToCheckRequirementsOn): array
     {
@@ -94,7 +94,7 @@ class RequirementsService
         $itemValues = [];
         $activeFacetItems = $facetToCheckRequirements->getAllFacetItems();
         foreach ($activeFacetItems as $item) {
-            /* @var AbstractFacetItem $item */
+            /** @var AbstractFacetItem $item */
             if ($item->getSelected()) {
                 $itemValues[] = $item->getUriValue();
             }
@@ -108,7 +108,7 @@ class RequirementsService
      */
     protected function getNegationWhenConfigured(bool $value, array $configuration = null): bool
     {
-        if (!is_array($configuration) || empty($configuration['negate']) || (bool)$configuration['negate'] === false) {
+        if (!is_array($configuration) || empty($configuration['negate'])) {
             return $value;
         }
 

--- a/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
+++ b/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
@@ -30,11 +30,7 @@ class SortingExpression
      */
     public function getForFacet(string|int|bool $sorting): string
     {
-        $noSortingSet = empty($sorting) && (int)$sorting !== 0 && (bool)$sorting !== false;
         $sortingIsCount = $sorting === 'count' || $sorting === 1 || $sorting === '1' || $sorting === true || $sorting === 'true';
-        if ($noSortingSet) {
-            return '';
-        }
         if ($sortingIsCount) {
             return 'count';
         }

--- a/Classes/Domain/Search/ResultSet/Grouping/GroupCollection.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupCollection.php
@@ -25,7 +25,7 @@ class GroupCollection extends AbstractCollection
     public function getByName(string $name): ?Group
     {
         foreach ($this->data as $group) {
-            /* @var Group $group */
+            /** @var Group $group */
             if ($group->getGroupName() === $name) {
                 return $group;
             }
@@ -36,7 +36,7 @@ class GroupCollection extends AbstractCollection
     public function getHasWithName(string $name): bool
     {
         foreach ($this->data as $group) {
-            /* @var Group $group */
+            /** @var Group $group */
             if ($group->getGroupName() === $name) {
                 return true;
             }
@@ -49,7 +49,7 @@ class GroupCollection extends AbstractCollection
     {
         $names = [];
         foreach ($this->data as $group) {
-            /* @var Group $group */
+            /** @var Group $group */
             $names[] = $group->getGroupName();
         }
         return $names;

--- a/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
@@ -106,7 +106,7 @@ class ResultParserRegistry implements SingletonInterface
      */
     public function getParser(SearchResultSet $resultSet): ?AbstractResultParser
     {
-        /* @var AbstractResultParser $parser */
+        /** @var AbstractResultParser $parser */
         foreach ($this->getParserInstances() as $parser) {
             if ($parser->canParse($resultSet)) {
                 return $parser;

--- a/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResultBuilder.php
@@ -34,7 +34,7 @@ class SearchResultBuilder
     public function fromApacheSolrDocument(Document $originalDocument): SearchResult
     {
         $searchResultClassName = $this->getResultClassName();
-        $result = GeneralUtility::makeInstance($searchResultClassName, $originalDocument->getFields() ?? []);
+        $result = GeneralUtility::makeInstance($searchResultClassName, $originalDocument->getFields());
 
         if (!$result instanceof SearchResult) {
             throw new InvalidArgumentException('Could not create result object with class: ' . $searchResultClassName, 1470037679);

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -221,7 +221,7 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
         $requirementsService = $this->getRequirementsService();
         $facets = $resultSet->getFacets();
         foreach ($facets as $facet) {
-            /* @var AbstractFacet $facet */
+            /** @var AbstractFacet $facet */
             $requirementsMet = $requirementsService->getAllRequirementsMet($facet);
             $facet->setAllRequirementsMet($requirementsMet);
         }

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -99,7 +99,7 @@ class SearchResultSetService
         $searchComponents = $this->getRegisteredSearchComponents();
 
         foreach ($searchComponents as $searchComponent) {
-            /* @var Search\SearchComponent $searchComponent */
+            /** @var Search\SearchComponent $searchComponent */
             $searchComponent->setSearchConfiguration($this->typoScriptConfiguration->getSearchConfiguration());
 
             if ($searchComponent instanceof QueryAware) {
@@ -161,7 +161,7 @@ class SearchResultSetService
 
         $resultSet->setUsedAdditionalFilters($this->queryBuilder->getAdditionalFilters());
 
-        /* @var VariantsProcessor $variantsProcessor */
+        /** @var VariantsProcessor $variantsProcessor */
         $variantsProcessor = GeneralUtility::makeInstance(
             VariantsProcessor::class,
             $this->typoScriptConfiguration,
@@ -169,7 +169,7 @@ class SearchResultSetService
         );
         $variantsProcessor->process($resultSet);
 
-        /* @var ResultSetReconstitutionProcessor $searchResultReconstitutionProcessor */
+        /** @var ResultSetReconstitutionProcessor $searchResultReconstitutionProcessor */
         $searchResultReconstitutionProcessor = GeneralUtility::makeInstance(ResultSetReconstitutionProcessor::class);
         $searchResultReconstitutionProcessor->process($resultSet);
 
@@ -183,7 +183,7 @@ class SearchResultSetService
      */
     protected function getParsedSearchResults(SearchResultSet $resultSet): void
     {
-        /* @var ResultParserRegistry $parserRegistry */
+        /** @var ResultParserRegistry $parserRegistry */
         $parserRegistry = GeneralUtility::makeInstance(ResultParserRegistry::class, $this->typoScriptConfiguration);
         $useRawDocuments = (bool)$this->typoScriptConfiguration->getValueByPathOrDefaultValue('plugin.tx_solr.features.useRawDocuments', false);
         $parserRegistry->getParser($resultSet)->parse($resultSet, $useRawDocuments);
@@ -213,8 +213,8 @@ class SearchResultSetService
      */
     protected function getInitializedSearchResultSet(SearchRequest $searchRequest): SearchResultSet
     {
-        /* @var SearchResultSet $resultSet */
         $resultSetClass = $this->getResultSetClassName();
+        /** @var SearchResultSet $resultSet */
         $resultSet = GeneralUtility::makeInstance($resultSetClass);
 
         $resultSet->setUsedSearchRequest($searchRequest);
@@ -348,7 +348,7 @@ class SearchResultSetService
      */
     public function getDocumentById(string $documentId): SearchResult
     {
-        /* @var SearchQuery $query */
+        /** @var SearchQuery $query */
         $query = $this->queryBuilder->newSearchQuery($documentId)->useQueryFields(QueryFields::fromString('id'))->getQuery();
         $response = $this->search->search($query, 0, 1);
         $parsedData = $response->getParsedData();

--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -44,7 +44,7 @@ class ScoreCalculationService
         $totalScore = 0;
 
         foreach ($highScores as $highScore) {
-            /* @var Score $highScore */
+            /** @var Score $highScore */
             $scores[] =
                 '<td>+ ' . htmlspecialchars(number_format($highScore->getScore(), 9)) . '</td>'
                 . '<td>' . htmlspecialchars($highScore->getFieldName()) . '</td>'
@@ -91,7 +91,7 @@ class ScoreCalculationService
             $scoreWasSetForFieldBefore = isset($highScores[$field]);
             $scoreIsHigher = false;
             if ($scoreWasSetForFieldBefore) {
-                /* @var Score $previousScore */
+                /** @var Score $previousScore */
                 $previousScore = $highScores[$field];
                 $scoreIsHigher = $previousScore->getScore() < $currentScoreValue;
             }

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -92,7 +92,7 @@ class SearchRequest
 
         // overwrite the plugin namespace and the persistentArgumentsPaths
         if (!is_null($typoScriptConfiguration)) {
-            $this->argumentNameSpace = $typoScriptConfiguration->getSearchPluginNamespace() ?? self::DEFAULT_PLUGIN_NAMESPACE;
+            $this->argumentNameSpace = $typoScriptConfiguration->getSearchPluginNamespace();
         }
 
         $this->persistentArgumentsPaths = [$this->argumentNameSpace . ':q', $this->argumentNameSpace . ':filter', $this->argumentNameSpace . ':sort', $this->argumentNameSpace . ':groupPage'];

--- a/Classes/Domain/Search/SearchRequestBuilder.php
+++ b/Classes/Domain/Search/SearchRequestBuilder.php
@@ -43,7 +43,6 @@ class SearchRequestBuilder
     {
         $controllerArguments = $this->adjustPageArgumentToPositiveInteger($controllerArguments);
 
-        /* @var SearchRequest $searchRequest */
         $argumentsNamespace = $this->typoScriptConfiguration->getSearchPluginNamespace();
         $searchRequest = $this->getRequest([$argumentsNamespace => $controllerArguments], $pageId, $languageId);
         return $this->applyPassedResultsPerPage($searchRequest);
@@ -101,7 +100,6 @@ class SearchRequestBuilder
      */
     public function buildForFrequentSearches(int $pageId, int $languageId): SearchRequest
     {
-        /* @var SearchRequest $searchRequest */
         return $this->getRequest([], $pageId, $languageId);
     }
 

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -88,6 +88,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
             'time_preparation' => $response->debug->timing->prepare->time ?? 0,
             // @extensionScannerIgnoreLine
             'time_processing' => $response->debug->timing->process->time ?? 0,
+            /** @phpstan-ignore-next-line */
             'feuser_id' => isset($TSFE->fe_user->user) ? (int)$TSFE->fe_user->user['uid'] ?? 0 : 0,
             'cookie' => $TSFE->fe_user->id ?? '',
             'ip' => IpAnonymizationUtility::anonymizeIp($this->getUserIp(), $ipMaskLength),

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -128,10 +128,13 @@ class SuggestService
         $bestSuggestionRequest->setAdditionalFilters($additionalFilters);
 
         // No results found, use first proposed suggestion to perform the search
-        if (count($documents) === 0 && !empty($suggestions) && ($searchResultSet = $this->doASearch($bestSuggestionRequest)) && count($searchResultSet->getSearchResults()) > 0) {
-            $didASecondSearch = true;
-            $documentsToAdd = $searchResultSet->getSearchResults();
-            $documents = $this->addDocumentsWhenLimitNotReached($documents, $documentsToAdd, $maxDocuments);
+        if (count($documents) === 0 && !empty($suggestions)) {
+            $searchResultSetForSuggestions = $this->doASearch($bestSuggestionRequest);
+            if (count($searchResultSetForSuggestions->getSearchResults()) > 0) {
+                $didASecondSearch = true;
+                $documentsToAdd = $searchResultSetForSuggestions->getSearchResults();
+                $documents = $this->addDocumentsWhenLimitNotReached($documents, $documentsToAdd, $maxDocuments);
+            }
         }
 
         return $this->getResultArray($searchRequest, $suggestions, $documents, $didASecondSearch);
@@ -194,7 +197,7 @@ class SuggestService
         int $maxDocuments,
     ): array {
         $additionalTopResultsFields = $this->typoScriptConfiguration->getSuggestAdditionalTopResultsFields();
-        /* @var SearchResult $document */
+        /** @var SearchResult $document */
         foreach ($documentsToAdd as $document) {
             $documents[] = $this->getDocumentAsArray($document, $additionalTopResultsFields);
             if (count($documents) >= $maxDocuments) {

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -190,11 +190,11 @@ class SearchUriBuilder
 
     public function getNewSearchUri(SearchRequest $previousSearchRequest, $queryString): string
     {
-        /* @var SearchRequest $request */
         $contextConfiguration = $previousSearchRequest->getContextTypoScriptConfiguration();
         $contextSystemLanguage = $previousSearchRequest->getContextSystemLanguageUid();
         $contextPageUid = $previousSearchRequest->getContextPageUid();
 
+        /** @var SearchRequest $request */
         $request = GeneralUtility::makeInstance(
             SearchRequest::class,
             [],
@@ -279,7 +279,7 @@ class SearchUriBuilder
             $this->uriBuilder->reset()->setTargetPageUid($pageUid);
             $uriCacheTemplate = $this->uriBuilder->setArguments($structure)->build();
 
-            /* @var UrlHelper $urlHelper */
+            /** @var UrlHelper $urlHelper */
             $urlHelper = GeneralUtility::makeInstance(UrlHelper::class, $uriCacheTemplate);
             self::$preCompiledLinks[$hash] = (string)$urlHelper;
         }
@@ -299,14 +299,14 @@ class SearchUriBuilder
             $this->routingService->fromRoutingConfiguration($routingConfigurations[0]);
         }
 
-        /* @var Uri $uri */
+        /** @var Uri $uri */
         $uri = GeneralUtility::makeInstance(
             Uri::class,
             $uriCacheTemplate
         );
 
         $urlEvent = new BeforeReplaceVariableInCachedUrlEvent($uri, $enhancedRouting);
-        /* @var BeforeReplaceVariableInCachedUrlEvent $urlEvent */
+        /** @var BeforeReplaceVariableInCachedUrlEvent $urlEvent */
         $urlEvent = $this->eventDispatcher->dispatch($urlEvent);
         $uriCacheTemplate = (string)$urlEvent->getUri();
 

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -90,7 +90,7 @@ class Site implements SiteInterface
     public function getSolrConnectionConfiguration(int $language = 0): array
     {
         if (!is_array($this->solrConnectionConfigurations[$language] ?? null)) {
-            /* @var NoSolrConnectionFoundException $noSolrConnectionException */
+            /** @var NoSolrConnectionFoundException $noSolrConnectionException */
             $noSolrConnectionException = GeneralUtility::makeInstance(
                 NoSolrConnectionFoundException::class,
                 'Could not find a Solr connection for root page [' . $this->getRootPageId() . '] and language [' . $language . '].',

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -74,6 +74,7 @@ class SiteRepository
      * Gets the Site for a specific page ID.
      *
      * @throws DBALException
+     * @throws InvalidArgumentException
      */
     public function getSiteByPageId(int $pageId, string $mountPointIdentifier = ''): ?Site
     {
@@ -85,6 +86,7 @@ class SiteRepository
      * Gets the Site for a specific root page-id.
      *
      * @throws DBALException
+     * @throws InvalidArgumentException
      */
     public function getSiteByRootPageId(int $rootPageId): ?Site
     {
@@ -173,6 +175,7 @@ class SiteRepository
      * Creates an instance of the Site object.
      *
      * @throws DBALException
+     * @throws InvalidArgumentException
      */
     protected function buildSite(int $rootPageId): ?Site
     {
@@ -194,7 +197,7 @@ class SiteRepository
      */
     protected function getSiteHashForDomain(string $domain): string
     {
-        /* @var SiteHashService $siteHashService */
+        /** @var SiteHashService $siteHashService */
         $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
         return $siteHashService->getSiteHashForDomain($domain);
     }

--- a/Classes/Domain/Variants/VariantsProcessor.php
+++ b/Classes/Domain/Variants/VariantsProcessor.php
@@ -62,7 +62,7 @@ class VariantsProcessor implements SearchResultSetProcessor
 
         $variantsField = $this->typoScriptConfiguration->getSearchVariantsField();
         foreach ($resultSet->getSearchResults() as $resultDocument) {
-            /* @var SearchResult $resultDocument */
+            /** @var SearchResult $resultDocument */
             $variantId = $resultDocument[$variantsField] ?? null;
 
             // when there is no value in the collapsing field, we can return

--- a/Classes/Eid/ApiEid.php
+++ b/Classes/Eid/ApiEid.php
@@ -66,7 +66,7 @@ class ApiEid
     {
         $domain = $request->getQueryParams()['domain'];
 
-        /* @var SiteHashService $siteHashService */
+        /** @var SiteHashService $siteHashService */
         $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);
         $siteHash = $siteHashService->getSiteHashForDomain($domain);
         return new JsonResponse(
@@ -132,7 +132,7 @@ class ApiEid
         foreach ($apiMethodDefinitions as $apiMethodName => $apiMethodDefinition) {
             $apiMethodDefinitions[$apiMethodName]['params']['required'] = array_merge(
                 self::REQUIRED_PARAMS_GLOBAL,
-                $apiMethodDefinition['params']['required'] ?? []
+                $apiMethodDefinition['params']['required']
             );
         }
         return $apiMethodDefinitions;

--- a/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
@@ -59,9 +59,6 @@ class CachedPathVariableModifier
             return;
         }
 
-        // TODO: Detect multiValue? Could be removed?
-        $multiValue = false;
-
         $standardizedKeys = $variableKeys;
 
         $variableKeysCount = count($variableKeys);
@@ -70,9 +67,8 @@ class CachedPathVariableModifier
             if (!$this->containsPathVariable($standardizedKey, $pathVariables) || empty($variableValues[$standardizedKey])) {
                 continue;
             }
-            $value = '';
             // Note: Some values contain the multi value separator
-            if ($multiValue) {
+            if ($this->containsMultiValue()) {
                 // Note: if the customer configured a + as separator an additional check on the facet value is required!
                 $facets = $this->routingService->pathFacetStringToArray(
                     $this->standardizeKey((string)$variableValues[$standardizedKey])
@@ -82,11 +78,7 @@ class CachedPathVariableModifier
                 $index = 0;
                 foreach ($facets as $facet) {
                     if (str_contains($facet, ':')) {
-                        [$prefix, $value] = explode(
-                            ':',
-                            $facet,
-                            2
-                        );
+                        $value = explode(':', $facet, 2)[1];
                         $singleValues[] = $value;
                         $index++;
                     } else {
@@ -95,11 +87,11 @@ class CachedPathVariableModifier
                 }
                 $value = $this->routingService->pathFacetsToString($singleValues);
             } else {
-                [$prefix, $value] = explode(
+                $value = explode(
                     ':',
                     $this->standardizeKey((string)$variableValues[$standardizedKey]),
                     2
-                );
+                )[1];
             }
             $standardizedKeys[$i] = $standardizedKey;
             $variableValues[$standardizedKey] = $value;
@@ -152,13 +144,19 @@ class CachedPathVariableModifier
         if (in_array($variableName, $pathVariables)) {
             return true;
         }
-        foreach ($pathVariables as $keyName => $value) {
+        foreach ($pathVariables as $value) {
             $segments = explode($this->routingService->getUrlFacetPathService()->getMultiValueSeparator(), $value);
             if (in_array($variableName, $segments)) {
                 return true;
             }
         }
 
+        return false;
+    }
+
+    protected function containsMultiValue(): bool
+    {
+        // @todo: implement the check, or remove contents of if statement.
         return false;
     }
 }

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -35,7 +35,7 @@ class PostEnhancedUriProcessor
         }
         $configuration = $event->getRouterConfiguration();
 
-        /* @var RoutingService $routingService */
+        /** @var RoutingService $routingService */
         $routingService = GeneralUtility::makeInstance(
             RoutingService::class,
             $configuration['solr'],

--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -47,11 +47,11 @@ class FrontendGroupsModifier
         }
 
         $jsonEncodedParameters = $event->getRequest()->getHeader(PageIndexerRequest::SOLR_INDEX_HEADER)[0];
-        /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
+        /** @var PageIndexerRequestHandler $pageIndexerRequestHandler */
         $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class, $jsonEncodedParameters);
 
         if (!$pageIndexerRequestHandler->getRequest()->isAuthenticated()) {
-            /* @var SolrLogManager $logger */
+            /** @var SolrLogManager $logger */
             $logger = GeneralUtility::makeInstance(SolrLogManager::class, self::class);
             $logger->log(
                 SolrLogManager::ERROR,
@@ -112,7 +112,7 @@ class FrontendGroupsModifier
         $stringAccessRootline = '';
 
         $jsonEncodedParameters = $request->getHeader(PageIndexerRequest::SOLR_INDEX_HEADER)[0];
-        /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
+        /** @var PageIndexerRequestHandler $pageIndexerRequestHandler */
         $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class, $jsonEncodedParameters);
 
         if ($pageIndexerRequestHandler->getRequest()->getParameter('accessRootline')) {

--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -42,7 +42,7 @@ class FrontendGroupsModifier
      */
     public function __invoke(ModifyResolvedFrontendGroupsEvent $event): void
     {
-        if ($event->getRequest() === null || !$event->getRequest()->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
+        if (!$event->getRequest()->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
             return;
         }
 

--- a/Classes/FieldProcessor/CategoryUidToHierarchy.php
+++ b/Classes/FieldProcessor/CategoryUidToHierarchy.php
@@ -114,7 +114,7 @@ class CategoryUidToHierarchy extends AbstractHierarchyProcessor implements Field
         while ($parentCategory !== 0) {
             $rootlineIds[] = $parentCategory;
             $childCategory = $this->systemCategoryRepository->findOneByUid($parentCategory);
-            if ($childCategory === null) {
+            if (!is_array($childCategory)) {
                 $parentCategory = 0;
             } else {
                 $parentCategory = (int)($childCategory['parent']);

--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -67,27 +67,27 @@ class Service
 
                 switch ($instruction) {
                     case 'timestampToUtcIsoDate':
-                        /* @var TimestampToUtcIsoDate $processor */
+                        /** @var TimestampToUtcIsoDate $processor */
                         $processor = GeneralUtility::makeInstance(TimestampToUtcIsoDate::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'timestampToIsoDate':
-                        /* @var TimestampToIsoDate $processor */
+                        /** @var TimestampToIsoDate $processor */
                         $processor = GeneralUtility::makeInstance(TimestampToIsoDate::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'pathToHierarchy':
-                        /* @var PathToHierarchy $processor */
+                        /** @var PathToHierarchy $processor */
                         $processor = GeneralUtility::makeInstance(PathToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'pageUidToHierarchy':
-                        /* @var PageUidToHierarchy $processor */
+                        /** @var PageUidToHierarchy $processor */
                         $processor = GeneralUtility::makeInstance(PageUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;
                     case 'categoryUidToHierarchy':
-                        /* @var CategoryUidToHierarchy $processor */
+                        /** @var CategoryUidToHierarchy $processor */
                         $processor = GeneralUtility::makeInstance(CategoryUidToHierarchy::class);
                         $fieldValue = $processor->process($fieldValue);
                         break;

--- a/Classes/FieldProcessor/TimestampToIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToIsoDate.php
@@ -40,7 +40,7 @@ class TimestampToIsoDate implements FieldProcessor
     public function process(array $values): array
     {
         $results = [];
-        /* @var FormatService $formatService */
+        /** @var FormatService $formatService */
         $formatService = GeneralUtility::makeInstance(FormatService::class);
 
         foreach ($values as $timestamp) {

--- a/Classes/FieldProcessor/TimestampToUtcIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToUtcIsoDate.php
@@ -40,7 +40,7 @@ class TimestampToUtcIsoDate implements FieldProcessor
     public function process(array $values): array
     {
         $results = [];
-        /* @var FormatService $formatService */
+        /** @var FormatService $formatService */
         $formatService = GeneralUtility::makeInstance(FormatService::class);
 
         foreach ($values as $timestamp) {

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -96,7 +96,7 @@ class Tsfe implements SingletonInterface
             return;
         }
 
-        /* @var Context $context */
+        /** @var Context $context */
         $context = clone GeneralUtility::makeInstance(Context::class);
         $site = $this->siteFinder->getSiteByPageId($pageId);
         // $siteLanguage and $languageAspect takes the language id into account.
@@ -134,7 +134,7 @@ class Tsfe implements SingletonInterface
                 )
             );
 
-            /* @var FrontendUserAuthentication $feUser */
+            /** @var FrontendUserAuthentication $feUser */
             $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
             // for certain situations we need to trick TSFE into granting us
             // access to the page in any case to make getPageAndRootline() work
@@ -149,10 +149,10 @@ class Tsfe implements SingletonInterface
             $feUser->fetchGroupData($serverRequest);
             $context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $userGroups));
 
-            /* @var PageArguments $pageArguments */
+            /** @var PageArguments $pageArguments */
             $pageArguments = GeneralUtility::makeInstance(PageArguments::class, $pageId, '0', []);
 
-            /* @var TypoScriptFrontendController $tsfe */
+            /** @var TypoScriptFrontendController $tsfe */
             $tsfe = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $siteLanguage, $pageArguments, $feUser);
 
             // @extensionScannerIgnoreLine
@@ -329,7 +329,7 @@ class Tsfe implements SingletonInterface
         if ($isSpacerOrSysfolder === false) {
             return $pidToUse;
         }
-        /* @var ConfigurationPageResolver $configurationPageResolve */
+        /** @var ConfigurationPageResolver $configurationPageResolver */
         $configurationPageResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
         $askedPid = $pidToUse;
         $pidToUse = $configurationPageResolver->getClosestPageIdWithActiveTemplate($pidToUse);

--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -69,7 +69,7 @@ class TypoScript implements SingletonInterface
             return $this->configurationObjectCache[$cacheId] = $this->buildTypoScriptConfigurationFromArray([], $pageId, $language, $path);
         }
 
-        /* @var TwoLevelCache $cache */
+        /** @var TwoLevelCache $cache */
         $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'tx_solr_configuration');
         $configurationArray = $cache->get($cacheId);
 
@@ -93,7 +93,7 @@ class TypoScript implements SingletonInterface
      */
     protected function buildConfigurationArray(int $pageId, string $path, int $language): array
     {
-        /* @var Tsfe $tsfeManager */
+        /** @var Tsfe $tsfeManager */
         $tsfeManager = GeneralUtility::makeInstance(Tsfe::class);
         try {
             $tsfe = $tsfeManager->getTsfeByPageIdAndLanguageId($pageId, $language);

--- a/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
+++ b/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
@@ -92,7 +92,7 @@ class AuthorizationService extends AbstractAuthenticationService
     ): array {
         $groupData = [];
 
-        /* @var PageIndexerRequestHandler $requestHandler */
+        /** @var PageIndexerRequestHandler $requestHandler */
         $requestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class);
         $accessRootline = $requestHandler->getRequest()->getParameter('accessRootline');
 

--- a/Classes/IndexQueue/FrontendHelper/Dispatcher.php
+++ b/Classes/IndexQueue/FrontendHelper/Dispatcher.php
@@ -66,7 +66,7 @@ class Dispatcher
         $frontendHelpers = $this->frontendHelperManager->getActivatedFrontendHelpers();
 
         foreach ($frontendHelpers as $frontendHelper) {
-            /* @var FrontendHelper $frontendHelper */
+            /** @var FrontendHelper $frontendHelper */
             $frontendHelper->deactivate();
         }
     }

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -166,7 +166,7 @@ class PageIndexer extends AbstractFrontendHelper
             return $this->request->getParameter('overridePageUrl');
         }
 
-        /* @var ContentObjectRenderer $contentObject */
+        /** @var ContentObjectRenderer $contentObject */
         $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
         $typolinkConfiguration = [
@@ -222,7 +222,7 @@ class PageIndexer extends AbstractFrontendHelper
 
             $solrConnection = $this->getSolrConnection($indexQueueItem);
 
-            /* @var Typo3PageIndexer $indexer */
+            /** @var Typo3PageIndexer $indexer */
             $indexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $this->page);
             $indexer->setSolrConnection($solrConnection);
             $indexer->setPageAccessRootline($this->getAccessRootline());
@@ -277,7 +277,7 @@ class PageIndexer extends AbstractFrontendHelper
      */
     protected function getSolrConnection(Item $indexQueueItem): SolrConnection
     {
-        /* @var ConnectionManager $connectionManager */
+        /** @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         return $connectionManager->getConnectionByRootPageId(
@@ -293,7 +293,7 @@ class PageIndexer extends AbstractFrontendHelper
      */
     protected function getIndexQueueItem(): ?Item
     {
-        /* @var Queue $indexQueue */
+        /** @var Queue $indexQueue */
         $indexQueue = GeneralUtility::makeInstance(Queue::class);
         return $indexQueue->getItem($this->request->getParameter('item'));
     }

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -123,7 +123,7 @@ class UserGroupDetector extends AbstractFrontendHelper implements
         PageRepository $parentObject
     ) {
         $disableGroupAccessCheck = true;
-        // @todo: Check if reseting "where_groupAccess" really wanted. Most probably the core aspect 'frontend.user' must be used instead.
+        // @todo: Check if reset "where_groupAccess" really wanted. Most probably the core aspect 'frontend.user' must be used instead.
         $parentObject->where_groupAccess = ''; // just to be on the safe side
     }
 

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -104,6 +104,7 @@ class Indexer extends AbstractIndexer
      * @throws FrontendEnvironmentException
      * @throws NoSolrConnectionFoundException
      * @throws SiteNotFoundException
+     * @throws IndexingException
      */
     public function index(Item $item): bool
     {
@@ -322,7 +323,7 @@ class Indexer extends AbstractIndexer
     {
         $rootPageId = (int)$item->getRootPageUid();
         $buildRootlineWithPid = $this->getPageIdOfItem($item);
-        /* @var RootlineUtility $rootlineUtility */
+        /** @var RootlineUtility $rootlineUtility */
         $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $buildRootlineWithPid);
         $rootline = $rootlineUtility->get();
 

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -131,7 +131,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     public function initialize(): bool
     {
-        /* @var ConnectionPool $connectionPool */
+        /** @var ConnectionPool $connectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
 
         $fetchItemsQuery = $this->buildSelectStatement() . ', "" as errors '

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -236,7 +236,7 @@ class Page extends AbstractInitializer
             return;
         }
 
-        /* @var Connection $connection */
+        /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_solr_indexqueue_item');
 
         $mountIdentifier = $this->getMountPointIdentifier($mountProperties);
@@ -275,7 +275,7 @@ class Page extends AbstractInitializer
         $mountPageItems = $this->queueItemRepository->findAllIndexQueueItemsByRootPidAndMountIdentifierAndMountedPids($this->site->getRootPageId(), $mountIdentifier, $mountedPages);
 
         foreach ($mountPageItems as $mountPageItemRecord) {
-            /* @var Item $mountPageItem */
+            /** @var Item $mountPageItem */
             $mountPageItem = GeneralUtility::makeInstance(Item::class, $mountPageItemRecord);
             $mountPageItem->setIndexingProperty('mountPageSource', $mountPage['mountPageSource']);
             $mountPageItem->setIndexingProperty('mountPageDestination', $mountPage['mountPageDestination']);

--- a/Classes/IndexQueue/Item.php
+++ b/Classes/IndexQueue/Item.php
@@ -201,6 +201,7 @@ class Item
      * Gets the site the item belongs to.
      *
      * @throws DBALException
+     * @throws InvalidArgumentException
      */
     public function getSite(): ?Site
     {

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -132,7 +132,7 @@ class PageIndexerRequest
      */
     public function send(string $url): PageIndexerResponse
     {
-        /* @var PageIndexerResponse $response */
+        /** @var PageIndexerResponse $response */
         $response = GeneralUtility::makeInstance(PageIndexerResponse::class);
         $decodedResponse = $this->getUrlAndDecodeResponse($url, $response);
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -154,7 +154,7 @@ class Queue
             return 0;
         }
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         foreach ($rootPageIds as $rootPageId) {
             $skipInvalidRootPage = $rootPageId === 0;

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -179,7 +179,7 @@ class RecordMonitor
      */
     protected function skipRecordByRootlineConfiguration(int $pid): bool
     {
-        /* @var RootlineUtility $rootlineUtility */
+        /** @var RootlineUtility $rootlineUtility */
         $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pid);
         try {
             $rootline = $rootlineUtility->get();

--- a/Classes/Middleware/PageIndexerFinisher.php
+++ b/Classes/Middleware/PageIndexerFinisher.php
@@ -36,7 +36,7 @@ class PageIndexerFinisher implements MiddlewareInterface
     {
         $response = $handler->handle($request);
         if ($request->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER)) {
-            /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
+            /** @var PageIndexerRequestHandler $pageIndexerRequestHandler */
             $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class);
             $pageIndexerRequestHandler->shutdown();
             $pageIndexResponse = $pageIndexerRequestHandler->getResponse();

--- a/Classes/Middleware/PageIndexerInitialization.php
+++ b/Classes/Middleware/PageIndexerInitialization.php
@@ -38,12 +38,12 @@ class PageIndexerInitialization implements MiddlewareInterface
             // disable TSFE cache for TYPO3 v10
             $request = $request->withAttribute('noCache', true);
             $jsonEncodedParameters = $request->getHeader(PageIndexerRequest::SOLR_INDEX_HEADER)[0];
-            /* @var PageIndexerRequestHandler $pageIndexerRequestHandler */
+            /** @var PageIndexerRequestHandler $pageIndexerRequestHandler */
             $pageIndexerRequestHandler = GeneralUtility::makeInstance(PageIndexerRequestHandler::class, $jsonEncodedParameters);
 
             $pageIndexerRequest = $pageIndexerRequestHandler->getRequest();
             if (!$pageIndexerRequest->isAuthenticated()) {
-                /* @var SolrLogManager $logger */
+                /** @var SolrLogManager $logger */
                 $logger = GeneralUtility::makeInstance(SolrLogManager::class, self::class);
                 $logger->log(
                     SolrLogManager::ERROR,

--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -131,7 +131,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
         [$slug, $parameters] = $this->extractParametersFromUriPath(
             $request->getUri(),
             $enhancerConfiguration['routePath'],
-            $page['slug'] ?? ''
+            $page['slug']
         );
 
         /*
@@ -153,8 +153,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
          */
         $uri = $request->getUri()->withPath(
             $this->getRoutingService()->cleanupHeadingSlash(
-                $this->language->getBase()->getPath() .
-                $page['slug'] ?? ''
+                $this->language->getBase()->getPath() . $page['slug']
             )
         );
         $request = $request->withUri($uri);

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -28,7 +28,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use TYPO3\CMS\Core\Log\Logger;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -189,7 +189,7 @@ class Faceting implements Modifier, SearchRequestAware
             if (($facetConfiguration['field'] ?? '') !== '' && $filterValue !== '') {
                 $filterParts[] = $facetConfiguration['field'] . ':' . $filterValue;
             } else {
-                /* @var $logger Logger */
+                /** @var LoggerInterface $logger */
                 $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
                 $logger->warning('Invalid filter options found, skipping.', ['facet' => $facetName, 'configuration' => $facetConfiguration]);
             }

--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -53,13 +53,13 @@ class SchemaStatus extends AbstractSolrStatus
     public function getStatus(): array
     {
         $reports = [];
-        /* @var ConnectionManager $connectionManager */
+        /** @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
         $solrConnections = $connectionManager->getAllConnections();
 
         foreach ($solrConnections as $solrConnection) {
             $adminService = $solrConnection->getAdminService();
-            /* @var SolrConnection $solrConnection */
+            /** @var SolrConnection $solrConnection */
             if (!$adminService->ping()) {
                 $url = $adminService->__toString();
                 $pingFailedMsg = 'Could not ping solr server, can not check version ' . $url;

--- a/Classes/Report/SiteHandlingStatus.php
+++ b/Classes/Report/SiteHandlingStatus.php
@@ -67,7 +67,7 @@ class SiteHandlingStatus extends AbstractSolrStatus
     {
         $reports = [];
 
-        /* @var Site $site */
+        /** @var Site $site */
         foreach ($this->siteRepository->getAvailableSites() as $site) {
             if (!($site instanceof Site)) {
                 $reports[] = GeneralUtility::makeInstance(
@@ -112,7 +112,6 @@ class SiteHandlingStatus extends AbstractSolrStatus
         }
 
         $renderedReport = $this->getRenderedReport('SiteHandlingStatus.html', $variables);
-        /* @var Status $status */
         return GeneralUtility::makeInstance(
             Status::class,
             sprintf('Site Identifier: "%s"', $ypo3Site->getIdentifier()),

--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -146,14 +146,17 @@ class SolrConfigurationStatus extends AbstractSolrStatus
                 if ($solrIsEnabledAndIndexingDisabled) {
                     $rootPagesWithIndexingOff[] = $rootPage;
                 }
+                /** @phpstan-ignore-next-line */
             } catch (RuntimeException) {
                 $rootPagesWithIndexingOff[] = $rootPage;
+                /** @phpstan-ignore-next-line */
             } catch (ServiceUnavailableException $sue) {
                 if ($sue->getCode() == 1294587218) {
                     //  No TypoScript template found, continue with next site
                     $rootPagesWithIndexingOff[] = $rootPage;
                     continue;
                 }
+                /** @phpstan-ignore-next-line */
             } catch (SiteNotFoundException $sue) {
                 if ($sue->getCode() == 1521716622) {
                     //  No site found, continue with next site

--- a/Classes/Report/SolrStatus.php
+++ b/Classes/Report/SolrStatus.php
@@ -110,6 +110,7 @@ class SolrStatus extends AbstractSolrStatus
         $configName = $this->checkSolrConfigName($solrAdmin);
         $schemaName = $this->checkSolrSchemaName($solrAdmin);
 
+        /** @phpstan-ignore-next-line */
         if ($this->responseStatus !== ContextualFeedbackSeverity::OK) {
             $header = 'Failed contacting the Solr server.';
         }

--- a/Classes/Report/SolrVersionStatus.php
+++ b/Classes/Report/SolrVersionStatus.php
@@ -50,7 +50,7 @@ class SolrVersionStatus extends AbstractSolrStatus
 
         foreach ($solrConnections as $solrConnection) {
             $coreAdmin = $solrConnection->getAdminService();
-            /* @var SolrConnection $solrConnection */
+            /** @var SolrConnection $solrConnection */
             if (!$coreAdmin->ping()) {
                 $url = $coreAdmin->__toString();
                 $pingFailedMsg = 'Could not ping solr server, can not check version ' . $url;

--- a/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
+++ b/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
@@ -40,7 +40,7 @@ class SolrFacetMaskAndCombineEnhancer extends AbstractEnhancer implements Routin
      */
     public function enhanceForMatching(RouteCollection $collection): void
     {
-        /* @var Route $defaultPageRoute */
+        /** @var Route $defaultPageRoute */
         $defaultPageRoute = $collection->get('default');
         $variant = $this->getVariant($defaultPageRoute, $this->configuration);
         $collection->add(
@@ -83,7 +83,7 @@ class SolrFacetMaskAndCombineEnhancer extends AbstractEnhancer implements Routin
         if (!is_array($parameters[$this->namespace] ?? null)) {
             return;
         }
-        /* @var Route $defaultPageRoute */
+        /** @var Route $defaultPageRoute */
         $defaultPageRoute = $collection->get('default');
         $variant = $this->getVariant($defaultPageRoute, $this->configuration);
         $compiledRoute = $variant->compile();
@@ -295,7 +295,7 @@ class SolrFacetMaskAndCombineEnhancer extends AbstractEnhancer implements Routin
      */
     protected function getRoutingService(): RoutingService
     {
-        /* @var RoutingService $routingService */
+        /** @var RoutingService $routingService */
         $routingService = GeneralUtility::makeInstance(
             RoutingService::class,
             $this->configuration['solr'],

--- a/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
+++ b/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
@@ -69,7 +69,7 @@ class SolrFacetMaskAndCombineEnhancer extends AbstractEnhancer implements Routin
         $variant->setDefaults(
             $variableProcessor->deflateKeys($this->configuration['defaults'] ?? [], $this->namespace, $arguments)
         );
-        $this->applyRouteAspects($variant, $this->aspects ?? [], $this->namespace);
+        $this->applyRouteAspects($variant, $this->aspects, $this->namespace);
         $this->applyRequirements($variant, $this->configuration['requirements'] ?? [], $this->namespace);
         return $variant;
     }

--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -815,7 +815,6 @@ class RoutingService implements LoggerAwareInterface
     public function convertStringIntoUri(string $base): ?UriInterface
     {
         try {
-            /* @var Uri $uri */
             return GeneralUtility::makeInstance(
                 Uri::class,
                 $base

--- a/Classes/Search/SortingComponent.php
+++ b/Classes/Search/SortingComponent.php
@@ -81,7 +81,7 @@ class SortingComponent extends AbstractComponent implements QueryAware, SearchRe
 
         // a passed sorting has always priority an overwrites the configured initial sorting
         $this->query->clearSorts();
-        /* @var SortingHelper $sortHelper */
+        /** @var SortingHelper $sortHelper */
         $sortHelper = GeneralUtility::makeInstance(SortingHelper::class, $this->searchConfiguration['sorting.']['options.'] ?? []);
         $sortFields = $sortHelper->getSortFieldFromUrlParameter($arguments['sort']);
         $this->queryBuilder->useSortings(Sortings::fromString($sortFields));

--- a/Classes/System/Cache/TwoLevelCache.php
+++ b/Classes/System/Cache/TwoLevelCache.php
@@ -43,7 +43,7 @@ class TwoLevelCache
     {
         $this->cacheName = $cacheName;
         if ($secondaryCacheFrontend == null) {
-            /* @var CacheManager $cacheManager */
+            /** @var CacheManager $cacheManager */
             $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
             $this->secondLevelCache = $cacheManager->getCache($cacheName);
         } else {

--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -71,7 +71,7 @@ class ConfigurationPageResolver
      */
     protected function calculateClosestPageIdWithActiveTemplate(int $startPageId): ?int
     {
-        /* @var RootlineUtility $rootlineUtility */
+        /** @var RootlineUtility $rootlineUtility */
         $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $startPageId);
         try {
             $rootline = $rootlineUtility->get();

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -15,6 +15,7 @@
 
 namespace ApacheSolrForTypo3\Solr\System\Configuration;
 
+use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Record;
 use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
@@ -1733,7 +1734,7 @@ class TypoScriptConfiguration
      *
      * plugin.tx_solr.view.pluginNamespace
      */
-    public function getSearchPluginNamespace(string $defaultIfEmpty = 'tx_solr'): string
+    public function getSearchPluginNamespace(string $defaultIfEmpty = SearchRequest::DEFAULT_PLUGIN_NAMESPACE): string
     {
         return (string)$this->getValueByPathOrDefaultValue('plugin.tx_solr.view.pluginNamespace', $defaultIfEmpty);
     }

--- a/Classes/System/Language/FrontendOverlayService.php
+++ b/Classes/System/Language/FrontendOverlayService.php
@@ -47,7 +47,7 @@ class FrontendOverlayService
      */
     public function getOverlay(string $tableName, array $record): ?array
     {
-        /* @var LanguageAspect $currentLanguageAspect */
+        /** @var LanguageAspect $currentLanguageAspect */
         $currentLanguageAspect = $this->tsfe->getContext()->getAspect('language');
         //        if ($tableName === 'pages') {
         //            return $this->tsfe->sys_page->getPageOverlay($record, $currentLanguageAspect);
@@ -118,7 +118,7 @@ class FrontendOverlayService
      */
     protected function getRecord(string $localTableName, int $localRecordUid): array|false
     {
-        /* @var QueryBuilder $queryBuilder */
+        /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($localTableName);
 
         return $queryBuilder

--- a/Classes/System/Records/AbstractRepository.php
+++ b/Classes/System/Records/AbstractRepository.php
@@ -57,7 +57,6 @@ abstract class AbstractRepository
      */
     protected function getQueryBuilder(): QueryBuilder
     {
-        /* @var QueryBuilder $queryBuilder */
         return GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($this->table);
     }
 
@@ -104,7 +103,7 @@ abstract class AbstractRepository
      */
     protected function isConnectionForAllTablesTheSame(string ...$tableNames): bool
     {
-        /* @var ConnectionPool $connectionPool */
+        /** @var ConnectionPool $connectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
         $connection = $connectionPool->getConnectionForTable(array_shift($tableNames));
         foreach ($tableNames as $tableName) {

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -224,10 +224,7 @@ abstract class AbstractSolrService
             return $logData;
         }
         // trigger data parsing
-        /**
-         * @noinspection PhpExpressionResultUnusedInspection
-         * @extensionScannerIgnoreLine
-         */
+        /** @phpstan-ignore-next-line */
         $solrResponse->response;
         $logData['response data'] = print_r($solrResponse, true);
         return $logData;

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -164,7 +164,7 @@ abstract class AbstractSolrService
      */
     protected function reviseUrl(string $url): string
     {
-        /* @var Uri $uri */
+        /** @var Uri $uri */
         $uri = GeneralUtility::makeInstance(Uri::class, $url);
 
         if ($uri->getPath() === '') {
@@ -224,6 +224,7 @@ abstract class AbstractSolrService
             return $logData;
         }
         // trigger data parsing
+        /** @noinspectionPhpExpressionResultUnusedInspection */
         /** @phpstan-ignore-next-line */
         $solrResponse->response;
         $logData['response data'] = print_r($solrResponse, true);

--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -101,7 +101,7 @@ class SolrAdminService extends AbstractSolrService
 
             /**
              * access a random property to trigger response parsing
-             * @noinspection PhpExpressionResultUnusedInspection
+             * @phpstan-ignore-next-line
              */
             $pluginsInformation->responseHeader;
             $this->pluginsData = $pluginsInformation;
@@ -150,7 +150,7 @@ class SolrAdminService extends AbstractSolrService
 
             /**
              * access a random property to trigger response parsing
-             * @noinspection PhpExpressionResultUnusedInspection
+             * @phpstan-ignore-next-line
              */
             $systemInformation->responseHeader;
             $this->systemData = $systemInformation;

--- a/Classes/System/Util/ArrayAccessor.php
+++ b/Classes/System/Util/ArrayAccessor.php
@@ -178,7 +178,7 @@ class ArrayAccessor
                 if (empty($currentElement)) {
                     unset($currentElement);
                 }
-            } elseif (isset($currentElement) && isset($currentElement[$pathSegment])) {
+            } elseif (isset($currentElement[$pathSegment])) {
                 $currentElement = &$currentElement[$pathSegment];
             }
         }

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -45,7 +45,7 @@ class SiteUtility
     {
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
         try {
-            /* @var SiteFinder $siteFinder */
+            /** @var SiteFinder $siteFinder */
             return $siteFinder->getSiteByPageId($pageId) instanceof Site;
         } catch (SiteNotFoundException) {
         }

--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -63,7 +63,7 @@ abstract class AbstractSolrTask extends AbstractTask
         }
 
         try {
-            /* @var SiteRepository $siteRepository */
+            /** @var SiteRepository $siteRepository */
             $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
             $this->site = $siteRepository->getSiteByRootPageId((int)$this->rootPageId);
         } catch (InvalidArgumentException) {

--- a/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
@@ -45,7 +45,7 @@ class EventQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFiel
         $task,
         SchedulerModuleController $schedulerModule
     ): array {
-        /* @var EventQueueWorkerTask $task */
+        /** @var EventQueueWorkerTask $task */
         $additionalFields = [];
 
         if (!$task instanceof EventQueueWorkerTask) {

--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -163,7 +163,7 @@ class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldPr
             return $selectorMarkup;
         }
 
-        /* @var CoreSelectorField $selectorField */
+        /** @var CoreSelectorField $selectorField */
         $selectorField = GeneralUtility::makeInstance(CoreSelectorField::class, $this->site);
         $selectorField->setFormElementName('tx_scheduler[cores]');
         $selectorField->setSelectedValues($this->task->getCoresToOptimizeIndex());

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -53,7 +53,7 @@ class ReIndexTask extends AbstractSolrTask
         $cleanUpResult = $this->cleanUpIndex();
 
         // initialize for re-indexing
-        /* @var Queue $indexQueue */
+        /** @var Queue $indexQueue */
         $indexQueue = GeneralUtility::makeInstance(Queue::class);
         $indexQueueInitializationResults = $indexQueue->getInitializationService()
             ->initializeBySiteAndIndexConfigurations($this->getSite(), $this->indexingConfigurationsToReIndex);

--- a/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Security/IfHasAccessToModuleViewHelper.php
@@ -61,7 +61,7 @@ class IfHasAccessToModuleViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        /* @var BackendUserAuthentication $beUser */
+        /** @var BackendUserAuthentication $beUser */
         $beUser = $GLOBALS['BE_USER'];
         try {
             $hasAccessToModule = $beUser->modAccess(

--- a/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
+++ b/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
@@ -69,7 +69,7 @@ class DocumentScoreAnalyzerViewHelper extends AbstractSolrFrontendViewHelper
 
         $document = $arguments['document'];
 
-        /* @var SearchResultSet $resultSet */
+        /** @var SearchResultSet $resultSet */
         $resultSet = self::getUsedSearchResultSetFromRenderingContext($renderingContext);
         $debugData = '';
         if (

--- a/Classes/ViewHelpers/Document/HighlightResultViewHelper.php
+++ b/Classes/ViewHelpers/Document/HighlightResultViewHelper.php
@@ -53,7 +53,7 @@ class HighlightResultViewHelper extends AbstractSolrFrontendViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ): string {
-        /* @var SearchResultSet $resultSet */
+        /** @var SearchResultSet $resultSet */
         $resultSet = $arguments['resultSet'];
         $fieldName = $arguments['fieldName'];
         $document = $arguments['document'];

--- a/Classes/ViewHelpers/Document/RelevanceViewHelper.php
+++ b/Classes/ViewHelpers/Document/RelevanceViewHelper.php
@@ -56,10 +56,10 @@ class RelevanceViewHelper extends AbstractSolrFrontendViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var SearchResult $document */
+        /** @var SearchResult $document */
         $document = $arguments['document'];
 
-        /* @var SearchResultSet $resultSet */
+        /** @var SearchResultSet $resultSet */
         $resultSet = $arguments['resultSet'];
 
         $maximumScore = $arguments['maximumScore'] ?? $resultSet->getMaximumScore();

--- a/Classes/ViewHelpers/Facet/Area/GroupViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Area/GroupViewHelper.php
@@ -54,7 +54,7 @@ class GroupViewHelper extends AbstractSolrFrontendViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var FacetCollection $facets */
+        /** @var FacetCollection $facets */
         $facets = $arguments['facets'];
         $requiredGroup = $arguments['groupName'] ?? 'main';
         $filtered = $facets->getByGroupName($requiredGroup);

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
@@ -50,7 +50,7 @@ class LabelFilterViewHelper extends AbstractSolrFrontendViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var OptionCollection $options */
+        /** @var OptionCollection $options */
         $options = $arguments['options'];
         $requiredPrefix = mb_strtolower($arguments['prefix'] ?? '');
         $filtered = $options->getByLowercaseLabelPrefix($requiredPrefix);

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
@@ -53,7 +53,7 @@ class LabelPrefixesViewHelper extends AbstractSolrFrontendViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        /* @var OptionCollection $options */
+        /** @var OptionCollection $options */
         $options = $arguments['options'];
         $length = $arguments['length'] ?? 1;
         $sortBy = $arguments['sortBy'] ?? 'count';

--- a/Classes/ViewHelpers/FrequentlySearchedViewHelper.php
+++ b/Classes/ViewHelpers/FrequentlySearchedViewHelper.php
@@ -56,13 +56,13 @@ class FrequentlySearchedViewHelper extends AbstractSolrViewHelper
      */
     public static function renderStatic(array $arguments, Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        /* @var TypoScriptFrontendController $tsfe */
+        /** @var TypoScriptFrontendController $tsfe */
         $tsfe = $GLOBALS['TSFE'];
         $cache = self::getInitializedCache();
-        /* @var ConfigurationManager $configurationManager */
+        /** @var ConfigurationManager $configurationManager */
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
         $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
-        /* @var FrequentSearchesService $frequentSearchesService */
+        /** @var FrequentSearchesService $frequentSearchesService */
         $frequentSearchesService = GeneralUtility::makeInstance(
             FrequentSearchesService::class,
             $typoScriptConfiguration,
@@ -87,8 +87,8 @@ class FrequentlySearchedViewHelper extends AbstractSolrViewHelper
     protected static function getInitializedCache(): ?FrontendInterface
     {
         $cacheIdentifier = 'tx_solr';
-        /* @var FrontendInterface $cacheInstance */
         try {
+            /** @var FrontendInterface $cacheInstance */
             $cacheInstance = GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheIdentifier);
         } catch (NoSuchCacheException) {
             return null;

--- a/Classes/ViewHelpers/LastSearchesViewHelper.php
+++ b/Classes/ViewHelpers/LastSearchesViewHelper.php
@@ -45,7 +45,7 @@ class LastSearchesViewHelper extends AbstractSolrViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var ConfigurationManager $configurationManager */
+        /** @var ConfigurationManager $configurationManager */
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
         $typoScriptConfiguration = $configurationManager->getTypoScriptConfiguration();
         $lastSearchesService = GeneralUtility::makeInstance(

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -101,7 +101,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
             $this->tag->addAttribute('data-suggest', $this->getSuggestUrl($this->arguments['additionalFilters'], $pageUid));
         }
         $this->tag->addAttribute('data-suggest-header', htmlspecialchars($this->arguments['suggestHeader'] ?? ''));
-        $this->tag->addAttribute('accept-charset', 'utf-8' ?? null);
+        $this->tag->addAttribute('accept-charset', 'utf-8');
 
         // Get search term
         // @extensionScannerIgnoreLine
@@ -189,7 +189,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         if ($resultSet === null) {
             return '';
         }
-        return trim($this->getSearchResultSet()->getUsedSearchRequest()->getRawUserQuery() ?? '');
+        return trim($this->getSearchResultSet()->getUsedSearchRequest()->getRawUserQuery());
     }
 
     protected function getSuggestUrl(?array $additionalFilters, int $pageUid): string

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -87,6 +87,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
      */
     public function render()
     {
+        /** @phpstan-ignore-next-line */
         $this->uriBuilder->setRequest($this->renderingContext->getRequest());
         $pageUid = $this->arguments['pageUid'] ?? null;
         if ($pageUid === null && !empty($this->getTypoScriptConfiguration()->getSearchTargetPage())) {
@@ -202,7 +203,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
             ->setArguments([$pluginNamespace => ['additionalFilters' => $additionalFilters]])
             ->build();
 
-        /* @var UrlHelper $urlService */
+        /** @var UrlHelper $urlService */
         $urlService = GeneralUtility::makeInstance(UrlHelper::class, $suggestUrl);
         return $urlService->withoutQueryParameter('cHash')->__toString();
     }

--- a/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
@@ -53,6 +53,7 @@ abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
 
         if ($renderingContext instanceof RenderingContext) {
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            /** @phpstan-ignore-next-line */
             $uriBuilder->reset()->setRequest($renderingContext->getRequest());
             self::$searchUriBuilder->injectUriBuilder($uriBuilder);
         }

--- a/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
@@ -48,7 +48,7 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     protected static function getValueFromArguments(array $arguments = []): string
     {
         if (isset($arguments['facetItem'])) {
-            /* @var AbstractFacetItem $facetItem */
+            /** @var AbstractFacetItem $facetItem */
             $facetItem = $arguments['facetItem'];
             $facetValue = $facetItem->getUriValue();
         } elseif (isset($arguments['facetItemValue'])) {
@@ -66,7 +66,7 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     protected static function getNameFromArguments(array $arguments = []): string
     {
         if (isset($arguments['facet'])) {
-            /* @var AbstractFacet $facet */
+            /** @var AbstractFacet $facet */
             $facet = $arguments['facet'];
             $facetName = $facet->getName();
         } elseif (isset($arguments['facetName'])) {
@@ -84,7 +84,7 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     protected static function getResultSetFromArguments(array $arguments = []): SearchResultSet
     {
         if (isset($arguments['facet'])) {
-            /* @var AbstractFacet $facet */
+            /** @var AbstractFacet $facet */
             $facet = $arguments['facet'];
             $resultSet = $facet->getResultSet();
         } elseif (isset($arguments['facetName'])) {

--- a/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use Closure;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -35,7 +34,6 @@ class AddFacetItemViewHelper extends AbstractValueViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var SearchResultSet $resultSet */
         $name = self::getNameFromArguments($arguments);
         $itemValue = self::getValueFromArguments($arguments);
         $resultSet = self::getResultSetFromArguments($arguments);

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
@@ -45,7 +45,7 @@ class RemoveFacetViewHelper extends AbstractUriViewHelper
         Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
     ) {
-        /* @var AbstractFacet $facet */
+        /** @var AbstractFacet $facet */
         $facet = $arguments['facet'];
         $previousRequest = $facet->getResultSet()->getUsedSearchRequest();
 

--- a/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
@@ -64,7 +64,7 @@ class AddSearchWordListViewHelper extends AbstractSolrFrontendViewHelper
         $addNoCache = $arguments['addNoCache'];
         $keepCHash = $arguments['keepCHash'];
 
-        /* @var SiteHighlighterUrlModifier $siteHighlighterUrlModifier */
+        /** @var SiteHighlighterUrlModifier $siteHighlighterUrlModifier */
         $siteHighlighterUrlModifier = GeneralUtility::makeInstance(SiteHighlighterUrlModifier::class);
 
         return $siteHighlighterUrlModifier->modify($url, $searchWords, $addNoCache, $keepCHash);

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -294,7 +294,7 @@ class RelationTest extends IntegrationTest
     {
         $tsfeMock = $this->createMock(TypoScriptFrontendController::class);
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class, $tsfeMock);
-        /* @var MockObject|ServerRequest $requestMock */
+        /** @var MockObject|ServerRequest $requestMock */
         $requestMock = $this->createMock(ServerRequest::class);
         $contentObjectRenderer->start(
             BackendUtility::getRecord($table, $uid),

--- a/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -73,7 +73,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
      */
     public function testReloadIndexConfigurationAction()
     {
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $selectedSite = $siteRepository->getFirstAvailableSite();
         $controller = $this->getControllerMockObject();
@@ -89,7 +89,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTest
      */
     public function testEmptyIndexAction()
     {
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $selectedSite = $siteRepository->getFirstAvailableSite();
         $controller = $this->getControllerMockObject();

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -166,7 +166,7 @@ class SearchResultSetServiceTest extends IntegrationTest
         self::assertSame(5, $secondResult->getVariantsNumFound());
 
         // We assume that the third result has no variants.
-        /* @var SearchResult $secondResult */
+        /** @var SearchResult $secondResult */
         $thirdResult = $searchResults[2];
         self::assertSame(0, count($thirdResult->getVariants()));
         self::assertSame('Baby Doe', $thirdResult->getAuthor());
@@ -259,14 +259,14 @@ class SearchResultSetServiceTest extends IntegrationTest
         $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId(1);
         $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
 
-        /* @var SearchResultSetService $searchResultsSetService */
+        /** @var SearchResultSetService $searchResultSetService */
         $searchResultSetService = GeneralUtility::makeInstance(
             SearchResultSetService::class,
             $typoScriptConfiguration,
             $search
         );
 
-        /* @var SearchRequest $searchRequest */
+        /** @var SearchRequest $searchRequest */
         $searchRequest = GeneralUtility::makeInstance(SearchRequest::class, [], 0, 0, $typoScriptConfiguration);
         $searchRequest->setRawQueryString($queryString);
         $searchRequest->setResultsPerPage(10);
@@ -283,7 +283,7 @@ class SearchResultSetServiceTest extends IntegrationTest
 
     protected function simulateFrontedUserGroups(array $feUserGroupArray): void
     {
-        /* @var Context $context */
+        /** @var Context $context */
         $context = GeneralUtility::makeInstance(Context::class);
         $userAuthentication = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
         // Simulate any user

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -31,7 +31,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         $fixtureTimestamp = 1471203378;
         $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
 
-        /* @var StatisticsRepository $repository */
+        /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getTopKeyWordsWithHits(1, $daysSinceFixture);
         $expectedResult = [
@@ -51,7 +51,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         $fixtureTimestamp = 1471203378;
         $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
 
-        /* @var StatisticsRepository $repository */
+        /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
 
@@ -71,7 +71,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         $fixtureTimestamp = 1480000000;
         $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
 
-        /* @var StatisticsRepository $repository */
+        /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
 
@@ -89,7 +89,7 @@ class StatisticsRepositoryTest extends IntegrationTest
         $fixtureTimestamp = 1480000000;
         $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
 
-        /* @var StatisticsRepository $repository */
+        /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
         $topHits = $repository->getSearchStatistics(37, $daysSinceFixture);
 
@@ -104,7 +104,7 @@ class StatisticsRepositoryTest extends IntegrationTest
     public function canSaveStatisticsRecord()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
-        /* @var StatisticsRepository $repository */
+        /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
 
         self::assertEquals(4, $repository->countByRootPageId(1), 'Does not contain all statistics records from fixtures.');

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -135,14 +135,11 @@ class StatisticsRepositoryTest extends IntegrationTest
 
     /**
      * Helper method to calculate the number of days from now to a specific timestamp.
-     *
-     * @param $timestamp
-     * @return float
      */
-    protected static function getDaysSinceTimestamp($timestamp)
+    protected static function getDaysSinceTimestamp(int $timestamp): int
     {
         $secondsUntilNow = time() - $timestamp;
         $days = floor($secondsUntilNow / (60*60*24));
-        return $days;
+        return (int)$days;
     }
 }

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -40,7 +40,7 @@ class SiteTest extends IntegrationTest
     public function canGetDefaultLanguage()
     {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        /* @var Site $site */
+        /** @var Site $site */
         $site = $siteRepository->getFirstAvailableSite();
         self::assertEquals(0, $site->getDefaultLanguageId(), 'Could not get default language from site');
     }
@@ -50,7 +50,7 @@ class SiteTest extends IntegrationTest
      */
     public function canCreateInstanceWithRootSiteUidOK()
     {
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByRootPageId(1);
         self::assertEquals(1, $site->getRootPageId());
@@ -62,7 +62,7 @@ class SiteTest extends IntegrationTest
     public function canCreateInstanceWithRootSiteUidNOK()
     {
         $this->expectException(InvalidArgumentException::class);
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByRootPageId(2);
     }
@@ -75,7 +75,7 @@ class SiteTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_create_instance_with_non_root_site.csv');
         $this->expectException(InvalidArgumentException::class);
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $siteRepository->getSiteByRootPageId(151);
     }
@@ -88,7 +88,7 @@ class SiteTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_create_instance_with_non_root_site.csv');
         $this->expectException(InvalidArgumentException::class);
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $siteRepository->getSiteByRootPageId(152);
     }
@@ -100,7 +100,7 @@ class SiteTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_translations_for_root_site.csv');
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getSiteByRootPageId(1);
         $languageIds = $site->getAvailableLanguageIds();

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -64,7 +64,7 @@ class IndexerTest extends IntegrationTest
         $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
         $this->indexer = GeneralUtility::makeInstance(Indexer::class);
 
-        /* @var BackendUserAuthentication $beUser */
+        /** @var BackendUserAuthentication $beUser */
         $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
         $GLOBALS['BE_USER'] = $beUser;
         $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -74,7 +74,7 @@ class PageTest extends IntegrationTest
     protected function initializeAllPageIndexQueues()
     {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $sites = $siteRepository->getAvailableSites();
 
         foreach ($sites as $site) {

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -452,7 +452,7 @@ class QueueTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');
         $this->assertItemsInQueue(4);
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $firstSite = $siteRepository->getFirstAvailableSite();
 
@@ -477,7 +477,7 @@ class QueueTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');
         $this->assertItemsInQueue(4);
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $firstSite = $siteRepository->getFirstAvailableSite();
 
@@ -502,7 +502,7 @@ class QueueTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');
         $this->assertItemsInQueue(4);
 
-        /* @var SiteRepository $siteRepository */
+        /** @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $firstSite = $siteRepository->getFirstAvailableSite();
 

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -252,10 +252,11 @@ abstract class IntegrationTest extends FunctionalTestCase
     protected function failWhenSolrDeprecationIsCreated(): void
     {
         error_reporting(error_reporting() & ~E_USER_DEPRECATED);
-        set_error_handler(function ($id, $msg) {
+        set_error_handler(function (int $id, string $msg, string $file, int $line): bool {
             if ($id === E_USER_DEPRECATED && str_starts_with($msg, 'solr:deprecation: ')) {
                 $this->fail('Executed deprecated EXT:solr code: ' . $msg);
             }
+            return true;
         });
     }
 

--- a/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
+++ b/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
@@ -39,7 +39,7 @@ class AccessFilterPluginInstalledStatusTest extends IntegrationTest
      */
     public function canGetGreenAccessFilterStatus()
     {
-        /* @var AccessFilterPluginInstalledStatus $accessFilterStatus */
+        /** @var AccessFilterPluginInstalledStatus $accessFilterStatus */
         $accessFilterStatus = GeneralUtility::makeInstance(AccessFilterPluginInstalledStatus::class);
         $violations = $accessFilterStatus->getStatus();
         self::assertEmpty($violations, 'We expect to get no violations against the test solr server ');

--- a/Tests/Integration/Report/SchemaStatusTest.php
+++ b/Tests/Integration/Report/SchemaStatusTest.php
@@ -40,7 +40,7 @@ class SchemaStatusTest extends IntegrationTest
      */
     public function canGetAGrennSchemaStatusAgainstTestServer()
     {
-        /* @var SchemaStatus $schemaStatus */
+        /** @var SchemaStatus $schemaStatus */
         $schemaStatus = GeneralUtility::makeInstance(SchemaStatus::class);
         $violations = $schemaStatus->getStatus();
 

--- a/Tests/Integration/Report/SiteHandlingStatusTest.php
+++ b/Tests/Integration/Report/SiteHandlingStatusTest.php
@@ -36,12 +36,12 @@ class SiteHandlingStatusTest extends IntegrationTest
     {
         $this->writeDefaultSolrTestSiteConfiguration();
 
-        /* @var SiteHandlingStatus $siteHandlingStatus */
+        /** @var SiteHandlingStatus $siteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
         foreach ($statusCollection as $status) {
-            /* @var Status $status */
+            /** @var Status $status */
             self::assertSame(ContextualFeedbackSeverity::OK, $status->getSeverity(), 'Expected that all status checks for site handling configuration of first test site should be ok');
         }
     }
@@ -59,12 +59,12 @@ class SiteHandlingStatusTest extends IntegrationTest
             'base' => 'authorityOnly.two.example.com',
         ]);
 
-        /* @var SiteHandlingStatus $siteHandlingStatus */
+        /** @var SiteHandlingStatus $siteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
         foreach ($statusCollection as $status) {
-            /* @var Status $status */
+            /** @var Status $status */
             self::assertSame(ContextualFeedbackSeverity::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if scheme in "Entry Point[base]" is not defined.');
             self::assertMatchesRegularExpression('~.*are empty or invalid: &quot;scheme&quot;~', $status->getMessage());
         }
@@ -83,12 +83,12 @@ class SiteHandlingStatusTest extends IntegrationTest
             'base' => '/',
         ]);
 
-        /* @var SiteHandlingStatus $siteHandlingStatus */
+        /** @var SiteHandlingStatus $siteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
         foreach ($statusCollection as $status) {
-            /* @var Status $status  */
+            /** @var Status $status  */
             self::assertSame(ContextualFeedbackSeverity::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
             self::assertMatchesRegularExpression('~.*are empty or invalid: &quot;scheme, host&quot;~', $status->getMessage());
         }
@@ -114,12 +114,12 @@ class SiteHandlingStatusTest extends IntegrationTest
 
         $this->mergeSiteConfiguration('integration_tree_two', $configuration2);
 
-        /* @var SiteHandlingStatus $siteHandlingStatus */
+        /** @var SiteHandlingStatus $siteHandlingStatus */
         $siteHandlingStatus = GeneralUtility::makeInstance(SiteHandlingStatus::class);
         $statusCollection = $siteHandlingStatus->getStatus();
 
         foreach ($statusCollection as $status) {
-            /* @var Status $status */
+            /** @var Status $status */
             self::assertSame(ContextualFeedbackSeverity::ERROR, $status->getSeverity(), 'Expected that status checks for site handling configuration should indicate an error if authority in "Entry Point[base]" is not defined.');
             self::assertMatchesRegularExpression('~.*is not valid URL\. Following parts of defined URL are empty or invalid: &quot;scheme&quot;~', $status->getMessage());
         }

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -39,7 +39,7 @@ class SolrConfigStatusTest extends IntegrationTest
      */
     public function canGetAGreenSolrConfigStatusAgainstTestServer()
     {
-        /* @var SolrConfigStatus $schemaStatus */
+        /** @var SolrConfigStatus $schemaStatus */
         $schemaStatus = GeneralUtility::makeInstance(SolrConfigStatus::class);
         $violations = $schemaStatus->getStatus();
         self::assertEmpty($violations, 'We expect to get no violations against the test solr server');

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -47,7 +47,7 @@ class SolrConfigurationStatusTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_green_solr_configuration_status_report.csv');
 
-        /* @var SolrConfigurationStatus $solrConfigurationStatus */
+        /** @var SolrConfigurationStatus $solrConfigurationStatus */
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
         self::assertEmpty($violations, 'We did not get an empty response from the solr configuration status report! Something is wrong');
@@ -60,7 +60,7 @@ class SolrConfigurationStatusTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_detect_missing_rootpage.csv');
 
-        /* @var SolrConfigurationStatus $solrConfigurationStatus */
+        /** @var SolrConfigurationStatus $solrConfigurationStatus */
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
 
@@ -77,7 +77,7 @@ class SolrConfigurationStatusTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_detect_indexing_disabled.csv');
 
-        /* @var SolrConfigurationStatus $solrConfigurationStatus   */
+        /** @var SolrConfigurationStatus $solrConfigurationStatus   */
         $solrConfigurationStatus = GeneralUtility::makeInstance(SolrConfigurationStatus::class);
         $violations = $solrConfigurationStatus->getStatus();
 

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -39,7 +39,7 @@ class SolrVersionStatusTest extends IntegrationTest
      */
     public function canGetAGreenSolrConfigStatusAgainstTestServer()
     {
-        /* @var SolrVersionStatus $solrVersionStatus */
+        /** @var SolrVersionStatus $solrVersionStatus */
         $solrVersionStatus = GeneralUtility::makeInstance(SolrVersionStatus::class);
         $violations = $solrVersionStatus->getStatus();
         self::assertEmpty($violations, 'We expect to get no violations against the test solr server');

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -20,13 +20,13 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\PhraseFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Slops;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\TrigramPhraseFields;
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Query;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
-use Solarium\QueryType\Select\Query\Query;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -42,11 +42,7 @@ class SearchTest extends IntegrationTest
      * @todo: Remove unnecessary fixtures and remove that property as intended.
      */
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
-
-    /**
-     * @var QueryBuilder
-     */
-    protected $queryBuilder;
+    protected QueryBuilder $queryBuilder;
 
     protected function setUp(): void
     {
@@ -64,13 +60,12 @@ class SearchTest extends IntegrationTest
     /**
      * @test
      */
-    public function canSearchForADocument()
+    public function canSearchForADocument(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/can_search.csv');
 
         $fakeTSFE = $this->getConfiguredTSFE();
 
-        /* @var Typo3PageIndexer $pageIndexer */
         $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
         $indexQueueItemMock = $this->createMock(Item::class);
         $indexQueueItemMock->expects(self::any())
@@ -81,7 +76,6 @@ class SearchTest extends IntegrationTest
 
         $this->waitToBeVisibleInSolr();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->queryBuilder
@@ -98,12 +92,11 @@ class SearchTest extends IntegrationTest
     /**
      * @test
      */
-    public function implicitPhraseSearchingBoostsDocsWithOccurringPhrase()
+    public function implicitPhraseSearchingBoostsDocsWithOccurringPhrase(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->queryBuilder
@@ -132,12 +125,11 @@ class SearchTest extends IntegrationTest
     /**
      * @test
      */
-    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByPhraseSlop()
+    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->queryBuilder
@@ -204,12 +196,11 @@ class SearchTest extends IntegrationTest
      *
      * Bigram Phrase
      */
-    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByBigramPhraseSlop()
+    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByBigramPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search_bigram.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $this->switchPhraseSearchFeature('bigramPhrase', 1);
@@ -290,12 +281,11 @@ class SearchTest extends IntegrationTest
      *
      * Trigram Phrase
      */
-    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByTrigramPhraseSlop()
+    public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByTrigramPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search_trigram.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $this->switchPhraseSearchFeature('trigramPhrase', 1);
@@ -371,7 +361,7 @@ class SearchTest extends IntegrationTest
     /**
      * @test
      */
-    public function explicitPhraseSearchMatchesMorePrecise()
+    public function explicitPhraseSearchMatchesMorePrecise(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->fillIndexForPhraseSearchTests();
@@ -394,12 +384,11 @@ class SearchTest extends IntegrationTest
     /**
      * @test
      */
-    public function explicitPhraseSearchPrecisionCanBeAdjustedByQuerySlop()
+    public function explicitPhraseSearchPrecisionCanBeAdjustedByQuerySlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->getSearchQueryForSolr();
@@ -433,12 +422,11 @@ class SearchTest extends IntegrationTest
         self::assertSame(7, $parsedData->response->numFound, 'Found wrong number of decuments by explicit phrase search query.');
     }
 
-    protected function fillIndexForPhraseSearchTests()
+    protected function fillIndexForPhraseSearchTests(): void
     {
         for ($i = 1; $i <= 15; $i++) {
             $fakeTSFE = $this->getConfiguredTSFE($i);
 
-            /* @var Typo3PageIndexer $pageIndexer */
             $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
             $indexQueueItemMock = $this->createMock(Item::class);
             $indexQueueItemMock->expects(self::any())
@@ -458,12 +446,11 @@ class SearchTest extends IntegrationTest
             ->getQuery();
     }
 
-    protected function switchPhraseSearchFeature(string $feature, int $state)
+    protected function switchPhraseSearchFeature(string $feature, int $state): void
     {
         $overwriteConfiguration = [];
         $overwriteConfiguration['search.']['query.'][$feature] = $state;
 
-        /* @var ConfigurationManager $configurationManager */
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
         $configurationManager->getTypoScriptConfiguration()->mergeSolrConfiguration($overwriteConfiguration);
     }
@@ -473,7 +460,6 @@ class SearchTest extends IntegrationTest
      */
     protected function getConfiguredTSFE(int $id = 1): TypoScriptFrontendController
     {
-        /* @var TSFETestBootstrapper $bootstrapper */
         $bootstrapper = GeneralUtility::makeInstance(TSFETestBootstrapper::class);
         return $bootstrapper->bootstrap($id);
     }

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -366,7 +366,7 @@ class SearchTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->fillIndexForPhraseSearchTests();
 
-        /* @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
+        /** @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->getSearchQueryForSolr();

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -31,7 +31,7 @@ class ConfigurationPageResolverTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_closest_template_page_id.csv');
 
-        /* @var ConfigurationPageResolver $configurationPageIdResolver */
+        /** @var ConfigurationPageResolver $configurationPageIdResolver */
         $configurationPageIdResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
 
         $pageIdWithActiveTypoScriptConfiguration = $configurationPageIdResolver->getClosestPageIdWithActiveTemplate(4);

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -28,7 +28,7 @@ class TypoScriptConfigurationTest extends IntegrationTest
 {
     protected function setUp(): void
     {
-        /* @var TypoScriptFrontendController|MockObject $tsfe */
+        /** @var TypoScriptFrontendController|MockObject $tsfe */
         $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)
             ->onlyMethods([])
             ->disableOriginalConstructor()
@@ -52,7 +52,7 @@ class TypoScriptConfigurationTest extends IntegrationTest
             ],
         ];
 
-        /* @var TypoScriptConfiguration $typoScriptConfiguration */
+        /** @var TypoScriptConfiguration $typoScriptConfiguration */
         $typoScriptConfiguration = GeneralUtility::makeInstance(TypoScriptConfiguration::class, $configuration, 0);
         $sorting = $typoScriptConfiguration->getSearchSorting();
         self::assertTrue($sorting, 'Can not get sorting configuration from typoscript');

--- a/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
@@ -33,7 +33,7 @@ class SystemCategoryRepositoryTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_category.csv');
 
-        /* @var SystemCategoryRepository $repository */
+        /** @var SystemCategoryRepository $repository */
         $repository = GeneralUtility::makeInstance(SystemCategoryRepository::class);
         $category = $repository->findOneByUid(2);
         self::assertSame('child', $category['title'], 'Can not retrieve system category by uid');

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -37,7 +37,7 @@ class SystemTemplateRepositoryTest extends IntegrationTest
             ['uid' => 8657],
         ];
 
-        /* @var SystemTemplateRepository $repository */
+        /** @var SystemTemplateRepository $repository */
         $repository = GeneralUtility::makeInstance(SystemTemplateRepository::class);
         $closestPageIdWithActiveTemplate = $repository->findOneClosestPageIdWithActiveTemplateByRootLine($fakeRootLine);
         self::assertEquals(33, $closestPageIdWithActiveTemplate, 'Can not find closest page id with active template.');

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -37,7 +37,7 @@ class SolrAdminServiceTest extends IntegrationTest
     protected function setUp(): void
     {
         parent::setUp();
-        /* @var EventDispatcher $eventDispatcher */
+        /** @var EventDispatcher $eventDispatcher */
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(
@@ -196,7 +196,7 @@ class SolrAdminServiceTest extends IntegrationTest
      */
     public function canParseLanguageFromSchema()
     {
-        /* @var EventDispatcher $eventDispatcher */
+        /** @var EventDispatcher $eventDispatcher */
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(

--- a/Tests/Integration/System/Solr/SolrConnectionTest.php
+++ b/Tests/Integration/System/Solr/SolrConnectionTest.php
@@ -57,7 +57,7 @@ class SolrConnectionTest extends IntegrationTest
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/slim_basic_sites.csv');
 
-        /* @var ConnectionManager $connectionManager */
+        /** @var ConnectionManager $connectionManager */
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
 
         $messageOnNoSolrConnectionFoundException = vsprintf(

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -55,7 +55,7 @@ class IndexQueueWorkerTaskTest extends IntegrationTest
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_trigger_frontend_calls_for_page_index.csv');
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $site = $siteRepository->getFirstAvailableSite();
-        /* @var IndexQueueWorkerTask $indexQueueQueueWorkerTask */
+        /** @var IndexQueueWorkerTask $indexQueueQueueWorkerTask */
         $indexQueueQueueWorkerTask = GeneralUtility::makeInstance(IndexQueueWorkerTask::class);
         $indexQueueQueueWorkerTask->setDocumentsToIndexLimit(1);
         $indexQueueQueueWorkerTask->setRootPageId($site->getRootPageId());

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -135,7 +135,7 @@ class ReIndexTaskTest extends IntegrationTest
         $site = $siteRepository->getFirstAvailableSite();
         $this->indexQueue->updateItem('pages', 1);
         $items = $this->indexQueue->getItems('pages', 1);
-        /* @var Indexer $indexer */
+        /** @var Indexer $indexer */
         $indexer = GeneralUtility::makeInstance(Indexer::class);
         $indexer->index($items[0]);
         $this->waitToBeVisibleInSolr();

--- a/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
+++ b/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
@@ -71,7 +71,7 @@ class SettingsPreviewOnPluginsTest extends SetUpUnitTestCase
         string $table = 'tt_content',
         array $record = [],
     ): PageContentPreviewRenderingEvent {
-        /* @var PageLayoutContext|MockObject $pageLayoutContextMock */
+        /** @var PageLayoutContext|MockObject $pageLayoutContextMock */
         $pageLayoutContextMock =  $this->createMock(PageLayoutContext::class);
         return new PageContentPreviewRenderingEvent(
             $table,

--- a/Tests/Unit/ContentObject/SetUpContentObject.php
+++ b/Tests/Unit/ContentObject/SetUpContentObject.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -32,15 +31,9 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 abstract class SetUpContentObject extends SetUpUnitTestCase
 {
-    use ProphecyTrait;
-
     protected bool $resetSingletonInstances = true;
 
-    /**
-     * @var ContentObjectRenderer
-     */
     protected ContentObjectRenderer $contentObjectRenderer;
-
     protected AbstractContentObject $testableContentObject;
 
     protected function setUp(): void

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -114,7 +114,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         $this->siteMock->expects(self::any())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
         $this->siteMock->expects(self::any())->method('getDomain')->willReturn('www.indextest.local');
 
-        /* @var IndexService|MockObject $indexService */
+        /** @var IndexService|MockObject $indexService */
         $indexService = $this->getMockBuilder(IndexService::class)
             ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->eventDispatcherMock, $this->logManagerMock])
             ->onlyMethods(['getIndexerByItem', 'restoreOriginalHttpHost'])
@@ -153,7 +153,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         $this->siteMock->expects(self::once())->method('getSolrConfiguration')->willReturn($fakeConfiguration);
         $this->siteMock->expects(self::any())->method('getDomain')->willReturn('www.indextest.local');
 
-        /* @var IndexService|MockObject $indexService  */
+        /** @var IndexService|MockObject $indexService  */
         $indexService = $this->getMockBuilder(IndexService::class)
             ->setConstructorArgs([$this->siteMock, $this->queueMock, $this->eventDispatcherMock, $this->logManagerMock])
             ->onlyMethods(['getIndexerByItem'])

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -75,26 +75,6 @@ class RepositoryTest extends SetUpUnitTestCase
     /**
      * @test
      */
-    public function findByPageIdAndByLanguageIdThrowsInvalidArgumentExceptionIfPageIdIsNotSet()
-    {
-        $this->expectException(TypeError::class);
-        $apacheSolrDocumentRepository = GeneralUtility::makeInstance(Repository::class);
-        $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(null, 3);
-    }
-
-    /**
-     * @test
-     */
-    public function findByPageIdAndByLanguageIdThrowsInvalidArgumentExceptionIfLanguageIdIsNotInteger()
-    {
-        $this->expectException(TypeError::class);
-        $apacheSolrDocumentRepository = GeneralUtility::makeInstance(Repository::class);
-        $apacheSolrDocumentRepository->findByPageIdAndByLanguageId(1, 'Abc');
-    }
-
-    /**
-     * @test
-     */
     public function findByPageIdAndByLanguageIdReturnsEmptyCollectionIfConnectionToSolrServerCanNotBeEstablished()
     {
         $apacheSolrDocumentRepository = $this->getAccessibleMock(

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -26,7 +26,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
-use TypeError;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -68,7 +67,7 @@ class RepositoryTest extends SetUpUnitTestCase
             ->method('findByPageIdAndByLanguageId')
             ->willReturn($apacheSolrDocumentCollection);
 
-        /* @var Repository $apacheSolrDocumentRepository */
+        /** @var Repository $apacheSolrDocumentRepository */
         self::assertSame($apacheSolrDocumentCollection[0], $apacheSolrDocumentRepository->findOneByPageIdAndByLanguageId(0, 0));
     }
 

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -685,7 +685,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function canEnableFaceting(): void
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
+        /** @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
         $faceting = new Faceting(true);
         $this->builder->startFrom($query)->useFaceting($faceting);
@@ -803,7 +803,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function canSetSpellChecking()
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
+        /** @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
 
         $spellchecking = Spellchecking::getEmpty();
@@ -827,7 +827,6 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function noSiteHashFilterIsSetWhenWildcardIsPassed()
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => '*']);
         $this->siteHashServiceMock->expects(self::once())->method('getAllowedSitesForPageIdAndAllowedSitesConfiguration')->willReturn('*');
@@ -846,7 +845,6 @@ class QueryBuilderTest extends SetUpUnitTestCase
      */
     public function filterIsAddedWhenAllowedSiteIsPassed()
     {
-        /* @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
         $configurationMock->expects(self::once())->method('getObjectByPathOrDefault')->willReturn(['allowedSites' => 'site1.local']);
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -46,7 +46,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
             $facetConfiguration
         );
 
-        /* @var HierarchyFacetParser $parser */
+        /** @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
         self::assertInstanceOf(HierarchyFacet::class, $facet);
@@ -99,7 +99,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
             $facetConfiguration
         );
 
-        /* @var HierarchyFacetParser $parser */
+        /** @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);
 
@@ -141,7 +141,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
             ['categoryHierarchyByTitle:/folder2\/level1\//folder2\/level2\//']
         );
 
-        /* @var HierarchyFacetParser $parser */
+        /** @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         /** @var HierarchyFacet $facet */
         $facet = $parser->parse($searchResultSet, 'categoryHierarchyByTitle', $facetConfiguration);
@@ -207,7 +207,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
             ['pageHierarchy:/1/14/']
         );
 
-        /* @var HierarchyFacetParser $parser */
+        /** @var HierarchyFacetParser $parser */
         $parser = $this->getInitializedParser(HierarchyFacetParser::class);
         /** @var HierarchyFacet $facet */
         $facet = $parser->parse($searchResultSet, 'pageHierarchy', $facetConfiguration['pageHierarchy.']);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -45,7 +45,7 @@ class DateRangeFacetParserTest extends SetUpFacetParser
             ['myCreated:201506020000-201706020000']
         );
 
-        /* @var DateRangeFacetParser $parser */
+        /** @var DateRangeFacetParser $parser */
         $parser = $this->getInitializedParser(DateRangeFacetParser::class);
 
         $facet = $parser->parse($searchResultSet, 'myCreated', $facetConfiguration['myCreated.']);

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -122,7 +122,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         // after the reconstitution they should be 1 facet present
         self::assertCount(1, $searchResultSet->getFacets());
 
-        /* @var OptionsFacet $optionFacet */
+        /** @var OptionsFacet $optionFacet */
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
         // @extensionScannerIgnoreLine
         self::assertSame('tx_myext_domain_model_mytype', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Custom type facet not found');

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -133,15 +133,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
             $this->queryBuilderMock
         );
 
-        try {
-            $suggestions = $suggestService->getSuggestions($fakeRequest);
-        } catch (\Error $error) {
-            self::fail(
-                'The method \ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService::getSolrSuggestions() ' .
-                'can not handle Apache Solr syntax errors. The method is failing with exception from below:' . PHP_EOL . PHP_EOL .
-                $error->getMessage() . ' in ' . $error->getFile() . ':' . $error->getLine()
-            );
-        }
+        $suggestions = $suggestService->getSuggestions($fakeRequest);
 
         $expectedSuggestions = ['status' => false];
         self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -31,7 +31,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\MockObject\MockBuilder;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -87,7 +87,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $fakeResponse = $this->getFixtureContentByName('fakeResponse.json');
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
 
-        /* @var MockObject|Item $queueItemMock */
+        /** @var MockObject|Item $queueItemMock */
         $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
@@ -108,7 +108,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $fakeResponse = $this->getFixtureContentByName('fakeResponse.json');
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
-        /* @var MockObject|Item $queueItemMock */
+        /** @var MockObject|Item $queueItemMock */
         $queueItemMock = $this->createMock(Item::class);
 
         $requestMock->setIndexQueueItem($queueItemMock);
@@ -127,7 +127,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $fakeResponse = 'invalidJsonString!!';
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
-        /* @var MockObject|Item $queueItemMock */
+        /** @var MockObject|Item $queueItemMock */
         $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
@@ -158,7 +158,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $fakeResponse = $this->getFixtureContentByName('fakeResponse.json');
 
         $requestMock = $this->getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse);
-        /* @var MockObject|Item $queueItemMock */
+        /** @var MockObject|Item $queueItemMock */
         $queueItemMock = $this->createMock(Item::class);
         $requestMock->setIndexQueueItem($queueItemMock);
 
@@ -170,7 +170,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
      */
     public function authenticationHeaderIsSetWhenUsernameAndPasswordHaveBeenPassed()
     {
-        /* @var MockObject|RequestFactory $requestFactoryMock */
+        /** @var MockObject|RequestFactory $requestFactoryMock */
         $requestFactoryMock = $this->createMock(RequestFactory::class);
         $requestFactoryMock->expects(self::once())->method('request')->willReturnCallback(function ($url, $method, $options) {
             $this->assertSame(['bob', 'topsecret'], $options['auth'], 'Authentication options have not been set');
@@ -179,15 +179,15 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
             return $this->getFakedGuzzleResponse($this->getFixtureContentByName('fakeResponse.json'));
         });
 
-        /* @var MockObject|SolrLogManager $solrLogManagerMock */
+        /** @var MockObject|SolrLogManager $solrLogManagerMock */
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
-        /* @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
+        /** @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
         $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
 
         $testParameters = json_encode(['requestId' => '581f76be71f60']);
         $pageIndexerRequest = new PageIndexerRequest($testParameters, $solrLogManagerMock, $extensionConfigurationMock, $requestFactoryMock);
 
-        /* @var MockObject|Item $queueItemMock */
+        /** @var MockObject|Item $queueItemMock */
         $queueItemMock = $this->createMock(Item::class);
         $pageIndexerRequest->setIndexQueueItem($queueItemMock);
         $pageIndexerRequest->setAuthorizationCredentials('bob', 'topsecret');
@@ -217,7 +217,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
     {
         $pageIndexerRequest = $this->getPageIndexerRequest();
 
-        /* @var MockObject|Item $itemMock */
+        /** @var MockObject|Item $itemMock */
         $itemMock = $this->createMock(Item::class);
         $pageIndexerRequest->setIndexQueueItem($itemMock);
         $headers = $pageIndexerRequest->getHeaders();
@@ -231,9 +231,9 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
      */
     protected function getPageIndexerRequest(string $jsonEncodedParameter = null, RequestFactory $requestFactory = null): PageIndexerRequest
     {
-        /* @var MockObject|SolrLogManager $solrLogManagerMock */
+        /** @var MockObject|SolrLogManager $solrLogManagerMock */
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
-        /* @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
+        /** @var MockObject|ExtensionConfiguration $extensionConfigurationMock */
         $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
         $requestFactory = $requestFactory ?? $this->createMock(RequestFactory::class);
         return new PageIndexerRequest($jsonEncodedParameter, $solrLogManagerMock, $extensionConfigurationMock, $requestFactory);
@@ -249,7 +249,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
         $extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
         $requestFactoryMock = $this->createMock(RequestFactory::class);
-        /* @var MockObject|PageIndexerRequest $requestMock */
+        /** @var MockObject|PageIndexerRequest $requestMock */
         $requestMock = $this->getMockBuilder(PageIndexerRequest::class)
             ->onlyMethods(['getUrl'])
             ->setConstructorArgs([
@@ -276,7 +276,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $bodyStream = $this->createMock(StreamInterface::class);
         $bodyStream->expects(self::any())->method('getContents')->willReturn($fakeResponse);
 
-        /* @var MockObject|ResponseInterface $responseMock */
+        /** @var MockObject|ResponseInterface $responseMock */
         $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->expects(self::any())->method('getBody')->willReturn($bodyStream);
         return $responseMock;

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -90,7 +90,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         $testUri = 'http://myfrontendurl.de/index.php?id=4711&L=0';
         $this->uriStrategyMock->expects(self::any())->method('getPageIndexingUriFromPageItemAndLanguageId')->willReturn($testUri);
 
-        /* @var Item|MockObject $item */
+        /** @var Item|MockObject $item */
         $item = $this->createMock(Item::class);
         $item->expects(self::any())->method('getRootPageUid')->willReturn(88);
         $item->expects(self::any())->method('getRecordUid')->willReturn(4711);

--- a/Tests/Unit/Query/Modifier/FacetingTest.php
+++ b/Tests/Unit/Query/Modifier/FacetingTest.php
@@ -57,10 +57,9 @@ class FacetingTest extends SetUpUnitTestCase
     ): array {
         $facetRegistry = new FacetRegistry();
 
-        /* @var SolrLogManager|MockObject $solrLogManagerMock */
+        /** @var SolrLogManager|MockObject $solrLogManagerMock */
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
 
-        /* @var Query $query */
         $queryBuilder = new QueryBuilder(
             $fakeConfiguration,
             $solrLogManagerMock,
@@ -107,7 +106,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
@@ -147,7 +146,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
@@ -185,7 +184,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
@@ -233,7 +232,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -280,7 +279,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -330,7 +329,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn([]);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -367,7 +366,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -411,7 +410,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -452,7 +451,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -489,7 +488,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -526,7 +525,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('color:red'), urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -564,7 +563,7 @@ class FacetingTest extends SetUpUnitTestCase
 
         $fakeArguments = ['filter' => [urlencode('type:product')]];
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -610,7 +609,7 @@ class FacetingTest extends SetUpUnitTestCase
         ];
         $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
 
-        /* @var SearchRequest|MockObject $fakeRequest */
+        /** @var SearchRequest|MockObject $fakeRequest */
         $fakeRequest = $this->createMock(SearchRequest::class);
         $fakeRequest->expects(self::once())->method('getArguments')->willReturn($fakeArguments);
         $fakeRequest->expects(self::any())->method('getContextTypoScriptConfiguration')->willReturn($fakeConfiguration);
@@ -639,7 +638,7 @@ class FacetingTest extends SetUpUnitTestCase
             ->method('getSearchFacetingUrlParameterStyle')
             ->willReturn(UrlFacetContainer::PARAMETER_STYLE_ASSOC);
 
-        /* @var SearchRequest|MockObject $searchRequestMock */
+        /** @var SearchRequest|MockObject $searchRequestMock */
         $searchRequestMock = $this->createMock(SearchRequest::class);
         $searchRequestMock->expects(self::once())
             ->method('getContextTypoScriptConfiguration')

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -86,7 +86,7 @@ class SolrConfigurationStatusTest extends SetUpUnitTestCase
 
         self::assertCount(1, $states, 'Expected to have one violation');
 
-        /* @var Status $firstState */
+        /** @var Status $firstState */
         $firstState = $states[0];
         self::assertSame(ContextualFeedbackSeverity::WARNING, $firstState->getSeverity(), 'Expected to have one violation');
     }

--- a/Tests/Unit/Task/OptimizeIndexTaskTest.php
+++ b/Tests/Unit/Task/OptimizeIndexTaskTest.php
@@ -30,7 +30,7 @@ class OptimizeIndexTaskTest extends SetUpUnitTestCase
      */
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
-        /* @var OptimizeIndexTask $indexQueuerWorker */
+        /** @var OptimizeIndexTask $indexQueuerWorker */
         $indexQueuerWorker = $this->getMockBuilder(OptimizeIndexTask::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSite'])

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -63,7 +63,7 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
      */
     public function canRenderCreateHighlightSnipped(array $input, $expectedOutput, $configuredWrap)
     {
-        /* @var RenderingContextInterface|MockObject $renderingContextMock */
+        /** @var RenderingContextInterface|MockObject $renderingContextMock */
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
 
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -43,7 +43,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $variableProvideMock = $this->createMock(StandardVariableProvider::class);
         $variableProvideMock->expects(self::once())->method('get')->with('resultSet')->willReturn($searchResultSetMock);
 
-        /* @var MockObject|RenderingContext $renderContextMock */
+        /** @var MockObject|RenderingContext $renderContextMock */
         $renderContextMock = $this->createMock(RenderingContext::class);
         $renderContextMock->expects(self::any())->method('getVariableProvider')->willReturn($variableProvideMock);
         $renderContextMock->expects(self::any())->method('getRequest')->willReturn($mockedControllerRequest);
@@ -51,7 +51,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $viewHelper = new RemoveAllFacetsViewHelper();
         $viewHelper->setRenderingContext($renderContextMock);
 
-        /* @var MockObject|SearchUriBuilder $searchUriBuilderMock */
+        /** @var MockObject|SearchUriBuilder $searchUriBuilderMock */
         $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
 
         // we expected that the getRemoveAllFacetsUri will be called on the searchUriBuilder in the end.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
   },
   "require-dev": {
     "dg/bypass-finals": "^1.4",
-    "phpspec/prophecy-phpunit":"*",
     "phpunit/phpunit": "^9.5",
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "~0.7.1",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -163,7 +163,7 @@ defined('TYPO3') or die('Access denied.');
     }
 
     // ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
-    /* @var \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration $extensionConfiguration */
+    /** @var \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration $extensionConfiguration */
     $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
         \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration::class
     );


### PR DESCRIPTION
# What this pr does

This change removes prophecy from all tests, as the framework is not actively maintained anymore.

Some tests which check for TypeErrors are removed as this is now part of PHP 8 language.

At the same time, phpstan is raised to level 5.

