### PR TITLE
Prevent PHP warning on getResponseBody in PageBrowserRangeViewHelper

### DIFF
--- a/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
+++ b/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
@@ -61,7 +61,7 @@ class PageBrowserRangeViewHelper extends AbstractSolrFrontendViewHelper
         $numberOfResultsOnPage = $resultSet->getSearchResults()->getCount();
         $numberOfAllResults = $resultSet->getAllResultCount();
 
-        $resultsFrom = $search->getResponseBody()->start + 1;
+        $resultsFrom = ($search->getResponseBody() ? $search->getResponseBody()->start : 0) + 1;
         $resultsTo = $resultsFrom + $numberOfResultsOnPage - 1;
         $variableProvider->add($from, $resultsFrom);
         $variableProvider->add($to, $resultsTo);


### PR DESCRIPTION
# What this pr does

Resolve PHP warning in getResponseBody() method.

# How to test

Just search for "examples" in solr-ddev-site package