### PR TITLE
Remove old txt files for TypoScript

### DIFF
--- a/Configuration/TypoScript/Examples/Ajaxify/setup.txt
+++ b/Configuration/TypoScript/Examples/Ajaxify/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Ajaxify/setup.typoscript'

--- a/Configuration/TypoScript/Examples/BoostQueries/setup.txt
+++ b/Configuration/TypoScript/Examples/BoostQueries/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/BoostQueries/setup.typoscript'

--- a/Configuration/TypoScript/Examples/EverythingOn/setup.txt
+++ b/Configuration/TypoScript/Examples/EverythingOn/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/EverythingOn/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/DateRange/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/DateRange/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/DateRange/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/Hierarchy/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/Hierarchy/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/Hierarchy/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/NumericRange/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/NumericRange/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/NumericRange/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/Options/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/Options/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/Options/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Facets/QueryGroup/setup.txt
+++ b/Configuration/TypoScript/Examples/Facets/QueryGroup/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/QueryGroup/setup.typoscript'

--- a/Configuration/TypoScript/Examples/FilterPages/setup.txt
+++ b/Configuration/TypoScript/Examples/FilterPages/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/FilterPages/setup.typoscript'

--- a/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueNews/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript'

--- a/Configuration/TypoScript/Examples/IndexQueueNewsContentElements/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueNewsContentElements/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueNewsContentElements/setup.typoscript'

--- a/Configuration/TypoScript/Examples/IndexQueueTtNews/setup.txt
+++ b/Configuration/TypoScript/Examples/IndexQueueTtNews/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueTtNews/setup.typoscript'

--- a/Configuration/TypoScript/Examples/Suggest/setup.txt
+++ b/Configuration/TypoScript/Examples/Suggest/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript'

--- a/Configuration/TypoScript/OpenSearch/constants.txt
+++ b/Configuration/TypoScript/OpenSearch/constants.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/OpenSearch/constants.typoscript'

--- a/Configuration/TypoScript/OpenSearch/setup.txt
+++ b/Configuration/TypoScript/OpenSearch/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/OpenSearch/setup.typoscript'

--- a/Configuration/TypoScript/Solr/constants.txt
+++ b/Configuration/TypoScript/Solr/constants.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Solr/constants.typoscript'

--- a/Configuration/TypoScript/Solr/setup.txt
+++ b/Configuration/TypoScript/Solr/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/Solr/setup.typoscript'

--- a/Configuration/TypoScript/StyleSheets/setup.txt
+++ b/Configuration/TypoScript/StyleSheets/setup.txt
@@ -1,2 +1,0 @@
-# Important: This file is deprecated and will removed with EXT:solr 12.x
-@import 'EXT:solr/Configuration/TypoScript/StyleSheets/setup.typoscript'


### PR DESCRIPTION
# What this pr does

With TYPO3 12 there is no support for loading the old txt files of TypoScript anymore.