### PR TITLE
[TASK] Housekeeping: Remove cache key from ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,32 +163,7 @@ jobs:
           coverage: pcov
           tools: composer:2.5.5
       -
-        name: Resolve CI build cache key
-        # CI_CACHE_VERSION is used and can be increased to be able to invalidate caches.
-        #    For example if some composer dependencies added or removed in composer.json or
-        #    in Build/Test/bootstrap.sh
-        run: |
-          export CURRENT_TYPO3_VERSION_REFERNCE=$(./Build/Helpers/TYPO3_SOURCE_REFERENCE.sh "$TYPO3_VERSION" --short)
-          export CURRENT_SOLARIUM_VERSION=$(cat composer.json | jq --raw-output '.require."solarium/solarium"')
-          export CI_CACHE_VERSION="2022.12.22@20:00"
-          export CI_BUILD_CACHE_KEY=${{ runner.os }}-PHP:${{ matrix.PHP }}-TYPO3:$TYPO3_VERSION@$CURRENT_TYPO3_VERSION_REFERNCE-SOLARIUM:$CURRENT_SOLARIUM_VERSION-"CI_CACHE_VERSION:"$CI_CACHE_VERSION
-          echo "COMPOSER_GLOBAL_REQUEREMENTS=$(composer config home)" >> $GITHUB_ENV
-          echo "CI_BUILD_CACHE_KEY=$CI_BUILD_CACHE_KEY" >> $GITHUB_ENV
-          echo "The key for actions/cache@v2 is \"$CI_BUILD_CACHE_KEY\""
-      -
-        name: Restore ci build caches
-        id: restore_ci_build_caches
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.CI_BUILD_DIRECTORY }}/Web
-            ${{ env.CI_BUILD_DIRECTORY }}/bin
-            ${{ env.CI_BUILD_DIRECTORY }}/vendor
-            ${{ env.COMPOSER_GLOBAL_REQUEREMENTS }}
-          key: ${{ env.CI_BUILD_CACHE_KEY }}
-      -
         name: CI-Bootstrap
-        if: steps.restore_ci_build_caches.outputs.cache-hit != 'true'
         run: |
           ./Build/Test/bootstrap.sh --skip-solr-install
           echo "Current Size of EXT:Solr build Artefacts before run: " \


### PR DESCRIPTION
# What this pr does

This change removes the cache key from the GitHub workflow as this is "OK" from a time-consuming performance.

Fixes: #3663