### PR TITLE
[TASK] Reduce usages of Util class

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -19,7 +19,6 @@ use ApacheSolrForTypo3\Solr\System\Language\FrontendOverlayService;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Result;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\RelationHandler;
@@ -69,7 +68,6 @@ class Relation extends AbstractContentObject
      * TYPO3-style m:n relations.
      * May resolve single value and multi value relations.
      *
-     * @throws AspectNotFoundException
      * @throws ContentRenderingException
      * @throws DBALException
      *
@@ -104,7 +102,6 @@ class Relation extends AbstractContentObject
      *
      * @return array Array of related items, values already resolved from related records
      *
-     * @throws AspectNotFoundException
      * @throws ContentRenderingException
      * @throws DBALException
      */
@@ -139,7 +136,6 @@ class Relation extends AbstractContentObject
      *
      * @return array Array of related items, values already resolved from related records
      *
-     * @throws AspectNotFoundException
      * @throws ContentRenderingException
      * @throws DBALException
      */
@@ -231,7 +227,6 @@ class Relation extends AbstractContentObject
      *
      * @return array Array of related items, values already resolved from related records
      *
-     * @throws AspectNotFoundException
      * @throws ContentRenderingException
      * @throws DBALException
      */
@@ -298,7 +293,6 @@ class Relation extends AbstractContentObject
      * @param ContentObjectRenderer $parentContentObject cObject
      * @param string $foreignTableName Related record table name
      *
-     * @throws AspectNotFoundException
      * @throws DBALException
      * @throws ContentRenderingException
      */
@@ -399,16 +393,13 @@ class Relation extends AbstractContentObject
     }
 
     /**
-     * Returns current language id fetched from object properties chain TSFE->context->language aspect->id.
+     * Returns current language id fetched from the SiteLanguage
      *
-     * @throws AspectNotFoundException
      * @throws ContentRenderingException
      */
     protected function getLanguageUid(): int
     {
-        return (int)$this->getTypoScriptFrontendController()
-            ->getContext()
-            ->getPropertyFromAspect('language', 'id');
+        return $this->getTypoScriptFrontendController()->getLanguage()->getLanguageId();
     }
 
     /**

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -24,9 +24,7 @@ use ApacheSolrForTypo3\Solr\Mvc\Variable\SolrVariableProvider;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPaginator;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
-use ApacheSolrForTypo3\Solr\Util;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Fluid\View\TemplateView;
@@ -92,7 +90,6 @@ class SearchController extends AbstractBaseController
     /**
      * Results
      *
-     * @throws AspectNotFoundException
      * @throws InvalidFacetPackageException
      *
      * @noinspection PhpUnused Is used by plugin.
@@ -106,7 +103,7 @@ class SearchController extends AbstractBaseController
         try {
             $arguments = $this->request->getArguments();
             $pageId = $this->typoScriptFrontendController->getRequestedId();
-            $languageId = Util::getLanguageUid();
+            $languageId = $this->typoScriptFrontendController->getLanguage()->getLanguageId();
             $searchRequest = $this->getSearchRequestBuilder()->buildForSearch($arguments, $pageId, $languageId);
 
             $searchResultSet = $this->searchService->search($searchRequest);
@@ -187,8 +184,6 @@ class SearchController extends AbstractBaseController
     /**
      * Frequently Searched
      *
-     * @throws AspectNotFoundException
-     *
      * @noinspection PhpUnused Is used by plugin.
      */
     public function frequentlySearchedAction(): ResponseInterface
@@ -197,7 +192,7 @@ class SearchController extends AbstractBaseController
         $searchResultSet = GeneralUtility::makeInstance(SearchResultSet::class);
 
         $pageId = $this->typoScriptFrontendController->getRequestedId();
-        $languageId = Util::getLanguageUid();
+        $languageId = $this->typoScriptFrontendController->getLanguage()->getLanguageId();
         $searchRequest = $this->getSearchRequestBuilder()->buildForFrequentSearches($pageId, $languageId);
         $searchResultSet->setUsedSearchRequest($searchRequest);
 

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -19,10 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\InvalidFacetPackageEx
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
-use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -37,7 +35,6 @@ class SuggestController extends AbstractBaseController
     /**
      * This method creates a suggest json response that can be used in a suggest layer.
      *
-     * @throws AspectNotFoundException
      * @throws DBALException
      * @throws InvalidFacetPackageException
      * @throws NoSolrConnectionFoundException
@@ -64,7 +61,7 @@ class SuggestController extends AbstractBaseController
 
             $additionalFilters = is_array($additionalFilters) ? array_map('htmlspecialchars', $additionalFilters) : [];
             $pageId = $this->typoScriptFrontendController->getRequestedId();
-            $languageId = Util::getLanguageUid();
+            $languageId = $this->typoScriptFrontendController->getLanguage()->getLanguageId();
             $arguments = $this->request->getArguments();
 
             $searchRequest = $this->getSearchRequestBuilder()->buildForSuggest($arguments, $rawQuery, $pageId, $languageId);

--- a/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
+++ b/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\FrequentSearches;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Core\Cache\Frontend\AbstractFrontend;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -98,7 +97,6 @@ class FrequentSearchesService
     /**
      * Gets frequent search terms from the statistics tracking table.
      *
-     * @throws AspectNotFoundException
      * @throws DBALException
      */
     protected function getFrequentSearchTermsFromStatistics(array $frequentSearchConfiguration = []): array
@@ -111,7 +109,7 @@ class FrequentSearchesService
             $checkRootPidWhere = '1';
         }
         if ($frequentSearchConfiguration['select.']['checkLanguage']) {
-            $checkLanguageWhere = ' AND language =' . Util::getLanguageUid();
+            $checkLanguageWhere = ' AND language =' . $this->tsfe->getLanguage()->getLanguageId();
         } else {
             $checkLanguageWhere = '';
         }
@@ -133,8 +131,6 @@ class FrequentSearchesService
 
     /**
      * Returns cache identifier for given $frequentSearchConfiguration
-     *
-     * @throws AspectNotFoundException
      */
     protected function getCacheIdentifier(array $frequentSearchConfiguration): string
     {
@@ -145,7 +141,7 @@ class FrequentSearchesService
             $identifier .= '_RP' . (int)$this->tsfe->tmpl->rootLine[0]['uid'];
         }
         if (isset($frequentSearchConfiguration['select.']['checkLanguage']) && $frequentSearchConfiguration['select.']['checkLanguage']) {
-            $identifier .= '_L' . Util::getLanguageUid();
+            $identifier .= '_L' . $this->tsfe->getLanguage()->getLanguageId();
         }
 
         $identifier .= '_' . md5(serialize($frequentSearchConfiguration));

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -119,12 +119,12 @@ class QueryBuilder extends AbstractQueryBuilder
         string $queryString,
         array $additionalFilters,
         int $requestedPageId,
-        string $groupList,
+        array $frontendUserGroupIds,
     ): SuggestQuery {
         $this->newSuggestQuery($queryString)
             ->useFiltersFromTypoScript()
             ->useSiteHashFromTypoScript($requestedPageId)
-            ->useUserAccessGroups(explode(',', $groupList))
+            ->useUserAccessGroups($frontendUserGroupIds)
             ->useOmitHeader();
 
         if (!empty($additionalFilters)) {

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -20,7 +20,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetProcessor;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
-use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
@@ -78,7 +77,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
             'pid' => $TSFE->id,
             'root_pid' => $root_pid,
             'tstamp' => $this->getTime(),
-            'language' => Util::getLanguageUid(),
+            'language' => $TSFE->getLanguage()->getLanguageId(),
             // @extensionScannerIgnoreLine
             'num_found' => $resultSet->getAllResultCount(),
             'suggestions_shown' => is_object($response->spellcheck->suggestions ?? null) ? (int)get_object_vars($response->spellcheck->suggestions) : 0,

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -78,9 +78,9 @@ class SuggestService
     public function getSuggestions(SearchRequest $searchRequest, array $additionalFilters = []): array
     {
         $requestId = $this->tsfe->getRequestedId();
-        $groupList = Util::getFrontendUserGroupsList();
+        $frontendUserGroupIds = Util::getFrontendUserGroups();
 
-        $suggestQuery = $this->queryBuilder->buildSuggestQuery($searchRequest->getRawUserQuery(), $additionalFilters, $requestId, $groupList);
+        $suggestQuery = $this->queryBuilder->buildSuggestQuery($searchRequest->getRawUserQuery(), $additionalFilters, $requestId, $frontendUserGroupIds);
         $solrSuggestions = $this->getSolrSuggestions($suggestQuery);
 
         if ($solrSuggestions === []) {
@@ -144,13 +144,12 @@ class SuggestService
      * Retrieves the suggestions from the solr server.
      *
      * @throws NoSolrConnectionFoundException
-     * @throws AspectNotFoundException
      * @throws DBALException
      */
     protected function getSolrSuggestions(SuggestQuery $suggestQuery): array
     {
         $pageId = $this->tsfe->getRequestedId();
-        $languageId = Util::getLanguageUid();
+        $languageId = $this->tsfe->getLanguage()->getLanguageId();
         $solr = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($pageId, $languageId);
         $search = GeneralUtility::makeInstance(Search::class, $solr);
         $response = $search->search($suggestQuery, 0, 0);

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -35,7 +35,6 @@ use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -336,9 +335,6 @@ class PageIndexer extends AbstractFrontendHelper
      * Builds the Solr document for the current page.
      *
      * @return Document A document representing the page
-     *
-     * @throws AspectNotFoundException
-     * @throws DBALException
      */
     protected function getPageDocument(TypoScriptFrontendController $tsfe, string $url, Rootline $pageAccessRootline, string $mountPointParameter): Document
     {
@@ -351,7 +347,6 @@ class PageIndexer extends AbstractFrontendHelper
      *
      * @return bool TRUE after successfully indexing the page, FALSE on error
      *
-     * @throws AspectNotFoundException
      * @throws DBALException
      * @throws Exception
      */

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -27,7 +27,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use Doctrine\DBAL\Exception as DBALException;
 use stdClass;
 use Throwable;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -59,7 +58,6 @@ class Search
     /**
      * Search constructor
      *
-     * @throws AspectNotFoundException
      * @throws DBALException
      * @throws NoSolrConnectionFoundException
      */
@@ -71,7 +69,7 @@ class Search
 
         if (is_null($solrConnection)) {
             $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
-            $this->solr = $connectionManager->getConnectionByPageId(($GLOBALS['TSFE']->id ?? 0), Util::getLanguageUid());
+            $this->solr = $connectionManager->getConnectionByPageId(($GLOBALS['TSFE']->id ?? 0), ($GLOBALS['TSFE']?->getLanguage()->getLanguageId() ?? 0));
         }
 
         $this->configuration = Util::getSolrConfiguration();

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -158,25 +158,6 @@ class Util
     }
 
     /**
-     * Returns the current language ID from the active context.
-     *
-     * @throws AspectNotFoundException
-     * @todo: Remove all usages of this method for all usages in isolated/capsuled TSFE approach.
-     */
-    public static function getLanguageUid(): int
-    {
-        return (int)self::getTYPO3CoreContext()->getPropertyFromAspect('language', 'id');
-    }
-
-    /**
-     * @throws AspectNotFoundException
-     */
-    public static function getFrontendUserGroupsList(): string
-    {
-        return implode(',', self::getFrontendUserGroups());
-    }
-
-    /**
      * @throws AspectNotFoundException
      */
     public static function getFrontendUserGroups(): array

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -19,7 +19,6 @@ namespace ApacheSolrForTypo3\Solr\ViewHelpers;
 
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
-use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -110,7 +109,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->add('pageUid', $pageUid);
         // @extensionScannerIgnoreLine
-        $this->getTemplateVariableContainer()->add('languageUid', Util::getLanguageUid());
+        $this->getTemplateVariableContainer()->add('languageUid', ($GLOBALS['TSFE']?->getLanguage()->getLanguageId() ?? 0));
         // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->add('existingParameters', $this->getExistingSearchParameters());
         // @extensionScannerIgnoreLine

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -1592,7 +1592,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
             ->onlyMethods(['useSiteHashFromTypoScript'])
             ->getMock();
 
-        $suggestQuery = $this->builder->buildSuggestQuery('foo', [], 3232, '');
+        $suggestQuery = $this->builder->buildSuggestQuery('foo', [], 3232, []);
         $queryParameters = $this->getAllQueryParameters($suggestQuery);
         self::assertSame('foo', $queryParameters['facet.prefix'], 'Passed query string is not used as facet.prefix argument');
     }
@@ -1614,7 +1614,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
                                 ->onlyMethods(['useSiteHashFromTypoScript'])
                                 ->getMock();
 
-        $suggestQuery = $this->builder->buildSuggestQuery('bar', [], 3232, '');
+        $suggestQuery = $this->builder->buildSuggestQuery('bar', [], 3232, []);
         $queryParameters = $this->getAllQueryParameters($suggestQuery);
         self::assertSame('*:*', $queryParameters['q.alt'], 'Alterntive query is not set to wildcard query by default');
     }


### PR DESCRIPTION
The Util class methods "getLanguageUid()" and "getFrontendUserGroupsList()" have been removed as they can be retrieved differently.

Fixes: #3669
