### PR TITLE
[TASK] Rename previously created PSR-14 events

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -17,9 +17,9 @@ namespace ApacheSolrForTypo3\Solr\Controller;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\InvalidFacetPackageException;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
-use ApacheSolrForTypo3\Solr\Event\Search\AfterFrequentlySearchedEvent;
-use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchEvent;
-use ApacheSolrForTypo3\Solr\Event\Search\FormEvent;
+use ApacheSolrForTypo3\Solr\Event\Search\AfterFrequentlySearchHasBeenExecutedEvent;
+use ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchFormIsShownEvent;
+use ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchResultIsShownEvent;
 use ApacheSolrForTypo3\Solr\Mvc\Variable\SolrVariableProvider;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPaginator;
@@ -124,9 +124,9 @@ class SearchController extends AbstractBaseController
             $pagination = GeneralUtility::makeInstance(ResultsPagination::class, $paginator);
             $pagination->setMaxPageNumbers($this->typoScriptConfiguration->getMaxPaginatorLinks());
 
-            /** @var AfterSearchEvent $afterSearchEvent */
+            /** @var BeforeSearchResultIsShownEvent $afterSearchEvent */
             $afterSearchEvent = $this->eventDispatcher->dispatch(
-                new AfterSearchEvent(
+                new BeforeSearchResultIsShownEvent(
                     $searchResultSet,
                     $this->getAdditionalFilters(),
                     $this->typoScriptConfiguration->getSearchPluginNamespace(),
@@ -163,9 +163,9 @@ class SearchController extends AbstractBaseController
             return $this->handleSolrUnavailable();
         }
 
-        /** @var FormEvent $formEvent */
+        /** @var BeforeSearchFormIsShownEvent $formEvent */
         $formEvent = $this->eventDispatcher->dispatch(
-            new FormEvent(
+            new BeforeSearchFormIsShownEvent(
                 $this->searchService->getSearch(),
                 $this->getAdditionalFilters(),
                 $this->typoScriptConfiguration->getSearchPluginNamespace()
@@ -198,9 +198,9 @@ class SearchController extends AbstractBaseController
 
         $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
 
-        /** @var AfterFrequentlySearchedEvent $afterFrequentlySearchedEvent*/
+        /** @var AfterFrequentlySearchHasBeenExecutedEvent $afterFrequentlySearchedEvent*/
         $afterFrequentlySearchedEvent = $this->eventDispatcher->dispatch(
-            new AfterFrequentlySearchedEvent(
+            new AfterFrequentlySearchHasBeenExecutedEvent(
                 $searchResultSet,
                 $this->getAdditionalFilters()
             )

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -20,7 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Opt
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
-use ApacheSolrForTypo3\Solr\Event\Parser\AfterFacetParsedEvent;
+use ApacheSolrForTypo3\Solr\Event\Parser\AfterFacetIsParsedEvent;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -99,9 +99,9 @@ class OptionsFacetParser extends AbstractFacetParser
         $this->applyReverseOrder($facet, $facetConfiguration);
 
         if (isset($this->eventDispatcher)) {
-            /** @var AfterFacetParsedEvent $afterFacetParsedEvent */
+            /** @var AfterFacetIsParsedEvent $afterFacetParsedEvent */
             $afterFacetParsedEvent = $this->eventDispatcher
-                ->dispatch(new AfterFacetParsedEvent($facet, $facetConfiguration));
+                ->dispatch(new AfterFacetIsParsedEvent($facet, $facetConfiguration));
             $facet = $afterFacetParsedEvent->getFacet();
         }
 

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -19,9 +19,9 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Uri;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
-use ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent;
-use ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent;
-use ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
@@ -305,12 +305,12 @@ class SearchUriBuilder
             $uriCacheTemplate
         );
 
-        $urlEvent = new BeforeReplaceVariableInCachedUrlEvent($uri, $enhancedRouting);
-        /** @var BeforeReplaceVariableInCachedUrlEvent $urlEvent */
+        $urlEvent = new BeforeVariableInCachedUrlAreReplacedEvent($uri, $enhancedRouting);
+        /** @var BeforeVariableInCachedUrlAreReplacedEvent $urlEvent */
         $urlEvent = $this->eventDispatcher->dispatch($urlEvent);
         $uriCacheTemplate = (string)$urlEvent->getUri();
 
-        $variableEvent = new BeforeProcessCachedVariablesEvent(
+        $variableEvent = new BeforeCachedVariablesAreProcessedEvent(
             $uri,
             $routingConfigurations,
             $keys,
@@ -332,7 +332,7 @@ class SearchUriBuilder
             Uri::class,
             $uri
         );
-        $uriEvent = new PostProcessUriEvent($uri, $routingConfigurations);
+        $uriEvent = new AfterUriIsProcessedEvent($uri, $routingConfigurations);
         $this->eventDispatcher->dispatch($uriEvent);
         $uri = $uriEvent->getUri();
         return (string)$uri;

--- a/Classes/Event/Indexing/AfterItemHasBeenIndexedEvent.php
+++ b/Classes/Event/Indexing/AfterItemHasBeenIndexedEvent.php
@@ -21,42 +21,28 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
- * This event is dispatched before the indexing of items starts
+ * This event is dispatched after the indexing of an item
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class BeforeIndexItemsEvent
+final class AfterItemHasBeenIndexedEvent
 {
-    /**
-     * @var array<Item>
-     */
-    private array $items;
+    private Item $item;
 
     private ?IndexQueueWorkerTask $task;
 
     private string $runId;
 
-    public function __construct(array $items, ?IndexQueueWorkerTask $task, string $runId)
+    public function __construct(Item $item, ?IndexQueueWorkerTask $task, string $runId)
     {
-        $this->items = $items;
+        $this->item = $item;
         $this->task = $task;
         $this->runId = $runId;
     }
 
-    /**
-     * @return array<Item>
-     */
-    public function getItems(): array
+    public function getItem(): Item
     {
-        return $this->items;
-    }
-
-    /**
-     * @param array<Item> $items
-     */
-    public function setItems(array $items): void
-    {
-        $this->items = $items;
+        return $this->item;
     }
 
     public function getTask(): ?IndexQueueWorkerTask

--- a/Classes/Event/Indexing/AfterItemsHaveBeenIndexedEvent.php
+++ b/Classes/Event/Indexing/AfterItemsHaveBeenIndexedEvent.php
@@ -21,28 +21,42 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
- * This event is dispatched after the indexing of an item
+ * This event is dispatched after the indexing of items ends
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class AfterIndexItemEvent
+final class AfterItemsHaveBeenIndexedEvent
 {
-    private Item $item;
+    /**
+     * @var array<Item>
+     */
+    private array $items;
 
     private ?IndexQueueWorkerTask $task;
 
     private string $runId;
 
-    public function __construct(Item $item, ?IndexQueueWorkerTask $task, string $runId)
+    public function __construct(array $items, ?IndexQueueWorkerTask $task, string $runId)
     {
-        $this->item = $item;
+        $this->items = $items;
         $this->task = $task;
         $this->runId = $runId;
     }
 
-    public function getItem(): Item
+    /**
+     * @return array<Item>
+     */
+    public function getItems(): array
     {
-        return $this->item;
+        return $this->items;
+    }
+
+    /**
+     * @param array<Item> $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
     }
 
     public function getTask(): ?IndexQueueWorkerTask

--- a/Classes/Event/Indexing/BeforeItemIsIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeItemIsIndexedEvent.php
@@ -25,7 +25,7 @@ use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class BeforeIndexItemEvent
+final class BeforeItemIsIndexedEvent
 {
     private Item $item;
 

--- a/Classes/Event/Indexing/BeforeItemsAreIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeItemsAreIndexedEvent.php
@@ -21,11 +21,11 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
- * This event is dispatched after the indexing of items ends
+ * This event is dispatched before the indexing of items starts
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class AfterIndexItemsEvent
+final class BeforeItemsAreIndexedEvent
 {
     /**
      * @var array<Item>

--- a/Classes/Event/Parser/AfterFacetIsParsedEvent.php
+++ b/Classes/Event/Parser/AfterFacetIsParsedEvent.php
@@ -24,7 +24,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class AfterFacetParsedEvent
+final class AfterFacetIsParsedEvent
 {
     /**
      * The facet that was processed

--- a/Classes/Event/Routing/AfterUriIsProcessedEvent.php
+++ b/Classes/Event/Routing/AfterUriIsProcessedEvent.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\UriInterface;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-class PostProcessUriEvent
+class AfterUriIsProcessedEvent
 {
     /**
      * The router configuration

--- a/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
+++ b/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\UriInterface;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-class BeforeProcessCachedVariablesEvent
+class BeforeCachedVariablesAreProcessedEvent
 {
     /**
      * The uri, used to identify, what placeholder is part of the path and which one is part of the query

--- a/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
+++ b/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\UriInterface;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-class BeforeReplaceVariableInCachedUrlEvent
+class BeforeVariableInCachedUrlAreReplacedEvent
 {
     protected UriInterface $uri;
 

--- a/Classes/Event/Search/AfterFrequentlySearchHasBeenExecutedEvent.php
+++ b/Classes/Event/Search/AfterFrequentlySearchHasBeenExecutedEvent.php
@@ -17,38 +17,32 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Event\Search;
 
-use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
- * This event is triggered before setting the form values
+ * This event is dispatched after the frequently searched was executed.
+ * It contains the result of that search request.
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class FormEvent
+final class AfterFrequentlySearchHasBeenExecutedEvent
 {
-    private Search $search;
+    private SearchResultSet $resultSet;
     private array $additionalFilters;
-    private string $pluginNamespace;
 
-    public function __construct(Search $search, array $additionalFilters, string $pluginNamespace)
+    public function __construct(SearchResultSet $resultSet, array $additionalFilters)
     {
-        $this->search = $search;
+        $this->resultSet = $resultSet;
         $this->additionalFilters = $additionalFilters;
-        $this->pluginNamespace = $pluginNamespace;
     }
 
-    public function getSearch(): Search
+    public function getResultSet(): SearchResultSet
     {
-        return $this->search;
+        return $this->resultSet;
     }
 
     public function getAdditionalFilters(): array
     {
         return $this->additionalFilters;
-    }
-
-    public function getPluginNamespace(): string
-    {
-        return $this->pluginNamespace;
     }
 }

--- a/Classes/Event/Search/BeforeSearchFormIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchFormIsShownEvent.php
@@ -17,32 +17,38 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Event\Search;
 
-use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\Search;
 
 /**
- * This event is dispatched after the frequently searched was executed.
- * It contains the result of that search request.
+ * This event is triggered before setting the form values
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class AfterFrequentlySearchedEvent
+final class BeforeSearchFormIsShownEvent
 {
-    private SearchResultSet $resultSet;
+    private Search $search;
     private array $additionalFilters;
+    private string $pluginNamespace;
 
-    public function __construct(SearchResultSet $resultSet, array $additionalFilters)
+    public function __construct(Search $search, array $additionalFilters, string $pluginNamespace)
     {
-        $this->resultSet = $resultSet;
+        $this->search = $search;
         $this->additionalFilters = $additionalFilters;
+        $this->pluginNamespace = $pluginNamespace;
     }
 
-    public function getResultSet(): SearchResultSet
+    public function getSearch(): Search
     {
-        return $this->resultSet;
+        return $this->search;
     }
 
     public function getAdditionalFilters(): array
     {
         return $this->additionalFilters;
+    }
+
+    public function getPluginNamespace(): string
+    {
+        return $this->pluginNamespace;
     }
 }

--- a/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
@@ -25,7 +25,7 @@ use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-final class AfterSearchEvent
+final class BeforeSearchResultIsShownEvent
 {
     private SearchResultSet $resultSet;
     private array $additionalFilters;

--- a/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 
-use ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -27,13 +27,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  *
- * @noinspection PhpUnused Listener for {@link BeforeProcessCachedVariablesEvent}
+ * @noinspection PhpUnused Listener for {@link BeforeCachedVariablesAreProcessedEvent}
  */
 class CachedPathVariableModifier
 {
     protected RoutingService $routingService;
 
-    public function __invoke(BeforeProcessCachedVariablesEvent $event): void
+    public function __invoke(BeforeCachedVariablesAreProcessedEvent $event): void
     {
         if (!$event->hasRouting()) {
             return;

--- a/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 
-use ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent;
 
 /**
  * This modifier is in use if the URL processed by a route enhancer
@@ -28,7 +28,7 @@ use ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent;
  */
 class CachedUrlModifier
 {
-    public function __invoke(BeforeReplaceVariableInCachedUrlEvent $event): void
+    public function __invoke(BeforeVariableInCachedUrlAreReplacedEvent $event): void
     {
         // Do not react on routing events
         if (!$event->hasRouting()) {

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 
-use ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent;
+use ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -28,7 +28,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PostEnhancedUriProcessor
 {
-    public function __invoke(PostProcessUriEvent $event): void
+    public function __invoke(AfterUriIsProcessedEvent $event): void
     {
         if (!$event->hasRouting()) {
             return;

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -50,6 +50,30 @@ Related hooks around this system have been moved to PSR-14 events as well:
   been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Search\AfterSearchHasBeenExecutedEvent`
 
 
+SignalSlots replaced by PSR-14 events
+-------------------------------------
+
+The previously available Extbase Signals have been removed from EXT:solr in favor of PSR-14 Events.
+
+* The signal :php:`ApacheSolrForTypo3\Solr\Domain\Index\IndexService::beforeIndexItems`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Indexing\BeforeItemsAreIndexedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Domain\Index\IndexService::beforeIndexItem`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Indexing\BeforeItemIsIndexedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Domain\Index\IndexService::afterIndexItem`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Indexing\AfterItemHasBeenIndexedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Domain\Index\IndexService::afterIndexItems`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Indexing\AfterItemsHaveBeenIndexedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionFacetParser::optionsParsed`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Parser\AfterFacetIsParsedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Controller\SearchController::resultsAction`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchResultIsShownEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Controller\SearchController::formAction`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchFormIsShownEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Controller\SearchController::frequentlySearchedAction`
+  has been replaced by :php:`ApacheSolrForTypo3\Solr\Event\Search\AfterFrequentlySearchHasBeenExecutedEvent`
+* The signal :php:`ApacheSolrForTypo3\Solr\Controller\SearchController::beforeSearch`
+  has been removed (see the new PSR-14 events below)
+
 Hooks replaced by PSR-14 events
 -------------------------------
 
@@ -89,6 +113,14 @@ is now superseded by the PSR-14 event :php:`ApacheSolrForTypo3\Solr\Event\Indexi
 The hook :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessIndexQueueUpdateItem']`
 is now superseded by the PSR-14 event :php:`ApacheSolrForTypo3\Solr\Event\Indexing\AfterIndexQueueItemHasBeenMarkedForReindexingEvent`
 
+PSR-14 events renamed
+---------------------
+
+Previous PSR-14 events have been renamed to be consistent with other PSR-14 Events in EXT:solr.
+
+* :php:`ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent` is now named :php:`ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent`
+* :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent` is now named :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent`
+* :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent` is now named :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent`
 
 Frontend Helper Changes
 -----------------------


### PR DESCRIPTION
New namings:

* `ApacheSolrForTypo3\Solr\Event\Indexing\AfterIndexItemEvent` is now called `ApacheSolrForTypo3\Solr\Event\Indexing\AfterItemHasBeenIndexedEvent`
* `ApacheSolrForTypo3\Solr\Event\Indexing\AfterIndexItemsEvent` is now called `ApacheSolrForTypo3\Solr\Event\Indexing\AfterItemsHaveBeenIndexedEvent`
* `ApacheSolrForTypo3\Solr\Event\Indexing\BeforeIndexItemEvent` is now called `ApacheSolrForTypo3\Solr\Event\Indexing\BeforeItemIsIndexedEvent`
* `ApacheSolrForTypo3\Solr\Event\Indexing\BeforeIndexItemsEvent` is now called `ApacheSolrForTypo3\Solr\Event\Indexing\BeforeItemsAreIndexedEvent`
* `ApacheSolrForTypo3\Solr\Event\Parser\AfterFacetParsedEvent` is now called `ApacheSolrForTypo3\Solr\Event\Parser\AfterFacedIsParsedEvent`
* `ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent` is now called `ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent`
* `ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent` is now called `ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent`
* `ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent` is now called `ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent`
* `ApacheSolrForTypo3\Solr\Event\Search\AfterFrequentlySearchedEvent` is now called `ApacheSolrForTypo3\Solr\Event\Search\AfterFrequentlySearchHasBeenExecutedEvent`
* `ApacheSolrForTypo3\Solr\Event\Search\AfterSearchEvent` is now called `ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchResultIsShownEvent`
* `ApacheSolrForTypo3\Solr\Event\Search\FormEvent` is now called `ApacheSolrForTypo3\Solr\Event\Search\BeforeSearchFormIsShownEvent`

Fixes: #3681

