### PR TITLE
 !!![TASK] Don't index shortcut pages anymore

### DIFF
--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -30,7 +30,7 @@ plugin.tx_solr {
         initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
 
         // allowed page types (doktype) when indexing records from table "pages"
-        allowedPageTypes = 1,4,7
+        allowedPageTypes = 1,7
 
         indexingPriority = 0
 
@@ -40,7 +40,7 @@ plugin.tx_solr {
         }
 
         // Only index standard pages and mount points that are not overlayed.
-        additionalWhereClause = (doktype = 1 OR doktype=4 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
+        additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
 
         //exclude some html parts inside TYPO3SEARCH markers by classname (comma list)
         excludeContentByClass = typo3-search-exclude

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -388,7 +388,7 @@ queue.pages.allowedPageTypes
 :Type: List of Integers
 :TS Path: plugin.tx_solr.index.queue.pages.allowedPageTypes
 :Since: 3.0
-:Default: 1,4,7
+:Default: 1,7
 
 Allows to set the pages types allowed to be indexed.
 

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -122,6 +122,13 @@ Previous PSR-14 events have been renamed to be consistent with other PSR-14 Even
 * :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent` is now named :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent`
 * :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent` is now named :php:`ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent`
 
+!!! Shortcut pages not indexed anymore
+----------------------------------
+
+Currently there is no important reason to index the shortcut pages,
+because the target pages are indexed as expected and the shortcuts are 307-redirected to their targets.
+So contents can be found in search results as expected.
+
 Frontend Helper Changes
 -----------------------
 


### PR DESCRIPTION
Currently there is no important reason to index the shortcut pages, because the target pages are indexed as expected and the shortcuts are 307-redirected to their targets. So contents can be found in search results as expected.

Fixes: #3685