### PR TITLE
[TASK] Make it possible to change solr unix GID:UID on docker image build

### DIFF
--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -2,8 +2,16 @@ FROM solr:9.2
 MAINTAINER dkd Internet Service GmbH <solr-eb-support@dkd.de>
 ENV TERM linux
 
+ARG SOLR_UNIX_UID="8983"
+ARG SOLR_UNIX_GID="8983"
+
 USER root
-RUN rm -fR /opt/solr/server/solr/*
+RUN rm -fR /opt/solr/server/solr/* \
+  && usermod --non-unique --uid "${SOLR_UNIX_UID}" solr \
+  && groupmod --non-unique --gid "${SOLR_UNIX_GID}" solr \
+  && chown -R solr:solr /var/solr /opt/solr \
+  && apt update && apt upgrade -y && apt install sudo -y \
+  && echo "solr ALL=NOPASSWD: /docker-entrypoint-initdb.d/as-sudo/*" > /etc/sudoers.d/solr
 COPY Docker/SolrServer/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d
 USER solr
 

--- a/Docker/SolrServer/docker-entrypoint-initdb.d/as-sudo-tweaks.sh
+++ b/Docker/SolrServer/docker-entrypoint-initdb.d/as-sudo-tweaks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# execute files in /docker-entrypoint-initdb.d/as-sudo/*.sh before starting solr
+while read -r f; do
+    case "$f" in
+        *.sh)     echo "$0: running 'sudo $f'"; sudo "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/as-sudo/ -mindepth 1 -type f | sort -n)

--- a/Docker/SolrServer/docker-entrypoint-initdb.d/as-sudo/fix-file-permissions.sh
+++ b/Docker/SolrServer/docker-entrypoint-initdb.d/as-sudo/fix-file-permissions.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+chown -R solr:solr /var/solr /opt/solr


### PR DESCRIPTION
This change makes it possible to change solr unix GID:UID on docker image build time. It is required for dev. environments and custom setups of EXT:solr docker containers.