### PR TITLE
 [RELEASE] 11.5.3 - Maintenance Release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Used versions (please complete the following information):**
  - TYPO3 Version: [e.g. 11.5.26]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 11.5.2]
+ - EXT:solr Version: [e.g. 11.5.3]
  - Used Apache Solr Version: [e.g. 8.11.1]
  - PHP Version: [e.g. 8.1.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -7,6 +7,15 @@
 Apache Solr for TYPO3 11.5
 ==========================
 
+Apache Solr for TYPO3 11.5.3
+============================
+
+This is a maintenance release for TYPO3 11.5, containing:
+
+- [BUGFIX] make CE search form in backend editable again by @rr-it in `#3626 <https://github.com/TYPO3-Solr/ext-solr/pull/3626>`__
+- [DOC] Fix wrong type for boostQuery in the docs and example by @dkd-kaehm in `#3e7ff72 <https://github.com/TYPO3-Solr/ext-solr/commit/3e7ff72b7bc8ddd9cb7f5b7e998a328773483dfb>`__
+- [TASK] Fix unit tests for 2023.06.07 by @dkd-kaehm in `#3695 <https://github.com/TYPO3-Solr/ext-solr/pull/3695>`__
+
 Apache Solr for TYPO3 11.5.2
 ============================
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -5,7 +5,7 @@
 
 project     = Apache Solr for TYPO3
 version     = 11.5
-release     = 11.5.2
+release     = 11.5.3
 copyright   = since 2009 by dkd & contributors
 
 [html_theme_options]

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '11.5.2',
+    'version' => '11.5.3',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich',


### PR DESCRIPTION
This is a maintenance release for TYPO3 11.5, containing:

* [BUGFIX] make CE search form in backend editable again by @rr-it in https://github.com/TYPO3-Solr/ext-solr/pull/3626
* [DOC] Fix wrong type for boostQuery in the docs and example by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/commit/3e7ff72b7bc8ddd9cb7f5b7e998a328773483dfb
*  [TASK] Fix unit tests for 2023.06.07 by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3695

Please read the release notes:
https://github.com/TYPO3-Solr/ext-solr/releases/tag/11.5.3

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0