### PR TITLE
[RELEASE] 11.2.3 - Maintenance Release (last non ELTS)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Used versions (please complete the following information):**
  - TYPO3 Version: [e.g. 10.4.23]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 11.2.2]
+ - EXT:solr Version: [e.g. 11.2.3]
  - Used Apache Solr Version: [e.g. 8.11.1]
  - PHP Version: [e.g. 7.4.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Releases/solr-release-11-2.rst
+++ b/Documentation/Releases/solr-release-11-2.rst
@@ -7,13 +7,21 @@
 Apache Solr for TYPO3 11.2
 ==========================
 
-Apache Solr for TYPO3 11.2.2 - Last non ELTS release
+Apache Solr for TYPO3 11.2.3 - Last non ELTS release
 ====================================================
 
 This is a maintenance release for TYPO3 10.4 and the last non ELTS release, as TYPO3 10 LTS reaches the ELTS phase on April 30, 2023.
 
 EXT:solr release-11.2.x will not be maintained in `TYPO3-Solr/ext-solr <https://github.com/TYPO3-Solr/ext-solr/>`__ repository any more. The maintenance and builds will be moved to a private
-repository and ELTS versions, EXT:solr 11.2.3+ for TYPO3 10 ELTS versions, can be obtained through the `dkd EB program <https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/>`__.
+repository and ELTS versions, EXT:solr 11.2.4+ for TYPO3 10 ELTS versions, can be obtained through the `dkd EB program <https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/>`__.
+
+This release contains:
+
+- [BUGFIX:P:11.2] make CE search form in backend editable again by @dkd-kaehm in `#3640 <https://github.com/TYPO3-Solr/ext-solr/pull/3640>`__
+* [DOC] Fix wrong type for boostQuery in the docs and example by @rr-it  and @dkd-kaehm in `a997a2f4 <https://github.com/TYPO3-Solr/ext-solr/commit/a997a2f464462bc998aa755215f765e5efc6f172>`__
+
+Apache Solr for TYPO3 11.2.2
+============================
 
 This release contains:
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -5,7 +5,7 @@
 
 project     = Apache Solr for TYPO3
 version     = 11.2
-release     = 11.2.2
+release     = 11.2.3
 copyright   = since 2009 by dkd & contributors
 
 [html_theme_options]

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '11.2.2',
+    'version' => '11.2.3',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich',


### PR DESCRIPTION
This is a maintenance release for TYPO3 10.4 and the last non ELTS release, as TYPO3 10 LTS reaches the ELTS phase on April 30, 2023.

EXT:solr release-11.2.x will not be maintained in this public repository any more. The maintenance and builds will be moved to a private repository and ELTS versions, EXT:solr 11.2.3+ for TYPO3 10 ELTS versions, can be obtained through the dkd EB program (https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3).

This release contains:

* [BUGFIX:P:11.2] make CE search form in backend editable again by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3640
* [DOC] Fix wrong type for boostQuery in the docs and example by @rr-it  and @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/commit/a997a2f464462bc998aa755215f765e5efc6f172

Please read the release notes:
https://github.com/TYPO3-Solr/ext-solr/releases/tag/11.2.3

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0