### PR TITLE
 [BUGFIX] Hierarchy facet items containing dashes cannot be unset

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
@@ -128,7 +128,7 @@ class HierarchyFacetParser extends AbstractFacetParser
 
         foreach ($values as $valueFromRequest) {
             // Attach the 'depth' param again to the value
-            if (!str_contains($valueFromRequest, '-')) {
+            if (preg_match('/^[0-9]+-/', $valueFromRequest)) {
                 $valueFromRequest = HierarchyTool::substituteSlashes($valueFromRequest);
                 $valueFromRequest = trim($valueFromRequest, '/');
                 $valueFromRequest = (count(explode('/', $valueFromRequest)) - 1) . '-' . $valueFromRequest . '/';


### PR DESCRIPTION
If you try to apply the hierarchy facet to a path of UUIDs instead of integers the facet can be selected, but not unselected anymore. This happens because the HierarchyFacetParser assumes that every value containing a dash is one that already contains the depth param. Which is not the case when dealing with uuids like /228d03bf-de44-4fcd-91fd-6ab05175fefc/901d43ca-28cf-4dbd-983d-ac96a0930530/a3f94d07-30fe-4ad1-a0cf-b5082db3aa94/.

This fix introduces a check that matches the value against the depth param pattern.

Replaces: #3070 by @tmaroschik

---
### Todos:

- [ ] cover this case with tests
- [ ] make functional, because it breaks
  - [ ]  HierarchyFacetParserTest::selectedOptionWithSlashInTitleOnHierarchicalFacetDoesNotBreakTheFacet
  - [ ] HierarchyFacetParserTest::facetIsActive
- [ ] port into release-11.5.x

### Broken tests:

```
1) ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacetParserTest::selectedOptionWithSlashInTitleOnHierarchicalFacetDoesNotBreakTheFacet
Selected facet-option with slash in title/name breaks the Hierarchical facets.
Failed asserting that 0 is identical to 1.

/home/runner/work/ext-solr/ext-solr/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php:165
/home/runner/work/ext-solr/ext-solr/.Build/bin/phpunit:123

2) ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacetParserTest::facetIsActive
Expected to have 15 sub items below path /1/14/
Failed asserting that 0 is identical to 15.

/home/runner/work/ext-solr/ext-solr/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php:223
/home/runner/work/ext-solr/ext-solr/.Build/bin/phpunit:123
```