### PR TITLE
[BUGFIX] Force score to float

### DIFF
--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -159,7 +159,7 @@ class SearchResult extends Document
 
     public function getScore(): float
     {
-        return $this->fields['score'] ?? 0.0;
+        return (float)($this->fields['score'] ?? 0.0);
     }
 
     public function getUrl(): string


### PR DESCRIPTION
Force the score to be a float.

TBH: I didn't yet that test that myself but a colleague had the issue and just patched it locally