### PR TITLE
!!![FEATURE] Allow using complex filter values in FlexForm

### DIFF
--- a/Classes/System/Service/ConfigurationService.php
+++ b/Classes/System/Service/ConfigurationService.php
@@ -98,12 +98,13 @@ class ConfigurationService
      */
     protected function getFilterFromFlexForm(array $flexFormConfiguration): array
     {
-        $filterConfiguration = [];
         $filters = ObjectAccess::getPropertyPath($flexFormConfiguration, 'search.query.filter');
 
         if (empty($filters)) {
-            return $filterConfiguration;
+            return [];
         }
+
+        $filterConfiguration = [];
 
         foreach ($filters as $filter) {
             $filter = $filter['field'];
@@ -111,12 +112,17 @@ class ConfigurationService
             $fieldName = $filter['field'];
             $fieldValue = $filter['value'];
 
-            if (!is_numeric($fieldValue) && !str_contains($fieldValue, '?') && !str_contains($fieldValue, '*')) {
-                $fieldValue = '"' . str_replace('"', '\"', $fieldValue) . '"';
+            if (
+                !is_numeric($fieldValue)
+                && !preg_match('/[+\-&|!(){}\[\]^"~*?:\\\\]|AND|NOT|OR/', $fieldValue)
+                && str_contains($fieldValue, ' ')
+            ) {
+                $fieldValue = '"' . $fieldValue . '"';
             }
 
             $filterConfiguration[] = $fieldName . ':' . $fieldValue;
         }
+
         return $filterConfiguration;
     }
 }

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -190,6 +190,24 @@ a minimum by only having two methods available:
 The actual PageIndexerRequest object is now available as a property of TYPO3's
 Request object as attribute named "solr.pageIndexingInstructions".
 
+!!!Complex query in FlexForm filter value
+-----------------------------------------
+
+It is now possible to use complex query in FlexForm filter value.
+If the value contains space and no special characters, the value is always automatically escaped.
+
+The old behaviour is still working,
+so if a string value contains space(s) and no special characters of the solr query parser,
+the string is always wrapped with double quotes.
+But if the string contains special characters no wrapping happen
+special characters are: :php:`+ - && || ! ( ) { } [ ] ^ " ~ * ? : \`
+
+There is some cases where this change can break,
+for example if the filter value is something like
+:php:`toto AND tata` or :php:`music (rock)` or `my "flow" is`.
+Here the wrapping and the escaping of the inner double quote have to be manually updated like this
+:php:`"toto AND tata"` or :php:`"music (rock)"` and :php:`"my \"flow\" is"`.
+
 Contributors
 ============
 
@@ -224,5 +242,3 @@ https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/
 or call:
 
 +49 (0)69 - 2475218 0
-
-


### PR DESCRIPTION
With this PR it is now possible to use complex query in FlexForm filter value.

I add a regex to prevent a too big breaking change. The old behaviour is still working, so if a string value contains space(s) and no special characters of the solr query parser, the string is always wrapped with double quotes. But if the string contains special characters no wrapping happen (special characters are `+ - && || ! ( ) { } [ ] ^ " ~ * ? : \`.

There is some cases where this PR can break, for example if the filter value is something like `toto AND tata` or `music (rock)` or `my "flow" is`. Here the wrapping and the escaping of the inner double quote have to be manually updated like this `"toto AND tata"`, `"music (rock)"` and `"my \"flow\" is"`.

Fixes: #2151
