### PR TITLE
[BUGFIX] Make BeforeSearchResultIsShownEvent more usable

### DIFF
--- a/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Event\Search;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
+use TYPO3\CMS\Core\Pagination\PaginationInterface;
 
 /**
  * This event is triggered before adding the search result to the fluid template
@@ -31,7 +32,7 @@ final class BeforeSearchResultIsShownEvent
     private array $additionalFilters;
     private string $pluginNamespace;
     private array $arguments;
-    private ResultsPagination $pagination;
+    protected PaginationInterface $pagination;
     private int $currentPage;
 
     public function __construct(
@@ -39,7 +40,7 @@ final class BeforeSearchResultIsShownEvent
         array $additionalFilters,
         string $pluginNamespace,
         array $arguments,
-        ResultsPagination $pagination,
+        PaginationInterface $pagination,
         int $currentPage
     ) {
         $this->resultSet = $resultSet;
@@ -70,7 +71,7 @@ final class BeforeSearchResultIsShownEvent
         return $this->arguments;
     }
 
-    public function getPagination(): ResultsPagination
+    public function getPagination(): PaginationInterface
     {
         return $this->pagination;
     }
@@ -78,5 +79,10 @@ final class BeforeSearchResultIsShownEvent
     public function getCurrentPage(): int
     {
         return $this->currentPage;
+    }
+
+    protected function setPagination(PaginationInterface $pagination): void
+    {
+        $this->pagination = $pagination;
     }
 }

--- a/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Event\Search;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
-use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
 use TYPO3\CMS\Core\Pagination\PaginationInterface;
 
 /**
@@ -81,7 +80,7 @@ final class BeforeSearchResultIsShownEvent
         return $this->currentPage;
     }
 
-    protected function setPagination(PaginationInterface $pagination): void
+    public function setPagination(PaginationInterface $pagination): void
     {
         $this->pagination = $pagination;
     }


### PR DESCRIPTION
It would be cool if properties of the event could be changed. Otherwise the event doesn't help much - IMO

I need it e.g. for the pagination to be changed
