### PR TITLE
[TASK] Improve site and document id determination

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -495,8 +495,14 @@ class Indexer extends AbstractIndexer
         $defaultLanguageUid = $this->getDefaultLanguageUid($item, $site->getRootPageRecord(), $siteLanguages);
         $translationOverlays = $this->getTranslationOverlaysWithConfiguredSite((int)$pageId, $site, $siteLanguages);
 
-        $defaultConnection = $this->connectionManager->getConnectionByPageId($rootPageId, $defaultLanguageUid, $item->getMountPointIdentifier() ?? '');
-        $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays);
+        $mountPointIdentifier = $item->getMountPointIdentifier() ?? '';
+        if ($mountPointIdentifier !== '') {
+            $defaultConnection = $this->connectionManager->getConnectionByPageId($rootPageId, $defaultLanguageUid, $mountPointIdentifier);
+        } else {
+            $defaultConnection = $this->connectionManager->getConnectionByRootPageId($rootPageId, $defaultLanguageUid);
+        }
+
+        $translationConnections = $this->getConnectionsForIndexableLanguages($translationOverlays, $rootPageId);
 
         if ($defaultLanguageUid == 0) {
             $solrConnections[0] = $defaultConnection;
@@ -588,20 +594,21 @@ class Indexer extends AbstractIndexer
     /**
      * Checks for which languages connections have been configured for translation overlays and returns these connections.
      *
+     * @param array $translationOverlays
+     * @param int $rootPageId
      * @return SolrConnection[]
      *
      * @throws DBALException
      */
-    protected function getConnectionsForIndexableLanguages(array $translationOverlays): array
+    protected function getConnectionsForIndexableLanguages(array $translationOverlays, int $rootPageId): array
     {
         $connections = [];
 
         foreach ($translationOverlays as $translationOverlay) {
-            $pageId = $translationOverlay['l10n_parent'];
             $languageId = $translationOverlay['sys_language_uid'];
 
             try {
-                $connection = $this->connectionManager->getConnectionByPageId($pageId, $languageId);
+                $connection = $this->connectionManager->getConnectionByRootPageId($rootPageId, $languageId);
                 $connections[$languageId] = $connection;
             } catch (NoSolrConnectionFoundException) {
                 // ignore the exception as we seek only those connections

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -61,7 +62,10 @@ class Util
             $additionalParameters = $mountPointParameter . '/' . $additionalParameters;
         }
 
-        return self::getDocumentId('pages', $uid, $uid, $additionalParameters);
+        $rootPageResolver = GeneralUtility::makeInstance(RootPageResolver::class);
+        $rootPageId = $rootPageResolver->getRootPageId($uid);
+
+        return self::getDocumentId('pages', $rootPageId, $uid, $additionalParameters);
     }
 
     /**
@@ -83,7 +87,7 @@ class Util
         string $additionalIdParameters = '',
     ): string {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        $site = $siteRepository->getSiteByPageId($rootPageId);
+        $site = $siteRepository->getSiteByRootPageId($rootPageId);
         $siteHash = $site->getSiteHash();
 
         $documentId = $siteHash . '/' . $table . '/' . $uid;


### PR DESCRIPTION
# What this pr does

Site and document id determination is improved by using root page ids if already available, so we can dispense with the unnecessary use of the RootPageResolver

Resolves: #3709
