### PR TITLE
Backend user should not be logged out after editing content on hidden pages

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -326,7 +326,7 @@ class Tsfe implements SingletonInterface
         }
         $pageRecord = BackendUtility::getRecord('pages', $pidToUse);
         $isSpacerOrSysfolder = ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SPACER || ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SYSFOLDER;
-        if ($isSpacerOrSysfolder === false) {
+        if ($isSpacerOrSysfolder === false && !$pageRecord['hidden']) {
             return $pidToUse;
         }
         /** @var ConfigurationPageResolver $configurationPageResolver */


### PR DESCRIPTION
# What this pr does

This PR adds a check for page's "hidden" property because hidden pages cannot normally be used for initializing TSFE.

# How to test

Have a tree like this:

```
|- Root
    |- Folder
        |- Hidden page
```

Try editing content on the hidden page.

Fixes: #3702
