### PR TITLE
Enable time-limited pages to be indexed automatically

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -326,7 +326,7 @@ class Tsfe implements SingletonInterface
         }
         $pageRecord = BackendUtility::getRecord('pages', $pidToUse);
         $isSpacerOrSysfolder = ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SPACER || ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SYSFOLDER;
-        if ($isSpacerOrSysfolder === false) {
+        if ($isSpacerOrSysfolder === false && $this->isPageAvailableForTSFE($pageRecord)) {
             return $pidToUse;
         }
         /** @var ConfigurationPageResolver $configurationPageResolver */
@@ -352,6 +352,22 @@ class Tsfe implements SingletonInterface
         }
 
         return $this->getPidToUseForTsfeInitialization($pidToUse, $rootPageId);
+    }
+
+    /**
+     * Checks if the page is available for TSFE.
+     *
+     * @param array $pageRecord
+     * @return bool
+     * @throws \TYPO3\CMS\Core\Context\Exception\AspectNotFoundException
+     */
+    protected function isPageAvailableForTSFE(array $pageRecord): bool
+    {
+        $currentTime = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp');
+        return $pageRecord['hidden'] === 0 &&
+            $pageRecord['starttime'] <= $currentTime &&
+            ($pageRecord['endtime'] === 0 || $pageRecord['endtime'] > 0 && $pageRecord['endtime'] > $currentTime)
+        ;
     }
 
     /**


### PR DESCRIPTION
# What this pr does

This PR allows to pages with publish time in future to be added to the index queue for automatic indexing when they go public.

Notes:

1. The side effect: scheduler task will not be 100% complete with such pages present in the queue.
2. This improves the PR [#3719](https://github.com/TYPO3-Solr/ext-solr/pull/3719)

# How to test

1. Add a page with time in future
3. You can now see that it appeared in the index queue table
4. Run the indexer, the page will not be indexed
5. Wait until publish time & next scheduler run
6. See the page appearing in the solr index
7. Change public time to future again
8. See the page disappearing from the index and being scheduled for indexing

Fixes: #3547, #3702

Related: #3702