### PR TITLE
BUGFIX: Add missing label key to prevent php warning

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -185,7 +185,7 @@ class IndexingConfigurationSelectorField
             'itemFormElID' => $this->formElementName,
             'itemFormElName' => $this->formElementName,
             'itemFormElValue' => $selectedValues,
-            'fieldConf' => ['config' => ['items' => $items]],
+            'fieldConf' => ['label' => '', 'config' => ['items' => $items]],
             'fieldTSConfig' => ['noMatchingValue_label' => ''],
         ];
 


### PR DESCRIPTION
Undefined array key "label" in vendor/typo3/cms-backend/Classes/Form/Element/AbstractFormElement.php line 146

# What this pr does

Please add a description here

# How to test

Please add a testing instruction here

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
