### PR TITLE
[BUGFIX] Handle float values in options facet parser

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -121,7 +121,7 @@ class OptionsFacetParser extends AbstractFacetParser
         foreach ($response->facets->{$facetName}->buckets as $bucket) {
             $optionValue = $bucket->val;
             $optionCount = $bucket->count;
-            $optionsFromSolrResponse[$optionValue] = $optionCount;
+            $optionsFromSolrResponse[(string)$optionValue] = $optionCount;
         }
 
         return $optionsFromSolrResponse;

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\OptionBased\Options;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacetParser;
+use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
+use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+
+class OptionsFacetParserTest extends SetUpUnitTestCase
+{
+    /**
+     * @test
+     */
+    public function canListFloatValuesAsOptionsFromSolrResponse(): void
+    {
+        $responseAdapter = new ResponseAdapter(
+            /* @lang JSON */
+            '{
+              "facets": {
+                "floatOptions": {
+                  "buckets": [
+                    { "val": 0.001, "count": 1 },
+                    { "val": 0.002, "count": 2 },
+                    { "val": 0.003, "count": 3 }
+                  ]
+                }
+              }
+            }'
+        );
+        $optionsFacetParser = $this->getAccessibleMock(
+            OptionsFacetParser::class,
+            null,
+            [],
+            '',
+            false
+        );
+        /** @link OptionsFacetParser::getOptionsFromSolrResponse */
+        $optionsArray = $optionsFacetParser->_call(
+            'getOptionsFromSolrResponse',
+            'floatOptions',
+            $responseAdapter,
+        );
+        self::assertCount(3, $optionsArray, 'EXT:solr can not list floats in facets.');
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -97,10 +97,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         self::assertEquals('options', $myFacet->getType());
     }
 
-    /**
-     * @return array
-     */
-    public function getIncludeInAvailableFacetsDataProvider()
+    public function getIncludeInAvailableFacetsDataProvider(): array
     {
         return [
             'default' => [null, true],
@@ -112,15 +109,23 @@ class OptionsFacetTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param mixed $includeInAvailableFacetsConfiguration
-     * @param mixed $expectedResult
      * @dataProvider getIncludeInAvailableFacetsDataProvider
      * @test
      */
-    public function getIncludeInAvailableFacets($includeInAvailableFacetsConfiguration, $expectedResult)
-    {
+    public function getIncludeInAvailableFacetsCastsSettingsToBoolProperly(
+        null|int|string $includeInAvailableFacetsConfiguration,
+        bool $expectedResult,
+    ): void {
         $resultSetMock = $this->createMock(SearchResultSet::class);
-        $myFacet = new OptionsFacet($resultSetMock, 'myFacet', 'myFacetFieldName', 'myTitle', ['includeInAvailableFacets' => $includeInAvailableFacetsConfiguration]);
+        $myFacet = new OptionsFacet(
+            $resultSetMock,
+            'myFacet',
+            'myFacetFieldName',
+            'myTitle',
+            [
+                'includeInAvailableFacets' => $includeInAvailableFacetsConfiguration,
+            ],
+        );
 
         self::assertSame($myFacet->getIncludeInAvailableFacets(), $expectedResult, 'Method getIncludeInAvailableFacets returns unexpected result');
     }


### PR DESCRIPTION
# What this pr does

Cast solr value to string to handle float values correctly.
When the result values are 0.01, 0.02, 0.03 the last count wins with the array key 0
see https://3v4l.org/2LOHk#v8.1.20

# Version
Tested on dev-master with TYPO3 12.4.3

### Maintainers notes:

Port:

- [x] release-11.0.x/ELTS
- [x] release-11.2.x/ELTS
- [x] release-11.5.x