### PR TITLE
[BUGFIX] Fix TypeError in SearchFormViewHelper

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -198,7 +198,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         $suggestUrl = $this->uriBuilder
             ->reset()
             ->setTargetPageUid($pageUid)
-            ->setTargetPageType($this->arguments['suggestPageType'])
+            ->setTargetPageType((int)$this->arguments['suggestPageType'])
             ->setArguments([$pluginNamespace => ['additionalFilters' => $additionalFilters]])
             ->build();
 
@@ -212,7 +212,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         return $this->uriBuilder
             ->reset()
             ->setTargetPageUid($pageUid)
-            ->setTargetPageType($this->arguments['pageType'] ?? 0)
+            ->setTargetPageType((int)($this->arguments['pageType'] ?? 0))
             ->setNoCache($this->arguments['noCache'] ?? false)
             ->setArguments($this->arguments['additionalParams'] ?? [])
             ->setCreateAbsoluteUri($this->arguments['absolute'] ?? false)


### PR DESCRIPTION
Problem:
Calling the `s:searchForm` ViewHelper with the `pageType` or `suggestPageType` argument with a value from a typoscript setting will lead to a TypeError

```html
<s:searchForm pageType="{settings.pageType}" suggestPageType="{settings.suggestPageType}">
```

`TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder::setTargetPageType(): Argument #1 ($targetPageType) must be of type int, string given, called in /var/www/html/private/typo3conf/ext/solr/Classes/ViewHelpers/SearchFormViewHelper.php`

Solution:
Cast both arguments to int