### PR TITLE
[BUGFIX] fix null-pointer-exception in AbstractStrategy

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -99,6 +99,11 @@ abstract class AbstractStrategy
                 continue;
             }
 
+            if ($site === null) {
+                $this->queue->deleteItem($indexQueueItem->getType(), $indexQueueItem->getIndexQueueUid());
+                continue;
+            }
+
             $enableCommitsSetting = $site->getSolrConfiguration()->getEnableCommits();
             $siteHash = $site->getSiteHash();
             // a site can have multiple connections (cores / languages)


### PR DESCRIPTION
# What this pr does

Fixes a null-pointer-exception that occurred when the "page type" field of a hidden root page was changed.

# How to test

We weren't able to re-create the issue on a mirrored instance, since the corresponding index-queue item could not be created via the "Index Queue" TYPO3 backend module. We directly imported the database record for reproduction. It's possible that such an item cannot be created during normal operations.

We checked the patch on TYPO3 11 with PHP 8 against the 11.5.3 release.