### PR TITLE
[BUGFIX] handle localizations with un-available tsfe more gracefully

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -259,9 +259,14 @@ class Indexer extends AbstractIndexer
 
         $pidToUse = $this->getPageIdOfItem($item);
 
-        return GeneralUtility::makeInstance(Tsfe::class)
-            ->getTsfeByPageIdAndLanguageId($pidToUse, $language, $item->getRootPageUid())
-            ->sys_page->getLanguageOverlay($item->getType(), $itemRecord);
+        $globalTsfe = GeneralUtility::makeInstance(Tsfe::class);
+        $specializedTsfe = $globalTsfe->getTsfeByPageIdAndLanguageId($pidToUse, $language, $item->getRootPageUid());
+
+        if ($specializedTsfe === null) {
+            return null;
+        }
+
+        return $specializedTsfe->sys_page->getLanguageOverlay($item->getType(), $itemRecord);
     }
 
     protected function isAFreeContentModeItemRecord(Item $item): bool


### PR DESCRIPTION
Given the following scenario:
- non-localized root page for multi-language site
- below this root page is a localized folder
- inside that localized folder are localized record to index

Since TypoScriptFrontendController is not initialized for sys_folder page records, it'll walk up to the parent page and try to initialize TypoScriptFrontendController for it. However, this isn't possible in the given scenario because the page isn't localized into all languages. Tsfe::getTsfeByPageIdAndLanguageId() returns null in this case, which triggers a NullPointerException when getLanguageOverlay() is called on it. When the NPE is thrown none of the localizations of the item will be indexed, even though some could have been successfully indexed.

This change checks aborts the operation when the specific TypoScriptFrontendController for the item is null, which causes queue items for which TypoScriptFrontendController could not be initialized to not get indexed.

# How to test

1. Have the following setup:
   - a site with multiple languages configured
   - the root page of that site is not localized for one of the languages
   - below the root page is a folder page record which localizations for all configured langauges
   - inside the folder page are database records for which an indexing configuration exists. They're also localized.
2. index the database records (manually via index queue backend module works too)

I tested the change in TYPO3 11.5.30 and ext-solr 11.5.3
