### PR TITLE
[BUGFIX] Prevent indexing error on missing 'foreignLabelField'

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -352,7 +352,8 @@ class Relation extends AbstractContentObject
             // adjust configuration for next level
             $this->configuration['localField'] = $foreignTableLabelField;
             $parentContentObject->data = $relatedRecord;
-            if (strpos($this->configuration['foreignLabelField'], '.') !== false) {
+            if (isset($this->configuration['foreignLabelField']) &&
+                strpos($this->configuration['foreignLabelField'], '.') !== false) {
                 list(, $this->configuration['foreignLabelField']) = explode(
                     '.',
                     $this->configuration['foreignLabelField'],


### PR DESCRIPTION
Prevent indexing error on missing 'foreignLabelField' of SOLR_RELATION

Related: #3734