### PR TITLE
[BUGFIX:BP:11.5] Fix EXT:solr route enhancer

### DIFF
--- a/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
@@ -52,7 +52,7 @@ class CachedPathVariableModifier
 
         $this->routingService = GeneralUtility::makeInstance(
             RoutingService::class,
-            $enhancerConfiguration['solr'],
+            $enhancerConfiguration['solr'] ?? [],
             (string)$enhancerConfiguration['extensionKey']
         );
 

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -38,7 +38,7 @@ class PostEnhancedUriProcessor
         /* @var RoutingService $routingService */
         $routingService = GeneralUtility::makeInstance(
             RoutingService::class,
-            $configuration['solr'],
+            $configuration['solr'] ?? [],
             (string)$configuration['extensionKey']
         );
 

--- a/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
+++ b/Classes/Routing/Enhancer/SolrFacetMaskAndCombineEnhancer.php
@@ -326,7 +326,7 @@ class SolrFacetMaskAndCombineEnhancer extends AbstractEnhancer implements Routin
     {
         return GeneralUtility::makeInstance(
             RoutingService::class,
-            $this->configuration['solr'],
+            $this->configuration['solr'] ?? [],
             (string)$this->configuration['extensionKey']
         )->withPathArguments($this->configuration['_arguments']);
     }

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -87,14 +87,11 @@ class SolrRoutingMiddlewareTest extends UnitTest
      * @test
      * @covers \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::process
      */
-    public function missingEnhancerHasNoEffectTest()
+    public function missingEnhancerHasNoEffectTest(): void
     {
         $serverRequest = new ServerRequest(
             'GET',
             'https://domain.example/facet/bar,buz,foo',
-            [
-                PageIndexerRequest::SOLR_INDEX_HEADER => '1',
-            ]
         );
         $siteMatcherMock = $this->getMockBuilder(SiteMatcher::class)
             ->disableOriginalConstructor()
@@ -142,6 +139,30 @@ class SolrRoutingMiddlewareTest extends UnitTest
         self::assertEquals(
             '/facet/bar,buz,foo',
             $uri->getPath()
+        );
+    }
+
+    /**
+     * @test
+     * @covers \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::process
+     */
+    public function enhancerInactiveDuringIndexingTest(): void
+    {
+        $serverRequest = new ServerRequest(
+            'GET',
+            'https://domain.example/',
+            [
+                PageIndexerRequest::SOLR_INDEX_HEADER => '1',
+            ]
+        );
+
+        $this->routingServiceMock->expects(self::never())->method('getSiteMatcher');
+        $solrRoutingMiddleware = new SolrRoutingMiddleware();
+        $solrRoutingMiddleware->setLogger(new NullLogger());
+        $solrRoutingMiddleware->injectRoutingService($this->routingServiceMock);
+        $solrRoutingMiddleware->process(
+            $serverRequest,
+            $this->responseOutputHandler
         );
     }
 }


### PR DESCRIPTION
Backport of #3742 
---

# What this pr does

SolrRoutingMiddleware was limited to indexing processs, but as the SolrFacetMaskAndCombineEnhancer requires this middleware to add the required parameters from the route path, this limitation causes that the route enhancer is ineffective.

This commit fixes this issue by reenabling the middleware for frontend requests and also ensures that route paths can be resolved correctly if PageTypeSuffix enhancer is active.

# How to test

Configure route enhancer:
- SolrFacetMaskAndCombineEnhancer
- PageTypeSuffix 

With this commit
- EXT:solr can handle and react to facet parameters in route path
- no warning `Could not resolve page by path "menu.json" and language "de"` if requesting a specific page type on root page
- no TypeError occurs if no options are passed to the SolrFacetMaskAndCombineEnhancer via `solr`

Ports: #3742 
Relates: #3202
Resolves: #3741
