### PR TITLE
[TASK] Disallow superfluous annotations in sources

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,7 +9,14 @@ $config
             'ordered_imports' => [
                 'imports_order' => ['class', 'function', 'const'],
                 'sort_algorithm' => 'alpha'
-            ]
+            ],
+            'general_phpdoc_annotation_remove' => [
+                'annotations' => [
+                    'author', 'autor',
+                    'copyright',
+                ]
+            ],
+            'no_superfluous_phpdoc_tags' => true
         ],
     )
     ->getFinder()

--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -53,8 +53,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  * In this case the lower case R tells us that we're dealing with a record
  * like tt_news or the like. For records the groups are checked using OR
  * instead of using AND as it would be the case with content elements.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Rootline
 {

--- a/Classes/Access/RootlineElement.php
+++ b/Classes/Access/RootlineElement.php
@@ -20,8 +20,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * An element in the "Access Rootline". Represents the frontend user group
  * access restrictions for a page, a page's content, or a generic record.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class RootlineElement
 {

--- a/Classes/Access/RootlineElementFormatException.php
+++ b/Classes/Access/RootlineElementFormatException.php
@@ -19,8 +19,6 @@ use InvalidArgumentException;
 
 /**
  * Signals a wrong format for the access definition of a page or the content.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class RootlineElementFormatException extends InvalidArgumentException
 {

--- a/Classes/Api.php
+++ b/Classes/Api.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr;
 
 /**
  * Remote API related methods
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Api
 {

--- a/Classes/Backend/CoreSelectorField.php
+++ b/Classes/Backend/CoreSelectorField.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Core selector form field.
- *
- * @author Jens Jacobsen <typo3@jens-jacobsen.de>
  */
 class CoreSelectorField
 {

--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Index Queue indexing configuration selector form field.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class IndexingConfigurationSelectorField
 {

--- a/Classes/Backend/SiteSelectorField.php
+++ b/Classes/Backend/SiteSelectorField.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * SiteSelectorField
  *
  * Responsible for generating SiteSelectorField
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class SiteSelectorField
 {

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -34,8 +34,6 @@ use function json_encode;
 
 /**
  * ConnectionManager is responsible to create SolrConnection objects.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class ConnectionManager implements SingletonInterface
 {

--- a/Classes/ContentObject/Content.php
+++ b/Classes/ContentObject/Content.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * A content object (cObj) to clean a database field in a way so that it can be
  * used to fill a Solr document's content field.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Content extends AbstractContentObject
 {

--- a/Classes/ContentObject/Multivalue.php
+++ b/Classes/ContentObject/Multivalue.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
  *   removeEmptyValues = 1 # a flag to remove empty strings from the list, on by default.
  *   removeDuplicateValues = 1 # a flag to remove duplicate strings from the list, off by default.
  * }
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Multivalue extends AbstractContentObject
 {

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -40,8 +40,6 @@ use TYPO3\CMS\Frontend\ContentObject\Exception\ContentRenderingException;
  * enableRecursiveValueResolution: if the specified remote table's label field is a relation to another table, the value will be resolved by following the relation recursively.
  * removeEmptyValues: Removes empty values when resolving relations, defaults to TRUE
  * removeDuplicateValues: Removes duplicate values
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Relation extends AbstractContentObject
 {

--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -34,9 +34,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class AbstractBaseController
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractBaseController extends ActionController
 {

--- a/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexAdministrationModuleController.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Index Administration Module
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class IndexAdministrationModuleController extends AbstractModuleController
 {

--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Index Queue Module
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class IndexQueueModuleController extends AbstractModuleController
 {

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -25,10 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class SuggestController
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
- * @copyright (c) 2017 Timo Hund <timo.hund@dkd.de>
  */
 class SuggestController extends AbstractBaseController
 {

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -36,8 +36,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Service to perform indexing operations
- *
- * @author Timo Hund <timo.schmidt@dkd.de>
  */
 class IndexService
 {

--- a/Classes/Domain/Index/Queue/QueueInitializationService.php
+++ b/Classes/Domain/Index/Queue/QueueInitializationService.php
@@ -29,9 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * The queue initialization service is responsible to run the initialization of the index queue for a combination of sites
  * and index queue configurations.
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Ingo Renner <ingo.renner@dkd.de>
  */
 class QueueInitializationService
 {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Extracted logic from the AbstractDataHandlerListener in order to
  * handle ConfigurationAwareRecords
- *
- * @author Thomas Hohn Hund <tho@systime.dk>
  */
 class ConfigurationAwareRecordService
 {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
@@ -26,8 +26,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * Extracted logic from the RecordMonitor to trigger mount page updates.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class MountPagesUpdater
 {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -35,8 +35,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  *
  * Responsibility: The RootPageResolver is responsible to determine all relevant site root page id's
  * for a certain records, by table and uid.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RootPageResolver implements SingletonInterface
 {

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -32,8 +32,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * Builder class to build an ApacheSolrDocument
  *
  * Responsible to build \ApacheSolrForTypo3\Solr\System\Solr\Document\Document
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Builder
 {

--- a/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
+++ b/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
@@ -28,10 +28,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * The FrequentSearchesService is used to retrieve the frequent searches from the database or cache.
- *
- * @author Dimitri Ebert <dimitri.ebert@dkd.de>
- * @author Timo Schmidt <timo.schmidt@dkd.de>
- * @copyright (c) 2015-2021 dkd Internet Service GmbH <info@dkd.de>
  */
 class FrequentSearchesService
 {

--- a/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
+++ b/Classes/Domain/Search/Highlight/SiteHighlighterUrlModifier.php
@@ -23,9 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * adding parameters to a document's URL property.
  *
  * Initial code from ApacheSolrForTypo3\Solr\ResultDocumentModifier\SiteHighlighter
- *
- * @author Stefan Sprenger <stefan.sprenger@dkd.de>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SiteHighlighterUrlModifier
 {

--- a/Classes/Domain/Search/LastSearches/LastSearchesService.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesService.php
@@ -24,8 +24,6 @@ use UnexpectedValueException;
 /**
  * The LastSearchesService is responsible to return the LastSearches from the session or database,
  * depending on the configuration.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class LastSearchesService
 {

--- a/Classes/Domain/Search/Query/Helper/EscapeService.php
+++ b/Classes/Domain/Search/Query/Helper/EscapeService.php
@@ -21,8 +21,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper;
  * The EscapeService is responsible to escape the querystring as expected for Apache Solr.
  *
  * This class should have no dependencies since it only contains static functions
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class EscapeService
 {

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -43,8 +43,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * The concrete QueryBuilder contains all TYPO3 specific initialization logic of solr queries, for TYPO3.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueryBuilder extends AbstractQueryBuilder
 {

--- a/Classes/Domain/Search/Query/SuggestQuery.php
+++ b/Classes/Domain/Search/Query/SuggestQuery.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\Util;
 
 /**
  * A query specialized to get search suggestions
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @copyright (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class SuggestQuery extends Query
 {

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
  * Value object that represent the options facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
@@ -19,9 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 /**
  * Abstract item that represent a value of a facet. E.g. an option or a node
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItemCollection.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 
 /**
  * Collection for facet options.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractFacetItemCollection extends AbstractCollection
 {

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
@@ -24,9 +24,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Class AbstractFacetParser
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractFacetParser implements FacetParserInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/FacetParserInterface.php
+++ b/Classes/Domain/Search/ResultSet/Facets/FacetParserInterface.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
  * Interface FacetParserInterface
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 interface FacetParserInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/FacetQueryBuilderInterface.php
+++ b/Classes/Domain/Search/ResultSet/Facets/FacetQueryBuilderInterface.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 
 /**
  * Query Filter Encoder Interface
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface FacetQueryBuilderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/FacetRegistry.php
+++ b/Classes/Domain/Search/ResultSet/Facets/FacetRegistry.php
@@ -26,9 +26,6 @@ use ApacheSolrForTypo3\Solr\System\Object\AbstractClassRegistry;
 
 /**
  * Class FacetRegistry
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class FacetRegistry extends AbstractClassRegistry
 {

--- a/Classes/Domain/Search/ResultSet/Facets/FacetUrlDecoderInterface.php
+++ b/Classes/Domain/Search/ResultSet/Facets/FacetUrlDecoderInterface.php
@@ -19,9 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 /**
  * The facet url encode is responsible to encode and decode values for EXT:solr urls.
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 interface FacetUrlDecoderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionFacetItem.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
 
 /**
  * Base class for all facet items that are represented as option
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class AbstractOptionFacetItem extends AbstractFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionsFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/AbstractOptionsFacet.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
  * Class AbstractOptionsFacet
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class AbstractOptionsFacet extends AbstractFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacet.php
@@ -22,9 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Value object that represent the options facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class HierarchyFacet extends AbstractFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoder.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetUrlDecoderInterf
 
 /**
  * Filter encoder to build Solr hierarchy queries from tx_solr[filter]
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class HierarchyUrlDecoder implements FacetUrlDecoderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
 
 /**
  * Value object that represent an option of an options-facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Node extends AbstractOptionFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
 
 /**
  * Collection for facet options.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NodeCollection extends AbstractFacetItemCollection
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/OptionCollection.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 
 /**
  * Collection for facet options.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class OptionCollection extends AbstractFacetItemCollection
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/Option.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
 
 /**
  * Value object that represent an option of an options facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Option extends AbstractOptionFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacet.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
 
 /**
  * Value object that represent an options facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class OptionsFacet extends AbstractOptionsFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/Option.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/Option.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
 
 /**
  * Value object that represent an option of a queryGroup facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Option extends AbstractOptionFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacet.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\AbstractO
 
 /**
  * Class QueryGroupFacet
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueryGroupFacet extends AbstractOptionsFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
@@ -23,9 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class QueryGroupFacetParser
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueryGroupFacetParser extends AbstractFacetParser
 {

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupUrlDecoder.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetUrlDecoderInterf
 
 /**
  * Filter encoder to build facet query parameters
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Ingo Renner <ingo@typo3.org>
  */
 class QueryGroupUrlDecoder implements FacetUrlDecoderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetItem.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
 
 /**
  * Abstract class that is used as base class for range facet items
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractRangeFacetItem extends AbstractFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/AbstractRangeFacetParser.php
@@ -29,9 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class AbstractRangeFacetParser
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractRangeFacetParser extends AbstractFacetParser
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCollection.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
 
 /**
  * Collection for facet options.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeCollection extends AbstractFacetItemCollection
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCount.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeCount.php
@@ -21,9 +21,6 @@ use DateTime;
 
 /**
  * Value object that represent a date range count. The count has a date and the count of documents
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeCount
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacet.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
 
 /**
  * Value object that represent a date range facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeFacet extends AbstractFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParser.php
@@ -26,9 +26,6 @@ use Exception;
 
 /**
  * Class DateRangeFacetParser
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeFacetParser extends AbstractRangeFacetParser
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoder.php
@@ -23,10 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Parser to build solr range queries from tx_solr[filter]
- *
- * @author Markus Goldbach <markus.goldbach@dkd.de>
- * @copyright (c) 2010-2011 Markus Goldbach <markus.goldbach@dkd.de>
- * @copyright (c) 2012-2015 Ingo Renner <ingo@typo3.org>
  */
 class DateRangeUrlDecoder implements FacetUrlDecoderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRange.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRange.php
@@ -24,9 +24,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\AbstractRa
  *
  * @property NumericRangeFacet $facet
  * @method NumericRangeFacet getFacet()
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRange extends AbstractRangeFacetItem
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCollection.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
 
 /**
  * Collection for facet options.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRangeCollection extends AbstractFacetItemCollection
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCount.php
@@ -15,9 +15,6 @@
 
 /**
  * Value object that represent a date range count. The count has a date and the count of documents
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 
 namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange;

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacet.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
 
 /**
  * Value object that represent a date range facet.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRangeFacet extends AbstractFacet
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParser.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
  * Class NumericRangeFacetParser
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRangeFacetParser extends AbstractRangeFacetParser
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoder.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoder.php
@@ -22,10 +22,6 @@ use InvalidArgumentException;
 
 /**
  * Parser to build Solr range queries from tx_solr[filter]
- *
- * @author Markus Goldbach <markus.goldbach@dkd.de>
- * @author Ingo Renner <ingo@typo3.org>
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class NumericRangeUrlDecoder implements FacetUrlDecoderInterface
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDate.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * If the input date can not be processed by the given inputFormat string it is
  * returned unprocessed.
- *
- * @author Hendrik Putzek <hendrik.putzek@dkd.de>
  */
 class FormatDate
 {

--- a/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RequirementsService.php
@@ -20,8 +20,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Service class to check for a facet if allRequirements are met for that facet.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RequirementsService
 {

--- a/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
+++ b/Classes/Domain/Search/ResultSet/Facets/SortingExpression.php
@@ -19,9 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 /**
  * Expression for facet sorting
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Jens Jacobsen <jens.jacobsen@ueberbit.de>
  */
 class SortingExpression
 {

--- a/Classes/Domain/Search/ResultSet/Facets/UrlFacetContainer.php
+++ b/Classes/Domain/Search/ResultSet/Facets/UrlFacetContainer.php
@@ -23,7 +23,6 @@ use Countable;
 /**
  * Data bag for facets inside an url
  *
- * @author Lars Tode <lars.tode@dkd.de>
  * @api
  */
 class UrlFacetContainer implements Countable

--- a/Classes/Domain/Search/ResultSet/Grouping/Group.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/Group.php
@@ -19,9 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping;
 
 /**
  * A group is identified by a groupName and can contain multiple groupItems (that reference the search results).
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Group
 {

--- a/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupItem.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 
 /**
  * Class GroupItem
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupItem extends SearchResultSet
 {

--- a/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/ResultParserRegistry.php
@@ -24,9 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class ResultParserRegistry
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ResultParserRegistry implements SingletonInterface
 {

--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 
 /**
  * Solr document class that should be used in the frontend in the search context.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SearchResult extends Document
 {

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -29,9 +29,6 @@ use UnexpectedValueException;
 /**
  * This processor is used to transform the solr response into a
  * domain object hierarchy that can be used in the application (controller and view).
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
 {

--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -32,8 +32,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 /**
  * The SearchResultSet is used to provide access to the Apache Solr Response and
  * other relevant information, like the used Query and Request objects.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SearchResultSet
 {

--- a/Classes/Domain/Search/ResultSet/SearchResultSetProcessor.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetProcessor.php
@@ -18,8 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet;
 /**
  * The implementation can be used to influence a SearchResultSet that is
  * created and processed in the SearchResultSetService.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 interface SearchResultSetProcessor
 {

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -42,8 +42,6 @@ use UnexpectedValueException;
 /**
  * The SearchResultSetService is responsible to build a SearchResultSet from a SearchRequest.
  * It encapsulates the logic to trigger a search in order to be able to reuse it in multiple places.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SearchResultSetService
 {

--- a/Classes/Domain/Search/ResultSet/Spellchecking/Suggestion.php
+++ b/Classes/Domain/Search/ResultSet/Spellchecking/Suggestion.php
@@ -19,9 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking;
 
 /**
  * Value object that represent a spellchecking suggestion.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Suggestion
 {

--- a/Classes/Domain/Search/Score/Score.php
+++ b/Classes/Domain/Search/Score/Score.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Score;
 
 /**
  * Holds the data of an analyzed score.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class Score
 {

--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -17,9 +17,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Score;
 
 /**
  * Provides the functionality to calculate scores and renders them in a minimalistic template.
- *
- * @author Ingo Renner <ingo.renner@gmail.com>
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class ScoreCalculationService
 {

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
 /**
  * The searchRequest is used to act as an api to the arguments that have been passed
  * with GET and POST.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SearchRequest
 {

--- a/Classes/Domain/Search/SearchRequestBuilder.php
+++ b/Classes/Domain/Search/SearchRequestBuilder.php
@@ -23,7 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * The SearchRequestBuilder is responsible to build a valid SearchRequest.
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchRequestBuilder
 {

--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 /**
  * Calculates the SearchQueryStatistics
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class StatisticsRepository extends AbstractRepository
 {

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -28,10 +28,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Writes statistics after searches have been conducted.
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @author Dimitri Ebert <dimitri.ebert@dkd.de>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class StatisticsWriterProcessor
 {

--- a/Classes/Domain/Search/Suggest/SuggestService.php
+++ b/Classes/Domain/Search/Suggest/SuggestService.php
@@ -38,9 +38,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class SuggestService
- *
- * @author Frans Saris <frans.saris@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SuggestService
 {

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -39,9 +39,6 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
  * The SearchUriBuilder is responsible to build uris, that are used in the
  * searchContext. It can use the previous request with its persistent
  * arguments to build the url for a search sub request.
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchUriBuilder
 {

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Site\Entity\Site as Typo3Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -207,7 +208,9 @@ class Site
      * @param int|null $pageId Page ID from where to start collection sub-pages. Uses and includes the root page if none given.
      * @param string|null $indexQueueConfigurationName The name of index queue.
      *
-     * @return array Array of pages (IDs) in this site
+     * @return int[] Array of pages (IDs) in this site
+     *
+     * @throws DBALException
      */
     public function getPages(
         ?int $pageId = null,

--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  * SiteHashService
  *
  * Responsible to provide sitehash related service methods.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SiteHashService
 {

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -37,8 +37,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class SiteRepository is responsible to retrieve instances of Site objects
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class SiteRepository
 {

--- a/Classes/Domain/Variants/IdBuilder.php
+++ b/Classes/Domain/Variants/IdBuilder.php
@@ -31,7 +31,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * <SystemHash>/type/uid
  *
  * A file from one system will get the same variantId, which could be useful for de-duplication.
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class IdBuilder
 {

--- a/Classes/Event/Indexing/AfterItemHasBeenIndexedEvent.php
+++ b/Classes/Event/Indexing/AfterItemHasBeenIndexedEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
  * This event is dispatched after the indexing of an item
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class AfterItemHasBeenIndexedEvent
 {

--- a/Classes/Event/Indexing/AfterItemsHaveBeenIndexedEvent.php
+++ b/Classes/Event/Indexing/AfterItemsHaveBeenIndexedEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
  * This event is dispatched after the indexing of items ends
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class AfterItemsHaveBeenIndexedEvent
 {

--- a/Classes/Event/Indexing/BeforeItemIsIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeItemIsIndexedEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
  * This event is dispatched before the indexing of an item starts
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class BeforeItemIsIndexedEvent
 {

--- a/Classes/Event/Indexing/BeforeItemsAreIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeItemsAreIndexedEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 
 /**
  * This event is dispatched before the indexing of items starts
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class BeforeItemsAreIndexedEvent
 {

--- a/Classes/Event/Parser/AfterFacetIsParsedEvent.php
+++ b/Classes/Event/Parser/AfterFacetIsParsedEvent.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 
 /**
  * This event is dispatched after a facet is parsed.
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class AfterFacetIsParsedEvent
 {

--- a/Classes/Event/Routing/AfterUriIsProcessedEvent.php
+++ b/Classes/Event/Routing/AfterUriIsProcessedEvent.php
@@ -21,8 +21,6 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * This event is invoked after an uri was processed.
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class AfterUriIsProcessedEvent
 {

--- a/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
+++ b/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
@@ -21,8 +21,6 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * This event will be triggered before process variable keys and values
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class BeforeCachedVariablesAreProcessedEvent
 {

--- a/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
+++ b/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
@@ -21,8 +21,6 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * This event will be triggered before start to replace placeholder inside cached URLs
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class BeforeVariableInCachedUrlAreReplacedEvent
 {

--- a/Classes/Event/Search/AfterFrequentlySearchHasBeenExecutedEvent.php
+++ b/Classes/Event/Search/AfterFrequentlySearchHasBeenExecutedEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 /**
  * This event is dispatched after the frequently searched was executed.
  * It contains the result of that search request.
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class AfterFrequentlySearchHasBeenExecutedEvent
 {

--- a/Classes/Event/Search/BeforeSearchFormIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchFormIsShownEvent.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Search;
 
 /**
  * This event is triggered before setting the form values
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class BeforeSearchFormIsShownEvent
 {

--- a/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
+++ b/Classes/Event/Search/BeforeSearchResultIsShownEvent.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Pagination\PaginationInterface;
 
 /**
  * This event is triggered before adding the search result to the fluid template
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 final class BeforeSearchResultIsShownEvent
 {

--- a/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Event listener to handle path elements containing placeholder
  *
- * @author Lars Tode <lars.tode@dkd.de>
  *
  * @noinspection PhpUnused Listener for {@link BeforeCachedVariablesAreProcessedEvent}
  */

--- a/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEv
  * This modifier is in use if the URL processed by a route enhancer
  *
  * In this case some characters need to be replaced in order to do a placeholder replacement later
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class CachedUrlModifier
 {

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This event listener concat the filter if configured or masking is active.
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class PostEnhancedUriProcessor
 {

--- a/Classes/EventListener/PageIndexer/AdditionalFieldsForPageIndexing.php
+++ b/Classes/EventListener/PageIndexer/AdditionalFieldsForPageIndexing.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * Adds page document fields as configured in
  * plugin.tx_solr.index.additionalFields.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AdditionalFieldsForPageIndexing
 {

--- a/Classes/FieldProcessor/AbstractHierarchyProcessor.php
+++ b/Classes/FieldProcessor/AbstractHierarchyProcessor.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\FieldProcessor;
 
 /**
  * Provides common methods for field processors creating a hierarchy.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 abstract class AbstractHierarchyProcessor
 {

--- a/Classes/FieldProcessor/CategoryUidToHierarchy.php
+++ b/Classes/FieldProcessor/CategoryUidToHierarchy.php
@@ -43,8 +43,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * 3-1/10/100/11
  *
  * which is finally saved in a multi-value field.
- *
- * @author Steffen Ritter <steffen.ritter@typo3.org>
  */
 class CategoryUidToHierarchy extends AbstractHierarchyProcessor implements FieldProcessor
 {

--- a/Classes/FieldProcessor/FieldProcessor.php
+++ b/Classes/FieldProcessor/FieldProcessor.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\FieldProcessor;
 
 /**
  * Field Processor interface
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface FieldProcessor
 {

--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -44,8 +44,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  * 3-1/10/100/11/
  *
  * which is finally saved in a multi-value field.
- *
- * @author Michael Knoll <knoll@punkt.de>
  */
 class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProcessor
 {

--- a/Classes/FieldProcessor/PathToHierarchy.php
+++ b/Classes/FieldProcessor/PathToHierarchy.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Processes a value that may appear as field value in documents
- *
- * @author Daniel Poetzinger <poetzinger@aoemedia.de>
  */
 class PathToHierarchy implements FieldProcessor
 {

--- a/Classes/FieldProcessor/Service.php
+++ b/Classes/FieldProcessor/Service.php
@@ -25,9 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Service class that modifies fields in an Apache Solr Document, used for
  * common field processing during indexing or resolving
- *
- * @author Daniel Poetzinger <poetzinger@aoemedia.de>
- * @copyright (c) 2009-2015 Daniel Poetzinger <poetzinger@aoemedia.de>
  */
 class Service
 {

--- a/Classes/FieldProcessor/TimestampToIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToIsoDate.php
@@ -22,9 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * A field processor that converts timestamps to ISO dates as needed by Solr
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @copyright (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class TimestampToIsoDate implements FieldProcessor
 {

--- a/Classes/FieldProcessor/TimestampToUtcIsoDate.php
+++ b/Classes/FieldProcessor/TimestampToUtcIsoDate.php
@@ -22,9 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * A field processor that converts timestamps to ISO dates as needed by Solr
- *
- * @author Andreas Allacher <andreas.allacher@cyberhouse.at>
- * @copyright (c) 2009-2015 Andreas Allacher <andreas.allacher@cyberhouse.at>
  */
 class TimestampToUtcIsoDate implements FieldProcessor
 {

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -220,8 +220,6 @@ class Tsfe implements SingletonInterface
      * of EXT:solr* stack is wanted and the language id does not matter.
      *
      * NOTE: This method MUST NOT be used on indexing context.
-     *
-     * @param int ...$languageFallbackChain
      */
     public function getTsfeByPageIdAndLanguageFallbackChain(int $pageId, int ...$languageFallbackChain): ?TypoScriptFrontendController
     {
@@ -357,8 +355,6 @@ class Tsfe implements SingletonInterface
     /**
      * Checks if the page is available for TSFE.
      *
-     * @param array $pageRecord
-     * @return bool
      * @throws \TYPO3\CMS\Core\Context\Exception\AspectNotFoundException
      */
     protected function isPageAvailableForTSFE(array $pageRecord): bool

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -33,9 +33,6 @@ use UnexpectedValueException;
  * set to hidden, is deleted or is otherwise made invisible to website visitors.
  *
  * Garbage collection will happen for online/LIVE workspaces only.
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class GarbageCollector implements SingletonInterface
 {

--- a/Classes/GarbageCollectorPostProcessor.php
+++ b/Classes/GarbageCollectorPostProcessor.php
@@ -19,8 +19,6 @@ namespace ApacheSolrForTypo3\Solr;
 
 /**
  * Garbage Collector Post Processor interface
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface GarbageCollectorPostProcessor
 {

--- a/Classes/HtmlContentExtractor.php
+++ b/Classes/HtmlContentExtractor.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 
 /**
  * A content extractor to get clean, indexable content from HTML markup.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class HtmlContentExtractor
 {

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -30,8 +30,6 @@ use UnexpectedValueException;
 /**
  * An abstract indexer class to collect a few common methods shared with other
  * indexers.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 abstract class AbstractIndexer
 {

--- a/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
+++ b/Classes/IndexQueue/FrontendHelper/AuthorizationService.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
 /**
  * Authentication service to authorize the Index Queue page indexer to access
  * protected pages.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AuthorizationService extends AbstractAuthenticationService
 {

--- a/Classes/IndexQueue/FrontendHelper/FrontendHelper.php
+++ b/Classes/IndexQueue/FrontendHelper/FrontendHelper.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 
 /**
  * Index Queue Frontend Helper interface.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface FrontendHelper
 {

--- a/Classes/IndexQueue/FrontendHelper/Manager.php
+++ b/Classes/IndexQueue/FrontendHelper/Manager.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Index Queue Page Indexer frontend helper manager.
  *
  * Manages frontend helpers and creates instances.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Manager
 {

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * Indexer to add / overwrite page document fields as defined in
  * plugin.tx_solr.index.queue.pages.fields.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageFieldMappingIndexer
 {

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -50,8 +50,6 @@ use UnexpectedValueException;
  * should be used by the Index Queue.
  *
  * Once the FrontendHelper construct is separated, this will be a standalone Indexer.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexer implements FrontendHelper, SingletonInterface
 {

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * The UserGroupDetector is responsible to identify the fe_group references on records that are visible on the page (not the page itself).
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class UserGroupDetector implements
     FrontendHelper,

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -51,9 +51,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  * records like news records, tt_address, and so on.
  * Specialized indexers can extend this class to handle advanced stuff like
  * category resolution in news records or file indexing.
- *
- * @author Ingo Renner <ingo@typo3.org>
- * @copyright  (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class Indexer extends AbstractIndexer
 {
@@ -594,8 +591,6 @@ class Indexer extends AbstractIndexer
     /**
      * Checks for which languages connections have been configured for translation overlays and returns these connections.
      *
-     * @param array $translationOverlays
-     * @param int $rootPageId
      * @return SolrConnection[]
      *
      * @throws DBALException

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -32,8 +32,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Abstract Index Queue initializer with implementation  of methods for common
  * needs during Index Queue initialization.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 abstract class AbstractInitializer implements IndexQueueInitializer
 {

--- a/Classes/IndexQueue/Initializer/IndexQueueInitializer.php
+++ b/Classes/IndexQueue/Initializer/IndexQueueInitializer.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 
 /**
  * Interface to initialize items in the Index Queue.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface IndexQueueInitializer
 {

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -32,8 +32,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Index Queue initializer for pages which also covers resolution of mount
  * pages.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Page extends AbstractInitializer
 {

--- a/Classes/IndexQueue/Initializer/Record.php
+++ b/Classes/IndexQueue/Initializer/Record.php
@@ -18,8 +18,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Initializer;
 /**
  * Simple Index Queue initializer for records as found in tables configured
  * through TCA.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Record extends AbstractInitializer
 {

--- a/Classes/IndexQueue/InvalidFieldNameException.php
+++ b/Classes/IndexQueue/InvalidFieldNameException.php
@@ -20,8 +20,6 @@ use RuntimeException;
 /**
  * Exception that is thrown when trying to add a field to a Solr document using
  * a reserved name.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class InvalidFieldNameException extends RuntimeException
 {

--- a/Classes/IndexQueue/Item.php
+++ b/Classes/IndexQueue/Item.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * indexed.
  *
  * @todo: Loose coupling from Repos
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Item
 {

--- a/Classes/IndexQueue/NoPidException.php
+++ b/Classes/IndexQueue/NoPidException.php
@@ -19,8 +19,6 @@ use Exception;
 
 /**
  * This Exception is thrown when the RecordMonitor handles a record without a valid pid.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NoPidException extends Exception
 {

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -35,8 +35,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * In the case of pages we can't directly index the page records, we need to
  * retrieve the content that belongs to a page from tt_content, too.
  * Also, plugins may be included on a page and thus may need to be executed.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexer extends Indexer
 {

--- a/Classes/IndexQueue/PageIndexerDataUrlModifier.php
+++ b/Classes/IndexQueue/PageIndexerDataUrlModifier.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 
 /**
  * Allows to modify the data url before call the frontend form the index queue
- *
- * @author Markus Goldbach <markus.goldbach@dkd.de>
  */
 interface PageIndexerDataUrlModifier
 {

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -30,8 +30,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Index Queue Page Indexer request with details about which actions to perform.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexerRequest
 {

--- a/Classes/IndexQueue/PageIndexerRequestHandler.php
+++ b/Classes/IndexQueue/PageIndexerRequestHandler.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * requested by them.
  *
  * This is added in the PSR-7 Frontend Request as "solr.pageIndexingInstructions" attribute
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexerRequestHandler
 {

--- a/Classes/IndexQueue/PageIndexerResponse.php
+++ b/Classes/IndexQueue/PageIndexerResponse.php
@@ -21,8 +21,6 @@ use RuntimeException;
 
 /**
  * Index Queue Page Indexer response to provide data for requested actions.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexerResponse
 {

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -38,8 +38,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * The Queue makes it possible to decouple the direct indexing of changed records and index them time-delayed in standalone process.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Queue
 {

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -33,8 +33,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 /**
  * A class that monitors changes to the records so that the changed record get
  * passed to the index queue to update the according index document.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class RecordMonitor
 {

--- a/Classes/IndexQueue/SerializedValueDetector.php
+++ b/Classes/IndexQueue/SerializedValueDetector.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 
 /**
  * Serialized value detector interface
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 interface SerializedValueDetector
 {

--- a/Classes/LanguageFileUnavailableException.php
+++ b/Classes/LanguageFileUnavailableException.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr;
 
 /**
  * Exception that is thrown when a language file is needed, but not available.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class LanguageFileUnavailableException extends Exception
 {

--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -49,7 +49,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *   ]
  * ];
  *
- * @author Lars Tode <lars.tode@dkd.de>
  * @see https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/RequestHandling/Index.html
  */
 class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface

--- a/Classes/NoSolrConnectionFoundException.php
+++ b/Classes/NoSolrConnectionFoundException.php
@@ -21,8 +21,6 @@ use Exception;
 
 /**
  * Exception that is thrown when no Solr connection could be found.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class NoSolrConnectionFoundException extends Exception
 {

--- a/Classes/Pagination/ResultsPagination.php
+++ b/Classes/Pagination/ResultsPagination.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Pagination\PaginatorInterface;
 
 /**
  * Class ResultsPagination
- *
- * @author Rudy Gnodde <rudy.gnodde@beech.it>
  */
 class ResultsPagination implements PaginationInterface
 {

--- a/Classes/Pagination/ResultsPaginator.php
+++ b/Classes/Pagination/ResultsPaginator.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Pagination\AbstractPaginator;
 
 /**
  * Class ResultsPaginator
- *
- * @author Rudy Gnodde <rudy.gnodde@beech.it>
  */
 class ResultsPaginator extends AbstractPaginator
 {

--- a/Classes/PingFailedException.php
+++ b/Classes/PingFailedException.php
@@ -21,8 +21,6 @@ use Exception;
 
 /**
  * Exception that is thrown when a ping fails
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class PingFailedException extends Exception
 {

--- a/Classes/Report/AbstractSolrStatus.php
+++ b/Classes/Report/AbstractSolrStatus.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Reports\StatusProviderInterface;
 
 /**
  * Provides shared functionality for all Solr reports.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractSolrStatus implements StatusProviderInterface
 {

--- a/Classes/Report/AccessFilterPluginInstalledStatus.php
+++ b/Classes/Report/AccessFilterPluginInstalledStatus.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about whether the Access Filter Query Parser Plugin
  * is installed on the Solr server.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AccessFilterPluginInstalledStatus extends AbstractSolrStatus
 {

--- a/Classes/Report/AllowUrlFOpenStatus.php
+++ b/Classes/Report/AllowUrlFOpenStatus.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about whether the php.ini setting allow_url_fopen
  * is activated or not.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AllowUrlFOpenStatus extends AbstractSolrStatus
 {

--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about which schema version is used and checks
  * whether it fits the recommended version shipping with the extension.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SchemaStatus extends AbstractSolrStatus
 {

--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about which solrconfig version is used and checks
  * whether it fits the recommended version shipping with the extension.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SolrConfigStatus extends AbstractSolrStatus
 {

--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report, which checks whether the configuration of the
  * extension is ok.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SolrConfigurationStatus extends AbstractSolrStatus
 {

--- a/Classes/Report/SolrStatus.php
+++ b/Classes/Report/SolrStatus.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about whether a connection to the Solr server can
  * be established.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SolrStatus extends AbstractSolrStatus
 {
@@ -103,7 +101,6 @@ class SolrStatus extends AbstractSolrStatus
     /**
      * Checks whether a Solr server is available and provides some information.
      *
-     * @param Site $site
      * @param array $solrConnection Solr connection parameters
      * @return Status Status of the Solr connection
      */

--- a/Classes/Report/SolrVersionStatus.php
+++ b/Classes/Report/SolrVersionStatus.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Provides a status report about whether the installed Solr version matches
  * the required version.
- *
- * @author Stefan Sprenger <stefan.sprenger@dkd.de>
  */
 class SolrVersionStatus extends AbstractSolrStatus
 {

--- a/Classes/Routing/Enhancer/SolrRouteEnhancerInterface.php
+++ b/Classes/Routing/Enhancer/SolrRouteEnhancerInterface.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\Routing\Enhancer;
 
 /**
  * This interface uses to determine if an enhancer handle Solr specific requests
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 interface SolrRouteEnhancerInterface
 {

--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -35,8 +35,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This service class bundles method required to process and manipulate routes.
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class RoutingService implements LoggerAwareInterface
 {

--- a/Classes/Routing/UrlFacetService.php
+++ b/Classes/Routing/UrlFacetService.php
@@ -19,8 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Routing;
 
 /**
  * Service class to wrap functions to handle facet values within the URL
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class UrlFacetService
 {

--- a/Classes/Search.php
+++ b/Classes/Search.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class to handle solr search requests
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Search
 {

--- a/Classes/Search/AccessComponent.php
+++ b/Classes/Search/AccessComponent.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 
 /**
  * Access search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AccessComponent
 {

--- a/Classes/Search/AnalysisComponent.php
+++ b/Classes/Search/AnalysisComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Analysis search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class AnalysisComponent
 {

--- a/Classes/Search/DebugComponent.php
+++ b/Classes/Search/DebugComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Debug search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class DebugComponent
 {

--- a/Classes/Search/ElevationComponent.php
+++ b/Classes/Search/ElevationComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Elevation search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class ElevationComponent
 {

--- a/Classes/Search/FacetingComponent.php
+++ b/Classes/Search/FacetingComponent.php
@@ -33,8 +33,6 @@ use Psr\Log\LoggerAwareTrait;
 
 /**
  * Modifies a query to add faceting parameters
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class FacetingComponent implements LoggerAwareInterface
 {
@@ -50,8 +48,6 @@ class FacetingComponent implements LoggerAwareInterface
     /**
      * Modifies the given query and adds the parameters necessary for faceted
      * search.
-     *
-     * @param AfterSearchQueryHasBeenPreparedEvent $event
      */
     public function __invoke(AfterSearchQueryHasBeenPreparedEvent $event): void
     {
@@ -84,7 +80,6 @@ class FacetingComponent implements LoggerAwareInterface
      * Modifies the given query and adds the parameters necessary for faceted
      * search.
      *
-     * @param Query $query The query to modify
      *
      * @return Query The modified query with faceting parameters
      *

--- a/Classes/Search/GroupingComponent.php
+++ b/Classes/Search/GroupingComponent.php
@@ -25,8 +25,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * GroupingComponent
- *
- * @author Frans Saris <frans@beech.it>
  */
 class GroupingComponent
 {

--- a/Classes/Search/HighlightingComponent.php
+++ b/Classes/Search/HighlightingComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Highlighting search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class HighlightingComponent
 {

--- a/Classes/Search/LastSearchesComponent.php
+++ b/Classes/Search/LastSearchesComponent.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Writes the last searches
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class LastSearchesComponent
 {

--- a/Classes/Search/RelevanceComponent.php
+++ b/Classes/Search/RelevanceComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Boosting search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class RelevanceComponent
 {

--- a/Classes/Search/SortingComponent.php
+++ b/Classes/Search/SortingComponent.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Sorting search component
  *
  * TODO maybe merge ApacheSolrForTypo3\Solr\Sorting into ApacheSolrForTypo3\Solr\Search\SortingComponent
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SortingComponent
 {

--- a/Classes/Search/SpellcheckingComponent.php
+++ b/Classes/Search/SpellcheckingComponent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Spellchecking search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SpellcheckingComponent
 {

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -24,8 +24,6 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
 
 /**
  * Statistics search component
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class StatisticsComponent
 {

--- a/Classes/System/Cache/TwoLevelCache.php
+++ b/Classes/System/Cache/TwoLevelCache.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Provides a two level cache that uses an in memory cache as the first level cache and
  * the TYPO3 caching framework cache as the second level cache.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class TwoLevelCache
 {

--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Configuration manager old the configuration instance.
  * Singleton
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class ConfigurationManager implements SingletonInterface
 {

--- a/Classes/System/Configuration/ConfigurationPageResolver.php
+++ b/Classes/System/Configuration/ConfigurationPageResolver.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 /**
  * This class is responsible to find the closest page id from the rootline where
  * a typoscript template is stored on.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ConfigurationPageResolver
 {

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This class encapsulates the access to the extension configuration.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ExtensionConfiguration
 {

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -45,10 +45,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * This was only introduced to be backwards compatible in long term only "getValueByPath", "isValidPath" or
  * speaking methods for configuration settings should be used!
- *
- * @author Marc Bastian Heinrichs <mbh@mbh-software.de>
- * @author Timo Schmidt <timo.schmidt@dkd.de>
- * @copyright (c) 2016 Timo Schmidt <timo.schmidt@dkd.de>
  */
 class TypoScriptConfiguration
 {

--- a/Classes/System/ContentObject/ContentObjectService.php
+++ b/Classes/System/ContentObject/ContentObjectService.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * StdWrap Service that can be used to apply the ContentObjectRenderer stdWrap functionality on data.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ContentObjectService
 {

--- a/Classes/System/DateTime/FormatService.php
+++ b/Classes/System/DateTime/FormatService.php
@@ -21,10 +21,6 @@ use Exception;
 
 /**
  * Testcase to check if the configuration object can be used as expected
- *
- * @author Hendrik Putzek <hendrik.putzek@dkd.de>
- * @author Timo Hund <timo.hund@dkd.de>
- * @copyright (c) 2011-2016 Timo Schmidt <timo.hund@dkd.de>
  */
 class FormatService
 {

--- a/Classes/System/Environment/CliEnvironment.php
+++ b/Classes/System/Environment/CliEnvironment.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\SingletonInterface;
 /**
  * Helper class for the cli environment helps to define the variables and constants
  * that are required in the cli context to allow frontend related operations in the cli context.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class CliEnvironment implements SingletonInterface
 {

--- a/Classes/System/Environment/WebRootAllReadyDefinedException.php
+++ b/Classes/System/Environment/WebRootAllReadyDefinedException.php
@@ -19,8 +19,6 @@ use Exception;
 
 /**
  * Exception that is thrown when a language file is needed, but not available.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class WebRootAllReadyDefinedException extends Exception
 {

--- a/Classes/System/Logging/DebugWriter.php
+++ b/Classes/System/Logging/DebugWriter.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 /**
  * The DebugWriter is used to write the devLog messages to the output of the page, or to the TYPO3 console in the
  * backend to provide a simple and lightweight debugging possibility.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DebugWriter
 {

--- a/Classes/System/Logging/SolrLogManager.php
+++ b/Classes/System/Logging/SolrLogManager.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Wrapper to for the TYPO3 Logging Framework
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class SolrLogManager implements LoggerInterface
 {
@@ -55,10 +53,6 @@ class SolrLogManager implements LoggerInterface
 
     /**
      * Logs with an arbitrary level.
-     *
-     * @param mixed $level
-     * @param string|\Stringable $message
-     * @param array $context
      */
     public function log($level, string|\Stringable $message, array $context = []): void
     {

--- a/Classes/System/Object/AbstractClassRegistry.php
+++ b/Classes/System/Object/AbstractClassRegistry.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * for a specific key.
  *
  * Can be used to retrieve different "strategies" for the same thing.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class AbstractClassRegistry implements SingletonInterface
 {

--- a/Classes/System/Page/Rootline.php
+++ b/Classes/System/Page/Rootline.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
  * Rootline class. This class is used to perform operations on a rootline array.
  * The constructor requires a rootline array as arguments (as you get it from
  * PageRepository::getRootline or TSFE->rootline.)
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Rootline
 {

--- a/Classes/System/Records/AbstractRepository.php
+++ b/Classes/System/Records/AbstractRepository.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Repository class to encapsulate the database access for records used in solr.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractRepository
 {

--- a/Classes/System/Records/SystemCategory/SystemCategoryRepository.php
+++ b/Classes/System/Records/SystemCategory/SystemCategoryRepository.php
@@ -22,8 +22,6 @@ use Doctrine\DBAL\Exception as DBALException;
 
 /**
  * Repository class for sys_category items of the TYPO3 system.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SystemCategoryRepository extends AbstractRepository
 {

--- a/Classes/System/Service/ConfigurationService.php
+++ b/Classes/System/Service/ConfigurationService.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 /**
  * Service to ease work with configurations.
- *
- * @author Daniel Siepmann <coding@daniel-siepmann.de>
  */
 class ConfigurationService
 {

--- a/Classes/System/Session/FrontendUserSession.php
+++ b/Classes/System/Session/FrontendUserSession.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 /**
  * Encapsulates the access to the session of the frontend user.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class FrontendUserSession
 {

--- a/Classes/System/Solr/Document/Document.php
+++ b/Classes/System/Solr/Document/Document.php
@@ -22,8 +22,6 @@ use Solarium\QueryType\Update\Query\Document as SolariumDocument;
 
 /**
  * Document representing the update query document
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Document extends SolariumDocument
 {

--- a/Classes/System/Solr/Node.php
+++ b/Classes/System/Solr/Node.php
@@ -24,8 +24,6 @@ use UnexpectedValueException;
  * Represent a server node of solr, in the most setups you would only have one, but sometimes
  * multiple for reading and writing.
  *
- * @author Timo Hund <timo.hund@dkd.de>
- * @copyright Copyright (c) 2009-2020 Timo Hund <timo.hund@dkd.de>
  *
  * @deprecated Class will be removed with Ext:solr 12.x. Use class \Solarium\Core\Client\Endpoint instead.
  */

--- a/Classes/System/Solr/Parser/SchemaParser.php
+++ b/Classes/System/Solr/Parser/SchemaParser.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class to parse the schema from a solr response.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SchemaParser
 {

--- a/Classes/System/Solr/Parser/StopWordParser.php
+++ b/Classes/System/Solr/Parser/StopWordParser.php
@@ -19,8 +19,6 @@ use InvalidArgumentException;
 
 /**
  * Class to parse the stopwords from a solr response.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class StopWordParser
 {

--- a/Classes/System/Solr/Parser/SynonymParser.php
+++ b/Classes/System/Solr/Parser/SynonymParser.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\System\Solr\Parser;
 
 /**
  * Class to parse the synonyms from a solr response.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SynonymParser
 {

--- a/Classes/System/Solr/Schema/Schema.php
+++ b/Classes/System/Solr/Schema/Schema.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\System\Solr\Schema;
 
 /**
  * Object representation of the solr schema.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class Schema
 {

--- a/Classes/System/Solr/Service/SolrWriteService.php
+++ b/Classes/System/Solr/Service/SolrWriteService.php
@@ -24,8 +24,6 @@ use Throwable;
 
 /**
  * Class SolrWriteService
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrWriteService extends AbstractSolrService
 {

--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -38,8 +38,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Solr Service Access
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class SolrConnection
 {

--- a/Classes/System/TCA/TCAService.php
+++ b/Classes/System/TCA/TCAService.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class to encapsulate TCA specific logic
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class TCAService
 {

--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -19,8 +19,6 @@ use TYPO3\CMS\Core\Http\Uri;
 
 /**
  * Class UrlHelper
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class UrlHelper extends Uri
 {

--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -31,8 +31,6 @@ use function str_starts_with;
 
 /**
  * This class contains all user functions for flexforms.
- *
- * @author Daniel Siepmann <coding@daniel-siepmann.de>
  */
 class FlexFormUserFunctions
 {

--- a/Classes/System/Validator/Path.php
+++ b/Classes/System/Validator/Path.php
@@ -17,8 +17,6 @@ namespace ApacheSolrForTypo3\Solr\System\Validator;
 
 /**
  * Class Path is used for Solr Path related methods
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class Path
 {

--- a/Classes/Task/EventQueueWorkerTask.php
+++ b/Classes/Task/EventQueueWorkerTask.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
 /**
  * A worker processing the queued data update events
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 final class EventQueueWorkerTask extends AbstractTask
 {

--- a/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/EventQueueWorkerTaskAdditionalFieldProvider.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
 /**
  * Additional field provider for the index queue worker task
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class EventQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {

--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -30,8 +30,6 @@ use TYPO3\CMS\Scheduler\ProgressProviderInterface;
 /**
  * A worker indexing the items in the index queue. Needs to be set up as one
  * task per root page.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class IndexQueueWorkerTask extends AbstractSolrTask implements ProgressProviderInterface
 {

--- a/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
@@ -30,8 +30,6 @@ use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
 /**
  * Additional field provider for the index queue worker task
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class IndexQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {

--- a/Classes/Task/OptimizeIndexTask.php
+++ b/Classes/Task/OptimizeIndexTask.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Scheduler task to empty the indexes of a site and re-initialize the
  * Solr Index Queue thus making the indexer re-index the site.
- *
- * @author Jens Jacobsen <typo3@jens-jacobsen.de>
  */
 class OptimizeIndexTask extends AbstractSolrTask
 {

--- a/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OptimizeIndexTaskAdditionalFieldProvider.php
@@ -36,8 +36,6 @@ use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
 /**
  * Adds additional field to specify the Solr server to initialize the index queue for
- *
- * @author Jens Jacobsen <typo3@jens-jacobsen.de>
  */
 class OptimizeIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -26,8 +26,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Scheduler task to empty the indexes of a site and re-initialize the
  * Solr Index Queue thus making the indexer re-index the site.
- *
- * @author Christoph Moeller <support@network-publishing.de>
  */
 class ReIndexTask extends AbstractSolrTask
 {

--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -34,8 +34,6 @@ use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
 /**
  * Adds additional field to specify the Solr server to initialize the index queue for
- *
- * @author Christoph Moeller <support@network-publishing.de>
  */
 class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {

--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -24,8 +24,6 @@ use function libxml_use_internal_errors;
 
 /**
  * Content extraction class for TYPO3 pages.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Typo3PageContentExtractor extends HtmlContentExtractor
 {

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -30,9 +30,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Utility class for tx_solr
- *
- * @author Ingo Renner <ingo@typo3.org>
- * (c) 2009-2015 Ingo Renner <ingo@typo3.org>
  */
 class Util
 {

--- a/Classes/Utility/RoutingUtility.php
+++ b/Classes/Utility/RoutingUtility.php
@@ -19,8 +19,6 @@ namespace ApacheSolrForTypo3\Solr\Utility;
 
 /**
  * This utility class contains several functions used inside the middleware and enhancer for routing purposes
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class RoutingUtility
 {

--- a/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendTagBasedViewHelper.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 
 /**
  * Class AbstractSolrFrontendTagBasedViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractSolrFrontendTagBasedViewHelper extends AbstractSolrTagBasedViewHelper
 {

--- a/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSolrFrontendViewHelper.php
@@ -24,9 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class AbstractSolrFrontendViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractSolrFrontendViewHelper extends AbstractSolrViewHelper
 {

--- a/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
+++ b/Classes/ViewHelpers/Debug/DocumentScoreAnalyzerViewHelper.php
@@ -31,8 +31,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 /**
  * Class DocumentScoreAnalyzerViewHelper
  *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  *
  * @noinspection PhpUnused Used in {@link Resources/Private/Partials/Result/Document.html}
  */

--- a/Classes/ViewHelpers/Debug/QueryViewHelper.php
+++ b/Classes/ViewHelpers/Debug/QueryViewHelper.php
@@ -26,8 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 /**
  * Class QueryViewHelper
  *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  *
  * @noinspection PhpUnused used in Fluid templates <s:debug.query />
  */

--- a/Classes/ViewHelpers/Document/HighlightResultViewHelper.php
+++ b/Classes/ViewHelpers/Document/HighlightResultViewHelper.php
@@ -27,9 +27,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class HighlightResultViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class HighlightResultViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Document/RelevanceViewHelper.php
+++ b/Classes/ViewHelpers/Document/RelevanceViewHelper.php
@@ -26,9 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class RelevanceViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RelevanceViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Facet/Area/GroupViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Area/GroupViewHelper.php
@@ -23,9 +23,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class GroupViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de> *
  */
 class GroupViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelper.php
@@ -23,8 +23,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class LabelFilterViewHelper
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class LabelFilterViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
+++ b/Classes/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelper.php
@@ -25,8 +25,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class LabelPrefixesViewHelper
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class LabelPrefixesViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Format/ArrayViewHelper.php
+++ b/Classes/ViewHelpers/Format/ArrayViewHelper.php
@@ -19,9 +19,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class ArrayViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ArrayViewHelper extends AbstractViewHelper
 {

--- a/Classes/ViewHelpers/FrequentlySearchedViewHelper.php
+++ b/Classes/ViewHelpers/FrequentlySearchedViewHelper.php
@@ -32,7 +32,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Class LastSearchesViewHelper
  *
- * @author Rudy Gnodde <rudy.gnodde@beech.it>
  *
  * @noinspection PhpUnused
  */

--- a/Classes/ViewHelpers/LastSearchesViewHelper.php
+++ b/Classes/ViewHelpers/LastSearchesViewHelper.php
@@ -25,7 +25,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Class LastSearchesViewHelper
  *
- * @author Rudy Gnodde <rudy.gnodde@beech.it>
  *
  * @noinspection PhpUnused
  */

--- a/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
+++ b/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
@@ -23,9 +23,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class PageBrowserRangeViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class PageBrowserRangeViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -28,8 +28,6 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 /**
  * Class SearchFormViewHelper
  *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  *
  * @property RenderingContext $renderingContext
  */

--- a/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
@@ -30,9 +30,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class AbstractUriViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AbstractValueViewHelper.php
@@ -23,9 +23,6 @@ use InvalidArgumentException;
 
 /**
  * Class AbstractValueViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 abstract class AbstractValueViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
@@ -20,9 +20,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class AddFacetItemViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class AddFacetItemViewHelper extends AbstractValueViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelper.php
@@ -21,9 +21,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class RemoveAllFacetsViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RemoveAllFacetsViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
@@ -20,9 +20,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class RemoveFacetItemViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RemoveFacetItemViewHelper extends AbstractValueViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetViewHelper.php
@@ -22,9 +22,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class RemoveFacetViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RemoveFacetViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
@@ -20,9 +20,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class SetFacetItemViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SetFacetItemViewHelper extends AbstractValueViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Paginate/GroupItemPageViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Paginate/GroupItemPageViewHelper.php
@@ -24,9 +24,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class GroupItemPageViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupItemPageViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Paginate/ResultPageViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Paginate/ResultPageViewHelper.php
@@ -23,9 +23,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class ResultPageViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ResultPageViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Result/AddSearchWordListViewHelper.php
@@ -26,8 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class AddSearchWordListViewHelper
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class AddSearchWordListViewHelper extends AbstractSolrFrontendViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/CurrentSearchViewHelper.php
@@ -21,9 +21,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class CurrentSearchViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class CurrentSearchViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Search/StartNewSearchViewHelper.php
@@ -21,9 +21,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class StartNewSearchViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class StartNewSearchViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/RemoveSortingViewHelper.php
@@ -21,9 +21,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class RemoveSortingViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RemoveSortingViewHelper extends AbstractUriViewHelper
 {

--- a/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Sorting/SetSortingViewHelper.php
@@ -21,9 +21,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class SetSortingViewHelper
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SetSortingViewHelper extends AbstractUriViewHelper
 {

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This testcase can be used to check if the ConnectionManager can be used
  * as expected.
- *
- * @author Timo Hund
  */
 class ConnectionManagerTest extends IntegrationTest
 {

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -29,7 +29,6 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
  * Integration testcase to test for the SearchController
  *
  * (c) 2010-2015 Timo Hund <timo.hund@dkd.de>
- * @author Timo Hund
  */
 class SearchControllerTest extends IntegrationTest
 {
@@ -930,9 +929,6 @@ class SearchControllerTest extends IntegrationTest
         self::assertStringContainsString('Parsed Query:', $resultPage1, 'No parsed query in response');
     }
 
-    /**
-     * @return array
-     */
     public function frontendWillRenderErrorMessageIfSolrNotAvailableDataProvider(): array
     {
         return [
@@ -942,8 +938,6 @@ class SearchControllerTest extends IntegrationTest
     }
 
     /**
-     * @param string $action
-     * @param array $getArguments
      * @dataProvider frontendWillRenderErrorMessageIfSolrNotAvailableDataProvider
      * @test
      * @group frontend
@@ -1414,7 +1408,6 @@ class SearchControllerTest extends IntegrationTest
      *
      * @param string $expectedToContain
      * @param string $content
-     * @param $id
      */
     protected function assertContainerByIdContains($expectedToContain, $content, $id)
     {
@@ -1427,7 +1420,6 @@ class SearchControllerTest extends IntegrationTest
      *
      * @param string $expectedToContain
      * @param string $content
-     * @param $id
      */
     protected function assertContainerByIdNotContains($expectedToContain, $content, $id)
     {

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -23,7 +23,6 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 /**
  * Integration testcase to test for {@link SuggestController}
  *
- * @author Timo Hund
  * @group frontend
  */
 class SuggestControllerTest extends IntegrationTest

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the record indexer
- *
- * @author Timo Schmidt
  */
 class IndexServiceTest extends IntegrationTest
 {

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the QueueItemRepository
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueueItemRepositoryTest extends IntegrationTest
 {

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -22,9 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ApacheSolrDocumentRepositoryTest extends IntegrationTest
 {
-    /**
-     * @var Repository|null
-     */
     protected ?Repository $apacheSolrDocumentRepository = null;
 
     protected function setUp(): void

--- a/Tests/Integration/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Integration/Domain/Site/SiteHashServiceTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Testcase to check if the SiteHashService class works as expected.
  *
  * The integration test is used to check if we get the expected results with a defined database state.
- *
- * @author Timo Hund <timo.hund.de>
  */
 class SiteHashServiceTest extends IntegrationTest
 {
@@ -34,9 +32,6 @@ class SiteHashServiceTest extends IntegrationTest
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @return array
-     */
     public function canResolveSiteHashAllowedSitesDataProvider(): array
     {
         return [

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to check if the SiteRepository class works as expected.
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class SiteRepositoryTest extends IntegrationTest
 {

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Site class tests
- *
- * @author Timo Schmidt
  */
 class SiteTest extends IntegrationTest
 {

--- a/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
+++ b/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the CategoryUidToHierarchy
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class CategoryUidToHierarchyTest extends IntegrationTest
 {

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -34,8 +34,6 @@ use TYPO3\CMS\Scheduler\Scheduler;
 /**
  * This testcase is used to check if the GarbageCollector can delete garbage from the
  * solr server as expected
- *
- * @author Timo Schmidt
  */
 class GarbageCollectorTest extends IntegrationTest
 {
@@ -135,9 +133,6 @@ class GarbageCollectorTest extends IntegrationTest
         );
     }
 
-    /**
-     * @param $amount
-     */
     protected function assertIndexQueueContainsItemAmount($amount): void
     {
         $itemsInQueue = $this->indexQueue->getAllItemsCount();
@@ -153,9 +148,6 @@ class GarbageCollectorTest extends IntegrationTest
         self::assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
     }
 
-    /**
-     * @param int $amount
-     */
     protected function assertEventQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->eventQueue->count();

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -27,9 +27,6 @@ use TYPO3\CMS\Frontend\Page\CacheHashCalculator;
 
 /**
  * Testcase to check if we can index page documents using the PageIndexer
- *
- * @author Timo Schmidt
- * (c) 2015 Timo Schmidt <timo.schmidt@dkd.de>
  */
 class PageIndexerTest extends IntegrationTest
 {

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -30,8 +30,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the record indexer
- *
- * @author Timo Schmidt
  */
 class IndexerTest extends IntegrationTest
 {
@@ -42,14 +40,8 @@ class IndexerTest extends IntegrationTest
         '../vendor/apache-solr-for-typo3/solr/Tests/Integration/Fixtures/Extensions/fake_extension2',
     ];
 
-    /**
-     * @var Queue|null
-     */
     protected ?Queue $indexQueue = null;
 
-    /**
-     * @var Indexer|null
-     */
     protected ?Indexer $indexer = null;
 
     protected function setUp(): void

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -26,8 +26,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to test the page queue initializer
- *
- * @author Timo Schmidt
  */
 class PageTest extends IntegrationTest
 {

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to test the Queue
- *
- * @author Timo Schmidt
  */
 class QueueTest extends IntegrationTest
 {

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -39,8 +39,6 @@ use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * Testcase for the record monitor
- *
- * @author Timo Schmidt
  */
 class RecordMonitorTest extends IntegrationTest
 {
@@ -119,9 +117,6 @@ class RecordMonitorTest extends IntegrationTest
         );
     }
 
-    /**
-     * @param int $amount
-     */
     protected function assertIndexQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->indexQueue->getAllItemsCount();
@@ -846,8 +841,6 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * Prepares the test cases mountPointIsOnlyAddedOnceForEachTree and
      * mountPointIsOnlyAddedOnceForEachTreeInDelayedMode
-     *
-     * @return array
      */
     protected function prepareMountPointIsOnlyAddedOnceForEachTree(): array
     {
@@ -1450,9 +1443,6 @@ class RecordMonitorTest extends IntegrationTest
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @return array
-     */
     public function updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider(): array
     {
         return [
@@ -1470,9 +1460,6 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
      * @test
-     *
-     * @param int $uid
-     * @param int $root
      */
     public function updateRecordOutsideSiteRootWithAdditionalWhereClause(int $uid, int $root): void
     {
@@ -1486,9 +1473,6 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
      * @test
-     *
-     * @param int $uid
-     * @param int $root
      */
     public function updateRecordOutsideSiteRootWithAdditionalWhereClauseInDelayedMode(int $uid, int $root): void
     {
@@ -1510,8 +1494,6 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * Prepares the test cases updateRecordOutsideSiteRootWithAdditionalWhereClause and
      * updateRecordOutsideSiteRootWithAdditionalWhereClauseInDelayedMode
-     *
-     * @param int $uid
      */
     protected function prepareUpdateRecordOutsideSiteRootWithAdditionalWhereClause(int $uid): void
     {
@@ -1804,9 +1786,6 @@ class RecordMonitorTest extends IntegrationTest
      * - updateRecordMonitoringTablesConfiguredNotForTableBeingUpdatedInDelayedModed
      * - updateRecordMonitoringTablesConfiguredForTableBeingUpdated
      * - updateRecordMonitoringTablesConfiguredForTableBeingUpdatedInDelayedModed
-     *
-     * @param int $monitoringType
-     * @param string $useConfigurationMonitorTables
      */
     protected function prepareUpdateRecordMonitoringTablesTests(int $monitoringType, string $useConfigurationMonitorTables): void
     {
@@ -1913,8 +1892,6 @@ class RecordMonitorTest extends IntegrationTest
 
     /**
      * Returns the data handler
-     *
-     * @return DataHandler
      */
     protected function getDataHandler(): DataHandler
     {

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -36,8 +36,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * Base class for all integration tests in the EXT:solr project
- *
- * @author Timo Schmidt
  */
 abstract class IntegrationTest extends FunctionalTestCase
 {
@@ -84,9 +82,6 @@ abstract class IntegrationTest extends FunctionalTestCase
         $this->failWhenSolrDeprecationIsCreated();
     }
 
-    /**
-     * @param string|null $coreName
-     */
     protected function cleanUpSolrServerAndAssertEmpty(?string $coreName = 'core_en'): void
     {
         $this->validateTestCoreName($coreName);
@@ -103,11 +98,6 @@ abstract class IntegrationTest extends FunctionalTestCase
         $this->assertSolrIsEmpty();
     }
 
-    /**
-     * @param string|null $coreName
-     *
-     * @return array|false
-     */
     protected function waitToBeVisibleInSolr(?string $coreName = 'core_en'): array|false
     {
         $this->validateTestCoreName($coreName);

--- a/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
+++ b/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the Solr Access Filter status report
- *
- * @author Timo Hund
  */
 class AccessFilterPluginInstalledStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/Report/SchemaStatusTest.php
+++ b/Tests/Integration/Report/SchemaStatusTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the schema status report
- *
- * @author Timo Hund
  */
 class SchemaStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the config status report
- *
- * @author Timo Hund
  */
 class SolrConfigStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the Solr configuration status report
- *
- * @author Timo Schmidt
  */
 class SolrConfigurationStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/Report/SolrStatusTest.php
+++ b/Tests/Integration/Report/SolrStatusTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the Solr status report
- *
- * @author Timo Hund
  */
 class SolrStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Reports\Status;
 
 /**
  * Integration test for the Solr version test
- *
- * @author Timo Hund
  */
 class SolrVersionStatusTest extends IntegrationTest
 {

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -32,8 +32,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Test class to perform a search on a real solr server
- *
- * @author Timo Schmidt
  */
 class SearchTest extends IntegrationTest
 {

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class ConfigurationPageResolverTest extends IntegrationTest
 {
     /**

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -21,9 +21,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class TypoScriptConfigurationTest extends IntegrationTest
 {
     protected function setUp(): void

--- a/Tests/Integration/System/Environment/CliEnvironmentTest.php
+++ b/Tests/Integration/System/Environment/CliEnvironmentTest.php
@@ -23,7 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to test the functionality of the CliEnvironment. Needs to be an integration test because
  * the constants stay defined in the unit test.
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class CliEnvironmentTest extends IntegrationTest
 {

--- a/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Integration test for the SystemCategoryRepository
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SystemCategoryRepositoryTest extends IntegrationTest
 {

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to check if the solr admin service is working as expected.
- *
- * @author Timo Hund
  */
 class SolrAdminServiceTest extends IntegrationTest
 {

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -29,9 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to check if the solr write service is working as expected.
- *
- * @author Timo Hund
- * (c) 2010-2015 Timo Schmidt <timo.schmidt@dkd.de>
  */
 class SolrWriteServiceTest extends IntegrationTest
 {

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Scheduler\Scheduler;
 /**
  * Test case to check if the scheduler task EventQueueWorkerTask can process
  * event queue entries
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class EventQueueWorkerTaskTest extends IntegrationTest
 {

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * TestCase to check if we can index from index queue worker task into a solr server
- *
- * @author Timo Schmidt
  */
 class IndexQueueWorkerTaskTest extends IntegrationTest
 {

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * TestCase to check if the index queue can be initialized by the ReIndex Task
- *
- * @author Timo Schmidt
  */
 class ReIndexTaskTest extends IntegrationTest
 {
@@ -73,9 +71,6 @@ class ReIndexTaskTest extends IntegrationTest
         );
     }
 
-    /**
-     * @param $amount
-     */
     protected function assertIndexQueryContainsItemAmount($amount)
     {
         self::assertEquals(

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
 
 /**
  * Testcase for AbstractIndexer
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class AbstractIndexerTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Access/RootlineElementTest.php
+++ b/Tests/Unit/Access/RootlineElementTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to verify the functionality of the RootlineElement
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RootlineElementTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to verify the functionality of the Rootline
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RootlineTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -36,8 +36,6 @@ use UnexpectedValueException;
 
 /**
  * PHP Unit test for connection manager
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class ConnectionManagerTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\ContentObject\Classification;
 
 /**
  * Tests for the SOLR_CLASSIFICATION cObj.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ClassificationTest extends SetUpContentObject
 {
@@ -58,9 +56,6 @@ class ClassificationTest extends SetUpContentObject
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @return array
-     */
     public function excludePatternDataProvider(): array
     {
         return [

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
 
 /**
  * Tests for the SOLR_MULTIVALUE cObj.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class MultivalueTest extends SetUpContentObject
 {

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -24,8 +24,6 @@ use Solarium\Core\Client\Endpoint;
 
 /**
  * Testcase for IndexQueueModuleController
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class IndexAdministrationModuleControllerTest extends AbstractModuleController
 {

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
 /**
  * Testcase for IndexQueueModuleController
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class IndexQueueModuleControllerTest extends AbstractModuleController
 {

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Classification\Classification;
 use ApacheSolrForTypo3\Solr\Domain\Index\Classification\ClassificationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class ClassificationServiceTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -28,9 +28,6 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class IndexServiceTest extends SetUpUnitTestCase
 {
     protected Site|MockObject $siteMock;
@@ -176,9 +173,6 @@ class IndexServiceTest extends SetUpUnitTestCase
         $indexService->indexItems(2);
     }
 
-    /**
-     * @param array $fakeItems
-     */
     protected function fakeQueueItemContent(array $fakeItems): void
     {
         $this->queueMock

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -39,9 +39,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class QueueInitializerServiceTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class RootPageResolverTest extends SetUpUnitTestCase
 {
     protected TwoLevelCache|MockObject $cacheMock;

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class QueueStatisticTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the DataUpdateHandler class.
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class DataUpdateHandlerTest extends SetUpUpdateHandler
 {
@@ -291,8 +289,6 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
 
     /**
      * Init basic page update expectations
-     *
-     * @param array $dummyPageRecord
      */
     protected function initBasicPageUpdateExpectations(array $dummyPageRecord): void
     {
@@ -955,9 +951,6 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
 
     /**
      * Inits a site repository and site mock to return a configuration mock
-     *
-     * @param int $pageId
-     * @return MockObject
      */
     protected function initSiteForDummyConfiguration(int $pageId): MockObject
     {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the DelayedProcessingEventListener
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class DelayedProcessingEventListenerTest extends SetUpEventListener
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 
 /**
  * Testcase for the DelayedProcessingFinishedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class DelayedProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 
 /**
  * Testcase for the DelayedProcessingQueuingFinishedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class DelayedProcessingQueuingFinishedEventTest extends SetUpProcessingFinishedEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 
 /**
  * Testcase for the ProcessingFinishedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class ProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Abstract testcase for the processing finished events
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 abstract class SetUpProcessingFinishedEvent extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
@@ -33,8 +33,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the ImmediateProcessingEventListener
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class ImmediateProcessingEventListenerTest extends SetUpEventListener
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdate
 
 /**
  * Testcase for the NoProcessingEventListener
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class NoProcessingEventListenerTest extends SetUpEventListener
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Abstract testcase for the event listeners
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 abstract class SetUpEventListener extends SetUpUnitTestCase
 {
@@ -69,8 +67,6 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
     }
 
     /**
-     * @param int $currentType
-     *
      * @test
      * @dataProvider inactiveMonitoringDataProvider
      */
@@ -105,8 +101,6 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
 
     /**
      * Returns the current monitoring type
-     *
-     * @return int
      */
     abstract protected function getMonitoringType(): int;
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentEleme
 
 /**
  * Testcase for the ContentElementDeletedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEve
 
 /**
  * Testcase for the PageMovedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class PageMovedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDelete
 
 /**
  * Testcase for the RecordDeletedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class RecordDeletedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbag
 
 /**
  * Testcase for the RecordGarbageCheckEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
 {
@@ -30,8 +28,6 @@ class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
 
     /**
      * @test
-     *
-     * @return AbstractDataUpdateEvent
      */
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
     {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedE
 
 /**
  * Testcase for the RecordMovedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class RecordMovedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdate
 
 /**
  * Testcase for the RecordUpdatedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class RecordUpdatedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Abstract testcase for the data update events
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
@@ -19,8 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwapp
 
 /**
  * Testcase for the VersionSwappedEvent
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class VersionSwappedEventTest extends SetUpDataUpdateEvent
 {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the GarbageHandler class.
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class GarbageHandlerTest extends SetUpUpdateHandler
 {
@@ -68,8 +66,6 @@ class GarbageHandlerTest extends SetUpUpdateHandler
      * Inits garbage collection expectations
      *
      * @param string $strategy Class name of strategy to expect
-     * @param string $table
-     * @param int $uid
      */
     protected function initGarbageCollectionExpectations(string $strategy, string $table, int $uid): void
     {

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/SetUpUpdateHandler.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/SetUpUpdateHandler.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Abstract testcase for the update handlers
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 abstract class SetUpUpdateHandler extends SetUpUnitTestCase
 {
@@ -57,9 +55,6 @@ abstract class SetUpUpdateHandler extends SetUpUnitTestCase
      */
     protected $indexQueueMock;
 
-    /**
-     * @var PagesRepository|MockObject
-     */
     protected PagesRepository|MockObject $pagesRepositoryMock;
 
     protected function setUp(): void

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Testcase for the Builder of ApacheSolrDocument
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class BuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
+++ b/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Highlight;
 use ApacheSolrForTypo3\Solr\Domain\Search\Highlight\SiteHighlighterUrlModifier;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SiteHighlighterUrlModifierTest extends SetUpUnitTestCase
 {
     public function canModifyDataProvider(): array

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Helper;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class EscapeHelperTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilde
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\BigramPhraseFields;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class BigramPhraseFieldsTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Grouping;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class GroupingTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilde
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class QueryFieldsTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -42,9 +42,6 @@ use Solarium\QueryType\Select\RequestBuilder;
 
 use function str_starts_with;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class QueryBuilderTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $configurationMock;

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SuggestQueryTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Class DefaultFacetQueryBuilderTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DefaultFacetQueryBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Class DefaultUrlEncoderTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DefaultUrlDecoderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Class FacetCollectionTest
- *
- * @author Frans Saris <frans@beech.it>
  */
 class FacetCollectionTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -24,9 +24,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcases for the Facet parser registry
- *
- * @author Frans Saris <frans@beech.it>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class FacetRegistryTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
 
 /**
  * Class HierarchyFacetParserTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
  */
 class HierarchyFacetParserTest extends SetUpFacetParser
 {
@@ -111,8 +108,6 @@ class HierarchyFacetParserTest extends SetUpFacetParser
 
     /**
      * Traverses the hierarchy facet and checks if some has more than one child.
-     *
-     * @param Node $node
      */
     protected function assertNoNodeHasMoreThanOneChildInTheHierarchy(Node $node)
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
@@ -21,7 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for query parser range
- * @author Markus Goldbach
  */
 class HierarchyUrlDecoderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to test the Node class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NodeTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Unit test for the OptionsFacet
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class OptionCollectionTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the dateRange queryBuilder
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -23,9 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Unit test for the OptionsFacet
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
  */
 class OptionsFacetTest extends SetUpUnitTestCase
 {
@@ -112,8 +109,6 @@ class OptionsFacetTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param mixed $includeInAvailableFacetsConfiguration
-     * @param mixed $expectedResult
      * @dataProvider getIncludeInAvailableFacetsDataProvider
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test for the QueryGroupFacet options collection
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
  */
 class OptionCollectionTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -27,9 +27,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
 
 /**
  * Class QueryGroupFacetParserTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
  */
 class QueryGroupFacetParserTest extends SetUpFacetParser
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the dateRange queryBuilder
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -23,9 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Unit test for the QueryGroupFacet
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
  */
 class QueryGroupFacetTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
 
 /**
  * Class DateRangeFacetParserTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeFacetParserTest extends SetUpFacetParser
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the dateRange queryBuilder
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for query parser range
- *
- * @author Markus Goldbach
  */
 class DateRangeUrlDecoderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
 
 /**
  * Class DateRangeFacetParserTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRangeFacetParserTest extends SetUpFacetParser
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the numericRange queryBuilder
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class NumericRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
@@ -22,10 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for query parser range
- *
- * @author Markus Goldbach <markus.goldbach@dkd.de>
- * @author Ingo Renner <ingo@typo3.org>
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
 {
@@ -44,8 +40,6 @@ class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
 
     /**
      * Provides data for filter decoding tests
-     *
-     * @return array
      */
     public function rangeQueryParsingDataProvider(): array
     {
@@ -61,10 +55,6 @@ class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
      *
      * @dataProvider rangeQueryParsingDataProvider
      * @test
-     *
-     * @param string $firstValue
-     * @param string $secondValue
-     * @param string $expectedResult
      */
     public function canParseRangeQuery(string $firstValue, string $secondValue, string $expectedResult)
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rend
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class FormatDateTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -24,7 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to test the RequirementsService
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RequirementsServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SetUpFacetParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SetUpFacetParser.php
@@ -27,10 +27,6 @@ use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
- */
 abstract class SetUpFacetParser extends SetUpUnitTestCase
 {
     protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile, array $facetConfiguration, array $activeFilters = []): SearchResultSet

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test for the SortingExpression
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Jens Jacobsen <jens.jacobsen@ueberbit.de>
  */
 class SortingExpressionTest extends SetUpUnitTestCase
 {
@@ -77,9 +74,6 @@ class SortingExpressionTest extends SetUpUnitTestCase
 
     /**
      * @param string|int|bool $sorting
-     * @param string $direction
-     * @param bool $isJson
-     * @param string $expectedResult
      * @dataProvider canBuildSortExpressionDataProvider
      * @test
      */

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetPackage;
 
 class TestPackage extends AbstractFacetPackage
 {
-    /**
-     * @return string
-     */
     public function getParserClassName(): string
     {
         return TestParser::class;

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcases for the url data bag
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class UrlFacetContainerTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the GroupCollection class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupCollectionTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the Group class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupItemTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -23,8 +23,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the Group class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -27,8 +27,6 @@ use Solarium\Component\Grouping;
 
 /**
  * Unit test case for the SearchResult.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class DefaultParserTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
@@ -25,8 +25,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to test the GroupedResultsParser.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupedResultsParserTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the ResultParserRegistryTest.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ResultParserRegistryTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 /**
  * Fake test parser
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class TestResultParser extends AbstractResultParser
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the SearchResultCollection.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchResultCollectionTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the SearchResult.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchResultTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -27,9 +27,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
- *
- * @author Timo Hund <timo.hund@dkd.de>
- * (c) 2015-2016 Timo Hund <timo.hund@dkd.de>
  */
 class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -35,9 +35,6 @@ use Solarium\Component\Grouping;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SearchResultSetServiceTest extends SetUpUnitTestCase
 {
     protected SearchResultSetService $searchResultSetService;

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -34,9 +34,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
-/**
- * @author Timo Schmidt <timo.schmidt@dkd.de>
- */
 class SearchResultSetTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $configurationMock;

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SortingTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
+++ b/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
@@ -18,14 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Score;
 use ApacheSolrForTypo3\Solr\Domain\Search\Score\ScoreCalculationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Schmidt <timo.schmidt@dkd.de>
- */
 class ScoreCalculationServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @var ScoreCalculationService
-     */
     protected ScoreCalculationService $scoreCalculationService;
 
     protected function setUp(): void

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SearchRequestBuilderTest extends SetUpUnitTestCase
 {
     protected FrontendUserSession|MockObject $sessionMock;

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Schmidt <timo.schmidt@dkd.de>
- */
 class SearchRequestTest extends SetUpUnitTestCase
 {
     /**
@@ -366,7 +363,6 @@ class SearchRequestTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param $query
      * @return SearchRequest
      */
     protected function getSearchRequestFromQueryString($query)

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Unit test case for the StatisticsWriterProcessor.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class StatisticsWriterProcessorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -37,9 +37,6 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SuggestServiceTest extends SetUpUnitTestCase
 {
     protected SuggestService|MockObject $suggestService;

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SearchUriBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -26,8 +26,6 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  * Testcase to check if the SiteHashService class works as expected.
  *
  * The unit test is used to make sure that the SiteHashService works as expected when the calls to Site:: are mocked
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SiteHashServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -30,9 +30,6 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  * Testcase to check if the SiteRepository class works as expected.
  *
  * The unit test is used to make sure that the SiteRepository works as expected
- *
- * @author Thomas Hohn <tho@systime.dk>
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SiteRepositoryTest extends SetUpUnitTestCase
 {
@@ -203,9 +200,6 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         return $siteMock;
     }
 
-    /**
-     * @param array $sitesInTYPO3
-     */
     protected function fakeSitesInTYPO3Systems(array $sitesInTYPO3): void
     {
         $this->siteFinderMock->expects(self::any())->method('getAllSites')->willReturn($sitesInTYPO3);

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
 /**
  * Testcase to check if the IdBuilder can be used to build proper variantIds.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class IdBuilderTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * tests the path to hierarchy processing
- *
- * @author    Daniel Pötzinger <poetzinger@aoemedia.de>
  */
 class PathToHierarchyTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * tests the processing Service class
- *
- * @author Daniel Poetzinger <poetzinger@aoemedia.de>
  */
 class ServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -29,8 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the GarbageCollector class.
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class GarbageCollectorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -20,9 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use UnexpectedValueException;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class AbstractIndexerTest extends SetUpUnitTestCase
 {
     protected function setUp(): void

--- a/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Manager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class ManagerTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -50,9 +50,6 @@ class IndexerTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param int $httpStatus
-     * @param bool $itemIndexed
-     *
      * @test
      * @dataProvider canTriggerIndexingAndIndicateIndexStatusDataProvider
      */

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class ItemTest extends SetUpUnitTestCase
 {
     /**
@@ -50,9 +47,6 @@ class ItemTest extends SetUpUnitTestCase
         self::assertSame('pages', $type, 'Can not get type from queue item');
     }
 
-    /**
-     * @return array
-     */
     public function getStateDataProvider(): array
     {
         return [

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Core\Http\RequestFactory;
 
 /**
  * Index Queue Page Indexer request test.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexerRequestTest extends SetUpUnitTestCase
 {
@@ -224,11 +222,6 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertContains('User-Agent: TYPO3', $headers, 'Header should contain a proper User-Agent');
     }
 
-    /**
-     * @param string|null $jsonEncodedParameter
-     * @param RequestFactory|null $requestFactory
-     * @return PageIndexerRequest
-     */
     protected function getPageIndexerRequest(string $jsonEncodedParameter = null, RequestFactory $requestFactory = null): PageIndexerRequest
     {
         /** @var MockObject|SolrLogManager $solrLogManagerMock */
@@ -239,11 +232,6 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         return new PageIndexerRequest($jsonEncodedParameter, $solrLogManagerMock, $extensionConfigurationMock, $requestFactory);
     }
 
-    /**
-     * @param $testParameters
-     * @param $fakeResponse
-     * @return MockObject|PageIndexerRequest
-     */
     protected function getMockedPageIndexerRequestWithUsedFakeResponse($testParameters, $fakeResponse): PageIndexerRequest|MockObject
     {
         $solrLogManagerMock = $this->createMock(SolrLogManager::class);
@@ -267,10 +255,6 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         return $requestMock;
     }
 
-    /**
-     * @param $fakeResponse
-     * @return ResponseInterface
-     */
     protected function getFakedGuzzleResponse($fakeResponse): ResponseInterface
     {
         $bodyStream = $this->createMock(StreamInterface::class);

--- a/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Index Queue Page Indexer response test.
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class PageIndexerResponseTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -31,8 +31,6 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * Testcase for the RecordMonitor class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RecordMonitorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -36,8 +36,6 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 
 /**
  * Test case to validate the behaviour of the middle ware
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -23,8 +23,6 @@ use TYPO3\CMS\Reports\Status;
 
 /**
  * Testcase for the SolrConfigurationStatus class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrConfigurationStatusTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Routing/RoutingServiceTest.php
+++ b/Tests/Unit/Routing/RoutingServiceTest.php
@@ -27,8 +27,6 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 
 /**
  * Unit test to cover functions inside the routing service
- *
- * @author Lars Tode <lars.tode@dkd.de>
  */
 class RoutingServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Search/ElevationComponentTest.php
+++ b/Tests/Unit/Search/ElevationComponentTest.php
@@ -27,8 +27,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Elevation class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ElevationComponentTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Search/FacetingComponentTest.php
+++ b/Tests/Unit/Search/FacetingComponentTest.php
@@ -34,8 +34,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Faceting class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class FacetingComponentTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -29,15 +29,9 @@ use Solarium\QueryType\Select\RequestBuilder;
 
 /**
  * Testcase for RelevanceComponent
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RelevanceComponentTest extends SetUpUnitTestCase
 {
-    /**
-     * @param $query
-     * @return array
-     */
     protected function getQueryParameters($query): array
     {
         $requestBuilder = new RequestBuilder();

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -29,8 +29,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for SortingComponent
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SortingComponentTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -31,14 +31,8 @@ class SearchTest extends SetUpUnitTestCase
      */
     protected SolrConnection|MockObject $solrConnectionMock;
 
-    /**
-     * @var SolrReadService|MockObject
-     */
     protected SolrReadService|MockObject $solrReadServiceMock;
 
-    /**
-     * @var Search
-     */
     protected Search $search;
 
     protected function setUp(): void

--- a/Tests/Unit/SetUpUnitTestCase.php
+++ b/Tests/Unit/SetUpUnitTestCase.php
@@ -21,8 +21,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Base class for all unit tests in the solr project
- *
- * @author Timo Hund
  */
 abstract class SetUpUnitTestCase extends UnitTestCase
 {
@@ -36,8 +34,6 @@ abstract class SetUpUnitTestCase extends UnitTestCase
 
     /**
      * Returns the absolute root path to the fixtures.
-     *
-     * @return string
      */
     protected function getFixtureRootPath(): string
     {
@@ -46,9 +42,6 @@ abstract class SetUpUnitTestCase extends UnitTestCase
 
     /**
      * Returns the absolute path to a fixture file.
-     *
-     * @param $fixtureName
-     * @return string
      */
     protected function getFixturePathByName($fixtureName): string
     {
@@ -59,7 +52,6 @@ abstract class SetUpUnitTestCase extends UnitTestCase
      * Returns the content of a fixture file.
      *
      * @param string $fixtureName
-     * @return string
      */
     protected function getFixtureContentByName($fixtureName): string
     {
@@ -82,8 +74,6 @@ abstract class SetUpUnitTestCase extends UnitTestCase
      *
      * @param object $object The object to be invoked
      * @param string $name the name of the method to call
-     * @param mixed $arguments
-     * @return mixed
      * @throws ReflectionException
      */
     protected function callInaccessibleMethod($object, $name, ...$arguments)

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -25,8 +25,6 @@ use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 
 /**
  * Unit testcase to check if the two level cache is working as expected.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class TwoLevelCacheTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
@@ -22,8 +22,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  * Testcase to test the functionallity of the extension configuration that comes from
  *
  * ext_conf_template.txt
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ExtensionConfigurationTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to check if the configuration object can be used as expected
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class TypoScriptConfigurationTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Testcase for ContentObjectService
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ContentObjectServiceTest extends SetUpUnitTestCase
 {
@@ -34,9 +32,6 @@ class ContentObjectServiceTest extends SetUpUnitTestCase
      */
     protected $contentObjectRendererMock;
 
-    /**
-     * @var ContentObjectService
-     */
     protected ContentObjectService $contentObjectService;
 
     protected function setUp(): void

--- a/Tests/Unit/System/Data/DateTimeTest.php
+++ b/Tests/Unit/System/Data/DateTimeTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Data;
 use ApacheSolrForTypo3\Solr\System\Data\DateTime;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class DateTimeTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/System/DateTime/FormatServiceTest.php
+++ b/Tests/Unit/System/DateTime/FormatServiceTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for FormatService
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class FormatServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\System\Logging\DebugWriter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Psr\Log\LogLevel;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class DebugWriterTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/System/Page/RootlineTest.php
+++ b/Tests/Unit/System/Page/RootlineTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the ArrayAccessor helper class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class RootlineTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -22,9 +22,6 @@ use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class ConfigurationServiceTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -22,16 +22,11 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 /**
  * Testcase for the SchemaParser class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class FrontendUserSessionTest extends SetUpUnitTestCase
 {
     protected FrontendUserAuthentication|MockObject $feUserMock;
 
-    /**
-     * @var FrontendUserSession
-     */
     protected FrontendUserSession $session;
 
     protected function setUp(): void

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -21,8 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the SchemaParser class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SchemaParserTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for StopWordParser
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class StopWordParserTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for StopWordParser
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SynonymParserTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -27,8 +27,6 @@ use function json_encode;
 
 /**
  * Tests the SolrAdminService class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrAdminServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -32,8 +32,6 @@ use Solarium\QueryType\Ping\Query as PingQuery;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SolrService class
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrReadServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
@@ -25,8 +25,6 @@ use Solarium\QueryType\Update\Result;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SolrService class
- *
- * @author Jens Jacobsen <typo3@jens-jacobsen.de>
  */
 class SolrWriteServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -32,23 +32,10 @@ use Solarium\Core\Client\Endpoint;
 
 /**
  * Class SolrConnectionTest
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SolrConnectionTest extends SetUpUnitTestCase
 {
     /**
-     * @param Node|null $readNode
-     * @param Node|null $writeNode
-     * @param TypoScriptConfiguration|null $configuration
-     * @param SynonymParser|null $synonymParser
-     * @param StopWordParser|null $stopWordParser
-     * @param SchemaParser|null $schemaParser
-     * @param SolrLogManager|null $logManager
-     * @param ClientInterface|null $psr7Client
-     * @param RequestFactoryInterface|null $requestFactory
-     * @param StreamFactoryInterface|null $streamFactory
-     * @param EventDispatcherInterface|null $eventDispatcher
      * @return SolrConnection
      */
     protected function getSolrConnectionWithDummyConstructorArgs(
@@ -124,9 +111,6 @@ class SolrConnectionTest extends SetUpUnitTestCase
         $connection->getAdminService();
     }
 
-    /**
-     * @return array
-     */
     public function coreNameDataProvider(): array
     {
         return [
@@ -150,9 +134,6 @@ class SolrConnectionTest extends SetUpUnitTestCase
         self::assertSame($expectedCoreName, $solrService->getReadService()->getPrimaryEndpoint()->getCore());
     }
 
-    /**
-     * @return array
-     */
     public function coreBasePathDataProvider(): array
     {
         return [

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -24,8 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to test the TCAService.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class TCAServiceTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase to check the functionallity of the UrlHelper
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class UrlHelperTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -18,9 +18,6 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\UserFunctions;
 use ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class FlexFormUserFunctionsTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/System/Util/ArrayAccessorTest.php
+++ b/Tests/Unit/System/Util/ArrayAccessorTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for the ArrayAccessor helper class.
- *
- * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
 class ArrayAccessorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -22,8 +22,6 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 
 /**
  * Testcase for the SiteUtilityTest helper class.
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class SiteUtilityTest extends SetUpUnitTestCase
 {
@@ -67,9 +65,6 @@ class SiteUtilityTest extends SetUpUnitTestCase
         self::assertSame('readhost', $property, 'Can not fallback to read property when write property is undefined');
     }
 
-    /**
-     * @return array
-     */
     public function writeConnectionTestsDataProvider(): array
     {
         return [
@@ -152,8 +147,6 @@ class SiteUtilityTest extends SetUpUnitTestCase
 
     /**
      * Data provider for testing boolean value handling
-     *
-     * @return array
      */
     public function siteConfigurationValueHandlingDataProvider(): array
     {
@@ -266,10 +259,6 @@ class SiteUtilityTest extends SetUpUnitTestCase
     /**
      * Tests if boolean values in site configuration can be handled
      *
-     * @param array $fakeConfiguration
-     * @param string $property
-     * @param string $scope
-     * @param mixed $expectedConfigurationValue
      *
      * @test
      * @dataProvider siteConfigurationValueHandlingDataProvider

--- a/Tests/Unit/System/Validator/PathTest.php
+++ b/Tests/Unit/System/Validator/PathTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase for the Path helper class.
- *
- * @author Thomas Hohn <tho@systime.dk>
  */
 class PathTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * Testcase for EventQueueWorkerTask
- *
- * @author Markus Friedrich <markus.friedrich@dkd.de>
  */
 class EventQueueWorkerTaskTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Core\Environment;
 
 /**
  * Testcase for IndexQueueWorkerTask
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Task/OptimizeIndexTaskTest.php
+++ b/Tests/Unit/Task/OptimizeIndexTaskTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for OptimizeIndexTask
- *
- * @author Jens Jacobsen <typo3@jens-jacobsen.de>
  */
 class OptimizeIndexTaskTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -20,8 +20,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 
 /**
  * Testcase for ReIndexTask
- *
- * @author Timo Hund <timo.hund@dkd.de>
  */
 class ReIndexTaskTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -21,8 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Tests the TYPO3 page content extractor
- *
- * @author Ingo Renner <ingo@typo3.org>
  */
 class Typo3PageContentExtractorTest extends SetUpUnitTestCase
 {

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -28,14 +28,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class HighlightingResultViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @return array
-     */
     public function canRenderCreateHighlightSnippedDataProvider(): array
     {
         return [

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -21,9 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\RelevanceViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class RelevanceViewHelperTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Area\GroupViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class GroupViewHelperTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelFilterVi
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class LabelFilterViewHelperTest extends SetUpUnitTestCase
 {
     /**

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -23,9 +23,6 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelPrefixes
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
 {
     /**
@@ -66,9 +63,6 @@ class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
         self::assertSame(['l', 'p', 'r'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
     }
 
-    /**
-     * @return OptionCollection
-     */
     protected function getTestFacetOptionCollection(): OptionCollection
     {
         $facet = $this->createMock(OptionsFacet::class);

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -30,9 +30,6 @@ use TYPO3\CMS\Fluid\View\TemplatePaths;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SearchFormViewHelperTest extends SetUpUnitTestCase
 {
     protected MockObject|SearchFormViewHelper $viewHelper;
@@ -75,9 +72,6 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @param int $pageUid
-     */
     protected function assertUriIsBuildForPageUid(int $pageUid)
     {
         $this->uriBuilderMock->expects(self::any())->method('reset')->willReturn($this->uriBuilderMock);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\AddFacetItemViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     /**

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -24,9 +24,6 @@ use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
 {
     /**

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetItemViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class RemoveFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     /**

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -19,10 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- * @author Frans Saris <frans@beech.it>
- */
 class RemoveFacetViewHelperTest extends SetUpFacetItemViewHelper
 {
     /**

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -19,9 +19,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\SetFacetItemViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 class SetFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     /**

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetUpFacetItemViewHelper.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetUpFacetItemViewHelper.php
@@ -22,9 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * @author Timo Hund <timo.hund@dkd.de>
- */
 abstract class SetUpFacetItemViewHelper extends SetUpUnitTestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
This change contains rule which disallows superfluous annotations:

* 'author', 'autor'
* 'copyright',
* superfluous
   * param, without proper description or important type infos
   * return, without proper description or important type infos

Fixes: #3745

---

### TODOS:

- [x] ~~extract all removed authors to a file~~ **No needs, because:**
   All authors/contributors are available on https://github.com/TYPO3-Solr/ext-solr/graphs/contributors
