### PR TITLE
[BUGFIX] Enable scripting module

### DIFF
--- a/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
@@ -9,6 +9,7 @@
 	<lib dir="${solr.install.dir:../../../..}/modules/langid/lib/" regex=".*\.jar" />
 	<lib dir="${solr.install.dir:../../../..}/modules/analytics/lib/" regex=".*\.jar" />
 	<lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex=".*\.jar" />
+	<lib dir="${solr.install.dir:../../../..}/modules/scripting/lib/" regex=".*\.jar" />
 
 	<!-- TYPO3 Plugins -->
 	<lib dir="typo3lib" regex=".*\.jar" />


### PR DESCRIPTION
# What this pr does

This PR fixes the Configuration for Solr by enabling the scripting module.
The XSLTResponseWriter is now part of this module and referenced later in the configuration.
Without enabling the scripting module Solr returns an error when trying to use the current configuration.

# How to test

Create a new Solr core with the new configuration, which now no longer results in an error.

Fixes: #3753
