### PR TITLE
[BUGFIX] Less strict return types on resolving values

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -119,7 +119,7 @@ abstract class AbstractIndexer
         string $solrFieldName,
         array $data,
         TypoScriptFrontendController $tsfe
-    ): array|float|int|string|null {
+    ): mixed {
         if (isset($indexingConfiguration[$solrFieldName . '.'])) {
             // configuration found => need to resolve a cObj
 
@@ -276,7 +276,7 @@ abstract class AbstractIndexer
      * @param string $fieldType The dynamic field's type
      * @return int|float|string|null Returns the value in the correct format for the field type
      */
-    protected function ensureFieldValueType(mixed $value, string $fieldType): int|float|string|null
+    protected function ensureFieldValueType(mixed $value, string $fieldType): mixed
     {
         switch ($fieldType) {
             case 'int':

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -102,7 +102,7 @@ class PageFieldMappingIndexer
      * @param string $solrFieldName The Solr field name to resolve the value from the item's record
      * @return string|array The resolved value to be indexed
      */
-    protected function resolveFieldValue(string $solrFieldName, Document $pageDocument, array $pageRecord): array|string
+    protected function resolveFieldValue(string $solrFieldName, Document $pageDocument, array $pageRecord): mixed
     {
         $pageIndexingConfiguration = $this->configuration->getIndexQueueFieldsConfigurationByConfigurationName($this->pageIndexingConfigurationName);
 


### PR DESCRIPTION
Resolves #3758

# What this pr does

Use less strict return types on some methods to allow all possible field types.

# How to test

Use fields like dateS, boolS and intS during indexing.

Fixes: #3758
