### PR TITLE
[BUGFIX] Delete index documents without available site

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -95,6 +95,10 @@ abstract class AbstractStrategy
             try {
                 $site = $indexQueueItem->getSite();
             } catch (InvalidArgumentException) {
+                $site = null;
+            }
+
+            if ($site === null) {
                 $this->queue->deleteItem($indexQueueItem->getType(), $indexQueueItem->getIndexQueueUid());
                 continue;
             }


### PR DESCRIPTION
This PR fixes a bug where an index document does not a have a site object assigned. In this case, the index document can be safely removed.

Since this bug occurred in a TYPO3 v11.5 environment, the PR should be backported to the 11.5.x branch.

Resolves: #3769
Releases: main, 11.5