### PR TITLE
[BUG] Fix detection of "draft records" in workspaces

### DIFF
--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -122,9 +122,14 @@ class Util
         $isWorkspaceRecord = false;
 
         if ((ExtensionManagementUtility::isLoaded('workspaces')) && (BackendUtility::isTableWorkspaceEnabled($table))) {
-            $record = BackendUtility::getRecord($table, $uid, 'pid, t3ver_state');
+            $record = BackendUtility::getRecord($table, $uid, 'pid, t3ver_state, t3ver_oid');
 
-            if ($record !== null && ($record['pid'] == '-1' || $record['t3ver_state'] > 0)) {
+            // \TYPO3\CMS\Core\Versioning\VersionState for an explanation of the t3ver_state field
+            // if it is >0, it is a draft record or
+            // if it is "0" (DEFAULT_STATE), could also be draft if t3ver_oid points to any uid (modified record)
+            if ($record !== null &&
+                ($record['pid'] == '-1' || $record['t3ver_state'] > 0 || (int)$record['t3ver_oid'] > 0)
+            ) {
                 $isWorkspaceRecord = true;
             }
         }


### PR DESCRIPTION
Also consider "modified placeholder records" as draft records to avoid them being indexed and also to avoid exceptions in the backend (PHP 8) in the garbage collector.

Resolves #3641
Relates: #3531
Ports: #3642