### PR TITLE
[BUGFIX] Do not index translations on default language fallbackType: free

### DIFF
--- a/Classes/Access/RootlineElementFormatException.php
+++ b/Classes/Access/RootlineElementFormatException.php
@@ -22,6 +22,4 @@ use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class RootlineElementFormatException extends InvalidArgumentException
-{
-}
+class RootlineElementFormatException extends InvalidArgumentException {}

--- a/Classes/Backend/SettingsPreviewOnPlugins.php
+++ b/Classes/Backend/SettingsPreviewOnPlugins.php
@@ -38,8 +38,7 @@ class SettingsPreviewOnPlugins
 
     public function __construct(
         protected FlexFormService $flexFormService
-    ) {
-    }
+    ) {}
 
     public function __invoke(PageContentPreviewRenderingEvent $event): void
     {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Exception/RootPageRecordNotFoundException.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Exception/RootPageRecordNotFoundException.php
@@ -20,6 +20,4 @@ use ApacheSolrForTypo3\Solr\Exception;
 /**
  * Exception that is thrown if the record of the root page couldn't be found
  */
-class RootPageRecordNotFoundException extends Exception
-{
-}
+class RootPageRecordNotFoundException extends Exception {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener
 /**
  * Delayed processing finished event
  */
-class DelayedProcessingFinishedEvent extends AbstractProcessingFinishedEvent
-{
-}
+class DelayedProcessingFinishedEvent extends AbstractProcessingFinishedEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener
 /**
  * Delayed processing queuing finished event
  */
-class DelayedProcessingQueuingFinishedEvent extends AbstractProcessingFinishedEvent
-{
-}
+class DelayedProcessingQueuingFinishedEvent extends AbstractProcessingFinishedEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener
 /**
  * Processing finished event
  */
-class ProcessingFinishedEvent extends AbstractProcessingFinishedEvent
-{
-}
+class ProcessingFinishedEvent extends AbstractProcessingFinishedEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a record is deleted
  */
-class RecordDeletedEvent extends AbstractDataUpdateEvent
-{
-}
+class RecordDeletedEvent extends AbstractDataUpdateEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a record garbage check is triggered
  */
-class RecordGarbageCheckEvent extends AbstractDataUpdateEvent
-{
-}
+class RecordGarbageCheckEvent extends AbstractDataUpdateEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a record is moved
  */
-class RecordMovedEvent extends AbstractDataUpdateEvent
-{
-}
+class RecordMovedEvent extends AbstractDataUpdateEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a record is created or updated
  */
-class RecordUpdatedEvent extends AbstractDataUpdateEvent
-{
-}
+class RecordUpdatedEvent extends AbstractDataUpdateEvent {}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEvent.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a version is swapped
  */
-class VersionSwappedEvent extends AbstractDataUpdateEvent
-{
-}
+class VersionSwappedEvent extends AbstractDataUpdateEvent {}

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -39,8 +39,7 @@ class Builder
 {
     public function __construct(
         protected readonly IdBuilder $variantIdBuilder
-    ) {
-    }
+    ) {}
 
     /**
      * This method can be used to build a Document from a TYPO3 page.

--- a/Classes/Domain/Search/Query/SearchQuery.php
+++ b/Classes/Domain/Search/Query/SearchQuery.php
@@ -17,6 +17,4 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
-class SearchQuery extends Query
-{
-}
+class SearchQuery extends Query {}

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacet.php
@@ -41,8 +41,7 @@ abstract class AbstractFacet
         protected string $field,
         protected string $label = '',
         protected array $facetConfiguration = []
-    ) {
-    }
+    ) {}
 
     /**
      * Returns facet name

--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
@@ -31,8 +31,7 @@ abstract class AbstractFacetItem
         protected int $documentCount = 0,
         protected bool $selected = false,
         protected array $metrics = []
-    ) {
-    }
+    ) {}
 
     public function getDocumentCount(): int
     {

--- a/Classes/Domain/Search/ResultSet/Facets/InvalidFacetPackageException.php
+++ b/Classes/Domain/Search/ResultSet/Facets/InvalidFacetPackageException.php
@@ -17,6 +17,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidFacetPackageException extends Exception
-{
-}
+class InvalidFacetPackageException extends Exception {}

--- a/Classes/Domain/Search/ResultSet/Facets/InvalidFacetParserException.php
+++ b/Classes/Domain/Search/ResultSet/Facets/InvalidFacetParserException.php
@@ -17,6 +17,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidFacetParserException extends Exception
-{
-}
+class InvalidFacetParserException extends Exception {}

--- a/Classes/Domain/Search/ResultSet/Facets/InvalidQueryBuilderException.php
+++ b/Classes/Domain/Search/ResultSet/Facets/InvalidQueryBuilderException.php
@@ -17,6 +17,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidQueryBuilderException extends Exception
-{
-}
+class InvalidQueryBuilderException extends Exception {}

--- a/Classes/Domain/Search/ResultSet/Facets/InvalidUrlDecoderException.php
+++ b/Classes/Domain/Search/ResultSet/Facets/InvalidUrlDecoderException.php
@@ -19,6 +19,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidUrlDecoderException extends Exception
-{
-}
+class InvalidUrlDecoderException extends Exception {}

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeCollection.php
@@ -25,6 +25,4 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class NodeCollection extends AbstractFacetItemCollection
-{
-}
+class NodeCollection extends AbstractFacetItemCollection {}

--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCollection.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeCollection.php
@@ -25,6 +25,4 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemColl
  * @author Frans Saris <frans@beech.it>
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class NumericRangeCollection extends AbstractFacetItemCollection
-{
-}
+class NumericRangeCollection extends AbstractFacetItemCollection {}

--- a/Classes/Domain/Search/ResultSet/Grouping/GroupItemCollection.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/GroupItemCollection.php
@@ -22,6 +22,4 @@ use ApacheSolrForTypo3\Solr\System\Data\AbstractCollection;
 /**
  * The GroupItemCollection contains the GroupItem objects.
  */
-class GroupItemCollection extends AbstractCollection
-{
-}
+class GroupItemCollection extends AbstractCollection {}

--- a/Classes/Domain/Search/Score/Score.php
+++ b/Classes/Domain/Search/Score/Score.php
@@ -27,8 +27,7 @@ class Score
         protected string $fieldName = '',
         protected float $score = 0.0,
         protected string $searchTerm = '',
-    ) {
-    }
+    ) {}
 
     public function getBoost(): float
     {

--- a/Classes/Domain/Site/Exception/InvalidSiteConfigurationCombinationException.php
+++ b/Classes/Domain/Site/Exception/InvalidSiteConfigurationCombinationException.php
@@ -19,6 +19,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site\Exception;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidSiteConfigurationCombinationException extends Exception
-{
-}
+class InvalidSiteConfigurationCombinationException extends Exception {}

--- a/Classes/Domain/Site/Exception/InvalidSiteRootPageException.php
+++ b/Classes/Domain/Site/Exception/InvalidSiteRootPageException.php
@@ -19,6 +19,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site\Exception;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class InvalidSiteRootPageException extends Exception
-{
-}
+class InvalidSiteRootPageException extends Exception {}

--- a/Classes/Domain/Site/Exception/UnexpectedTYPO3SiteInitializationException.php
+++ b/Classes/Domain/Site/Exception/UnexpectedTYPO3SiteInitializationException.php
@@ -19,6 +19,4 @@ namespace ApacheSolrForTypo3\Solr\Domain\Site\Exception;
 
 use ApacheSolrForTypo3\Solr\Exception;
 
-class UnexpectedTYPO3SiteInitializationException extends Exception
-{
-}
+class UnexpectedTYPO3SiteInitializationException extends Exception {}

--- a/Classes/Domain/Variants/IdBuilder.php
+++ b/Classes/Domain/Variants/IdBuilder.php
@@ -37,8 +37,7 @@ class IdBuilder
 {
     public function __construct(
         protected readonly EventDispatcherInterface $eventDispatcher
-    ) {
-    }
+    ) {}
 
     /**
      * This method is used to build a variantId.

--- a/Classes/Event/IndexQueue/AfterIndexQueueHasBeenInitializedEvent.php
+++ b/Classes/Event/IndexQueue/AfterIndexQueueHasBeenInitializedEvent.php
@@ -35,8 +35,7 @@ final class AfterIndexQueueHasBeenInitializedEvent
         private readonly string $type,
         private readonly array $indexingConfiguration,
         private bool $isInitialized
-    ) {
-    }
+    ) {}
 
     public function getInitializer(): AbstractInitializer
     {

--- a/Classes/Event/IndexQueue/AfterIndexQueueItemHasBeenMarkedForReindexingEvent.php
+++ b/Classes/Event/IndexQueue/AfterIndexQueueItemHasBeenMarkedForReindexingEvent.php
@@ -31,8 +31,7 @@ final class AfterIndexQueueItemHasBeenMarkedForReindexingEvent
         private readonly int $forcedChangeTime,
         private int $updateCount,
         private ?array $validLanguageUids
-    ) {
-    }
+    ) {}
 
     public function getItemType(): string
     {

--- a/Classes/Event/IndexQueue/AfterRecordsForIndexQueueItemsHaveBeenRetrievedEvent.php
+++ b/Classes/Event/IndexQueue/AfterRecordsForIndexQueueItemsHaveBeenRetrievedEvent.php
@@ -28,8 +28,7 @@ final class AfterRecordsForIndexQueueItemsHaveBeenRetrievedEvent
         private readonly string $table,
         private readonly array $uids,
         private array $records
-    ) {
-    }
+    ) {}
 
     public function getTable(): string
     {

--- a/Classes/Event/Indexing/AfterFrontendPageUriForIndexingHasBeenGeneratedEvent.php
+++ b/Classes/Event/Indexing/AfterFrontendPageUriForIndexingHasBeenGeneratedEvent.php
@@ -34,8 +34,7 @@ class AfterFrontendPageUriForIndexingHasBeenGeneratedEvent
         protected readonly int $languageId,
         protected readonly string $mountPointParameter,
         protected readonly array $options
-    ) {
-    }
+    ) {}
 
     public function getItem(): Item
     {

--- a/Classes/Event/Indexing/AfterPageDocumentIsCreatedForIndexingEvent.php
+++ b/Classes/Event/Indexing/AfterPageDocumentIsCreatedForIndexingEvent.php
@@ -40,8 +40,7 @@ final class AfterPageDocumentIsCreatedForIndexingEvent
         private readonly SiteLanguage $siteLanguage,
         private readonly array $record,
         private readonly TypoScriptConfiguration $configuration
-    ) {
-    }
+    ) {}
 
     public function getDocument(): Document
     {

--- a/Classes/Event/Indexing/BeforeDocumentsAreIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeDocumentsAreIndexedEvent.php
@@ -37,8 +37,7 @@ class BeforeDocumentsAreIndexedEvent
         private readonly Item $indexQueueItem,
         /**  @var Document[] */
         private array $documents,
-    ) {
-    }
+    ) {}
 
     public function getSite(): Site
     {

--- a/Classes/Event/Search/AfterInitialSearchResultSetHasBeenCreatedEvent.php
+++ b/Classes/Event/Search/AfterInitialSearchResultSetHasBeenCreatedEvent.php
@@ -35,8 +35,7 @@ final class AfterInitialSearchResultSetHasBeenCreatedEvent
         private readonly SearchRequest $searchRequest,
         private readonly Search $search,
         private readonly TypoScriptConfiguration $typoScriptConfiguration
-    ) {
-    }
+    ) {}
 
     public function getSearchResultSet(): SearchResultSet
     {

--- a/Classes/Event/Search/AfterSearchHasBeenExecutedEvent.php
+++ b/Classes/Event/Search/AfterSearchHasBeenExecutedEvent.php
@@ -39,8 +39,7 @@ final class AfterSearchHasBeenExecutedEvent
         private readonly SearchRequest $searchRequest,
         private readonly Search $search,
         private readonly TypoScriptConfiguration $typoScriptConfiguration
-    ) {
-    }
+    ) {}
 
     public function getSearchResultSet(): SearchResultSet
     {

--- a/Classes/Event/Search/AfterSearchQueryHasBeenPreparedEvent.php
+++ b/Classes/Event/Search/AfterSearchQueryHasBeenPreparedEvent.php
@@ -37,8 +37,7 @@ final class AfterSearchQueryHasBeenPreparedEvent
         private readonly SearchRequest $searchRequest,
         private readonly Search $search,
         private readonly TypoScriptConfiguration $typoScriptConfiguration
-    ) {
-    }
+    ) {}
 
     public function getQuery(): Query
     {

--- a/Classes/Event/Variants/AfterVariantIdWasBuiltEvent.php
+++ b/Classes/Event/Variants/AfterVariantIdWasBuiltEvent.php
@@ -36,8 +36,7 @@ final class AfterVariantIdWasBuiltEvent
         private readonly array $itemRecord,
         private readonly Site $site,
         private readonly Document $document
-    ) {
-    }
+    ) {}
 
     public function getVariantId(): string
     {

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr;
 /**
  * Generic Apache Solr for TYPO3 exception
  */
-class Exception extends \Exception
-{
-}
+class Exception extends \Exception {}

--- a/Classes/Exception/InvalidArgumentException.php
+++ b/Classes/Exception/InvalidArgumentException.php
@@ -22,6 +22,4 @@ use ApacheSolrForTypo3\Solr\Exception;
 /**
  * Exception that is thrown if a given argument is invalid.
  */
-class InvalidArgumentException extends Exception
-{
-}
+class InvalidArgumentException extends Exception {}

--- a/Classes/FrontendEnvironment/Exception/Exception.php
+++ b/Classes/FrontendEnvironment/Exception/Exception.php
@@ -21,6 +21,4 @@ use ApacheSolrForTypo3\Solr\Exception as ExtSolrException;
  * Exception that is thrown on initialization of EXT:solr FrontendEnvironment.
  * This exception should be used for any errors on indexing .
  */
-class Exception extends ExtSolrException
-{
-}
+class Exception extends ExtSolrException {}

--- a/Classes/IndexQueue/Exception/DocumentPreparationException.php
+++ b/Classes/IndexQueue/Exception/DocumentPreparationException.php
@@ -18,6 +18,4 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\Exception;
 /**
  * Exception that is thrown on TYPO3 side in indexing process.
  */
-class DocumentPreparationException extends IndexingException
-{
-}
+class DocumentPreparationException extends IndexingException {}

--- a/Classes/IndexQueue/Exception/IllegalStateException.php
+++ b/Classes/IndexQueue/Exception/IllegalStateException.php
@@ -20,6 +20,4 @@ use ApacheSolrForTypo3\Solr\Exception;
 /**
  * Exception that is thrown on indexing process and any potentially unusual state.
  */
-class IllegalStateException extends Exception
-{
-}
+class IllegalStateException extends Exception {}

--- a/Classes/IndexQueue/Exception/IndexingException.php
+++ b/Classes/IndexQueue/Exception/IndexingException.php
@@ -21,6 +21,4 @@ use ApacheSolrForTypo3\Solr\Exception;
  * Exception that is thrown on indexing process. Does not matter on which side, TYPO3 or Apache.
  * This exception should be used for any errors on indexing process.
  */
-class IndexingException extends Exception
-{
-}
+class IndexingException extends Exception {}

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -239,6 +239,14 @@ class Indexer extends AbstractIndexer
         ) {
             return null;
         }
+        // skip translated records for default language within "free content mode"-languages
+        if ($language === 0
+            && isset($languageField)
+            && (int)($itemRecord[$languageField] ?? null) !== $language
+            && $this->isLanguageInAFreeContentMode($item, (int)($itemRecord[$languageField] ?? null))
+        ) {
+            return null;
+        }
 
         $pidToUse = $this->getPageIdOfItem($item);
 

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -47,9 +47,7 @@ class Page extends AbstractInitializer
      *
      * @param string $type Type to initialize (ignored).
      */
-    public function setType(string $type): void
-    {
-    }
+    public function setType(string $type): void {}
 
     /**
      * Initializes Index Queue page items for a site. Includes regular pages

--- a/Classes/IndexQueue/InvalidFieldNameException.php
+++ b/Classes/IndexQueue/InvalidFieldNameException.php
@@ -23,6 +23,4 @@ use RuntimeException;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class InvalidFieldNameException extends RuntimeException
-{
-}
+class InvalidFieldNameException extends RuntimeException {}

--- a/Classes/IndexQueue/NoPidException.php
+++ b/Classes/IndexQueue/NoPidException.php
@@ -22,6 +22,4 @@ use ApacheSolrForTypo3\Solr\Exception;
  *
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class NoPidException extends Exception
-{
-}
+class NoPidException extends Exception {}

--- a/Classes/LanguageFileUnavailableException.php
+++ b/Classes/LanguageFileUnavailableException.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr;
  *
  * @author Ingo Renner <ingo@typo3.org>
  */
-class LanguageFileUnavailableException extends Exception
-{
-}
+class LanguageFileUnavailableException extends Exception {}

--- a/Classes/Pagination/ResultsPaginator.php
+++ b/Classes/Pagination/ResultsPaginator.php
@@ -52,9 +52,7 @@ class ResultsPaginator extends AbstractPaginator
     /**
      * Update paginated items
      */
-    public function updatePaginatedItems(int $itemsPerPage, int $offset): void
-    {
-    }
+    public function updatePaginatedItems(int $itemsPerPage, int $offset): void {}
 
     /**
      * Get amount of items on current page

--- a/Classes/PingFailedException.php
+++ b/Classes/PingFailedException.php
@@ -22,6 +22,4 @@ namespace ApacheSolrForTypo3\Solr;
  *
  * @author Timo Schmidt <timo.schmidt@dkd.de>
  */
-class PingFailedException extends Exception
-{
-}
+class PingFailedException extends Exception {}

--- a/Classes/Routing/Enhancer/SolrRouteEnhancerInterface.php
+++ b/Classes/Routing/Enhancer/SolrRouteEnhancerInterface.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\Routing\Enhancer;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
-interface SolrRouteEnhancerInterface
-{
-}
+interface SolrRouteEnhancerInterface {}

--- a/Classes/Search/AccessComponent.php
+++ b/Classes/Search/AccessComponent.php
@@ -31,8 +31,7 @@ class AccessComponent
 {
     public function __construct(
         protected readonly QueryBuilder $queryBuilder
-    ) {
-    }
+    ) {}
 
     /**
      * Initializes the search component.

--- a/Classes/Search/AnalysisComponent.php
+++ b/Classes/Search/AnalysisComponent.php
@@ -27,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class AnalysisComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Initializes the search component.

--- a/Classes/Search/DebugComponent.php
+++ b/Classes/Search/DebugComponent.php
@@ -27,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class DebugComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Initializes the search component.

--- a/Classes/Search/ElevationComponent.php
+++ b/Classes/Search/ElevationComponent.php
@@ -27,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class ElevationComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Enables the query's elevation mode.

--- a/Classes/Search/GroupingComponent.php
+++ b/Classes/Search/GroupingComponent.php
@@ -30,9 +30,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class GroupingComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Triggers grouping if activated

--- a/Classes/Search/HighlightingComponent.php
+++ b/Classes/Search/HighlightingComponent.php
@@ -27,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class HighlightingComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Initializes the search component.

--- a/Classes/Search/RelevanceComponent.php
+++ b/Classes/Search/RelevanceComponent.php
@@ -29,8 +29,7 @@ class RelevanceComponent
 {
     public function __construct(
         protected readonly QueryBuilder $queryBuilder
-    ) {
-    }
+    ) {}
 
     /**
      * Sets minimum match, boost function, boost query and tie-breaker.

--- a/Classes/Search/SortingComponent.php
+++ b/Classes/Search/SortingComponent.php
@@ -32,9 +32,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SortingComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Sets the sorting query parameters

--- a/Classes/Search/SpellcheckingComponent.php
+++ b/Classes/Search/SpellcheckingComponent.php
@@ -27,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
  */
 class SpellcheckingComponent
 {
-    public function __construct(protected readonly QueryBuilder $queryBuilder)
-    {
-    }
+    public function __construct(protected readonly QueryBuilder $queryBuilder) {}
 
     /**
      * Initializes the search component.

--- a/Classes/Search/StatisticsComponent.php
+++ b/Classes/Search/StatisticsComponent.php
@@ -32,8 +32,7 @@ class StatisticsComponent
     public function __construct(
         protected readonly QueryBuilder $queryBuilder,
         protected readonly StatisticsWriterProcessor $statisticsWriterProcessor
-    ) {
-    }
+    ) {}
 
     /**
      * Enables the query's debug mode to get more detailed information.

--- a/Classes/System/Environment/WebRootAllReadyDefinedException.php
+++ b/Classes/System/Environment/WebRootAllReadyDefinedException.php
@@ -22,6 +22,4 @@ use ApacheSolrForTypo3\Solr\Exception;
  *
  * @author Timo Hund <timo.hund@dkd.de>
  */
-class WebRootAllReadyDefinedException extends Exception
-{
-}
+class WebRootAllReadyDefinedException extends Exception {}

--- a/Classes/System/Language/FrontendOverlayService.php
+++ b/Classes/System/Language/FrontendOverlayService.php
@@ -37,8 +37,7 @@ class FrontendOverlayService
     public function __construct(
         protected readonly TCAService $tcaService,
         protected readonly TypoScriptFrontendController $tsfe
-    ) {
-    }
+    ) {}
 
     /**
      * Return the translated record

--- a/Classes/System/Mvc/Backend/Component/Exception/InvalidViewObjectNameException.php
+++ b/Classes/System/Mvc/Backend/Component/Exception/InvalidViewObjectNameException.php
@@ -19,6 +19,4 @@ namespace ApacheSolrForTypo3\Solr\System\Mvc\Backend\Component\Exception;
 
 use TYPO3\CMS\Extbase\Mvc\Exception;
 
-class InvalidViewObjectNameException extends Exception
-{
-}
+class InvalidViewObjectNameException extends Exception {}

--- a/Classes/System/Solr/SolrIncompleteResponseException.php
+++ b/Classes/System/Solr/SolrIncompleteResponseException.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\System\Solr;
 /**
  * This exception should be thrown when the response from solr was incomplete
  */
-class SolrIncompleteResponseException extends SolrCommunicationException
-{
-}
+class SolrIncompleteResponseException extends SolrCommunicationException {}

--- a/Classes/System/Solr/SolrInternalServerErrorException.php
+++ b/Classes/System/Solr/SolrInternalServerErrorException.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\System\Solr;
 /**
  * This exception is used when the solr an 500 internal server error is thrown by the solr server
  */
-class SolrInternalServerErrorException extends SolrCommunicationException
-{
-}
+class SolrInternalServerErrorException extends SolrCommunicationException {}

--- a/Classes/System/Solr/SolrUnavailableException.php
+++ b/Classes/System/Solr/SolrUnavailableException.php
@@ -20,6 +20,4 @@ namespace ApacheSolrForTypo3\Solr\System\Solr;
 /**
  * This exception is used when the solr server is unavailable.
  */
-class SolrUnavailableException extends SolrCommunicationException
-{
-}
+class SolrUnavailableException extends SolrCommunicationException {}

--- a/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
+++ b/Classes/Task/IndexQueueWorkerTaskAdditionalFieldProvider.php
@@ -37,8 +37,7 @@ class IndexQueueWorkerTaskAdditionalFieldProvider extends AbstractAdditionalFiel
 {
     public function __construct(
         protected readonly SiteRepository $siteRepository
-    ) {
-    }
+    ) {}
 
     /**
      * Used to define fields to provide the TYPO3 site to index and number of

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -103,8 +103,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
      */
     public function resolveFieldValue(array $indexingConfiguration, string $solrFieldName, array $data, $expectedValue): void
     {
-        $subject = new class () extends AbstractIndexer {
-        };
+        $subject = new class () extends AbstractIndexer {};
         $tsfe = $this->createMock(TypoScriptFrontendController::class);
         self::assertEquals(
             $this->callInaccessibleMethod(

--- a/Tests/Unit/IndexQueue/FrontendHelper/InvalidFakeHelper.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/InvalidFakeHelper.php
@@ -2,6 +2,4 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
 
-class InvalidFakeHelper
-{
-}
+class InvalidFakeHelper {}

--- a/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
+++ b/Tests/Unit/IndexQueue/InvalidSerializedValueDetector.php
@@ -15,6 +15,4 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
-class InvalidSerializedValueDetector
-{
-}
+class InvalidSerializedValueDetector {}


### PR DESCRIPTION
# What this pr does

With fallbackType: free the index queue contains an entry for each available language. Without this check all the entries are additionally indexed in the default language. They should be only indexed for the language, the record has defined as sys_language_uid.
See extensive debuggin in the issue.

# How to test

Have a record based indexing configuration and change `fallbackType` to `free` in your site config. Do not set any `fallbacks`

Fixes #3560
