### PR TITLE
[BUGFIX] Do not index translations on default language in languages free mode

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -264,6 +264,14 @@ class Indexer extends AbstractIndexer
         ) {
             return null;
         }
+        // skip translated records for default language within "free content mode"-languages
+        if ($language === 0
+            && isset($languageField)
+            && (int)($itemRecord[$languageField] ?? null) !== $language
+            && $this->isLanguageInAFreeContentMode($item, (int)($itemRecord[$languageField] ?? null))
+        ) {
+            return null;
+        }
 
         $pidToUse = $this->getPageIdOfItem($item);
 


### PR DESCRIPTION
With fallbackType: free the index queue contains an entry for each available language. Without this check all the entries are additionally indexed in the default language. They should be only indexed for the language, the record has defined as sys_language_uid.

Fixes #3560
Ports: #3785