### PR TITLE
[TASK:BP:11.6] Ensure recursive page update on page movement

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -272,13 +272,27 @@ class DataUpdateHandler extends AbstractUpdateHandler
      * Handle page move
      *
      * @param int $uid
+     * @param int|null $previousParentId
      * @throws DBALDriverException
      * @throws DBALException|\Doctrine\DBAL\DBALException
      * @throws Throwable
      */
-    public function handleMovedPage(int $uid): void
+    public function handleMovedPage(int $uid, ?int $previousParentId = null): void
     {
+        $excludedPages = $this->pagesRepository->findAllPagesWithinNoSearchSubEntriesMarkedPages();
+        if (in_array($uid, $excludedPages)) {
+            return;
+        }
+
         $this->applyPageChangesToQueue($uid);
+
+        if ($previousParentId !== null) {
+            $pageRecord = BackendUtility::getRecord('pages', $uid);
+            if ($pageRecord !== null && (int)$pageRecord['pid'] !== $previousParentId) {
+                $treePageIds = $this->getSubPageIds($uid);
+                $this->updatePageIdItems($treePageIds);
+            }
+        }
     }
 
     /**
@@ -560,7 +574,8 @@ class DataUpdateHandler extends AbstractUpdateHandler
     protected function updatePageIdItems(array $treePageIds): void
     {
         foreach ($treePageIds as $treePageId) {
-            $this->indexQueue->updateItem('pages', $treePageId);
+            $this->indexQueue->updateItem('pages', $treePageId, time());
+            $this->mountPageUpdater->update($treePageId);
         }
     }
 

--- a/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListener.php
@@ -102,7 +102,7 @@ class ImmediateProcessingEventListener extends AbstractBaseEventListener
     protected function handleRecordMovedEvent(RecordMovedEvent $event): void
     {
         if ($event->isPageUpdate()) {
-            $this->getDataUpdateHandler()->handleMovedPage($event->getUid());
+            $this->getDataUpdateHandler()->handleMovedPage($event->getUid(), $event->getPreviousParentId());
         } else {
             $this->getDataUpdateHandler()->handleMovedRecord($event->getUid(), $event->getTable());
         }
@@ -146,7 +146,7 @@ class ImmediateProcessingEventListener extends AbstractBaseEventListener
      */
     protected function handlePageMovedEvent(PageMovedEvent $event): void
     {
-        $this->getGarbageHandler()->handlePageMovement($event->getUid());
+        $this->getGarbageHandler()->handlePageMovement($event->getUid(), $event->getPreviousParentId());
     }
 
     /**

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/AbstractRecordMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/AbstractRecordMovedEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
+
+/**
+ * Abstract event base for events fired if a record or page is moved
+ */
+abstract class AbstractRecordMovedEvent extends AbstractDataUpdateEvent
+{
+    /**
+     * pid of the record prior moving
+     *
+     * @var int|null
+     */
+    protected ?int $previousParentId = null;
+
+    /**
+     * Sets the record's pid prior moving
+     *
+     * @param int $pid
+     */
+    public function setPreviousParentId(int $pid)
+    {
+        $this->previousParentId = $pid;
+    }
+
+    /**
+     * Returns the record's pid prior moving
+     *
+     * @return int|null
+     */
+    public function getPreviousParentId(): ?int
+    {
+        return $this->previousParentId;
+    }
+}

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/PageMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/PageMovedEvent.php
@@ -20,7 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a page is moved
  */
-class PageMovedEvent extends AbstractDataUpdateEvent
+class PageMovedEvent extends AbstractRecordMovedEvent
 {
     /**
      * Constructor

--- a/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEvent.php
@@ -20,6 +20,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events;
 /**
  * Event fired if a record is moved
  */
-class RecordMovedEvent extends AbstractDataUpdateEvent
+class RecordMovedEvent extends AbstractRecordMovedEvent
 {
 }

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -264,6 +264,14 @@ class Indexer extends AbstractIndexer
         ) {
             return null;
         }
+        // skip translated records for default language within "free content mode"-languages
+        if ($language === 0
+            && isset($languageField)
+            && (int)($itemRecord[$languageField] ?? null) !== $language
+            && $this->isLanguageInAFreeContentMode($item, (int)($itemRecord[$languageField] ?? null))
+        ) {
+            return null;
+        }
 
         $pidToUse = $this->getPageIdOfItem($item);
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -114,9 +114,14 @@ class Util
         $isWorkspaceRecord = false;
 
         if ((ExtensionManagementUtility::isLoaded('workspaces')) && (BackendUtility::isTableWorkspaceEnabled($table))) {
-            $record = BackendUtility::getRecord($table, $uid, 'pid, t3ver_state');
+            $record = BackendUtility::getRecord($table, $uid, 'pid, t3ver_state, t3ver_oid');
 
-            if ($record !== null && ($record['pid'] == '-1' || $record['t3ver_state'] > 0)) {
+            // \TYPO3\CMS\Core\Versioning\VersionState for an explanation of the t3ver_state field
+            // if it is >0, it is a draft record or
+            // if it is "0" (DEFAULT_STATE), could also be draft if t3ver_oid points to any uid (modified record)
+            if ($record !== null &&
+                ($record['pid'] == '-1' || $record['t3ver_state'] > 0 || (int)$record['t3ver_oid'] > 0)
+            ) {
                 $isWorkspaceRecord = true;
             }
         }

--- a/Tests/Integration/Fixtures/can_collect_garbage_if_page_tree_is_moved.xml
+++ b/Tests/Integration/Fixtures/can_collect_garbage_if_page_tree_is_moved.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>2</uid>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<title>1st subpage in root 1</title>
+		<sorting>10</sorting>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<title>2nd subpage in root 1</title>
+		<sorting>20</sorting>
+	</pages>
+	<pages>
+		<uid>4</uid>
+		<doktype>254</doktype>
+		<pid>1</pid>
+		<title>sysfolder with set option no_search_sub_entries</title>
+		<no_search_sub_entries>1</no_search_sub_entries>
+		<sorting>99</sorting>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>root of subtree to be moved</title>
+		<sorting>30</sorting>
+	</pages>
+	<pages>
+		<uid>11</uid>
+		<doktype>1</doktype>
+		<pid>10</pid>
+		<title>first child of subtree to be moved</title>
+	</pages>
+	<pages>
+		<uid>12</uid>
+		<doktype>1</doktype>
+		<pid>10</pid>
+		<title>2nd child of subtree to be moved</title>
+	</pages>
+	<pages>
+		<uid>13</uid>
+		<doktype>1</doktype>
+		<pid>11</pid>
+		<title>3rd child of subtree to be moved</title>
+	</pages>
+</dataset>

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -330,6 +330,83 @@ class GarbageCollectorTest extends IntegrationTest
     /**
      * @test
      */
+    public function canCollectGarbageIfPageTreeIsMoved(): void
+    {
+        $this->importDataSetFromFixture('can_collect_garbage_if_page_tree_is_moved.xml');
+
+        $this->assertEmptyIndexQueue();
+        $this->addToQueueAndIndexRecord('pages', 10);
+        $this->addToQueueAndIndexRecord('pages', 11);
+        $this->addToQueueAndIndexRecord('pages', 12);
+        $this->addToQueueAndIndexRecord('pages', 13);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(4);
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => 2]]],
+            $this->fakeBEUser(1, 0)
+        );
+
+        $this->dataHandler->process_cmdmap();
+        $this->assertIndexQueueContainsItemAmount(4);
+        $this->assertSolrContainsDocumentCount(0);
+    }
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageIfPageTreeIsMovedToSysfolderWithDisabledOptionIncludeSubEntriesInSearch(): void
+    {
+        $this->importDataSetFromFixture('can_collect_garbage_if_page_tree_is_moved.xml');
+
+        $this->assertEmptyIndexQueue();
+        $this->addToQueueAndIndexRecord('pages', 10);
+        $this->addToQueueAndIndexRecord('pages', 11);
+        $this->addToQueueAndIndexRecord('pages', 12);
+        $this->addToQueueAndIndexRecord('pages', 13);
+        $this->waitToBeVisibleInSolr();
+        $this->assertIndexQueueContainsItemAmount(4);
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => 4]]],
+            $this->fakeBEUser(1, 0)
+        );
+        $this->dataHandler->process_cmdmap();
+        $this->assertEmptyIndexQueue();
+        $this->assertSolrContainsDocumentCount(0);
+    }
+
+    /**
+     * @test
+     */
+    public function canCollectGarbageIfPageTreeIsMovedButStaysOnSamePage(): void
+    {
+        $this->importDataSetFromFixture('can_collect_garbage_if_page_tree_is_moved.xml');
+
+        $this->assertEmptyIndexQueue();
+        $this->addToQueueAndIndexRecord('pages', 10);
+        $this->addToQueueAndIndexRecord('pages', 11);
+        $this->addToQueueAndIndexRecord('pages', 12);
+        $this->addToQueueAndIndexRecord('pages', 13);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(4);
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => -2]]],
+            $this->fakeBEUser(1, 0)
+        );
+
+        $this->dataHandler->process_cmdmap();
+        $this->assertIndexQueueContainsItemAmount(4);
+        $this->assertSolrContainsDocumentCount(3);
+    }
+
+    /**
+     * @test
+     */
     public function canRemoveDeletedContentElement(): void
     {
         $this->prepareCanRemoveDeletedContentElement();

--- a/Tests/Integration/IndexQueue/Fixtures/can_handle_mounted_page_tree_movement.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_handle_mounted_page_tree_movement.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>2</uid>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<title>1st subpage in root 1</title>
+		<sorting>10</sorting>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<doktype>7</doktype>
+		<pid>1</pid>
+		<title>mount point for subtree</title>
+		<sorting>20</sorting>
+		<mount_pid_ol>0</mount_pid_ol>
+		<mount_pid>10</mount_pid>
+	</pages>
+	<pages>
+		<uid>4</uid>
+		<doktype>254</doktype>
+		<pid>1</pid>
+		<title>sysfolder with set option no_search_sub_entries</title>
+		<no_search_sub_entries>1</no_search_sub_entries>
+		<sorting>99</sorting>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>root of subtree to be moved</title>
+		<sorting>30</sorting>
+	</pages>
+	<pages>
+		<uid>11</uid>
+		<doktype>1</doktype>
+		<pid>10</pid>
+		<title>first child of subtree to be moved</title>
+	</pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_handle_page_tree_movement.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_handle_page_tree_movement.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>2</uid>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<title>1st subpage in root 1</title>
+		<sorting>10</sorting>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<title>2nd subpage in root 1</title>
+		<sorting>20</sorting>
+	</pages>
+	<pages>
+		<uid>4</uid>
+		<doktype>254</doktype>
+		<pid>1</pid>
+		<title>sysfolder with set option no_search_sub_entries</title>
+		<no_search_sub_entries>1</no_search_sub_entries>
+		<sorting>99</sorting>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<hidden>0</hidden>
+		<title>root of subtree to be moved</title>
+		<sorting>30</sorting>
+	</pages>
+	<pages>
+		<uid>11</uid>
+		<doktype>1</doktype>
+		<pid>10</pid>
+		<title>first child of subtree to be moved</title>
+	</pages>
+	<pages>
+		<uid>12</uid>
+		<doktype>1</doktype>
+		<pid>10</pid>
+		<title>2nd child of subtree to be moved</title>
+	</pages>
+	<pages>
+		<uid>13</uid>
+		<doktype>1</doktype>
+		<pid>11</pid>
+		<title>3rd child of subtree to be moved</title>
+	</pages>
+</dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -805,6 +805,57 @@ class RecordMonitorTest extends IntegrationTest
     /**
      * @test
      */
+    public function canHandePageTreeMovement(): void
+    {
+        $this->importDataSetFromFixture('can_handle_page_tree_movement.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => 2]]],
+            $this->fakeBEUser(1, 0)
+        );
+        $this->dataHandler->process_cmdmap();
+        $this->assertIndexQueueContainsItemAmount(4);
+    }
+
+    /**
+     * @test
+     */
+    public function canHandePageTreeMovementIfPageTreeIsMovedToSysfolderWithDisabledOptionIncludeSubEntriesInSearch(): void
+    {
+        $this->importDataSetFromFixture('can_handle_page_tree_movement.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => 4]]],
+            $this->fakeBEUser(1, 0)
+        );
+        $this->dataHandler->process_cmdmap();
+        $this->assertEmptyIndexQueue();
+    }
+
+    /**
+     * @test
+     */
+    public function canHandePageTreeMovementIfPageTreeIsMounted(): void
+    {
+        $this->importDataSetFromFixture('can_handle_mounted_page_tree_movement.xml');
+        $this->assertEmptyIndexQueue();
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [10 => ['move' => 2]]],
+            $this->fakeBEUser(1, 0)
+        );
+        $this->dataHandler->process_cmdmap();
+        $this->assertIndexQueueContainsItemAmount(3);
+    }
+
+    /**
+     * @test
+     */
     public function mountPointIsOnlyAddedOnceForEachTree(): void
     {
         $data = $this->prepareMountPointIsOnlyAddedOnceForEachTree();

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -91,11 +91,6 @@ class GarbageHandlerTest extends AbstractUpdateHandlerTest
     public function handlePageMovementTriggersGarbageCollectionAndReindexing(): void
     {
         $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
-        $this->indexQueueMock
-            ->expects(self::once())
-            ->method('updateItem')
-            ->with('pages', 123);
-
         $this->garbageHandler->handlePageMovement(123);
     }
 


### PR DESCRIPTION
Backport of https://github.com/TYPO3-Solr/ext-solr/pull/3787

This PR also contains backports of 2 commits missing in 11.6:
- https://github.com/TYPO3-Solr/ext-solr/pull/3785
- https://github.com/TYPO3-Solr/ext-solr/pull/3780

---

# What this pr does

If a page is moved, subpages have to be considered, e.g. as rootline and slug might have changed. Also the MountPagesUpdater has to be triggerd to ensure mounted pages will be updated too.

This commit adds the missing recursive updates, an extension to the RecordMovedEvent and PageMovedEvent is done allowing that recursive updates on move operations will only be done if the parent page of the page has changed.

# How to test

Move a page with subpages and check index and queue, moved pages have to be removed from index and queued for reindexing.

Resolves: #206
