### PR TITLE
[TASK:BP:11.5] Migrate top.fsMod

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -222,11 +222,6 @@ abstract class AbstractModuleController extends ActionController
             return;
         }
 
-        $this->moduleTemplate->addJavaScriptCode(
-            'mainJsFunctions',
-            '
-                top.fsMod.recentIds["searchbackend"] = ' . $this->selectedPageUID . ';'
-        );
         if ($this->selectedSite === null) {
             return;
         }

--- a/Resources/Private/Layouts/Backend/WithPageTree.html
+++ b/Resources/Private/Layouts/Backend/WithPageTree.html
@@ -3,6 +3,8 @@
         <f:render partial="Backend/NoSiteAvailable" arguments="{_all}"/>
     </f:then>
     <f:else>
+        <f:variable name="args" value="{0: 'searchbackend', 1: pageUID}" />
+        <typo3-immediate-action action="TYPO3.Backend.Storage.ModuleStateStorage.update" args="{args -> f:format.json() -> f:format.htmlspecialchars()}"></typo3-immediate-action>
 
         <f:render partial="Backend/FlashMessages" />
         <f:render section="Main"/>


### PR DESCRIPTION
# What this pr does

JavaScript top.fsMod is deprecated since TYPO3 11.4, this commit replaces the old top.fsMod usage with the ModuleStateStorage, now the ImmediateActionElement is used.

# How to test

1. Open EXT:solr backend module and select a page in the page tree
2. Select another solr module, check `ModuleStateStorage.current('searchbackend')`

=> Selected page should be stored in the `ModuleStateStorage`

Ports: #3794
Fixes: #3489
