### PR TITLE
 [TASK] Require TYPO3 12.4.3 to get typo3fluid/fluid >= 2.9.2 

### DIFF
--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -126,7 +126,6 @@ class SearchControllerTest extends IntegrationTest
      */
     public function canDoAPaginatedSearch()
     {
-        self::markTestSkipped('Skipped due https://github.com/TYPO3-Solr/ext-solr/issues/3691');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
         $this->addTypoScriptToTemplateRecord(
             1,

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "ext-simplexml": "*",
     "solarium/solarium": "6.3.2",
     "typo3/cms-backend": "*",
-    "typo3/cms-core": "^v12.4.2",
+    "typo3/cms-core": "^v12.4.3",
     "typo3/cms-extbase": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-frontend": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '12.4.0-12.4.99',
+            'typo3' => '12.4.3-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Due to an internal bug in typo3fluid/fluid the pagination might fail, this bug is fixed in typo3fluid/fluid 2.9.2.

We now require typo3fluid/fluid >= 2.9.2 to ensure the right version is used and the pagination works as expected.

The failing test is reenabled.

Resolves: #3691