### PR TITLE
[TASK] Always delegate simulated TSFE via PSR-14 events instead of Site/SiteLanguage

### DIFF
--- a/Classes/Event/Indexing/AfterPageDocumentIsCreatedForIndexingEvent.php
+++ b/Classes/Event/Indexing/AfterPageDocumentIsCreatedForIndexingEvent.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Allows third party extensions to replace or modify the page document
@@ -36,9 +37,8 @@ final class AfterPageDocumentIsCreatedForIndexingEvent
     public function __construct(
         private Document $document,
         private readonly Item $indexQueueItem,
-        private readonly Site $site,
-        private readonly SiteLanguage $siteLanguage,
         private readonly array $record,
+        private readonly TypoScriptFrontendController $tsfe,
         private readonly TypoScriptConfiguration $configuration
     ) {}
 
@@ -64,12 +64,12 @@ final class AfterPageDocumentIsCreatedForIndexingEvent
 
     public function getSite(): Site
     {
-        return $this->site;
+        return $this->tsfe->getSite();
     }
 
     public function getSiteLanguage(): SiteLanguage
     {
-        return $this->siteLanguage;
+        return $this->tsfe->getLanguage();
     }
 
     public function getRecord(): array
@@ -80,5 +80,10 @@ final class AfterPageDocumentIsCreatedForIndexingEvent
     public function getConfiguration(): TypoScriptConfiguration
     {
         return $this->configuration;
+    }
+
+    public function getTsfe(): TypoScriptFrontendController
+    {
+        return clone $this->tsfe;
     }
 }

--- a/Classes/Event/Indexing/BeforeDocumentIsProcessedForIndexingEvent.php
+++ b/Classes/Event/Indexing/BeforeDocumentIsProcessedForIndexingEvent.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Allows third party extensions to provide additional documents which
@@ -38,21 +39,20 @@ class BeforeDocumentIsProcessedForIndexingEvent
 
     public function __construct(
         private readonly Document $document,
-        private readonly Site $site,
-        private readonly SiteLanguage $siteLanguage,
-        private readonly Item $indexQueueItem
+        private readonly Item $indexQueueItem,
+        private readonly TypoScriptFrontendController $tsfe,
     ) {
         $this->documents[] = $this->document;
     }
 
     public function getSite(): Site
     {
-        return $this->site;
+        return $this->tsfe->getSite();
     }
 
     public function getSiteLanguage(): SiteLanguage
     {
-        return $this->siteLanguage;
+        return $this->tsfe->getLanguage();
     }
 
     public function getIndexQueueItem(): Item
@@ -79,5 +79,10 @@ class BeforeDocumentIsProcessedForIndexingEvent
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    public function getTsfe(): TypoScriptFrontendController
+    {
+        return clone $this->tsfe;
     }
 }

--- a/Classes/Event/Indexing/BeforeDocumentsAreIndexedEvent.php
+++ b/Classes/Event/Indexing/BeforeDocumentsAreIndexedEvent.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * An event to manipulate documents right before they get added to the Solr index.
@@ -32,21 +33,20 @@ class BeforeDocumentsAreIndexedEvent
 {
     public function __construct(
         private readonly Document $document,
-        private readonly Site $site,
-        private readonly SiteLanguage $siteLanguage,
         private readonly Item $indexQueueItem,
         /**  @var Document[] */
         private array $documents,
+        private readonly TypoScriptFrontendController $tsfe,
     ) {}
 
     public function getSite(): Site
     {
-        return $this->site;
+        return $this->tsfe->getSite();
     }
 
     public function getSiteLanguage(): SiteLanguage
     {
-        return $this->siteLanguage;
+        return $this->tsfe->getLanguage();
     }
 
     public function getIndexQueueItem(): Item
@@ -73,5 +73,10 @@ class BeforeDocumentsAreIndexedEvent
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    public function getTsfe(): TypoScriptFrontendController
+    {
+        return clone $this->tsfe;
     }
 }

--- a/Classes/Event/Indexing/BeforePageDocumentIsProcessedForIndexingEvent.php
+++ b/Classes/Event/Indexing/BeforePageDocumentIsProcessedForIndexingEvent.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Allows to add more documents to the Solr index.
@@ -37,21 +38,20 @@ class BeforePageDocumentIsProcessedForIndexingEvent
 
     public function __construct(
         private readonly Document $document,
-        private readonly Site $site,
-        private readonly SiteLanguage $siteLanguage,
-        private readonly Item $indexQueueItem
+        private readonly Item $indexQueueItem,
+        private readonly TypoScriptFrontendController $tsfe,
     ) {
         $this->documents[] = $this->document;
     }
 
     public function getSite(): Site
     {
-        return $this->site;
+        return $this->tsfe->getSite();
     }
 
     public function getSiteLanguage(): SiteLanguage
     {
-        return $this->siteLanguage;
+        return $this->tsfe->getLanguage();
     }
 
     public function getIndexQueueItem(): Item
@@ -78,5 +78,10 @@ class BeforePageDocumentIsProcessedForIndexingEvent
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    public function getTsfe(): TypoScriptFrontendController
+    {
+        return clone $this->tsfe;
     }
 }

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -36,6 +36,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class IndexerTest
@@ -63,7 +64,11 @@ class IndexerTest extends SetUpUnitTestCase
 
         $indexer = $this->getAccessibleMock(
             Indexer::class,
-            ['itemToDocument', 'processDocuments'],
+            [
+                'itemToDocument',
+                'processDocuments',
+                'getTsfeByItemAndLanguageId',
+            ],
             [],
             '',
             false
@@ -94,6 +99,12 @@ class IndexerTest extends SetUpUnitTestCase
             ->method('processDocuments')
             ->with($itemMock, [$itemDocumentMock])
             ->willReturnArgument(1);
+        $indexer
+            ->expects(self::any())
+            ->method('getTsfeByItemAndLanguageId')
+            ->willReturn(
+                $this->createMock(TypoScriptFrontendController::class)
+            );
 
         $writeServiceMock
             ->expects(self::atLeastOnce())
@@ -138,11 +149,20 @@ class IndexerTest extends SetUpUnitTestCase
     {
         $indexer = $this->getAccessibleMock(
             Indexer::class,
-            null,
+            [
+                'getTsfeByItemAndLanguageId',
+            ],
             [],
             '',
             false
         );
+
+        $indexer
+            ->expects(self::any())
+            ->method('getTsfeByItemAndLanguageId')
+            ->willReturn(
+                $this->createMock(TypoScriptFrontendController::class)
+            );
 
         $eventDispatcher = new MockEventDispatcher();
         if ($listener) {


### PR DESCRIPTION
Almost all in EXT:solr 12-ALPHA introduced events propagate the Site and SiteLanguage objects, which are fetched from simulated TSFE object. That does not allow to use the required TSFE in subsequent processing directly, without instantiate TSFE objects manually. EXT:solr* stack requires exact the same TSFE object, which is used by indexed Records/Pages, to process correctly.

This change makes it possible to reuse simulated TSFE object in listeners to be able to delegate right Core-Context objects for TYPO3 CORE components.  The Site and SiteLanguage getters are still available.

Fixes: #3800