### PR TITLE
[BUGFIX] Fix result highlighting fragment size

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -133,6 +133,7 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
             $query->getHighlighting()->setUseFastVectorHighlighter(true);
             $query->getHighlighting()->setTagPrefix($this->getPrefix());
             $query->getHighlighting()->setTagPostfix($this->getPostfix());
+            $query->getHighlighting()->setMethod('fastVector');
         } else {
             $query->getHighlighting()->setUseFastVectorHighlighter(false);
             $query->getHighlighting()->setTagPrefix('');

--- a/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
@@ -155,6 +155,7 @@
 			<int name="hl.snippets">3</int>
 			<str name="hl.mergeContiguous">true</str>
 			<str name="hl.requireFieldMatch">true</str>
+			<str name="hl.method">original</str>
 
 			<str name="f.content.hl.alternateField">content</str>
 			<str name="f.content.hl.maxAlternateFieldLength">200</str>


### PR DESCRIPTION
# What this pr does

Since Apache Solr 9 the Unified Highlighter is used by default,  causing the fragment size setting to be ignored in our setup.

By configuring the Original Highlighter as default, this issue is fixed till we update our highlighting setup to use the recommended highlighter.

# How to test

1. Index contents
2. Activate the results highlighting 
`plugin.tx_solr.search.results.resultsHighlighting = 1`
3. Test the results in the frontend with different `fragmentSize` settings, e.g. `20` (fastVector) and `15` (original) 

With this bugfix the fragment size will be considered and ensured that the `fastVector` or `original` hightlighter is used.

Resolves: #3798
