### PR TITLE
!!![CLEANUP] Remove obsolete TYPO3 registry usages

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Validator\Path;
 use Doctrine\DBAL\Exception as DBALException;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
@@ -207,13 +206,9 @@ class InfoModuleController extends AbstractModuleController
             ];
             if ($coreAdmin->ping()) {
                 $lukeData = $coreAdmin->getLukeMetaData();
-
-                /** @var Registry $registry */
-                $registry = GeneralUtility::makeInstance(Registry::class);
-                $limit = $registry->get('tx_solr', 'luke.limit', 20000);
                 $limitNote = '';
 
-                if (isset($lukeData->index->numDocs) && $lukeData->index->numDocs > $limit) {
+                if (isset($lukeData->index->numDocs) && $lukeData->index->numDocs > 20000) {
                     $limitNote = '<em>Too many terms</em>';
                 } elseif (isset($lukeData->index->numDocs)) {
                     $limitNote = 'Nothing indexed';

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -29,7 +29,6 @@ use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use Doctrine\DBAL\Exception as DBALException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,8 +45,6 @@ class SiteRepository
 
     protected TwoLevelCache $runtimeCache;
 
-    protected Registry $registry;
-
     protected SiteFinder $siteFinder;
 
     protected ExtensionConfiguration $extensionConfiguration;
@@ -57,14 +54,12 @@ class SiteRepository
     public function __construct(
         RootPageResolver $rootPageResolver = null,
         TwoLevelCache $twoLevelCache = null,
-        Registry $registry = null,
         SiteFinder $siteFinder = null,
         ExtensionConfiguration $extensionConfiguration = null,
         FrontendEnvironment $frontendEnvironment = null
     ) {
         $this->rootPageResolver = $rootPageResolver ?? GeneralUtility::makeInstance(RootPageResolver::class);
         $this->runtimeCache = $twoLevelCache ?? GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
-        $this->registry = $registry ?? GeneralUtility::makeInstance(Registry::class);
         $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
         $this->extensionConfiguration = $extensionConfiguration ?? GeneralUtility::makeInstance(ExtensionConfiguration::class);
         $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -38,7 +37,6 @@ class SiteRepositoryTest extends SetUpUnitTestCase
 {
     protected TwoLevelCache|MockObject $cacheMock;
     protected RootPageResolver|MockObject $rootPageResolverMock;
-    protected Registry|MockObject $registryMock;
     protected SiteRepository|MockObject $siteRepository;
     protected SiteFinder|MockObject $siteFinderMock;
 
@@ -47,12 +45,11 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];
         $this->cacheMock = $this->createMock(TwoLevelCache::class);
         $this->rootPageResolverMock = $this->createMock(RootPageResolver::class);
-        $this->registryMock = $this->createMock(Registry::class);
         $this->siteFinderMock = $this->createMock(SiteFinder::class);
 
         // we mock buildSite to avoid the creation of real Site objects and pass all dependencies as mock
         $this->siteRepository = $this->getMockBuilder(SiteRepository::class)
-            ->setConstructorArgs([$this->rootPageResolverMock, $this->cacheMock, $this->registryMock, $this->siteFinderMock])
+            ->setConstructorArgs([$this->rootPageResolverMock, $this->cacheMock, $this->siteFinderMock])
             ->onlyMethods(['buildSite'])
             ->getMock();
         parent::setUp();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -103,13 +103,6 @@ CREATE TABLE tx_solr_eventqueue_item (
 ) ENGINE=InnoDB;
 
 #
-# Update size of entry_value for table 'sys_registry'
-#
-CREATE TABLE sys_registry (
-	entry_value longblob
-) ENGINE=InnoDB;
-
-#
 # Extending 'pages' table with extra keys
 #
 CREATE TABLE pages (


### PR DESCRIPTION
# What this pr does

TYPO3 registry was mainly used for connection storage, which is obsolete since the introduction of the Site handling. Luke limit read by the InfoModuleController was never set in the registry, so for now the fallback value of 20000 is used.

This is a breaking change as the SiteRepository expected the registry to be passed, which is no longer necessary.

Resolves: #3792