### PR TITLE
[FEATURE] Better index cleanup

### DIFF
--- a/Classes/Task/CleanupIndexTask.php
+++ b/Classes/Task/CleanupIndexTask.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Task;
 
-use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueInitializationService;
+use ApacheSolrForTypo3\Solr\ConnectionManager;
 use Doctrine\DBAL\ConnectionException as DBALConnectionException;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,16 +28,22 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author Christoph Moeller <support@network-publishing.de>
  */
-class ReIndexTask extends AbstractSolrTask
+class CleanupIndexTask extends AbstractSolrTask
 {
-    /**
-     * Indexing configurations to re-initialize.
-     */
-    protected array $indexingConfigurationsToReIndex = [];
+    protected ?int $deleteOlderThanDays = null;
+
+    public function getDeleteOlderThanDays(): ?int
+    {
+        return $this->deleteOlderThanDays;
+    }
+
+    public function setDeleteOlderThanDays(?int $deleteOlderThanDays): void
+    {
+        $this->deleteOlderThanDays = $deleteOlderThanDays;
+    }
 
     /**
-     * Initializes the Index Queue
-     * and returns TRUE if the execution was successful
+     * Deletes old documents from index
      *
      * @return bool Returns TRUE on success, FALSE on failure.
      *
@@ -48,29 +54,28 @@ class ReIndexTask extends AbstractSolrTask
      */
     public function execute()
     {
-        // initialize for re-indexing
-        /** @var QueueInitializationService $indexQueueInitializationService */
-        $indexQueueInitializationService = GeneralUtility::makeInstance(QueueInitializationService::class);
-        $indexQueueInitializationResults = $indexQueueInitializationService
-            ->initializeBySiteAndIndexConfigurations($this->getSite(), $this->indexingConfigurationsToReIndex);
+        $cleanUpResult = true;
+        $solrConfiguration = $this->getSite()->getSolrConfiguration();
+        $solrServers = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionsBySite($this->getSite());
+        $enableCommitsSetting = $solrConfiguration->getEnableCommits();
 
-        return !in_array(false, $indexQueueInitializationResults);
-    }
+        foreach ($solrServers as $solrServer) {
+            $deleteQuery = 'siteHash:' . $this->getSite()->getSiteHash() . sprintf(' AND indexed:[* TO NOW-%dDAYS]', $this->deleteOlderThanDays ?? 1);
+            $solrServer->getWriteService()->deleteByQuery($deleteQuery);
 
-    /**
-     * Gets the indexing configurations to re-index.
-     */
-    public function getIndexingConfigurationsToReIndex(): array
-    {
-        return $this->indexingConfigurationsToReIndex;
-    }
+            if (!$enableCommitsSetting) {
+                // Do not commit
+                continue;
+            }
 
-    /**
-     * Sets the indexing configurations to re-index.
-     */
-    public function setIndexingConfigurationsToReIndex(array $indexingConfigurationsToReIndex): void
-    {
-        $this->indexingConfigurationsToReIndex = $indexingConfigurationsToReIndex;
+            $response = $solrServer->getWriteService()->commit(false, false);
+            if ($response->getHttpStatus() != 200) {
+                $cleanUpResult = false;
+                break;
+            }
+        }
+
+        return $cleanUpResult;
     }
 
     /**
@@ -92,14 +97,6 @@ class ReIndexTask extends AbstractSolrTask
             return 'Invalid site configuration for scheduler please re-create the task!';
         }
 
-        $information = 'Site: ' . $this->getSite()->getLabel();
-        if (!empty($this->indexingConfigurationsToReIndex)) {
-            $information .= ', Indexing Configurations: ' . implode(
-                ', ',
-                $this->indexingConfigurationsToReIndex
-            );
-        }
-
-        return $information;
+        return 'Site: ' . $this->getSite()->getLabel();
     }
 }

--- a/Classes/Task/CleanupTaskAdditionalFieldProvider.php
+++ b/Classes/Task/CleanupTaskAdditionalFieldProvider.php
@@ -166,7 +166,7 @@ class CleanupTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
      * class matches.
      *
      * @param array $submittedData array containing the data submitted by the user
-     * @param ReIndexTask $task reference to the current task object
+     * @param CleanupIndexTask $task reference to the current task object
      */
     public function saveAdditionalFields(
         array $submittedData,

--- a/Classes/Task/CleanupTaskAdditionalFieldProvider.php
+++ b/Classes/Task/CleanupTaskAdditionalFieldProvider.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Task;
+
+use ApacheSolrForTypo3\Solr\Backend\SiteSelectorField;
+use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use Doctrine\DBAL\Exception as DBALException;
+use LogicException;
+use TYPO3\CMS\Backend\Form\Exception as BackendFormException;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\AbstractAdditionalFieldProvider;
+use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
+
+/**
+ * Adds additional field to specify the Solr server to initialize the index queue for
+ *
+ * @author Christoph Moeller <support@network-publishing.de>
+ */
+class CleanupTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
+{
+    protected array $taskInformation = [];
+
+    /**
+     * Scheduler task
+     */
+    protected ?CleanupIndexTask $task;
+
+    protected ?SchedulerModuleController $schedulerModule = null;
+
+    /**
+     * Selected site
+     */
+    protected ?Site $site = null;
+
+    protected SiteRepository $siteRepository;
+
+    protected ?PageRenderer $pageRenderer = null;
+
+    public function __construct()
+    {
+        $this->siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+    }
+
+    /**
+     * Initialize object
+     *
+     * @throws DBALException
+     */
+    protected function initialize(
+        array $taskInfo,
+        ?CleanupIndexTask $task,
+        SchedulerModuleController $schedulerModule
+    ): void {
+        /* ReIndexTask @var $task  */
+        $this->taskInformation = $taskInfo;
+        $this->task = $task;
+        $this->schedulerModule = $schedulerModule;
+
+        $currentAction = $schedulerModule->getCurrentAction();
+
+        if ($currentAction->equals(Action::EDIT)) {
+            $this->site = $this->siteRepository->getSiteByRootPageId((int)$task->getRootPageId());
+        }
+    }
+
+    /**
+     * Used to define fields to provide the Solr server address when adding
+     * or editing a task.
+     *
+     * @param array $taskInfo reference to the array containing the info used in the add/edit form
+     * @param CleanupIndexTask $task when editing, reference to the current task object. Null when adding.
+     * @param SchedulerModuleController $schedulerModule reference to the calling object (Scheduler's BE module)
+     *
+     * @return array Array containing all the information pertaining to the additional fields
+     *               The array is multidimensional, keyed to the task class name and each field's id
+     *               For each field it provides an associative sub-array with the following:
+     *
+     * @throws BackendFormException
+     * @throws UnexpectedTYPO3SiteInitializationException
+     * @throws DBALException
+     *
+     * @noinspection PhpParameterByRefIsNotUsedAsReferenceInspection
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public function getAdditionalFields(
+        array &$taskInfo,
+        $task,
+        SchedulerModuleController $schedulerModule
+    ) {
+        $additionalFields = [];
+
+        if (!$this->isTaskInstanceofCleanupIndexTask($task)) {
+            return $additionalFields;
+        }
+
+        $this->initialize($taskInfo, $task, $schedulerModule);
+        $siteSelectorField = GeneralUtility::makeInstance(SiteSelectorField::class);
+
+        $additionalFields['site'] = [
+            'code' => $siteSelectorField->getAvailableSitesSelector(
+                'tx_scheduler[site]',
+                $this->site
+            ),
+            'label' => 'LLL:EXT:solr/Resources/Private/Language/locallang.xlf:field_site',
+        ];
+
+        $additionalFields['deleteOlderThanDays'] = [
+            'code' => '<input class="form-control" type="number" name="tx_scheduler[deleteOlderThanDays]" value="' . ($schedulerModule->getCurrentAction() == Action::EDIT ? $task->getDeleteOlderThanDays() ?? 1 : 1) . '" />',
+            'label' => 'LLL:EXT:solr/Resources/Private/Language/locallang.xlf:task.cleanupIndex.deleteOlderThanDays',
+        ];
+
+        return $additionalFields;
+    }
+
+    /**
+     * Checks any additional data that is relevant to this task. If the task
+     * class is not relevant, the method is expected to return TRUE
+     *
+     * @param array $submittedData reference to the array containing the data submitted by the user
+     * @param SchedulerModuleController $schedulerModule reference to the calling object (Scheduler's BE module)
+     *
+     * @return bool True if validation was ok (or selected class is not relevant), FALSE otherwise
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     *
+     * @noinspection PhpParameterByRefIsNotUsedAsReferenceInspection
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public function validateAdditionalFields(
+        array &$submittedData,
+        SchedulerModuleController $schedulerModule
+    ): bool {
+        $result = false;
+
+        // validate site
+        $sites = $this->siteRepository->getAvailableSites();
+        if (array_key_exists($submittedData['site'], $sites)) {
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Saves any additional input into the current task object if the task
+     * class matches.
+     *
+     * @param array $submittedData array containing the data submitted by the user
+     * @param ReIndexTask $task reference to the current task object
+     */
+    public function saveAdditionalFields(
+        array $submittedData,
+        CleanupIndexTask|AbstractTask $task
+    ): void {
+        if (!$this->isTaskInstanceofCleanupIndexTask($task)) {
+            return;
+        }
+
+        $task->setRootPageId((int)$submittedData['site']);
+        $task->setDeleteOlderThanDays($submittedData['deleteOlderThanDays'] ? (int)$submittedData['deleteOlderThanDays'] : null);
+    }
+
+    /**
+     * Check that a task is an instance of ReIndexTask
+     */
+    protected function isTaskInstanceofCleanupIndexTask(?AbstractTask $task): bool
+    {
+        if ((!is_null($task)) && (!($task instanceof CleanupIndexTask))) {
+            throw new LogicException(
+                '$task must be an instance of ReIndexTask, '
+                . 'other instances are not supported.',
+                1487500366
+            );
+        }
+        return true;
+    }
+}

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -36,6 +36,18 @@
 				<source>Forced webroot (only needed when webroot is not PATH_site)</source>
 				<target>Forced webroot (Nur notwendig wenn webroot von PATH_site abweicht)</target>
 			</trans-unit>
+			<trans-unit id="task.cleanupIndex.title">
+				<source>Index Cleanup</source>
+				<target>Index-Bereinigung</target>
+			</trans-unit>
+			<trans-unit id="task.cleanupIndex.description">
+				<source>Delete old documents from index</source>
+				<target>Löscht alte Dokumente aus dem Index</target>
+			</trans-unit>
+			<trans-unit id="task.cleanupIndex.deleteOlderThanDays">
+				<source>Delete documents older than # days</source>
+				<target>Lösche alle Dokumente älter als # Tage</target>
+			</trans-unit>
 			<trans-unit id="field_host" xml:space="preserve" approved="yes">
 				<source>Solr Host</source>
 				<target>Solr host</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -110,6 +110,15 @@
 			<trans-unit id="indexqueueworker_field_forcedWebRoot" xml:space="preserve">
 				<source>Forced webroot (only needed when webroot is not PATH_site)</source>
 			</trans-unit>
+			<trans-unit id="task.cleanupIndex.title">
+				<source>Index Cleanup</source>
+			</trans-unit>
+			<trans-unit id="task.cleanupIndex.description">
+				<source>Delete old documents from index</source>
+			</trans-unit>
+			<trans-unit id="task.cleanupIndex.deleteOlderThanDays">
+				<source>Delete documents older than # days</source>
+			</trans-unit>
 			<trans-unit id="field_host" xml:space="preserve">
 				<source>Solr Host</source>
 			</trans-unit>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,6 +15,8 @@ use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\UserGroupDetector;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\Routing\Enhancer\SolrFacetMaskAndCombineEnhancer;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Task\CleanupIndexTask;
+use ApacheSolrForTypo3\Solr\Task\CleanupTaskAdditionalFieldProvider;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTaskAdditionalFieldProvider;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
@@ -85,6 +87,13 @@ defined('TYPO3') or die('Access denied.');
         'title' => 'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.title',
         'description' => 'LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:task.eventQueueWorkerTask.description',
         'additionalFields' => EventQueueWorkerTaskAdditionalFieldProvider::class,
+    ];
+
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][CleanupIndexTask::class] = [
+        'extension' => 'solr',
+        'title' => 'LLL:EXT:solr/Resources/Private/Language/locallang_.xlf:task.cleanupIndex.title',
+        'description' => 'LLL:EXT:solr/Resources/Private/Language/locallang.xlf:task.cleanupIndex.description',
+        'additionalFields' => CleanupTaskAdditionalFieldProvider::class,
     ];
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][TableGarbageCollectionTask::class]['options']['tables']['tx_solr_statistics'])) {


### PR DESCRIPTION
* removes cleanup logic from `ReIndex` task to avoid having an empty index/no search results directly afterwards
* adds new `CleanupIndex` task which deletes all documents older than the given time in days

Fixes: #3808 
