### PR TITLE
[BUGFIX] Return value getPageItemChangedTime() must be of the type int

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -374,7 +374,7 @@ class Queue implements QueueInterface, QueueInitializationServiceAwareInterface
     {
         if (!empty($page['content_from_pid'])) {
             // canonical page, get the original page's last changed time
-            return $this->queueItemRepository->getPageItemChangedTimeByPageUid((int)$page['content_from_pid']);
+            return $this->queueItemRepository->getPageItemChangedTimeByPageUid((int)$page['content_from_pid']) ?? 0;
         }
         return $this->queueItemRepository->getPageItemChangedTimeByPageUid((int)$page['uid']) ?? 0;
     }


### PR DESCRIPTION
Fixes the error:
Uncaught TYPO3 Exception: Return value of ApacheSolrForTypo3\Solr\IndexQueue\Queue::getPageItemChangedTime() must be of the type int, null returned

Fixes: #3806