### PR TITLE
!!![TASK] Configuration option enableRouteEnhancer

### DIFF
--- a/Classes/Event/Routing/AfterUriIsProcessedEvent.php
+++ b/Classes/Event/Routing/AfterUriIsProcessedEvent.php
@@ -34,7 +34,7 @@ class AfterUriIsProcessedEvent
     protected UriInterface $uri;
 
     /**
-     * BeforeReplaceVariableInCachedUrlEvent constructor.
+     * AfterUriIsProcessedEvent constructor.
      */
     public function __construct(UriInterface $uri, array $routerConfiguration)
     {

--- a/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
+++ b/Classes/Event/Routing/BeforeCachedVariablesAreProcessedEvent.php
@@ -47,7 +47,7 @@ class BeforeCachedVariablesAreProcessedEvent
     protected array $variableValues = [];
 
     /**
-     * BeforeReplaceVariableInCachedUrlEvent constructor.
+     * BeforeCachedVariablesAreProcessedEvent constructor.
      */
     public function __construct(
         UriInterface $uri,

--- a/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
+++ b/Classes/Event/Routing/BeforeVariableInCachedUrlAreReplacedEvent.php
@@ -34,7 +34,7 @@ class BeforeVariableInCachedUrlAreReplacedEvent
     protected bool $routing = false;
 
     /**
-     * BeforeReplaceVariableInCachedUrlEvent constructor.
+     * BeforeVariableInCachedUrlAreReplacedEvent constructor.
      */
     public function __construct(UriInterface $uri, bool $routing = false)
     {

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -151,6 +151,14 @@ class ExtensionConfiguration
         return (int)$this->getConfigurationOrDefaultValue('monitoringType', 0);
     }
 
+    /**
+     * Get configuration for enableRouteEnhancer
+     */
+    public function getIsRouteEnhancerEnabled(): bool
+    {
+        return (bool)$this->getConfigurationOrDefaultValue('enableRouteEnhancer', false);
+    }
+
     protected function getConfigurationOrDefaultValue(string $key, mixed $defaultValue = null): mixed
     {
         return $this->configuration[$key] ?? $defaultValue;

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,18 +1,26 @@
 <?php
 
 /** @noinspection PhpFullyQualifiedNameUsageInspection */
-return [
-    'frontend' => [
-        'apache-solr-for-typo3/page-indexer-initialization' => [
-            'target' => \ApacheSolrForTypo3\Solr\Middleware\PageIndexerInitialization::class,
-            'before' => ['typo3/cms-frontend/tsfe'],
-            'after' => ['typo3/cms-core/normalized-params-attribute'],
-        ],
-        'apache-solr-for-typo3/solr-route-enhancer' => [
-            'target' => \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::class,
-            'before' => [
-                'typo3/cms-frontend/site',
-            ],
-        ],
+$requestMiddlewares = [
+    'apache-solr-for-typo3/page-indexer-initialization' => [
+        'target' => \ApacheSolrForTypo3\Solr\Middleware\PageIndexerInitialization::class,
+        'before' => ['typo3/cms-frontend/tsfe'],
+        'after' => ['typo3/cms-core/normalized-params-attribute'],
     ],
+];
+
+$extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+    \ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration::class
+);
+if ($extensionConfiguration->getIsRouteEnhancerEnabled()) {
+    $requestMiddlewares['apache-solr-for-typo3/solr-route-enhancer'] = [
+        'target' => \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::class,
+        'before' => [
+            'typo3/cms-frontend/site',
+        ],
+    ];
+}
+
+return [
+    'frontend' => $requestMiddlewares,
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -86,17 +86,17 @@ services:
     tags:
       - name: event.listener
         identifier: 'solr.routing.cachedurl-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeReplaceVariableInCachedUrlEvent
+        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent
   ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\CachedPathVariableModifier:
     tags:
       - name: event.listener
         identifier: 'solr.routing.cachedurl-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeProcessCachedVariablesEvent
+        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent
   ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\PostEnhancedUriProcessor:
     tags:
       - name: event.listener
         identifier: 'solr.routing.postenhanceduriprocessor-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\PostProcessUriEvent
+        event: ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent
   ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener:
     arguments:
       $extensionConfiguration: '@ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration'

--- a/Documentation/Development/Events.rst
+++ b/Documentation/Development/Events.rst
@@ -52,6 +52,6 @@ SearchUriBuilder
 The SearchUriBuilder is responsible to build uris, that are used in the searchContext. Since the route enhancer is introduced you can use the following
 event to influence the build uris:
 
-- BeforeReplaceVariableInCachedUrlEvent
-- BeforeProcessCachedVariablesEvent
-- PostProcessUriEvent
+- BeforeVariableInCachedUrlAreReplacedEvent
+- BeforeCachedVariablesAreProcessedEvent
+- AfterUriIsProcessedEvent

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -154,9 +154,20 @@ If you've used this class or the SolrConnection directly, you have to adapt your
 - use \Solarium\Core\Client\Endpoint instead of \ApacheSolrForTypo3\Solr\System\Solr\Node
 - call \ApacheSolrForTypo3\Solr\System\Solr\SolrConnection->getEndpoint() instead of \ApacheSolrForTypo3\Solr\System\Solr\SolrConnection\getNode(),
   method will return Solarium Endpoint
-- Node could be converted to string to get the core base URI, getCoreBaseUri() can be used instead. 
+- Node could be converted to string to get the core base URI, getCoreBaseUri() can be used instead.
 
 Note: With dropping the Node implementation we also dropped the backwards compatibility that allows to define the Solr path segment "/solr" within "solr_path_read" or "solr_path_write". Be sure your configuration doesn't contain this path segment!
+
+
+!!! Solr route enhancer disabled by default
+-------------------------------------------
+
+EXT:solr offers the possibility to create speaking URLs for Solr facets, but as this feature requires additional configuration and costly processing this feature is now disabled by default.
+
+If you've already used the route enhancer you must set option "enableRouteEnhancer":
+
+:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr']['enableRouteEnhancer']`
+
 
 
 Frontend Helper Changes

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -3,6 +3,9 @@
 	<file source-language="en" datatype="plaintext" original="EXT:solr/Resources/Private/Language/locallang_be.xlf" date="2021-12-15T13:10:00Z" product-name="solr">
 		<header/>
 		<body>
+			<trans-unit id="extConf.category.routeEnhancer" resname="extConf.category.routeEnhancer">
+				<source>Route Enhancer</source>
+			</trans-unit>
 			<trans-unit id="extConf.monitoringType" xml:space="preserve">
 				<source>Monitoring: Define how data updates should be monitored</source>
 			</trans-unit>
@@ -14,6 +17,9 @@
 			</trans-unit>
 			<trans-unit id="extConf.monitoringType.I.2" xml:space="preserve">
 				<source>No monitoring at all</source>
+			</trans-unit>
+			<trans-unit id="extConf.enableRouteEnhancer" xml:space="preserve">
+				<source>Enable route enhancer: If you want to use speaking URLs for Solr facets, you have to enable this option, otherwise the required Middleware is not active and the route enhancer has no effect.</source>
 			</trans-unit>
 
 			<trans-unit id="task.eventQueueWorkerTask.title" xml:space="preserve">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,3 +1,5 @@
+# customcategory=Routes=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.category.routeEnhancer
+
 # cat=basic/enable/8; type=string; label=A list of white listed plugin namespaces (Required by cacheHash/excludedParameters and plugin flex form): Note: This list only is available in Plugin -> Options -> Plugin Namespace
 pluginNamespaces = tx_solr
 
@@ -18,3 +20,6 @@ allowSelfSignedCertificates = 0
 
 # cat=basic/enable/50; type=options[LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.0=0,LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.1=1,LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType.I.2=2]; label=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.monitoringType
 monitoringType = 0
+
+# cat=Routes/enable/10; type=boolean; label=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.enableRouteEnhancer
+enableRouteEnhancer = 0


### PR DESCRIPTION
# What this pr does

- [BUGFIX] Fix facet route enhancer
- !!![TASK] Configuration option enableRouteEnhancer

# How to test

1) Configure EXT:solr route enhancer, e.g.:
```
routeEnhancers:
  solrContentType:
    type: SolrFacetMaskAndCombineEnhancer
    limitToPages:
      - 6
    extensionKey: tx_solr
    routePath: '/contentType/{type}'
    _arguments:
      type: filter-type
    requirements:
      type: '.*'
```
2) Check facet links with enabled and disabled option "enableRouteEnhancer"

Fixes: #3810

---

**Caution**: PR contains an additional bugfix for the route enhancer in general, do not squash!
