### PR TITLE
[BUGFIX:BP:11.5] TSFE can not be initialized for pages with fe_group="-2"

### DIFF
--- a/Tests/Integration/FrontendEnvironment/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.xml
+++ b/Tests/Integration/FrontendEnvironment/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<pages>
+		<uid>2</uid>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<fe_group>1</fe_group>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<is_siteroot>0</is_siteroot>
+		<doktype>1</doktype>
+		<pid>1</pid>
+		<fe_group>-2</fe_group>
+	</pages>
+
+	<fe_groups>
+		<uid>1</uid>
+		<pid>1</pid>
+		<title>dummy group</title>
+	</fe_groups>
+</dataset>


### PR DESCRIPTION
The TSFE can not be initialized in record-monitoring(BE editiing) context for pages,  whichs fe_group is set to -2(show if fe_user is logged in).

This leads to following behavior:
* After editing the [sub]pages in BE, the page is removed from index and never indexed again.
* By reinitialization of pages index queue the page is indexed as expected with expected groups.

Fixes: #3351
Relates: #3347
Ports: #3352