### PR TITLE
[DOC:BP:11.5] Add FAQ how to generate URLs to restricted pages

### DIFF
--- a/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript
+++ b/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript
@@ -65,6 +65,7 @@ plugin.tx_solr.index.queue {
 					typolink.parameter.field = internalurl
 					typolink.useCacheHash = 1
 					typolink.returnLast = url
+					typolink.linkAccessRestrictedPages = 1
 				}
 
 				# External
@@ -81,6 +82,7 @@ plugin.tx_solr.index.queue {
 					typolink.additionalParams.insertData = 1
 					typolink.useCacheHash = 1
 					typolink.returnLast = url
+					typolink.linkAccessRestrictedPages = 1
 				}
 			}
 		}

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -72,6 +72,21 @@ We provide an addon called EXT:solrfal, that allows you to index files from FAL 
 
 |
 
+**The indexer does not generate URLs to restricted pages. How can I force the generation of URLs?**
+
+If you have a detail page for e.g. news records that is restricted, please use the typolink attribute `linkAccessRestrictedPages <https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/Functions/Typolink.html#linkaccessrestrictedpages>`_ :
+
+|
+
+.. code-block:: typoscript
+
+    default = TEXT
+    default {
+      // ... other typolink settings
+      typolink.linkAccessRestrictedPages = 1
+    }
+|
+
 **How can i use Fluid templates with EXT:solr < v7.0.0?**
 
 For the Fluid rendering in EXT:Solr >= 5.0 <= 6.1 we provide the addon EXT:solrfluid, that allows you to render your search results with Fluid.


### PR DESCRIPTION
* adds explanation how to generate URLs to restricted pages
* enables `typolink.linkAccessRestrictedPages` for EXT:news index example

Fixes: #3615
Ports: #3620