### PR TITLE
[TASK] Add response object to return array of SolrWriteService::extractByQuery()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,14 @@
-/Build/ export-ignore
-/Tests/ export-ignore
 /.dockerignore export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.php export-ignore
 /.scrutinizer.yml export-ignore
 /.styleci.yml export-ignore
-/Dockerfile export-ignore
+/Build/ export-ignore
 /CONTRIBUTING.md export-ignore
-/.github
+/dependabot.yml export-ignore
+/Dockerfile export-ignore
+/PULL_REQUEST_TEMPLATE.md export-ignore
+/Tests/ export-ignore

--- a/Classes/System/Solr/Service/SolrWriteService.php
+++ b/Classes/System/Solr/Service/SolrWriteService.php
@@ -41,7 +41,11 @@ class SolrWriteService extends AbstractSolrService
     {
         try {
             $response = $this->createAndExecuteRequest($query);
-            return [$response->file, $response->file_metadata];
+            return [
+                $response->file,
+                $response->file_metadata,
+                $response,
+            ];
         } catch (Throwable $e) {
             $param = $query->getRequestBuilder()->build($query)->getParams();
             $this->logger->error(

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -60,7 +60,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_port_read'] = [
 
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_read'] = [
     'label' => 'URL path to Apache Solr server',
-    'description' => 'Must not contain "/solr/"! Unlesss you have an additional "solr" segment in your path like "http://localhost:8983/solr/solr/core_en".',
+    'description' => 'Must not contain "/solr/"! Unless you have an additional "solr" segment in your path like "http://localhost:8983/solr/solr/core_en".',
     'config' => [
         'type' => 'input',
         'eval' => 'trim',

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,10 @@
   },
   "replace": {
     "apache-solr-for-typo3/solrfluid": "*",
+    "apache-solr-for-typo3/solrfluidgrouping": "*",
     "typo3-ter/solr": "self.version",
-    "typo3-ter/solrfluid": "*"
+    "typo3-ter/solrfluid": "*",
+    "typo3-ter/solrfluidgrouping": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This change makes it possible to find out the causes by unexpected behaviour of service. For example it will be used by EXT:tika 12.0.1+ in Reports module to find out the cause of trouble with Tika-Cell connection.

Relates: https://github.com/TYPO3-Solr/ext-tika/issues/211