### PR TITLE
[BUGFIX][DOC] avoid creation of symlink inside the prod docs

### DIFF
--- a/Build/generate_documentation.sh
+++ b/Build/generate_documentation.sh
@@ -27,8 +27,8 @@ fi
 dockrun_t3rd makehtml-no-cache
 
 if [[ "$BUILD_DOCS_FOR_PRODUCTION" == 1 || "$BUILD_DOCS_FOR_PRODUCTION" == "true" ]]; then
-  rm -Rf "${PRODUCTION_DOCS_PATH}"
+  rm -Rf "${PRODUCTION_DOCS_PATH}" "Documentation.HTML"
   mv -v "Documentation-GENERATED-temp/Result/project/0.0.0" "${PRODUCTION_DOCS_PATH}"
-  ln -sf "${PRODUCTION_DOCS_PATH}" "Documentation.HTML"
+  ln -s "${PRODUCTION_DOCS_PATH}" "Documentation.HTML"
   rm -Rf "Documentation-GENERATED-temp"
 fi


### PR DESCRIPTION
After second run of "composer t3:docs:build:prod" the unneccessary  symlink `Documentation -> Resources/Public/Documentation` inside of `Resources/Public/Documentation` was created because of `-f` option on `ln` command. The symlink `Documentation.HTML` is now removed each time, and the `-f` option is remod from `ln -s`  comman

