### PR TITLE
[FEATURE] Monitor extbase records

### DIFF
--- a/Classes/EventListener/Extbase/PersistenceEventListener.php
+++ b/Classes/EventListener/Extbase/PersistenceEventListener.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\EventListener\Extbase;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use ApacheSolrForTypo3\Solr\Trait\SkipMonitoringTrait;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Extbase\Event\Persistence\EntityPersistedEvent;
+use TYPO3\CMS\Extbase\Event\Persistence\EntityRemovedFromPersistenceEvent;
+use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapFactory;
+
+/**
+ * Event listener that handle record changes by \TYPO3\CMS\Extbase\Persistence\Generic\Backend
+ */
+class PersistenceEventListener
+{
+    use SkipMonitoringTrait;
+
+    public function __construct(
+        protected DataMapFactory $dataMapFactory,
+        protected EventDispatcher $eventDispatcher
+    ) {}
+
+    public function entityPersisted(EntityPersistedEvent $event): void
+    {
+        $object = $event->getObject();
+        $tableName = $this->getTableName($object);
+        if (!$this->skipMonitoringOfTable($tableName)) {
+            // Entity might turn inaccessable
+            $this->eventDispatcher->dispatch(new RecordGarbageCheckEvent($object->getUid(), $tableName));
+            // Entity added/updated
+            $this->eventDispatcher->dispatch(new RecordUpdatedEvent($object->getUid(), $tableName));
+        }
+    }
+
+    public function entityRemoved(EntityRemovedFromPersistenceEvent $event): void
+    {
+        $object = $event->getObject();
+        $tableName = $this->getTableName($object);
+        if (!$this->skipMonitoringOfTable($tableName)) {
+            $this->eventDispatcher->dispatch(new RecordDeletedEvent($object->getUid(), $tableName));
+        }
+    }
+
+    protected function getTableName(object $object): string
+    {
+        $dataMap = $this->dataMapFactory->buildDataMap(get_class($object));
+        return $dataMap->getTableName();
+    }
+}

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -21,7 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentEleme
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
-use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\Trait\SkipMonitoringTrait;
 use ApacheSolrForTypo3\Solr\Util;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -39,6 +39,8 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
  */
 class RecordMonitor
 {
+    use SkipMonitoringTrait;
+
     protected array $trackedRecords = [];
     protected EventDispatcherInterface $eventDispatcher;
 
@@ -163,26 +165,6 @@ class RecordMonitor
         $this->eventDispatcher->dispatch(
             new RecordUpdatedEvent((int)$recordUid, $table, $fields)
         );
-    }
-
-    /**
-     * Check if the provided table is explicitly configured for monitoring
-     */
-    protected function skipMonitoringOfTable(string $table): bool
-    {
-        static $configurationMonitorTables;
-
-        if (empty($configurationMonitorTables)) {
-            $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-            $configurationMonitorTables = $configuration->getIsUseConfigurationMonitorTables();
-        }
-
-        // No explicit configuration => all tables should be monitored
-        if (empty($configurationMonitorTables)) {
-            return false;
-        }
-
-        return !in_array($table, $configurationMonitorTables);
     }
 
     /**

--- a/Classes/Trait/SkipMonitoringTrait.php
+++ b/Classes/Trait/SkipMonitoringTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Trait;
+
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+trait SkipMonitoringTrait
+{
+    /**
+     * Check if the provided table is explicitly configured for monitoring
+     */
+    protected function skipMonitoringOfTable(string $table): bool
+    {
+        static $configurationMonitorTables;
+
+        if (empty($configurationMonitorTables)) {
+            $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+            $configurationMonitorTables = $configuration->getIsUseConfigurationMonitorTables();
+        }
+
+        // No explicit configuration => all tables should be monitored
+        if (empty($configurationMonitorTables)) {
+            return false;
+        }
+
+        return !in_array($table, $configurationMonitorTables);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -284,6 +284,16 @@ services:
       - name: event.listener
         identifier: 'solr.index.PageFieldMappingIndexer'
 
+  ApacheSolrForTypo3\Solr\EventListener\Extbase\PersistenceEventListener:
+    autowire: true
+    tags:
+      - name: event.listener
+        identifier: 'solr.index.ExtbaseEntityPersisted'
+        method: 'entityPersisted'
+      - name: event.listener
+        identifier: 'solr.index.ExtbaseEntityRemoved'
+        method: 'entityRemoved'
+
   ###  EXT:solr content objects
   ApacheSolrForTypo3\Solr\ContentObject\Classification:
     tags:

--- a/Tests/Integration/Extbase/Fixtures/delete_items.csv
+++ b/Tests/Integration/Extbase/Fixtures/delete_items.csv
@@ -1,0 +1,6 @@
+"tx_fakeextension_domain_model_foo",
+,"uid","pid","title","tstamp","deleted"
+,3,1,"delete me",0,0
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","changed","errors","indexing_configuration"
+,3,1,"tx_fakeextension_domain_model_foo",3,0,0,"foo"

--- a/Tests/Integration/Extbase/Fixtures/hidden_items.csv
+++ b/Tests/Integration/Extbase/Fixtures/hidden_items.csv
@@ -1,0 +1,6 @@
+"tx_fakeextension_domain_model_foo",
+,"uid","pid","title","tstamp","deleted"
+,4,1,"hide me",0,0
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","changed","errors"
+,4,1,"tx_fakeextension_domain_model_foo",4,0,0

--- a/Tests/Integration/Extbase/Fixtures/update_items.csv
+++ b/Tests/Integration/Extbase/Fixtures/update_items.csv
@@ -1,0 +1,3 @@
+"tx_fakeextension_domain_model_foo",
+,"uid","pid","title","tstamp"
+,2,1,"update me",0

--- a/Tests/Integration/Extbase/PersistenceEventListenerTest.php
+++ b/Tests/Integration/Extbase/PersistenceEventListenerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Extbase;
+
+use ApacheSolrForTypo3\FakeExtension\Domain\Model\Foo;
+use ApacheSolrForTypo3\FakeExtension\Domain\Repository\FooRepository;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class PersistenceEventListenerTest extends IntegrationTest
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/solr',
+        '../vendor/apache-solr-for-typo3/solr/Tests/Integration/Fixtures/Extensions/fake_extension',
+    ];
+
+    protected ?Queue $indexQueue = null;
+    protected ?FooRepository $repository = null;
+    protected ?PersistenceManager $persistenceManager = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->addTypoScriptToTemplateRecord(1, '
+            plugin.tx_solr.index.queue.foo = 1
+            plugin.tx_solr.index.queue.foo.type = tx_fakeextension_domain_model_foo
+        ');
+        $this->indexQueue = GeneralUtility::makeInstance(Queue::class);
+        $this->repository = GeneralUtility::makeInstance(FooRepository::class);
+        $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
+    }
+
+    /**
+     * @test
+     */
+    public function newEntityIsAddedToIndexQueue()
+    {
+        $object = new Foo();
+        $object->setTitle('Added');
+        $object->setPid(1);
+        $repository = GeneralUtility::makeInstance(FooRepository::class);
+        $repository->add($object);
+        $this->persistenceManager->persistAll();
+        self::assertTrue($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 1));
+    }
+
+    /**
+     * @test
+     */
+    public function newHiddenEntityIsNotAddedToIndexQueue()
+    {
+        $object = new Foo();
+        $object->setTitle('Added');
+        $object->setHidden(true);
+        $object->setPid(1);
+        $repository = GeneralUtility::makeInstance(FooRepository::class);
+        $repository->add($object);
+        $this->persistenceManager->persistAll();
+        self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 1));
+    }
+
+    /**
+     * @test
+     */
+    public function updatedEntityIsUpdatedInIndexQueue()
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/update_items.csv');
+        /** @var Foo $object */
+        $object = $this->repository->findByUid(2);
+        $object->setTitle('Updated');
+        $this->repository->update($object);
+        $this->persistenceManager->persistAll();
+
+        $context = GeneralUtility::makeInstance(Context::class);
+        $currentTimestamp = $context->getPropertyFromAspect('date', 'timestamp');
+
+        self::assertTrue($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 2));
+
+        $item = $this->indexQueue->getItem(1);
+        self::assertSame(2, $item->getRecordUid());
+        self::assertSame('foo', $item->getIndexingConfigurationName());
+        self::assertSame($currentTimestamp, $item->getChanged());
+    }
+
+    /**
+     * @test
+     */
+    public function softDeletedEntityIsRemovedFromIndexQueue()
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/delete_items.csv');
+        /** @var Foo $object */
+        $object = $this->repository->findByUid(3);
+        $this->repository->remove($object);
+        $this->persistenceManager->persistAll();
+
+        self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 3));
+    }
+
+    /**
+     * @test
+     */
+    public function deletedEntityIsRemovedFromIndexQueue()
+    {
+        unset($GLOBALS['TCA']['tx_fakeextension_domain_model_foo']['ctrl']['delete']);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/delete_items.csv');
+        /** @var Foo $object */
+        $object = $this->repository->findByUid(3);
+        $this->repository->remove($object);
+        $this->persistenceManager->persistAll();
+
+        self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 3));
+    }
+
+    /**
+     * @test
+     */
+    public function updatedEntityTurnedHiddenIsRemovedFromIndexQueue()
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/hidden_items.csv');
+        /** @var Foo $object */
+        $object = $this->repository->findByUid(4);
+        $object->setHidden(true);
+        $this->repository->update($object);
+        $this->persistenceManager->persistAll();
+
+        self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 4));
+    }
+}

--- a/Tests/Integration/Fixtures/Extensions/fake_extension/Classes/Domain/Model/Foo.php
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension/Classes/Domain/Model/Foo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ApacheSolrForTypo3\FakeExtension\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class Foo extends AbstractEntity
+{
+    protected string $title;
+    protected bool $hidden;
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
+    public function setHidden(bool $hidden): void
+    {
+        $this->hidden = $hidden;
+    }
+}

--- a/Tests/Integration/Fixtures/Extensions/fake_extension/Classes/Domain/Repository/FooRepository.php
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension/Classes/Domain/Repository/FooRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApacheSolrForTypo3\FakeExtension\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class FooRepository extends Repository {}

--- a/Tests/Integration/Fixtures/Extensions/fake_extension/Configuration/Services.yaml
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  ApacheSolrForTypo3\FakeExtension\:
+    resource: '../Classes/*'

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
   "autoload-dev": {
     "psr-4": {
       "ApacheSolrForTypo3\\Solr\\Tests\\": "Tests/",
+      "ApacheSolrForTypo3\\FakeExtension\\": "Tests/Integration/Fixtures/Extensions/fake_extension/Classes/",
       "ApacheSolrForTypo3\\SolrFakeExtension2\\": "Tests/Integration/Fixtures/Extensions/fake_extension2/Classes/",
       "ApacheSolrForTypo3\\SolrFakeExtension3\\": "Tests/Integration/Fixtures/Extensions/fake_extension3/Classes/",
       "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms-core/Tests/"


### PR DESCRIPTION
# What this pr does

Extbase records are now monitored.

* New entities are added to index queue
* Updated entities are updated in the index queue
* Entities turned inaccessable are removed from index queue
* Soft/Hard deleted entities are removed in the index queue

# How to test

`.Build/bin/phpunit --config=Build/Test/IntegrationTests.xml Tests/Integration/Extbase/PersistenceEventListenerTest.php`

Fixes: #126

---

### Maintainers comments:

- [x] Backport into release-11.6.x 