### PR TITLE
[TASK] Log solr response in case of Page indexing issue

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -349,6 +349,7 @@ class PageIndexer implements FrontendHelper, SingletonInterface
             foreach ($documentChunks as $documentChunk) {
                 $response = $this->solrConnection->getWriteService()->addDocuments($documentChunk);
                 if ($response->getHttpStatus() != 200) {
+                    $this->logger->error('Solr could not index page.', [$response->getRawResponse()]);
                     throw new \RuntimeException('Solr Request failed.', 1331834983);
                 }
             }


### PR DESCRIPTION
Logging the response eases debugging.
Integrators and developers can check the response in order to retrieve the actual reported issue, a crucial info in order to fix indexing issues.

# What this pr does

Add an error log entry with solr response body in case indexing a page did not succeed.

# How to test

Create a broken page indexing and check the log for the new entry.

Fixes: #3846, #2590
