### PR TITLE
[BUGFIX] Provide proper Uri Builder Request in VH

### DIFF
--- a/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AbstractUriViewHelper.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\ViewHelpers\AbstractSolrFrontendViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -40,9 +41,16 @@ abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
 
     protected static SearchUriBuilder $searchUriBuilder;
 
+    protected static RequestBuilder $requestBuilder;
+
     public function injectSearchUriBuilder(SearchUriBuilder $searchUriBuilder): void
     {
         self::$searchUriBuilder = $searchUriBuilder;
+    }
+
+    public function injectRequestBuilder(RequestBuilder $requestBuilder): void
+    {
+        self::$requestBuilder = $requestBuilder;
     }
 
     protected static function getSearchUriBuilder(RenderingContextInterface $renderingContext = null): SearchUriBuilder
@@ -50,11 +58,14 @@ abstract class AbstractUriViewHelper extends AbstractSolrFrontendViewHelper
         if (!isset(self::$searchUriBuilder)) {
             self::$searchUriBuilder = GeneralUtility::makeInstance(SearchUriBuilder::class);
         }
+        if (!isset(self::$requestBuilder)) {
+            self::$requestBuilder = GeneralUtility::makeInstance(RequestBuilder::class);
+        }
 
         if ($renderingContext instanceof RenderingContext) {
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-            /** @phpstan-ignore-next-line */
-            $uriBuilder->reset()->setRequest($renderingContext->getRequest());
+            $request = self::$requestBuilder->build($renderingContext->getRequest());
+            $uriBuilder->reset()->setRequest($request);
             self::$searchUriBuilder->injectUriBuilder($uriBuilder);
         }
 

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\AddFacetItemViewHelper;
+use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -36,10 +37,12 @@ class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
         $viewHelper->setRenderingContext($renderContextMock);
 
         $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
+        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
 
         // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
+        $viewHelper->injectRequestBuilder($requestUriBuilderStub);
         // @extensionScannerIgnoreLine
         $viewHelper->setArguments(['facet' => $facet, 'facetItem' => $facet->getOptions()->getByPosition(0)]);
         $viewHelper->render();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveAllFacetsViewHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Extbase\Mvc\Request;
+use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -40,6 +41,9 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $searchResultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($mockedPreviousFakedRequest);
 
+        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
+        $requestUriBuilderStub->method('build')->willReturn($mockedControllerRequest);
+
         $variableProvideMock = $this->createMock(StandardVariableProvider::class);
         $variableProvideMock->expects(self::once())->method('get')->with('resultSet')->willReturn($searchResultSetMock);
 
@@ -57,6 +61,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         // we expected that the getRemoveAllFacetsUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getRemoveAllFacetsUri')->with($mockedPreviousFakedRequest);
         $viewHelper->injectSearchUriBuilder($searchUriBuilderMock);
+        $viewHelper->injectRequestBuilder($requestUriBuilderStub);
 
         $viewHelper->render();
     }


### PR DESCRIPTION
Checking RenderingContext is not enough as it might provide either a ServerRequest or Extbase Request.
We use the RequestBuilder to ensure there is a proper Extbase Request.

A none Extbase Request might exist in case of usage within StandaloneView or other contexts without providing an Extbase Request.

Fixes: #3851

# What this pr does

Ensure that an Extbase request is provided.

# How to test

I don't have an easy step by step way … Maybe test that this won't break anything instead?