### PR TITLE
[BUGFIX] prevent empty array key if foreignLabelField is null

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -170,7 +170,7 @@ class Relation extends AbstractContentObject
                 && !empty($this->configuration['enableRecursiveValueResolution'])
             ) {
                 $this->configuration['localField'] = $foreignTableLabelField;
-                if (str_contains($this->configuration['foreignLabelField'], '.')) {
+                if (str_contains($this->configuration['foreignLabelField'] ?? '', '.')) {
                     $foreignTableLabelFieldArr = explode('.', $this->configuration['foreignLabelField']);
                     unset($foreignTableLabelFieldArr[0]);
                     $this->configuration['foreignLabelField'] = implode('.', $foreignTableLabelFieldArr);


### PR DESCRIPTION
# What this pr does

If you enableRecursiveValueResolution and the foreignLabelField is not set because the record has no relation, the item can not be indexed.

# How to test

See Ticket.

Fixes: #3856
