### PR TITLE
[RELEASE] 11.5.4 - Maintenance Release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Used versions (please complete the following information):**
  - TYPO3 Version: [e.g. 11.5.26]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 11.5.3]
+ - EXT:solr Version: [e.g. 11.5.4]
  - Used Apache Solr Version: [e.g. 8.11.1]
  - PHP Version: [e.g. 8.1.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Appendix/VersionMatrix.rst
+++ b/Documentation/Appendix/VersionMatrix.rst
@@ -9,20 +9,30 @@ Appendix - Version Matrix
 Supported versions
 ------------------
 
+Supported versions
+------------------
+
 List of EXT:solr versions and the matching versions of Apache Solr and TYPO3 that are supported:
 
-========= ========== ========== =========== =============== ================== ============================= =============== =============== =================
-       Basic components                Funding contribution extensions          Published funding contribution extensions         Solr configuration
-------------------------------- ---------------------------------------------- --------------------------------------------- ---------------------------------
-TYPO3     EXT: solr  EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrfluidgrouping         EXT:solrmlt     Apache Solr     Configset
-========= ========== ========== =========== =============== ================== ============================= =============== =============== =================
-12.4      12.0 (ᾱ)   12.0 (Ø)   12.0 (Ø)    12.0 (Ø)        12.0 (Ø)           12.0 (Ø)                      12.0 (Ø)        9.2.0           ext_solr_12_0_0
-11.5      11.5       11.0       11.0        11.0            11.0               11.0                          11.0 (Ø)        8.11.1          ext_solr_11_5_0
-========= ========== ========== =========== =============== ================== ============================= =============== =============== =================
+========= ========== ========== =========== =============== ================== ================================ =============== =============== =================
+       Basic components                Funding contribution extensions          Published funding contribution    Extensions         Solr configuration
+------------------------------- ---------------------------------------------- -------------------------------- --------------- ---------------------------------
+TYPO3     EXT:solr   EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrfluidgrouping            EXT:solrmlt     Apache Solr     Configset
+========= ========== ========== =========== =============== ================== ================================ =============== =============== =================
+12.4      12.0       12.0       12.0        12.0 (Ø)        12.0               N/A (integrated in EXT:solr)     12.0 (Ø)        9.3.0           ext_solr_12_0_0
+11.5      11.5       11.0       11.0        11.0            11.0               11.0                             11.0 (Ø)        8.11.1          ext_solr_11_5_0
+========= ========== ========== =========== =============== ================== ================================ =============== =============== =================
 
-Ø  - not yet available
-ᾱ  - non stable alpha release
-rc - release candidate available
+| Ø  - not yet available
+| ᾱ  - non stable alpha release
+| β  - non stable beta release
+| rc - release candidate available
+
+.. important::
+
+    | Non-stable releases are not available in TER, but
+    | via Composer or as a ZIP file attachment on GitHub `release <https://github.com/TYPO3-Solr/ext-solr/releases>`_ page.
+
 
 Extended Long Term Support (ELTS)
 ---------------------------------
@@ -33,10 +43,10 @@ selected older versions. The following table illustrates the offers and availabl
 ========= =========== ========== =========== =============== ================== =============== ====================
        Basic components                 Funding contribution extensions                 Solr configuration
 -------------------------------- ---------------------------------------------- ------------------------------------
-TYPO3     EXT: solr   EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools Apache Solr     Configset
+TYPO3     EXT:solr    EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools Apache Solr     Configset
 ========= =========== ========== =========== =============== ================== =============== ====================
-10.4      11.2.3+ Ø   10.0       10.0        10.0            10.0               9.2.0           ext_solr_11_2_0_elts
-9.5-10.4  11.0.8+     6.0.3+     8.0.2+      4.0.2+          1.1.3+             9.2.0           ext_solr_11_0_0_elts
+10.4      11.2.4+ Ø   10.0       10.0        10.0            10.0               9.2.1           ext_solr_11_2_0_elts
+9.5-10.4  11.0.8+     6.0.3+     8.0.2+      4.0.2+          1.1.3+             9.2.1           ext_solr_11_0_0_elts
 ========= =========== ========== =========== =============== ================== =============== ====================
 
 Our Apache Solr for TYPO3 EB-partners newsletter will keep you updated!
@@ -46,25 +56,25 @@ Our Apache Solr for TYPO3 EB-partners newsletter will keep you updated!
 No longer supported versions
 ----------------------------
 
-========= ========== ========= =========== =============== ================== ===================== =========== =========== ================
-TYPO3     EXT: solr  EXT:tika  EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrfluidgrouping EXT:solrmlt Apache Solr Configset
-========= ========== ========= =========== =============== ================== ===================== =========== =========== ================
-10.4      11.2.0-2   10.0      10.0        10.0            10.0               10.0                  10.0        8.11        ext_solr_11_2_0
-10.4      11.1       10.0      10.0        10.0            10.0               10.0                  10.0        8.9         ext_solr_11_1_0
-9.5-10.4  11.0.0-7   6.0.0-2   8.0.0-1     4.0.0-1         1.1.2              2.1                   3.1         8.5         ext_solr_11_0_0
-9.5       10.0       5.0       7.0         3.0             1.1.1              2.0                   3.0         8.2         ext_solr_10_0_0
-8.7-9.5   9.0        4.0       6.0         2.0             1.1.0              2.0                   3.0         7.6         ext_solr_9_0_0
-8.7       8.1        3.1       5.1         1.0             1.0.0              1.1                   2.0         6.6         ext_solr_8_1_0
-8.7       8.0        3.0       5.0         N/A             N/A                1.0                   N/A         6.6         ext_solr_8_0_0
-8.7       7.5        2.4       4.2         N/A             N/A                N/A                   N/A         6.6         ext_solr_7_5_0
-8.7       7.0        2.4       4.2         N/A             N/A                N/A                   N/A         6.3         ext_solr_7_0_0
-========= ========== ========= =========== =============== ================== ===================== =========== =========== ================
+========= ========== ========= =========== =============== ================== =========== =========== ================
+TYPO3     EXT:solr   EXT:tika  EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrmlt Apache Solr Configset
+========= ========== ========= =========== =============== ================== =========== =========== ================
+10.4      11.2.0-3   10.0      10.0        10.0            10.0               10.0        8.11        ext_solr_11_2_0
+10.4      11.1       10.0      10.0        10.0            10.0               10.0        8.9         ext_solr_11_1_0
+9.5-10.4  11.0.0-7   6.0.0-2   8.0.0-1     4.0.0-1         1.1.2              3.1         8.5         ext_solr_11_0_0
+9.5       10.0       5.0       7.0         3.0             1.1.1              3.0         8.2         ext_solr_10_0_0
+8.7-9.5   9.0        4.0       6.0         2.0             1.1.0              3.0         7.6         ext_solr_9_0_0
+8.7       8.1        3.1       5.1         1.0             1.0.0              2.0         6.6         ext_solr_8_1_0
+8.7       8.0        3.0       5.0         N/A             N/A                N/A         6.6         ext_solr_8_0_0
+8.7       7.5        2.4       4.2         N/A             N/A                N/A         6.6         ext_solr_7_5_0
+8.7       7.0        2.4       4.2         N/A             N/A                N/A         6.3         ext_solr_7_0_0
+========= ========== ========= =========== =============== ================== =========== =========== ================
 
 Obsolete versions
 -----------------
 
 ========== ========= ========= =========== ============= ================ ================ =========== ======================== ======================== ============
-TYPO3      EXT: solr EXT:tika  EXT:solrfal EXT:solrfluid EXT:solrgrouping EXT:solrmlt      Apache Solr Schema                   Solrconfig               Accessplugin
+TYPO3      EXT:solr  EXT:tika  EXT:solrfal EXT:solrfluid EXT:solrgrouping EXT:solrmlt      Apache Solr Schema                   Solrconfig               Accessplugin
 ========== ========= ========= =========== ============= ================ ================ =========== ======================== ======================== ============
 7.6 - 8.x  6.5       2.3       4.1         2.0           1.3              N/A              6.6.2       tx_solr-6-5-0--20171023  tx_solr-6-5-0--20171023  2.0
 7.6 - 8.7  6.1       2.3       4.1         2.0           1.3              N/A              6.3         tx_solr-6-1-0--20170206  tx_solr-6-1-0--20161220  2.0

--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -7,6 +7,37 @@
 Apache Solr for TYPO3 11.5
 ==========================
 
+Apache Solr for TYPO3 11.5.4
+============================
+
+
+This is a maintenance release for TYPO3 11.5 and the last release that supports Apache Solr 8.11. Next EXT:solr release for TYPO3 11.5 will be 11.6.0, it
+will contain support for Apache Solr 9 and some breaking improvements.
+
+11.5.4 contains the following changes:
+
+- [TASK] Fix CI 2023.09.11 on release-11.5.x by @dkd-kaehm in `#3777 <https://github.com/TYPO3-Solr/ext-solr/pull/3777>`__
+- [BUGFIX:BP:11.5] Fix EXT:solr route enhancer by @dkd-friedrich in `#3743 <https://github.com/TYPO3-Solr/ext-solr/pull/3743>`__
+- [BUG] Fix detection of "draft records" in workspaces by @baschny in `#3642 <https://github.com/TYPO3-Solr/ext-solr/pull/3642>`__
+- [BUGFIX] Do not index translations on default language in languages free mode by @dkd-kaehm in `#3786 <https://github.com/TYPO3-Solr/ext-solr/pull/3786>`__
+- [BUGFIX:BP:11.5] Retry Uri Building after exception by @dkd-friedrich in `#3789 <https://github.com/TYPO3-Solr/ext-solr/pull/3789>`__
+- [BUGFIX] Delete index documents without available site by @dkd-kaehm in `#3778 <https://github.com/TYPO3-Solr/ext-solr/pull/3778>`__
+- [TASK:BP:11.5] Ensure recursive page update on page movement by @dkd-friedrich in `#3771 <https://github.com/TYPO3-Solr/ext-solr/pull/3771>`__
+- [FEATURE:BP:11.5] Add index queue indices by @dkd-friedrich in `#3791 <https://github.com/TYPO3-Solr/ext-solr/pull/3791>`__
+- [TASK:BP:11.5] Migrate top.fsMod by @dkd-friedrich in `#3795 <https://github.com/TYPO3-Solr/ext-solr/pull/3795>`__
+- [BUGFIX:BP:11.5] Return value getPageItemChangedTime() must be of the type int by @dkd-kaehm in `#3813 <https://github.com/TYPO3-Solr/ext-solr/pull/3813>`__
+- [TASK:BP:11.5] Remove duplicate withHeader() by @dkd-kaehm in `#3817 <https://github.com/TYPO3-Solr/ext-solr/pull/3626>`__
+- [BUGFIX:BP:11.5] Do not list cores twice in Index Inspector by @dkd-kaehm in `#3818 <https://github.com/TYPO3-Solr/ext-solr/pull/3818>`__
+- [BUGFIX] Fixes multiple sortings by @BastiLu in `#3762 <https://github.com/TYPO3-Solr/ext-solr/pull/3762>`__
+- [BUGFIX:BP:11.5] Fix missing frontend.typoscript request attribute while indexing by @dkd-kaehm in `#3822 <https://github.com/TYPO3-Solr/ext-solr/pull/3822>`__
+- [BUGFIX] Prevent indexing error on missing 'foreignLabelField' by @kitzberger in `#3740 <https://github.com/TYPO3-Solr/ext-solr/pull/3740>`__
+- [BUGFIX:BP:11.5] Force score to float by @dkd-kaehm in `#3824 <https://github.com/TYPO3-Solr/ext-solr/pull/3824>`__
+- [BUGFIX:BP:11.5] Fix possible notice by @dkd-kaehm in `#3825 <https://github.com/TYPO3-Solr/ext-solr/pull/3825>`__
+- [DOC:BP:11.5] Add FAQ how to generate URLs to restricted pages by @dkd-kaehm in `#3826 <https://github.com/TYPO3-Solr/ext-solr/pull/3826>`__
+- [BUGFIX:BP:11.5] Handle float values in options facet parser by @dkd-kaehm in `#3827 <https://github.com/TYPO3-Solr/ext-solr/pull/3827>`__
+- [BUGFIX:BP:11.5] handle localizations with un-available tsfe more gracefully by @dkd-kaehm in `#3832 <https://github.com/TYPO3-Solr/ext-solr/pull/3832>`__
+- [TASK] Update the version matrix by @dkd-friedrich in `#3860 <https://github.com/TYPO3-Solr/ext-solr/pull/3860>`__
+
 Apache Solr for TYPO3 11.5.3
 ============================
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -5,7 +5,7 @@
 
 project     = Apache Solr for TYPO3
 version     = 11.5
-release     = 11.5.3
+release     = 11.5.4
 copyright   = since 2009 by dkd & contributors
 
 [html_theme_options]

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '11.5.3',
+    'version' => '11.5.4',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich',


### PR DESCRIPTION
This is a maintenance release for TYPO3 11.5 and the last release that supports Apache Solr 8.11. Next EXT:solr release for TYPO3 11.5 will be 11.6.0, it will contain support for Apache Solr 9 and some breaking improvements.

11.5.4 contains the following changes:

- [TASK] Fix CI 2023.09.11 on release-11.5.x by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3777
- [BUGFIX:BP:11.5] Fix EXT:solr route enhancer by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3743
- [BUG] Fix detection of "draft records" in workspaces by @baschny in https://github.com/TYPO3-Solr/ext-solr/pull/3642
- [BUGFIX] Do not index translations on default language in languages free mode by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3786
- [BUGFIX:BP:11.5] Retry Uri Building after exception by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3789
- [BUGFIX] Delete index documents without available site by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3778
- [TASK:BP:11.5] Ensure recursive page update on page movement by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3771
- [FEATURE:BP:11.5] Add index queue indices by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3791
- [TASK:BP:11.5] Migrate top.fsMod by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3795
- [BUGFIX:BP:11.5] Return value getPageItemChangedTime() must be of the type int by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3813
- [TASK:BP:11.5] Remove duplicate withHeader() by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3626
- [BUGFIX:BP:11.5] Do not list cores twice in Index Inspector by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3818
- [BUGFIX] Fixes multiple sortings by @BastiLu in https://github.com/TYPO3-Solr/ext-solr/pull/3762
- [BUGFIX:BP:11.5] Fix missing frontend.typoscript request attribute while indexing by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3822
- [BUGFIX] Prevent indexing error on missing 'foreignLabelField' by @kitzberger in https://github.com/TYPO3-Solr/ext-solr/pull/3740
- [BUGFIX:BP:11.5] Force score to float by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3824
- [BUGFIX:BP:11.5] Fix possible notice by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3825
- [DOC:BP:11.5] Add FAQ how to generate URLs to restricted pages by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3826
- [BUGFIX:BP:11.5] Handle float values in options facet parser by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3827
- [BUGFIX:BP:11.5] handle localizations with un-available tsfe more gracefully by @dkd-kaehm in https://github.com/TYPO3-Solr/ext-solr/pull/3832
- [TASK] Update the version matrix by @dkd-friedrich in https://github.com/TYPO3-Solr/ext-solr/pull/3860

Please read the release notes:
https://github.com/TYPO3-Solr/ext-solr/releases/tag/11.5.4

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
existing pull requests
* Go to [www.typo3-solr.com](http://www.typo3-solr.com/) or call dkd to sponsor the ongoing
development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0