### PR TITLE
[DOC:11.6] Fix changelogs and add hints about outdated state on branches

### DIFF
--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -51,9 +51,6 @@ This is a maintenance release for TYPO3 11.5, containing:
 Release 11.5.2
 --------------
 
-Release 11.5.2
---------------
-
 This is a maintenance release for TYPO3 11.5, containing:
 
 - [BUGFIX:BP:11.5] Fix error when indexing pages with field processing instruction categoryUidToHierarchy by @dkd-kaehm in `#3462 <https://github.com/TYPO3-Solr/ext-solr/pull/3462>`__


### PR DESCRIPTION
The changelog is a single file, each major version.  This change allows us to avoid porting of changelog files across release-zz.y branches. Most probably we'll introduce single file - each commit changelog approach to avoid  all the problems related to our current approach.

Relates: #3854
Ports: #3863

---

The commit of this pull-request should be ported back to older branches.