### PR TITLE
[TASK] Rename namespace \\Trait\\ to \\Traits\\, due of consistency with 11.6.x

### DIFF
--- a/Classes/EventListener/Extbase/PersistenceEventListener.php
+++ b/Classes/EventListener/Extbase/PersistenceEventListener.php
@@ -20,7 +20,7 @@ namespace ApacheSolrForTypo3\Solr\EventListener\Extbase;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDeletedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
-use ApacheSolrForTypo3\Solr\Trait\SkipMonitoringTrait;
+use ApacheSolrForTypo3\Solr\Traits\SkipMonitoringTrait;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Extbase\Event\Persistence\EntityPersistedEvent;
 use TYPO3\CMS\Extbase\Event\Persistence\EntityRemovedFromPersistenceEvent;

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -21,7 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentEleme
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
-use ApacheSolrForTypo3\Solr\Trait\SkipMonitoringTrait;
+use ApacheSolrForTypo3\Solr\Traits\SkipMonitoringTrait;
 use ApacheSolrForTypo3\Solr\Util;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;

--- a/Classes/Traits/SkipMonitoringTrait.php
+++ b/Classes/Traits/SkipMonitoringTrait.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace ApacheSolrForTypo3\Solr\Trait;
+namespace ApacheSolrForTypo3\Solr\Traits;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
The \\Trait\\  namespace is allowed on PHP 8.0+ only.
To avoid confusions between EXT:solr 11.6 and 12.0 the namespace is adjusted to 11.6.x state.

Relates: #3843, #3844