### PR TITLE
[TASK] Add missing groups-key to TS Path

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1575,7 +1575,7 @@ grouping.groups.[groupName].field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Type: String
-:TS Path: plugin.tx_solr.search.grouping.[groupName].field
+:TS Path: plugin.tx_solr.search.grouping.groups.[groupName].field
 :Default: empty
 :Since: 12.0
 
@@ -1588,7 +1588,7 @@ grouping.groups.[groupName].queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Type: Array
-:TS Path: plugin.tx_solr.search.grouping.[groupName].queries
+:TS Path: plugin.tx_solr.search.grouping.groups.[groupName].queries
 :Default: empty
 :Since: 12.0
 


### PR DESCRIPTION
For `grouping.groups.[groupName].*` there was the groups-key missing in "TS Path" of documentation.

Fixes: #3871
