### PR TITLE
[BUGFIX:11.5]  Infinite loop in SolrRoutingMiddleware 

### DIFF
--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -366,7 +366,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
 
                 if ($scan) {
                     $elements = explode('/', $path);
-                    if (empty($elements)) {
+                    if (empty($elements) || $path === '') {
                         $scan = false;
                     } else {
                         array_pop($elements);


### PR DESCRIPTION
# What this pr does

Fixes infinite loop and therefore server crashing if route doesn't exist or URl is in the scheme like domain/id=123456

# How to test

Steps to reproduce the behavior:
use old school requests like /index.php?id=123 or any URI which will not be found in the slug Provider class (any none existing URI with speaking URL)

Fixes: #3873
