### PR TITLE
!!![BUGFIX:11.5] Exception with tx_solr_statistics after latest TYPO3 security update

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -97,7 +97,7 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
             // @extensionScannerIgnoreLine
             'time_processing' => $response->debug->timing->process->time ?? 0,
             'feuser_id' => isset($TSFE->fe_user->user) ? (int)$TSFE->fe_user->user['uid'] ?? 0 : 0,
-            'cookie' => $TSFE->fe_user->id ?? '',
+            'cookie' => $TSFE->fe_user->getSession()->getIdentifier() ?? '',
             'ip' => IpAnonymizationUtility::anonymizeIp($this->getUserIp(), $ipMaskLength),
             'page' => $page,
             'keywords' => $keywords,

--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -6,13 +6,21 @@
 Releases 11.5
 =============
 
-..  include:: HintAboutOutdatedChangelog.rst.txt
+Release 11.5.5
+--------------
+
+This is a maintenance release for TYPO3 11.5 and the last release that supports Apache Solr 8.11.
+Next EXT:solr release for TYPO3 11.5 will be 11.6.0, it
+will contain support for Apache Solr 9 and some breaking improvements.
+
+**Note:** This change requires the database schema update, due of database schema change from `pull-request #3880 <https://github.com/TYPO3-Solr/ext-solr/pull/3880>`__
+
+11.5.5 contains the following changes:
+
+- !!![BUGFIX:11.5] Exception with tx_solr_statistics after latest TYPO3 security update by @dkd-kaehm in `#3880 <https://github.com/TYPO3-Solr/ext-solr/pull/3880>`__
 
 Release 11.5.4
 --------------
-
-This is a maintenance release for TYPO3 11.5 and the last release that supports Apache Solr 8.11. Next EXT:solr release for TYPO3 11.5 will be 11.6.0, it
-will contain support for Apache Solr 9 and some breaking improvements.
 
 11.5.4 contains the following changes:
 

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -83,6 +84,7 @@ class StatisticsWriterProcessorTest extends UnitTest
     {
         /* @var TypoScriptFrontendController $fakeTSFE */
         $fakeTSFE = $this->getDumbMock(TypoScriptFrontendController::class);
+        $fakeTSFE->fe_user = $this->getDumbMock(FrontendUserAuthentication::class);
         $fakeTSFE->id = 888;
         $fakeTime = 100;
         $fakeIP = '192.168.2.22';

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE tx_solr_statistics (
 	time_processing int(11) DEFAULT '0' NOT NULL,
 
 	feuser_id int(11) unsigned DEFAULT '0' NOT NULL,
-	cookie varchar(32) DEFAULT '' NOT NULL,
+	cookie varchar(255) DEFAULT '' NOT NULL,
 	ip varchar(255) DEFAULT '' NOT NULL,
 
 	keywords varchar(128) DEFAULT '' NOT NULL,


### PR DESCRIPTION
**Note:** This change requires the database schema update.

With the Security update at November, 14th 2023 the cookie generation changed in the TYPO3 core.

This leads to an exception, when executing the search and statistics are enabled.

Reason is, that the generated cookies are longer than the old ones and do not fit in the tx_solr_statistics.cookie any more. The available length is 32 chars, TYPO3 core allows up to 190.

This change increases the length of `tx_solr_statistics.cookie` field to 255 characters. Beside of that, the deprecated method to fetch the fe_user cookie value is adjusted to new TYPO3 API.

Fixes: #3877