### PR TITLE
[BUGFIX]  Infinite loop in SolrRoutingMiddleware #3873

### DIFF
--- a/Classes/Middleware/SolrRoutingMiddleware.php
+++ b/Classes/Middleware/SolrRoutingMiddleware.php
@@ -336,7 +336,7 @@ class SolrRoutingMiddleware implements MiddlewareInterface, LoggerAwareInterface
 
                 if ($scan) {
                     $elements = explode('/', $path);
-                    if (empty($elements)) {
+                    if (empty($elements) || $path === '') {
                         $scan = false;
                     } else {
                         array_pop($elements);


### PR DESCRIPTION
Fixes infinite loop and therefore server crashing if route doesn't exist or URl is in the scheme like domain/id=123456

Fixes: #3873
Ports: #3878