### PR TITLE
[BUGFIX:11.5] Indexer does not work for extbase-records with sys_language_uid=-1

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -805,7 +805,7 @@ class Indexer extends AbstractIndexer
      */
     protected function isLanguageInAFreeContentMode(Item $item, int $language): bool
     {
-        if ($language === 0) {
+        if ($language === 0 || $language === -1) {
             return false;
         }
         $typo3site = $item->getSite()->getTypo3SiteObject();


### PR DESCRIPTION
Indexer does not work for extbase-records with sys_language_uid=-1 This change adds additional check for '-1'  `Indexer::isLanguageInAFreeContentMode()`  to avoid the fetching the language -1 from TYPO3 site object. 

Fixes: #3879
Ports: #3885