### PR TITLE
[BUGFIX] Broken IndexQueueModule.css asset path in backend

### DIFF
--- a/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
@@ -2,7 +2,7 @@
 <f:layout name="Backend/WithPageTree"/>
 
 <f:section name="Main">
-	<f:be.pageRenderer includeCssFiles="{0: '{f:uri.resource(path:\'StyleSheets/Backend/IndexQueueModule.css\')}'}" includeRequireJsModules="{0:'TYPO3/CMS/Solr/FormModal'}"/>
+	<f:be.pageRenderer includeCssFiles="{0: 'EXT:solr/Resources/Public/StyleSheets/Backend/IndexQueueModule.css'}" includeRequireJsModules="{0:'TYPO3/CMS/Solr/FormModal'}"/>
 
 	<h1>Index Queue</h1>
 	<p class="lead"><f:translate key="solr.backend.index_queue_module.description" /></p>


### PR DESCRIPTION
The path should use EXT: syntax.
That way TYPO3 can properly handle the file and add version numbers and check for existence.

# How to test

Open the queue backend module and check that the css file has a proper timestamp as parameter when setting `$GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']` to `0`

Fixes: #3897