### PR TITLE
[BUGFIX] false as field value is not allowed

### DIFF
--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -77,13 +77,14 @@ abstract class AbstractIndexer
             }
 
             $fieldValue = $this->resolveFieldValue($indexingConfiguration, $solrFieldName, $data, $tsfe);
-            if ($fieldValue === null) {
+            if ($fieldValue === null
+                || $fieldValue === ''
+                || (is_array($fieldValue) && empty($fieldValue))
+            ) {
                 continue;
             }
 
-            if (!empty($fieldValue)) {
-                $document->setField($solrFieldName, $fieldValue);
-            }
+            $document->setField($solrFieldName, $fieldValue);
         }
 
         return $document;


### PR DESCRIPTION
`AbstractIndexer::addDocumentFieldsFromTyposcript()` disallows any PHPs empty value. This change adds explicit checks for disallowed values:
* null
* empty string
* empty array

Fixes: #3900