### PR TITLE
[TASK] Remove unused field `cookie` in tx_solr_statistics

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -97,7 +97,6 @@ class StatisticsWriterProcessor implements SearchResultSetProcessor
             // @extensionScannerIgnoreLine
             'time_processing' => $response->debug->timing->process->time ?? 0,
             'feuser_id' => isset($TSFE->fe_user->user) ? (int)$TSFE->fe_user->user['uid'] ?? 0 : 0,
-            'cookie' => $TSFE->fe_user->getSession()->getIdentifier() ?? '',
             'ip' => IpAnonymizationUtility::anonymizeIp($this->getUserIp(), $ipMaskLength),
             'page' => $page,
             'keywords' => $keywords,

--- a/Tests/Integration/Domain/Search/StatisticsRepository/Fixtures/can_get_statistics.xml
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/Fixtures/can_get_statistics.xml
@@ -12,7 +12,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>29</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>content</keywords>
         <page>0</page>
@@ -32,7 +31,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>29</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>content</keywords>
         <page>0</page>
@@ -52,7 +50,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>23</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>typo3</keywords>
         <page>0</page>
@@ -72,7 +69,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>18</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>cms</keywords>
         <page>0</page>

--- a/Tests/Integration/Domain/Search/StatisticsRepository/Fixtures/can_save_statistics_record.xml
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/Fixtures/can_save_statistics_record.xml
@@ -12,7 +12,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>29</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>content</keywords>
         <page>0</page>
@@ -32,7 +31,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>29</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>content</keywords>
         <page>0</page>
@@ -52,7 +50,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>23</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>typo3</keywords>
         <page>0</page>
@@ -72,7 +69,6 @@
         <time_preparation>0</time_preparation>
         <time_processing>18</time_processing>
         <feuser_id>0</feuser_id>
-        <cookie>875f6aa287</cookie>
         <ip>192.168.144.1</ip>
         <keywords>cms</keywords>
         <page>0</page>

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -120,7 +120,6 @@ class StatisticsRepositoryTest extends IntegrationTest
             'time_preparation' => 2,
             'time_processing' => 27,
             'feuser_id' => 0,
-            'cookie' => '0ad2582d058e2843c9bc3b2273309248',
             'ip' => '192.168.144.1',
             'page' => 0,
             'keywords' => 'inserted record',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -27,7 +27,6 @@ CREATE TABLE tx_solr_statistics (
 	time_processing int(11) DEFAULT '0' NOT NULL,
 
 	feuser_id int(11) unsigned DEFAULT '0' NOT NULL,
-	cookie varchar(255) DEFAULT '' NOT NULL,
 	ip varchar(255) DEFAULT '' NOT NULL,
 
 	keywords varchar(128) DEFAULT '' NOT NULL,


### PR DESCRIPTION
This PR removes the unused field cookie from the tx_solr_statistics table. The field has never been used in the extension and has most likely been introduced by accident since the initial statistics table structure partly seems to be similar to ext:indexedsearch statistics table (see https://github.com/TYPO3/typo3/blob/TYPO3_4-5/typo3/sysext/indexed_search/ext_tables.sql#L107C2-L107C2).

Ports: #3893