### PR TITLE
[BUGFIX:P:11.5] Broken IndexQueueModule.css asset path in backend

### DIFF
--- a/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
@@ -2,7 +2,7 @@
 <f:layout name="Backend/WithPageTree"/>
 
 <f:section name="Main">
-	<f:be.pageRenderer includeCssFiles="{0: '{f:uri.resource(path:\'StyleSheets/Backend/IndexQueueModule.css\')}'}" includeRequireJsModules="{0:'TYPO3/CMS/Solr/FormModal'}"/>
+	<f:be.pageRenderer includeCssFiles="{0: 'EXT:solr/Resources/Public/StyleSheets/Backend/IndexQueueModule.css'}" includeRequireJsModules="{0:'TYPO3/CMS/Solr/FormModal'}"/>
 
 	<h1>Index Queue</h1>
 	<p class="lead"><f:translate key="solr.backend.index_queue_module.description" /></p>


### PR DESCRIPTION
The path should use EXT: syntax.
That way TYPO3 can properly handle the file and add version numbers and check for existence.

Resolves: #3897
Ports: #3898