### PR TITLE
[BUGFIX] `AfterFacetIsParsedEvent` was never dispatched

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetItem.php
@@ -48,6 +48,11 @@ abstract class AbstractFacetItem
         return $this->label;
     }
 
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
     public function getSelected(): bool
     {
         return $this->selected;

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -99,10 +99,10 @@ class OptionsFacetParser extends AbstractFacetParser
         $this->applyReverseOrder($facet, $facetConfiguration);
 
         if (isset($this->eventDispatcher)) {
-            /** @var AfterFacetIsParsedEvent $afterFacetParsedEvent */
-            $afterFacetParsedEvent = $this->eventDispatcher
+            /** @var AfterFacetIsParsedEvent $afterFacetIsParsedEvent */
+            $afterFacetIsParsedEvent = $this->eventDispatcher
                 ->dispatch(new AfterFacetIsParsedEvent($facet, $facetConfiguration));
-            $facet = $afterFacetParsedEvent->getFacet();
+            $facet = $afterFacetIsParsedEvent->getFacet();
         }
 
         return $facet;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,6 +14,17 @@ services:
     autowire: true
     shared: false
 
+  facets:
+    namespace: ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\
+    resource: '../Classes/Domain/Search/ResultSet/Facets/*'
+    exclude:
+      - '../Classes/Domain/Search/ResultSet/Facets/{OptionBased/Hierarchy/Node.php,*/Abstract*}'
+      - '../Classes/Domain/Search/ResultSet/Facets/*/*/*Facet.php'
+      - '../Classes/Domain/Search/ResultSet/Facets/RangeBased/*/*RangeCount.php'
+    public: true
+    autowire: true
+    shared: false
+
   viewhelper:
     namespace: ApacheSolrForTypo3\Solr\ViewHelpers\
     resource: '../Classes/ViewHelpers/*'

--- a/Documentation/Development/Events.rst
+++ b/Documentation/Development/Events.rst
@@ -6,6 +6,12 @@ In version 11 we started with the implementation of events, using the EventDispa
 
 Step by step the events will replace older hooks and signals. In the following you will find a description of the available events
 
+.. tip::
+   If you miss any feature useful to the general public, please create a feature request
+   `in our issue tracker <https://github.com/TYPO3-Solr/ext-solr/issues/new?template=feature_request.md&title=%5BFEATURE%5D+new+event+for+>`__.
+
+
+
 Monitoring
 ^^^^^^^^^^
 
@@ -55,3 +61,10 @@ event to influence the build uris:
 - BeforeVariableInCachedUrlAreReplacedEvent
 - BeforeCachedVariablesAreProcessedEvent
 - AfterUriIsProcessedEvent
+
+Facets
+^^^^^^
+
+Currently EXT:solr provides following events for Facets-Component modification:
+
+- AfterFacetIsParsedEvent


### PR DESCRIPTION
The `AfterFacetIsParsedEvent` was newer dispatched, because the `::injectEventDispatcher()`  was never called due of missing dependency injection settings. This change sets almost all classes within `ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\` namespace  to autowire and public DI. 
The non-wireable classes are excluded from autowire and public DI and should behave the same as before this change.

**In addition the `AfterFacetIsParsedEvent` is added to all available facet types.**

Fixes: #3920

---

## Mainteners Notes:

We want the integration tests to check if the events are fired properly.