### PR TITLE
[BUGFIX] update acces to backend user modules

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -17,7 +17,7 @@ return [
     ],
     'searchbackend_info' => [
         'parent' => 'searchbackend',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/searchbackend/info',
         'iconIdentifier' => 'extensions-solr-module-info',
         'labels' => 'LLL:EXT:solr/Resources/Private/Language/locallang_mod_info.xlf',
@@ -30,7 +30,7 @@ return [
     ],
     'searchbackend_coreoptimization' => [
         'parent' => 'searchbackend',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/searchbackend/core-optimization',
         'iconIdentifier' => 'extensions-solr-module-solr-core-optimization',
         'labels' => 'LLL:EXT:solr/Resources/Private/Language/locallang_mod_coreoptimize.xlf',
@@ -46,7 +46,7 @@ return [
     ],
     'searchbackend_indexqueue' => [
         'parent' => 'searchbackend',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/searchbackend/index-queue',
         'iconIdentifier' => 'extensions-solr-module-index-queue',
         'labels' => 'LLL:EXT:solr/Resources/Private/Language/locallang_mod_indexqueue.xlf',
@@ -60,7 +60,7 @@ return [
     ],
     'searchbackend_indexadministration' => [
         'parent' => 'searchbackend',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/searchbackend/index-administration',
         'iconIdentifier' => 'extensions-solr-module-index-administration',
         'labels' => 'LLL:EXT:solr/Resources/Private/Language/locallang_mod_indexadmin.xlf',


### PR DESCRIPTION
See https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.html#confval-access

# What this pr does

This PR makes the modules selectable for editors and groups again.

# How to test

Edit the permissions of a user group.

Fixes: #3923
