### PR TITLE
[BUGFIX] Ensure method return value of root-page-UID is an integer

### DIFF
--- a/Classes/System/Page/Rootline.php
+++ b/Classes/System/Page/Rootline.php
@@ -66,7 +66,7 @@ class Rootline
 
         foreach ($this->rootLineArray as $page) {
             if (SiteUtility::isRootPage($page)) {
-                $rootPageId = $page['uid'];
+                $rootPageId = (int)$page['uid'];
                 break;
             }
         }


### PR DESCRIPTION
Ensure method return value of root-page-UID is an integer `System\Page::getRootPageId()`

Fixes: #3928