### PR TITLE
[BUGFIX:BP:11.5] Ensure method return value of root-page-UID is an integer

### DIFF
--- a/Classes/System/Page/Rootline.php
+++ b/Classes/System/Page/Rootline.php
@@ -84,7 +84,7 @@ class Rootline
 
         foreach ($this->rootLineArray as $page) {
             if (Site::isRootPage($page)) {
-                $rootPageId = $page['uid'];
+                $rootPageId = (int)$page['uid'];
                 break;
             }
         }


### PR DESCRIPTION
Ensure method return value of root-page-UID is an integer System\Page::getRootPageId()

Fixes: #3928
Ports: #3929