### PR TITLE
[BUGFIX:BP:11.5] Exception in CLI mode when using suggest TS example

### DIFF
--- a/Configuration/TypoScript/Examples/Suggest/setup.typoscript
+++ b/Configuration/TypoScript/Examples/Suggest/setup.typoscript
@@ -23,7 +23,7 @@ tx_solr_suggest {
     }
 }
 
-[traverse(request.getQueryParams(), 'tx_solr/callback') == '']
+[request && traverse(request.getQueryParams(), 'tx_solr/callback') == '']
     tx_solr_suggest.config.additionalHeaders.10.header = Content-type: application/json
 [global]
 


### PR DESCRIPTION
This change fixes an exception in CLI mode due to the missing request object

Fixes: #3916
Ports: #3917