### PR TITLE
Power up for magic filter __pageSections

### DIFF
--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -368,6 +368,13 @@ class QueryBuilder extends AbstractQueryBuilder
 
         // special filter to limit search to specific page tree branches
         if (array_key_exists('__pageSections', $searchQueryFilters)) {
+            if ($searchQueryFilters['__pageSections.'] ?? false) {
+                $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+                $searchQueryFilters['__pageSections'] = $cObj->stdWrap(
+                    $searchQueryFilters['__pageSections'],
+                    $searchQueryFilters['__pageSections.']
+                );
+            }
             $pageIds = GeneralUtility::trimExplode(',', $searchQueryFilters['__pageSections']);
             $this->usePageSectionsFromPageIds($pageIds);
             $this->typoScriptConfiguration->removeSearchQueryFilterForPageSections();

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -296,6 +296,17 @@ query.filter.__pageSections
 
 This is a magic/reserved filter (thus the double underscore). It limits the query and the results to certain branches/sections of the page tree. Multiple starting points can be provided as a comma-separated list of page IDs.
 
+Since version 11.5.6 it's possible to apply a stdWrap to it.
+
+Example:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.filter {
+        __pageSections = TEXT
+        __pageSections.data = leveluid:0
+    }
+
 
 query.sortBy
 ~~~~~~~~~~~~

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -39,6 +39,8 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\QueryType\Select\RequestBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 use function str_starts_with;
 
@@ -176,6 +178,92 @@ class QueryBuilderTest extends SetUpUnitTestCase
     {
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
         self::assertArrayNotHasKey('q.alt', $this->getAllQueryParameters($query), 'The alterativeQuery is not null when nothing was set');
+    }
+
+    /**
+     * @test
+     * @dataProvider buildSearchIsRespectingPageSectionFiltersDataProvider
+     */
+    public function buildSearchIsRespectingPageSectionFilters(
+        array $rootLines,
+        array $filterConfiguration,
+        string $expectedResult
+    ): void {
+        $rootLinesCount = count($rootLines);
+        $rootlineUtilityMock = $this->createMock(RootlineUtility::class);
+        $matcher = self::exactly($rootLinesCount);
+        $rootlineUtilityMock->method('get')->willReturnCallback(static function () use ($matcher, $rootLines): array {
+            if (isset($rootLines[$matcher->getInvocationCount()])) {
+                return $rootLines[$matcher->getInvocationCount()];
+            }
+            self::fail('unexpected invocation count');
+        });
+
+        for ($i = 0; $i < $rootLinesCount; $i++) {
+            GeneralUtility::addInstance(RootlineUtility::class, $rootlineUtilityMock);
+        }
+
+        $this->configurationMock->method('getSearchQueryFilterConfiguration')->willReturn($filterConfiguration);
+        $this->builder->newSearchQuery('*:*')->useFiltersFromTypoScript();
+        $query = $this->builder->getQuery();
+
+        $filter = $query->getFilterQuery('pageSections');
+        self::assertNotNull($filter);
+        self::assertEquals($expectedResult, $filter->getQuery());
+    }
+
+    public static function buildSearchIsRespectingPageSectionFiltersDataProvider(): \Traversable
+    {
+        yield 'static page section filter' => [
+            [
+                [
+                    1 => [
+                        'uid' => 123,
+                        'pid' => 1,
+                    ],
+                    0 => [
+                        'uid' => 1,
+                        'pid' => 0,
+                    ],
+                ],
+            ],
+            [
+                '__pageSections' => 123,
+            ],
+            'rootline:"2-0/1/123/"',
+        ];
+
+        yield 'static page section filter, with wrapping' => [
+            [
+                [
+                    1 => [
+                        'uid' => 123,
+                        'pid' => 1,
+                    ],
+                    0 => [
+                        'uid' => 1,
+                        'pid' => 0,
+                    ],
+                ],
+                [
+                    1 => [
+                        'uid' => 321,
+                        'pid' => 1,
+                    ],
+                    0 => [
+                        'uid' => 1,
+                        'pid' => 0,
+                    ],
+                ],
+            ],
+            [
+                '__pageSections' => 123,
+                '__pageSections.' => [
+                    'wrap' => '|,321',
+                ],
+            ],
+            'rootline:"2-0/1/123/" OR rootline:"2-0/1/321/"',
+        ];
     }
 
     /**


### PR DESCRIPTION
# What this pr does

Before this it's required to define a hardcoded comma separated list of page uids. Now it's possible to use the power of TypoScript to fill it with all sorts of things.

# How to test

    plugin.tx_solr.search.query.filter {
        __pageSections = TEXT
        __pageSections.data = leveluid:0
    }

Fixes: #3936
