### PR TITLE
[BUGFIX] Add record to index queue when published

### DIFF
--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -99,7 +99,7 @@ class RecordMonitor
 
         // track publish / swap events for records (workspace support)
         // command "version"
-        if ($command === 'version' && $value['action'] === 'swap') {
+        if ($command === 'version' && $value['action'] === 'publish') {
             $this->eventDispatcher->dispatch(
                 new VersionSwappedEvent($uid, $table),
             );

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -99,7 +99,7 @@ class RecordMonitor
 
         // track publish / swap events for records (workspace support)
         // command "version"
-        if ($command === 'version' && $value['action'] === 'publish') {
+        if ($command === 'version' && ($value['action'] === 'publish' || $value['action'] === 'swap')) {
             $this->eventDispatcher->dispatch(
                 new VersionSwappedEvent($uid, $table),
             );


### PR DESCRIPTION
# What this pr does

Checks if action is "publish" and add record to index queue.
Removed "swap" action as it's removed with https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92206-RemoveWorkspaceSwappingOfElements.html.

# How to test

1. Create a workspace
2. Switch to workspace and create page
3. Page is not in index queue -> correct
4. Publish the page to LIVE workspace
5. Page is not in index queue -> incorrect

Fixes:  #3718
