### PR TITLE
Update PageBrowserRangeViewHelper.php solves #3942

### DIFF
--- a/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
+++ b/Classes/ViewHelpers/PageBrowserRangeViewHelper.php
@@ -65,7 +65,11 @@ class PageBrowserRangeViewHelper extends AbstractSolrFrontendViewHelper
         $numberOfResultsOnPage = $resultSet->getSearchResults()->getCount();
         $numberOfAllResults = $resultSet->getAllResultCount();
 
-        $resultsFrom = $search->getResponseBody()->start + 1;
+        $resultsFrom = 0;
+        if ($search->getResponseBody() !== null) {
+            $resultsFrom = $search->getResponseBody()->start + 1;
+        }
+
         $resultsTo = $resultsFrom + $numberOfResultsOnPage - 1;
         $variableProvider->add($from, $resultsFrom);
         $variableProvider->add($to, $resultsTo);


### PR DESCRIPTION
Fix for [BUG] tx_solr 11.5.5 and solrfluidgrouping 11.0.0 PHP 8.1 #3942

---

### Maintainers note:

- [x] use Squash and merge button and enrich the commit message:
    ```
    [BUGFIX] error with active EXT:solrfluidgrouping 11.0 within PHP 8.1
    
    Fixes error with PHP 8.1if EXT:solrfluidgrouping 11.0 is installed: 
    `Attempt to read property "start" on null in .../solr/Classes/ViewHelpers/PageBrowserRangeViewHelper.php line 68`
    
    Fixes: #3942
    ```