### PR TITLE
[BUGFIX] Prevent exception in AccessComponent

### DIFF
--- a/Classes/Search/AccessComponent.php
+++ b/Classes/Search/AccessComponent.php
@@ -40,6 +40,10 @@ class AccessComponent
      */
     public function __invoke(AfterSearchQueryHasBeenPreparedEvent $event): void
     {
+        if (!isset($GLOBALS['TSFE'])) {
+            return;
+        }
+
         $query = $this->queryBuilder
             ->startFrom($event->getQuery())
             ->useSiteHashFromTypoScript($GLOBALS['TSFE']->id)


### PR DESCRIPTION
AccessComponent expects to find the TypoScriptFrontendController in $GLOBALS['TSFE'], and will cause an exception in CLI context.

To prevent this an additional check for TSFE in AccessComponent is added, similiar to other components like LastSearchesComponent.

Relates: #3675
Resolves: #3944