### PR TITLE
[TASK] Support several Apache Solr versions

### DIFF
--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:9.3.0
+FROM solr:9.5.0
 MAINTAINER dkd Internet Service GmbH <solr-eb-support@dkd.de>
 ENV TERM linux
 

--- a/Documentation/Appendix/VersionMatrix.rst
+++ b/Documentation/Appendix/VersionMatrix.rst
@@ -14,14 +14,15 @@ List of EXT:solr versions and the matching versions of Apache Solr and TYPO3 tha
 ------------------------------- ---------------------------------------------- -------------------------------- --------------- ---------------------------------
 TYPO3     EXT:solr   EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrfluidgrouping            EXT:solrmlt     Apache Solr     Configset
 ========= ========== ========== =========== =============== ================== ================================ =============== =============== =================
-12.4      12.0       12.0       12.0        12.0 (Ø)        12.0               N/A (integrated in EXT:solr)     12.0 (Ø)        9.3.0           ext_solr_12_0_0
-11.5      11.5       11.0       11.0        11.0            11.0               11.0                             11.0 (Ø)        8.11.1          ext_solr_11_5_0
+12.4      12.0       12.0       12.0        12.0            12.0               N/A (integrated in EXT:solr)     12.0 (Ø)        9.5.0¹          ext_solr_12_0_0
+11.5      11.5       11.0       11.0        11.0            11.0               11.0                             11.0 (Ø)        8.11.2¹         ext_solr_11_5_0
 ========= ========== ========== =========== =============== ================== ================================ =============== =============== =================
 
 | Ø  - not yet available
 | ᾱ  - non stable alpha release
 | β  - non stable beta release
 | rc - release candidate available
+|¹ - recommended Apache Solr version, check version matrix in composer.json (composer info:solr-versions) for full list
 
 .. important::
 
@@ -40,13 +41,14 @@ selected older versions. The following table illustrates the offers and availabl
 -------------------------------- ---------------------------------------------- ------------------------------------
 TYPO3     EXT:solr    EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools Apache Solr     Configset
 ========= =========== ========== =========== =============== ================== =============== ====================
-10.4      11.2.4+ Ø   10.0       10.0        10.0            10.0               9.2.1           ext_solr_11_2_0_elts
-9.5-10.4  11.0.8+     6.0.3+     8.0.2+      4.0.2+          1.1.3+             9.2.1           ext_solr_11_0_0_elts
+10.4      11.2.4+     10.0       10.0        10.0            10.0               9.5.0¹          ext_solr_11_2_0_elts
+9.5-10.4  11.0.9+     6.0.3+     8.0.2+      4.0.2+          1.1.3+             9.5.0¹          ext_solr_11_0_0_elts
 ========= =========== ========== =========== =============== ================== =============== ====================
 
 Our Apache Solr for TYPO3 EB-partners newsletter will keep you updated!
 
 Ø - not yet available
+¹ - recommended Apache Solr version, check version matrix in composer.json (composer info:solr-versions) for full list
 
 No longer supported versions
 ----------------------------

--- a/Resources/Private/Templates/Backend/Reports/SolrVersionStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/SolrVersionStatus.html
@@ -1,22 +1,34 @@
-<p style="margin-bottom: 10px;">Found an
-    outdated Apache Solr server version. <br />The <strong>minimum
-        required version is <code>{requiredVersion}</code></strong>, you have <code>{currentVersion}</code>.</p>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	data-namespace-typo3-fluid="true"
+>
+
+<p style="margin-bottom: 10px;">Found an unsupported Apache Solr server version. <br />
+	It is strongly recommended to use one of the explicitly tested versions, preferably the latest one.<br />
+	The currently supported versions are:
+	<f:for each="{supportedSolrVersions}" as="version" iteration="iterator">
+		<strong><code>{version}</code></strong>{f:if(condition: '{iterator.isLast}', then: '.', else: ',')}
+	</f:for>
+	<br />Your version is: <code>{currentVersion}</code>.
+</p>
 <table class="table table-condensed table-hover table-striped">
-    <thead>
-    <tr>
-        <td colspan="2">Affected Solr server</td>
-    </tr>
-    </thead>
-    <tr>
-        <th>Host</th>
-        <td>{solr.primaryEndpoint.host}</td>
-    </tr>
-    <tr>
-        <th>Path</th>
-        <td>{solr.corePath}</td>
-    </tr>
-    <tr>
-        <th>Port</th>
-        <td>{solr.primaryEndpoint.port}</td>
-    </tr>
+		<thead>
+		<tr>
+				<td colspan="2">Affected Solr server</td>
+		</tr>
+		</thead>
+		<tr>
+				<th>Host</th>
+				<td>{solr.primaryEndpoint.host}</td>
+		</tr>
+		<tr>
+				<th>Path</th>
+				<td>{solr.corePath}</td>
+		</tr>
+		<tr>
+				<th>Port</th>
+				<td>{solr.primaryEndpoint.port}</td>
+		</tr>
 </table>
+
+</html>

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,12 @@
     }
   },
   "scripts": {
+    "info:solr-versions": [
+      "@composer config extra.TYPO3-Solr.version-matrix.Apache-Solr"
+    ],
+    "info:recommended-solr-version": [
+      "@composer config extra.TYPO3-Solr.version-matrix.Apache-Solr.0"
+    ],
     "post-autoload-dump": [
       "mkdir -p .Build/vendor/apache-solr-for-typo3",
       "[ -L .Build/vendor/apache-solr-for-typo3/solr ] || ln -snvf ../../../. .Build/vendor/apache-solr-for-typo3/solr"
@@ -143,7 +149,12 @@
         "ext-solrconsole": "^12.0",
         "ext-solrdebugtools": "^12.0",
         "ext-solrmlt": "^12.0",
-        "Apache-Solr": "9.3.0",
+        "Apache-Solr": [
+          "9.5.0",
+          "9.4.1",
+          "9.4.0",
+          "9.3.0"
+        ],
         "configset": "ext_solr_12_0_0"
       },
       "ext-solrfal": {


### PR DESCRIPTION
As incompatibilities can also occur in minor versions, all versions will be explicitly tested and listed.

Currently tested and supported versions are: 9.3.0, 9.4.0, 9.4.1, 9.5.0.

It is always recommended to use the latest tested version.

Resolves: #3955 