### PR TITLE
[TASK:BP:11.5] Support several Apache Solr versions

### DIFF
--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -1,9 +1,13 @@
-FROM solr:8.11.1
+FROM solr:8.11.3
 MAINTAINER dkd Internet Service GmbH <solr-eb-support@dkd.de>
 ENV TERM linux
 
 USER root
-RUN rm -fR /opt/solr/server/solr/*
+RUN rm -fR /opt/solr/server/solr/* \
+  && echo '# EXT:solr relevant changes: ' >> /etc/default/solr.in.sh \
+    && echo 'SOLR_OPTS="$SOLR_OPTS -Dsolr.enableRemoteStreaming=true -Dsolr.enableStreamBody=true"' >> /etc/default/solr.in.sh \
+    && echo '# END: EXT:solr' >> /etc/default/solr.in.sh
+
 USER solr
 
 COPY --chown=solr:solr Resources/Private/Solr/ /var/solr/data

--- a/Documentation/Appendix/VersionMatrix.rst
+++ b/Documentation/Appendix/VersionMatrix.rst
@@ -21,5 +21,12 @@ Requirements for EXT:solr* 11.5 stack
 ------------------------------- ---------------------------------------------- --------------------------------------------- ---------------------------------
 TYPO3     EXT: solr  EXT:tika   EXT:solrfal EXT:solrconsole EXT:solrdebugtools EXT:solrfluidgrouping         EXT:solrmlt     Apache Solr     Configset
 ========= ========== ========== =========== =============== ================== ============================= =============== =============== =================
-11.5      11.5       11.0       11.0        11.0            11.0               11.0                          11.0 (Ø)        8.11.1          ext_solr_11_5_0
+11.5      11.5       11.0       11.0        11.0            11.0               11.0                          11.0 (Ø)        8.11.3¹         ext_solr_11_5_0
 ========= ========== ========== =========== =============== ================== ============================= =============== =============== =================
+
+|¹ - recommended Apache Solr version, check version matrix in composer.json (composer info:solr-versions) for full list
+
+..  warning::
+   Apache Solr 8.11.3 contains a breaking change, see security fix "SOLR-14853: Make enableRemoteStreaming option global; not configSet". EXT:solr relies on stream bodies
+   which aren't enabled by default since 8.11.3. EXT:solr 11.5.6 contains all required settings, but if you're updating and not using our Docker image, you have to
+   set "enableRemoteStreaming=true" and "solr.enableStreamBody=true". TYPO3 reports module will print a warning if you have to reconfigure.

--- a/Documentation/Releases/solr-release-11-5.rst
+++ b/Documentation/Releases/solr-release-11-5.rst
@@ -6,6 +6,15 @@
 Releases 11.5
 =============
 
+
+Release 11.5.6
+--------------
+
+..  warning::
+   Apache Solr 8.11.3 contains a breaking change, see security fix "SOLR-14853: Make enableRemoteStreaming option global; not configSet". EXT:solr relies on stream bodies
+   which aren't enabled by default since 8.11.3. EXT:solr 11.5.6 contains all required settings, but if you're updating and not using our Docker image, you have to
+   set "enableRemoteStreaming=true" and "solr.enableStreamBody=true". TYPO3 reports module will print a warning if you have to reconfigure.
+
 Release 11.5.5
 --------------
 

--- a/Resources/Private/Templates/Backend/Reports/SolrVersionStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/SolrVersionStatus.html
@@ -1,22 +1,34 @@
-<p style="margin-bottom: 10px;">Found an
-    outdated Apache Solr server version. <br />The <strong>minimum
-        required version is <code>{requiredVersion}</code></strong>, you have <code>{currentVersion}</code>.</p>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	data-namespace-typo3-fluid="true"
+>
+
+<p style="margin-bottom: 10px;">Found an unsupported Apache Solr server version. <br />
+	It is strongly recommended to use one of the explicitly tested versions, preferably the latest one.<br />
+	The currently supported versions are:
+	<f:for each="{supportedSolrVersions}" as="version" iteration="iterator">
+		<strong><code>{version}</code></strong>{f:if(condition: '{iterator.isLast}', then: '.', else: ',')}
+	</f:for>
+	<br />Your version is: <code>{currentVersion}</code>.
+</p>
 <table class="table table-condensed table-hover table-striped">
-    <thead>
-    <tr>
-        <td colspan="2">Affected Solr server</td>
-    </tr>
-    </thead>
-    <tr>
-        <th>Host</th>
-        <td>{solr.primaryEndpoint.host}</td>
-    </tr>
-    <tr>
-        <th>Path</th>
-        <td>{solr.corePath}</td>
-    </tr>
-    <tr>
-        <th>Port</th>
-        <td>{solr.primaryEndpoint.port}</td>
-    </tr>
+	<thead>
+	<tr>
+		<td colspan="2">Affected Solr server</td>
+	</tr>
+	</thead>
+	<tr>
+		<th>Host</th>
+		<td>{solr.primaryEndpoint.host}</td>
+	</tr>
+	<tr>
+		<th>Path</th>
+		<td>{solr.corePath}</td>
+	</tr>
+	<tr>
+		<th>Port</th>
+		<td>{solr.primaryEndpoint.port}</td>
+	</tr>
 </table>
+
+</html>

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 use ApacheSolrForTypo3\Solr\Report\SolrVersionStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Reports\Status;
 
 /**
  * Integration test for the solr version test
@@ -41,7 +42,14 @@ class SolrVersionStatusTest extends IntegrationTest
 
         /** @var $solrVersionStatus  SolrVersionStatus */
         $solrVersionStatus = GeneralUtility::makeInstance(SolrVersionStatus::class);
-        $violations = $solrVersionStatus->getStatus();
-        self::assertEmpty($violations, 'We expect to get no violations against the test solr server');
+        $results = $solrVersionStatus->getStatus();
+        self::assertCount(6, $results);
+        self::assertEmpty(
+            array_filter(
+                $results,
+                static fn (Status $status): bool => $status->getSeverity() !== Status::OK
+            ),
+            'We expect to get no violations against the test Solr server '
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,12 @@
     "tests:unit": "Runs unit tests"
   },
   "scripts": {
+    "info:solr-versions": [
+      "@composer config extra.TYPO3-Solr.version-matrix.Apache-Solr"
+    ],
+    "info:recommended-solr-version": [
+      "@composer config extra.TYPO3-Solr.version-matrix.Apache-Solr.0"
+    ],
     "post-autoload-dump": [
       "mkdir -p .Build/Web/typo3conf/ext/",
       "[ -L .Build/Web/typo3conf/ext/solr ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/solr"
@@ -140,7 +146,11 @@
         "ext-solrdebugtools": "^11.0",
         "ext-solrfluidgrouping": "^11.0",
         "ext-solrmlt": "^11.0",
-        "Apache-Solr": "8.11.1",
+        "Apache-Solr": [
+          "8.11.3",
+          "8.11.2",
+          "8.11.1"
+        ],
         "configset": "ext_solr_11_5_0"
       },
       "ext-solrfal": {


### PR DESCRIPTION
As incompatibilities can also occur in minor versions, all versions will be explicitly tested and listed.

Currently tested and supported versions are: 8.11.1, 8.11.2., 8.11.3

It is always recommended to use the latest tested version.

Note: Apache Solr 8.11.3 contains a breaking change, see security fix "SOLR-14853: Make enableRemoteStreaming option global; not configSet". EXT:solr relies on stream bodies which aren't enabled by default since 8.11.3. EXT:solr 11.5.6 contains all required settings, but if you're updating and not using our Docker image, you have to set `solr.enableRemoteStreaming=true` and `solr.enableStreamBody=true`. TYPO3 reports module will print a warning if you have to reconfigure.

Ports: #3956
Resolves: #3955 