### PR TITLE
[TASK:BP:11.5] Provide encryptionKey in unit tests

### DIFF
--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -26,31 +26,13 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 class IdBuilderTest extends UnitTest
 {
     /**
-     * @var string
-     */
-    protected $oldEncryptionKey;
-
-    protected function setUp(): void
-    {
-        $this->oldEncryptionKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'testkey';
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $this->oldEncryptionKey;
-        parent::tearDown();
-    }
-
-    /**
      * @test
      */
     public function canBuildVariantId()
     {
         $build = new IdBuilder();
         $variantId = $build->buildFromTypeAndUid('pages', 4711);
-        self::assertSame('e99b3552a0451f1a2e7aca4ac06ccaba063393de/pages/4711', $variantId);
+        self::assertSame('c523304ea47711019595d2bb352b623d1db40427/pages/4711', $variantId);
     }
 
     /**

--- a/Tests/Unit/UnitTest.php
+++ b/Tests/Unit/UnitTest.php
@@ -28,11 +28,23 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 abstract class UnitTest extends UnitTestCase
 {
     protected $resetSingletonInstances = true;
+    protected ?string $originalEncryptionKey;
 
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/Berlin');
+        $this->originalEncryptionKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'solr-tests-secret-encryption-key';
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']);
+        if ($this->originalEncryptionKey !== null) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = $this->originalEncryptionKey;
+        }
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
Since TYPO3 12.4.11 and 11.5.35 the encryptionKey is not initialized in the default configuration, thus some unit tests will fail.

This commit ensures an encryptionKey is set for the unit tests.

Ports: #3959
Resolves: #3958
