### PR TITLE
[FEATURE:BP:11.5] Power up for magic filter __pageSection

### DIFF
--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -450,6 +450,13 @@ class QueryBuilder extends AbstractQueryBuilder
 
         // special filter to limit search to specific page tree branches
         if (array_key_exists('__pageSections', $searchQueryFilters)) {
+            if ($searchQueryFilters['__pageSections.'] ?? false) {
+                $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+                $searchQueryFilters['__pageSections'] = $cObj->stdWrap(
+                    $searchQueryFilters['__pageSections'],
+                    $searchQueryFilters['__pageSections.']
+                );
+            }
             $pageIds = GeneralUtility::trimExplode(',', $searchQueryFilters['__pageSections']);
             $this->usePageSectionsFromPageIds($pageIds);
             $this->typoScriptConfiguration->removeSearchQueryFilterForPageSections();

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -296,6 +296,17 @@ query.filter.__pageSections
 
 This is a magic/reserved filter (thus the double underscore). It limits the query and the results to certain branches/sections of the page tree. Multiple starting points can be provided as a comma-separated list of page IDs.
 
+Since version 11.5.6 it's possible to apply a stdWrap to it.
+
+Example:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.filter {
+        __pageSections = TEXT
+        __pageSections.data = leveluid:0
+    }
+
 
 query.sortBy
 ~~~~~~~~~~~~


### PR DESCRIPTION
Before this it's required to define a hardcoded comma separated list of page uids. Now it's possible to use the power of TypoScript to fill it with all sorts of things.

This can e.g. look like:

plugin.tx_solr.search.query.filter {
  __pageSections = TEXT
  __pageSections.data = leveluid:0
}

Ports: #3937
Resolves: #3936