### PR TITLE
[FEATURE] Support stdWrap to resolve relation label field

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Frontend\ContentObject\Exception\ContentRenderingException;
  *
  * localField: the record's field to use to resolve relations
  * foreignLabelField: Usually the label field to retrieve from the related records is determined automatically using TCA, using this option the desired field can be specified explicitly
+ * foreignLabel: Defines how to build the label for indexing, stdWrap is applied. Can be used to overrule foreignLabelField. Referencing to "field" e.g. inside dataWrap will resolve to resolved record.
  * multiValue: whether to return related records suitable for a multi value field
  * singleValueGlue: when not using multiValue, the related records need to be concatenated using a glue string, by default this is ", ". Using this option a custom glue can be specified. The custom value must be wrapped by pipe (|) characters.
  * relationTableSortingField: field in a mm relation table to sort by, usually "sorting"
@@ -307,7 +308,9 @@ class Relation extends AbstractContentObject
             $relatedRecord = $this->getFrontendOverlayService()->getOverlay($foreignTableName, $relatedRecord);
         }
 
-        $values = [$relatedRecord[$foreignTableLabelField]];
+        $contentObject = clone $parentContentObject;
+        $contentObject->start($relatedRecord, $foreignTableName);
+        $values = [$contentObject->stdWrapValue('foreignLabel', $this->configuration, $relatedRecord[$foreignTableLabelField])];
 
         if (
             !empty($foreignTableName)

--- a/Documentation/Configuration/Reference/TxSolrIndex.rst
+++ b/Documentation/Configuration/Reference/TxSolrIndex.rst
@@ -599,6 +599,25 @@ The current record's field name to use to resolve the relation to the foreign ta
 
 Usually the label field to retrieve from the related records is determined automatically using TCA, using this option the desired field can be specified explicitly. To specify the label field for recursive relations, the field names can be separated by a dot, e.g. for a category hierarchy to get the name of the parent category one could use "parent.name" (since version:2.9).
 
+**foreignLabel**
+
+:Type: String
+:TS Path: plugin.tx_solr.index.queue.[indexConfig].fields.[fieldName].foreignLabel
+:Since: 12.1
+
+Defines how to build the label for indexing, stdWrap is applied. Can be used to overrule foreignLabelField. Referencing to "field" e.g. inside dataWrap will resolve to resolved record.
+
+Example:
+
+.. code-block:: typoscript
+
+   authorsNames_stringM = SOLR_RELATION
+   authorsNames_stringM {
+       localField = author
+       foreignLabel.dataWrap = {field : first_name} {field : last_name}
+       multiValue = 1
+   }
+
 **multiValue**
 
 :Type: Boolean


### PR DESCRIPTION
# What this pr does

Adds a new TypoScript option to allow stdWrap usages to build the actual label for indexing when resolving relations via SOLR_RELATION.

# How to test

Index a field using SOLR_RELATION with the new option. E.g. try EXT:tt_address and use the provided example.

Fixes: #3975