### PR TITLE
[BUGFIX] Allow fe_group modification when indexing subpage of restricted page

### DIFF
--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -40,15 +40,20 @@ class FrontendGroupsModifier
     public function __invoke(ModifyResolvedFrontendGroupsEvent $event): void
     {
         $pageIndexerRequest = $event->getRequest()->getAttribute('solr.pageIndexingInstructions');
-        if (!$pageIndexerRequest instanceof PageIndexerRequest
-            || (
-                (int)$pageIndexerRequest->getParameter('userGroup') === 0
-                && (
-                    (int)$pageIndexerRequest->getParameter('pageUserGroup') !== -2
-                    &&
-                    (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1
-                )
+        if (!$pageIndexerRequest instanceof PageIndexerRequest) {
+            return;
+        }
+
+        $groups = $this->resolveFrontendUserGroups($pageIndexerRequest);
+
+        $noRelevantFrontendUserGroupResolved = empty($groups) || (count($groups) === 1 && $groups[0] === 0);
+        if ((int)$pageIndexerRequest->getParameter('userGroup') === 0
+            && (
+                (int)$pageIndexerRequest->getParameter('pageUserGroup') !== -2
+                &&
+                (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1
             )
+            && $noRelevantFrontendUserGroupResolved
         ) {
             return;
         }
@@ -76,7 +81,6 @@ class FrontendGroupsModifier
             );
         }
 
-        $groups = $this->resolveFrontendUserGroups($pageIndexerRequest);
         if ((int)$pageIndexerRequest->getParameter('pageUserGroup') > 0) {
             $groups[] = (int)$pageIndexerRequest->getParameter('pageUserGroup');
         }

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_sub_page_of_protected_page_with_extend_to_subpage.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_sub_page_of_protected_page_with_extend_to_subpage.csv
@@ -1,0 +1,13 @@
+"fe_groups",
+,"uid","pid","title"
+,1,1,"group 1"
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp","fe_group",extendToSubpages
+,2,1,0,1,"/protected_page","protected page","",1449151778,1449151778,1,1
+,3,2,0,1,/sub_page,sub page, ,1449151779,1449151779,0,0
+"tt_content",
+,"uid","pid","CType","header","fe_group","sorting"
+,10,3,"header",public content of protected page,0,10
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
+,4711,1,"pages",3,"pages",1449151778,0,0,0,0,0

--- a/Tests/Integration/IndexQueue/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/PageIndexerTest.php
@@ -202,6 +202,17 @@ class PageIndexerTest extends IntegrationTestBase
                 'protected ce',
             ],
         ];
+
+        yield 'page protected by extend to subpages' => [
+            'can_index_sub_page_of_protected_page_with_extend_to_subpage',
+            1,
+            [
+                '2:1/c:0',
+            ],
+            [
+                'public content of protected page',
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
# What this pr does
When indexing a page, the authorized user is manipulated depending on which access is required to index.
Previously this did not take restrictions of parent pages into account when the page to index was not directly indexed.

# How to test
1. Create a page called parent and restrict it to any fe_group
2. Check Extend to Subpages for the page parent
3. Create a subpage for the page parent called child
4. Index the pages

The subpage should be indexed now too.

Fixes #3969
