### PR TITLE
[TASK] Full fixed french translation

### DIFF
--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -7,65 +7,65 @@
 		<!-- Index Administration -->
 			<trans-unit id="solr.backend.index_administration.description" xml:space="preserve">
 				<source>The Index Administration Module is responsible for emptying the cores(deleting documents) on Solr Server and index queues in TYPO3 CMS. </source>
-				<target>Le module d&apos;administration d&apos;index est chargé de vider les noyaux (suppression de documents) sur le serveur Solr et les files d&apos;attente d&apos;index dans le CMS TYPO3. </target>
+				<target>Le module d&apos;administration de l&apos;index est chargé de vider les noyaux (suppression de documents) sur le serveur Solr et les files d&apos;indexation dans le CMS TYPO3. </target>
 			</trans-unit>
 
 			<trans-unit id="solr.backend.index_administration.index_emptied_all" xml:space="preserve">
 				<source>Index emptied for Site "%s" (%s).</source>
-				<target>Index vidé pour le site « %s » (%s).</target>
+				<target>Index vidé pour le site « %s » (%s).</target>
 			</trans-unit>
 
 			<trans-unit id="solr.backend.index_administration.success.queue_emptied" xml:space="preserve">
 				<source>Index Queue emptied for Site "%s".</source>
-				<target>File d&apos;attente d’index vidée pour le site « %s ».</target>
+				<target>File d&apos;indexation vidée pour le site « %s ».</target>
 			</trans-unit>
 
 			<trans-unit id="solr.backend.index_administration.error.on_empty_index" xml:space="preserve">
 				<source>An error occurred while trying to delete documents from the index: %s</source>
-				<target>Une erreur s&apos;est produite lors de la tentative de suppression de documents de l&apos;index : %s</target>
+				<target>Une erreur s&apos;est produite lors de la tentative de suppression de documents de l&apos;index : %s</target>
 			</trans-unit>
 		<!-- End: Index Maintenance -->
 
 			<!-- From Backend/locallang.xlf //-->
 			<trans-unit id="module_indexinspector" xml:space="preserve" approved="yes">
 				<source>Search Index Inspector</source>
-				<target>Inspecteur de l'index de recherche</target>
+				<target>Inspecteur de l&apos;index de recherche</target>
 			</trans-unit>
 			<trans-unit id="plugin_results" xml:space="preserve" approved="yes">
 				<source>Search</source>
-				<target></target>
+				<target>Recherche</target>
 			</trans-unit>
 			<trans-unit id="plugin_results_description" xml:space="preserve" approved="yes">
 				<source>A search form and results list.</source>
-				<target></target>
+				<target>Un formulaire de recherche et une liste de résultat.</target>
 			</trans-unit>
 
 		<!-- Backend Components -->
 			<!-- SiteSelector -->
 			<trans-unit id="siteselector_switched_successfully" xml:space="preserve">
 				<source>Successfully switched to Site "%s".</source>
-				<target>Passage réussi au site « %s ».</target>
+				<target>Passage réussi au site « %s ».</target>
 			</trans-unit>
 
 			<trans-unit id="siteselector_switched_to_first_available_site" xml:space="preserve">
 				<source>The previously selected Site "%s" does not exist or the indexing for that Site was disabled. Switched to "%s", which was the first available one.</source>
-				<target>Le site « %s » précédemment sélectionné n&apos;existe pas ou l&apos;indexation de ce site a été désactivée. Passage au site « %s », qui était le premier disponible.</target>
+				<target>Le site « %s » précédemment sélectionné n&apos;existe pas ou l&apos;indexation de ce site a été désactivée. Passage au site « %s », qui était le premier disponible.</target>
 			</trans-unit>
 
 			<trans-unit id="siteselector_site_does_not_exist_anymore" xml:space="preserve">
 				<source>Couldn't switch to the Site "%s". This site does not exist anymore or the indexing for that Site was disabled. Switched to the first available Site "%s".</source>
-				<target>Impossible de passer au site « %s ». Ce site n&apos;existe plus ou l&apos;indexation de ce site a été désactivée. Passage au premier site disponible « %s ».</target>
+				<target>Impossible de passer au site « %s ». Ce site n&apos;existe plus ou l&apos;indexation de ce site a été désactivée. Passage au premier site disponible « %s ».</target>
 			</trans-unit>
 
 			<!-- CoreSelector -->
 			<trans-unit id="coreselector_switched_to_default_core" xml:space="preserve">
 				<source>The previously selected core "%s" is not available in "%s" site, therefore switched to default core "%s".</source>
-				<target>Le noyau « %s » sélectionné précédemment n&apos;est pas disponible sur le site « %s », passage au noyau par défaut « %s ».</target>
+				<target>Le noyau « %s » sélectionné précédemment n&apos;est pas disponible sur le site « %s », passage au noyau par défaut « %s ».</target>
 			</trans-unit>
 
 			<trans-unit id="coreselector_switched_successfully" xml:space="preserve">
 				<source>Successfully switched to core "%s".</source>
-				<target>Passage réussi au noyau « %s ».</target>
+				<target>Passage réussi au noyau « %s ».</target>
 			</trans-unit>
 		<!-- End: Backend Components -->
 
@@ -76,7 +76,7 @@
 			</trans-unit>
 			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
 				<source>Allows you to manage Apache Solr from TYPO3.&lt;br /&gt;&lt;em&gt;Access for 'admin' users only!&lt;/em&gt;</source>
-				<target>Vous permet d&apos;exécuter Apache Solr depuis TYPO3.&lt;br /&gt;&lt;em&gt;Accès réservé aux utilisateurs &apos;admin&apos; uniquement !&lt;/em&gt;</target>
+				<target>Vous permet d&apos;exécuter Apache Solr depuis TYPO3.&lt;br /&gt;&lt;em&gt;Accès réservé aux utilisateurs &apos;admin&apos; uniquement&amp;!&lt;/em&gt;</target>
 			</trans-unit>
 			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
 				<source>Search</source>
@@ -94,21 +94,21 @@
 			</trans-unit>
 			<trans-unit id="statistics_title" xml:space="preserve" approved="yes">
 				<source>Apache Solr Statistics</source>
-				<target>Statistiques d'Apache Solr</target>
+				<target>Statistiques d&apos;Apache Solr</target>
 			</trans-unit>
 			<trans-unit id="statistics_description" xml:space="preserve" approved="yes">
 				<source>Provides several Solr usage statistics</source>
-				<target>Fourni plusieurs statistiques d'usage de Solr</target>
+				<target>Fourni plusieurs statistiques d&apos;usage de Solr</target>
 			</trans-unit>
 
 			<!-- From ModuleScheduler/locallang.xlf //-->
 			<trans-unit id="optimizeindex_title" xml:space="preserve">
 				<source>Optimize index of a site</source>
-				<target>Optimiser l'index d'un site</target>
+				<target>Optimiser l&apos;index d'un site</target>
 			</trans-unit>
 			<trans-unit id="optimizeindex_description" xml:space="preserve">
 				<source>Optimizes the index of a site.</source>
-				<target>Optimise l'index d'un site.</target>
+				<target>Optimise l&apos;index d&apos;un site.</target>
 			</trans-unit>
 			<trans-unit id="reindex_title" xml:space="preserve" approved="yes">
 				<source>Force Re-Indexing of a site</source>
@@ -116,15 +116,15 @@
 			</trans-unit>
 			<trans-unit id="reindex_description" xml:space="preserve" approved="yes">
 				<source>Purges the Solr Index and initializes the Index Queue of a site.</source>
-				<target>Purge l'index de Solr et initialise la file d'attente d'indexation d'un site.</target>
+				<target>Purge l&apos;index de Solr et initialise la file d&apos;indexation d&apos;un site.</target>
 			</trans-unit>
 			<trans-unit id="indexqueueworker_title" xml:space="preserve" approved="yes">
 				<source>Index Queue Worker</source>
-				<target>Tâche de traitement de la file d'indexation.</target>
+				<target>Traitement de la File d&apos;Indexation</target>
 			</trans-unit>
 			<trans-unit id="indexqueueworker_description" xml:space="preserve" approved="yes">
 				<source>Processes the items in the Index Queue and sends them to Solr.</source>
-				<target>Traite les élément de la file d'attente et les envoie à Solr.</target>
+				<target>Traite les élément de la file d&apos;indexation et les envoie à Solr.</target>
 			</trans-unit>
 			<trans-unit id="indexqueueworker_field_documentsToIndexLimit" xml:space="preserve" approved="yes">
 				<source>Number of documents to index</source>
@@ -132,7 +132,7 @@
 			</trans-unit>
 			<trans-unit id="indexqueueworker_field_forcedWebRoot" xml:space="preserve">
 				<source>Forced webroot (only needed when webroot is not PATH_site)</source>
-				<target>Forced webroot (only needed when webroot is not PATH_site)</target>
+				<target>Racine forcée (nécessaire uniquement lorsque la racine n&apos;est pas PATH_site)</target>
 			</trans-unit>
 			<trans-unit id="field_host" xml:space="preserve" approved="yes">
 				<source>Solr Host</source>
@@ -144,7 +144,7 @@
 			</trans-unit>
 			<trans-unit id="field_path" xml:space="preserve" approved="yes">
 				<source>Solr Path</source>
-				<target>URI Solr</target>
+				<target>Chemin Solr</target>
 			</trans-unit>
 			<trans-unit id="field_server" xml:space="preserve" approved="yes">
 				<source>Solr Server</source>
@@ -162,7 +162,7 @@
 			</trans-unit>
 			<trans-unit id="searchFailed" xml:space="preserve" approved="yes">
 				<source>We're sorry. The request you tried to make could not be processed.</source>
-				<target>Désolé. Votre demande n'a pas pu être traitée.</target>
+				<target>Désolé. Votre demande n&apos;a pas pu être traitée.</target>
 			</trans-unit>
 			<trans-unit id="searchWord" xml:space="preserve" approved="yes">
 				<source>Search Term</source>
@@ -214,7 +214,7 @@
 			</trans-unit>
 			<trans-unit id="results_found.singular" xml:space="preserve" approved="yes">
 				<source>Found 1 result in @resultsTime milliseconds.</source>
-				<target>1 résultats ont été trouvés en @resultsTime millisecondes.</target>
+				<target>1 résultat a été trouvé en @resultsTime millisecondes.</target>
 			</trans-unit>
 			<trans-unit id="results_searched_for" xml:space="preserve" approved="yes">
 				<source>Searched for &quot;@searchWord&quot;.</source>
@@ -258,11 +258,11 @@
 			</trans-unit>
 			<trans-unit id="results_per_page" xml:space="preserve" approved="yes">
 				<source>Results per page:</source>
-				<target>Résultats par page:</target>
+				<target>Résultats par page :</target>
 			</trans-unit>
 			<trans-unit id="error_errors" xml:space="preserve" approved="yes">
 				<source>We're sorry, there were some errors:</source>
-				<target>Nous sommes désolés, il y a eu quelques erreurs :</target>
+				<target>Nous sommes désolés, il y a eu quelques erreurs :</target>
 			</trans-unit>
 			<trans-unit id="error_emptyQuery" xml:space="preserve" approved="yes">
 				<source>Please enter your search term in the box above.</source>
@@ -286,21 +286,21 @@
 			</trans-unit>
 			<trans-unit id="suggest_header" xml:space="preserve">
 				<source>Top Results</source>
-				<target>Top Results</target>
+				<target>Meilleurs résultats</target>
 			</trans-unit>
 
 			<!-- From locallang.xlf -->
 			<trans-unit id="solr.backend.index_queue_module.description" xml:space="preserve">
 				<source>The Index Queue manages content indexing. Content enters the Index Queue by initialization below or when new content is created based on configuration. Items in the Index Queue are indexed newest changes first until all items in the queue have been indexed.</source>
-				<target>La file d’attente de l’index gère l’indexation du contenu. Le contenu entre dans la file d&apos;attente de l&apos;index par l’initialisation ci-dessous ou lors de la création d&apos;un nouveau contenu selon la configuration. Les éléments de la file d&apos;attente de l&apos;index sont indexés en commençant par les changements les plus récents jusqu&apos;à ce que tous les éléments de la file d&apos;attente aient été indexés.</target>
+				<target>La file l&apos;indexation gère l&apos;indexation du contenu. Le contenu entre dans la file d&apos;indexation par l&apos;initialisation ci-dessous ou lors de la création d&apos;un nouveau contenu selon la configuration. Les éléments de la file d&apos;indexation sont indexés en commençant par les changements les plus récents jusqu&apos;à ce que tous les éléments de la file d&apos;indexation aient été indexés.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.reset_button" xml:space="preserve">
 				<source>Reset errors</source>
-				<target>Erreurs de réinitialisation</target>
+				<target>Réinitialiser les erreurs</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.headline" xml:space="preserve">
 				<source>Indexing Errors</source>
-				<target>Erreurs d’indexation</target>
+				<target>Erreurs d&apos;indexation</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.id" xml:space="preserve">
 				<source>ID</source>
@@ -308,44 +308,44 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.item_type" xml:space="preserve">
 				<source>Item Type</source>
-				<target>Type d’élément</target>
+				<target>Type d&apos;élément</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.item_uid" xml:space="preserve">
 				<source>Item UID</source>
-				<target>Afficher l’erreur</target>
+				<target>Afficher l&apos;erreur</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.errors.show_button" xml:space="preserve">
 				<source>Show error</source>
-				<target>Afficher l’erreur</target>
+				<target>Afficher l&apos;erreur</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.index_manual" xml:space="preserve">
 				<source>An error occurred while indexing manual from the backend.</source>
-				<target>Une erreur s&apos;est produite lors de l’indexation manuelle de l’application en arrière-plan.</target>
+				<target>Une erreur s&apos;est produite lors de l&apos;indexation manuelle de l&apos;application en arrière-plan.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.reset_errors" xml:space="preserve">
 				<source>An error occurred while resetting the error log in the index queue.</source>
-				<target>Une erreur s&apos;est produite lors de la réinitialisation du fichier d’erreurs dans la file d’attente de l&apos;index.</target>
+				<target>Une erreur s&apos;est produite lors de la réinitialisation du fichier d&apos;erreurs dans la file d&apos;indexation.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.single_item_not_requeued" xml:space="preserve">
 				<source>Single item was not requeued.</source>
-				<target>Single item was not requeued.</target>
+				<target>L'élément n'a pas été remis dans la file.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.no_selection" xml:space="preserve">
 				<source>No indexing configurations selected.</source>
-				<target>Aucune configuration d’indexation sélectionnée.</target>
+				<target>Aucune configuration d&apos;indexation sélectionnée.</target>
 			</trans-unit>
 
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.success" xml:space="preserve">
 				<source>Initialized indexing configurations: %s</source>
-				<target>Configurations d’indexation initialisées : %s</target>
+				<target>Configurations d&apos;indexation initialisées : %s</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.initialize.title" xml:space="preserve">
 				<source>Index Queue initialized</source>
-				<target>File d&apos;attente de l’index initialisée</target>
+				<target>File d&apos;indexation initialisée</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.not_initialized.title" xml:space="preserve">
 				<source>Index Queue not initialized</source>
-				<target>File d&apos;attente de l’index non initialisée</target>
+				<target>File d&apos;indexation non initialisée</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.reset_errors" xml:space="preserve">
 				<source>All errors have been reset.</source>
@@ -353,15 +353,15 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.index_manual" xml:space="preserve">
 				<source>Indexing from the backend was successfully finished.</source>
-				<target>L&apos;indexation de l’application en arrière-plan s&apos;est terminée avec succès.</target>
+				<target>L&apos;indexation de l&apos;application en arrière-plan s&apos;est terminée avec succès.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.success.single_item_was_requeued" xml:space="preserve">
 				<source>Single item was successfully marked for reindexing.</source>
-				<target>Single item was successfully marked for reindexing.</target>
+				<target>L'élément a été marqué pour ré-indexation avec succès.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.title" xml:space="preserve">
 				<source>Index Queue</source>
-				<target>File d&apos;attente de l’index</target>
+				<target>File d&apos;&apos;indexation</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.index_manual" xml:space="preserve">
 				<source>Manual Indexing</source>
@@ -369,7 +369,7 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.help" xml:space="preserve">
 				<source>Initializing the Index Queue is the most complete way to force re-indexing, or to build the Index Queue for the first time. The Index Queue Worker scheduler task will then index the items listed in the Index Queue.</source>
-				<target>L&apos;initialisation de la file d&apos;attente de l&apos;index est le moyen le plus complet de forcer la ré-indexation ou de générer la file d&apos;attente de l&apos;index pour la première fois. La tâche du planificateur de l’exécuteur de file d&apos;attente de l&apos;index indexera alors les éléments énumérés dans la file d&apos;attente de l&apos;index.</target>
+				<target>L&apos;initialisation de la file d&apos;indexation est le moyen le plus complet de forcer la ré-indexation ou de générer la file d&apos;indexation pour la première fois. La tâche Traitement de la File d&apos;Indexation du planificateur indexera alors les éléments énumérés dans la file d&apos;indexation.</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.status.errors" xml:space="preserve">
 				<source> Errors</source>
@@ -389,15 +389,15 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.header_init" xml:space="preserve">
 				<source>Index Queue Initialization</source>
-				<target>Initialisation de la file d&apos;attente de l’index</target>
+				<target>Initialisation de la file d&apos;indexation</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.header_status" xml:space="preserve">
 				<source>Index Queue Status</source>
-				<target>État de la file d&apos;attente de l’index</target>
+				<target>État de la file d&apos;indexation</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.button.clear_index_queue" xml:space="preserve">
 				<source>Clear Index Queue</source>
-				<target>Supprimer la file d&apos;attente de l’index</target>
+				<target>Vider la file d&apos;indexation</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.back" xml:space="preserve">
 				<source>Go back</source>
@@ -405,11 +405,11 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.flashmessage.error.no_queue_item_for_queue_error" xml:space="preserve">
 				<source>No valid queue item passed to show the error information!</source>
-				<target>Aucun élément de file d&apos;attente valide transmis pour afficher les informations d&apos;erreur !</target>
+				<target>Aucun élément de file d&apos;attente valide transmis pour afficher les informations d&apos;erreur !</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.error_details" xml:space="preserve">
 				<source>Error details for queue item</source>
-				<target>Détails de l&apos;erreur pour l’élément de la file d&apos;attente</target>
+				<target>Détails de l&apos;erreur pour l&apos;élément de la file d&apos;attente</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.index_queue_module.index_now" xml:space="preserve">
 				<source>Index now</source>
@@ -419,15 +419,15 @@
 			<!-- From locallang_db.xlf -->
 			<trans-unit id="tt_content.list_type_pi_frequentsearches" xml:space="preserve" approved="yes">
 				<source>Search: Frequent Searches</source>
-				<target>Rechercher: Recherches fréquentes</target>
+				<target>Recherche : Recherches fréquentes</target>
 			</trans-unit>
 			<trans-unit id="tt_content.list_type_pi_results" xml:space="preserve" approved="yes">
 				<source>Search: Form, Result, Additional Components</source>
-				<target>Rechercher: Formulaire, Résultats, Composants additionnels</target>
+				<target>Recherche : Formulaire, Résultats, Composants additionnels</target>
 			</trans-unit>
 			<trans-unit id="tt_content.list_type_pi_search" xml:space="preserve" approved="yes">
 				<source>Search: Form only</source>
-				<target>Rechercher: Formulaire seul</target>
+				<target>Recherche : Formulaire seul</target>
 			</trans-unit>
 
 			<trans-unit id="solr.backend.search_statistics_module.item_phrase" xml:space="preserve">
@@ -436,31 +436,31 @@
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.item_count" xml:space="preserve">
 				<source>Number of Queries</source>
-				<target>Number of Queries</target>
+				<target>Nombre de Requêtes</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.results" xml:space="preserve">
 				<source>Number of Results (Average)</source>
-				<target>Number of Results (Average)</target>
+				<target>Nombre de Résultats (Moyenne)</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.percentage" xml:space="preserve">
 				<source>Percentage</source>
-				<target>Percentage</target>
+				<target>Pourçentage</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.no_records_found" xml:space="preserve">
 				<source>No records found. Did you enabled 'plugin.tx_solr.statistics = 1' in the typoscript configuration of your site?</source>
-				<target>No records found. Did you enabled 'plugin.tx_solr.statistics = 1' in the typoscript configuration of your site?</target>
+				<target>Pas d'enregistrement trouvé. Avez-vous activé 'plugin.tx_solr.statistics = 1' dans la configuration typoscript de votre site ?</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases" xml:space="preserve">
 				<source>Top 5 Search Phrases</source>
-				<target>Top 5 Search Phrases</target>
+				<target>Les 5 phrases les plus recherchées</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.top_search_phrases_without_hits" xml:space="preserve">
 				<source>Top 5 Search Phrases Without Hits</source>
-				<target>Top 5 Search Phrases Without Hits</target>
+				<target>Les 5 phrases sans correspondance les plus recherchées</target>
 			</trans-unit>
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>
-				<target>Search Phrase Statistics</target>
+				<target>Statistiques des phrases cherchées</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/fr.locallang_be.xlf
+++ b/Resources/Private/Language/fr.locallang_be.xlf
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="EXT:solr/Resources/Private/Language/locallang_be.xlf" date="2021-12-15T13:10:00Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="extConf.monitoringType" xml:space="preserve">
+				<source>Monitoring: Define how data updates should be monitored</source>
+				<target>Surveillance: Définir comment les mise à jour des données sont surveillées</target>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.0" xml:space="preserve">
+				<source>Immediate</source>
+				<target>Immédiatement</target>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.1" xml:space="preserve">
+				<source>Delayed (Scheduler task)</source>
+				<target>Différée (Tâche planifiée)</target>
+			</trans-unit>
+			<trans-unit id="extConf.monitoringType.I.2" xml:space="preserve">
+				<source>No monitoring at all</source>
+				<target>Pas de Surveillance du tout</target>
+			</trans-unit>
+
+			<trans-unit id="task.eventQueueWorkerTask.title" xml:space="preserve">
+				<source>Event Queue Worker</source>
+				<target>Traitement de la file d&apos;événement</target>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.description" xml:space="preserve">
+				<source>Task handling the queue data update events. Required if monitoringType is set to "Delayed".</source>
+				<target>Tâche gérant les événements de mise à jour de données. Requis si monitoringType est défini à « Différée ».</target>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.limit" xml:space="preserve">
+				<source>Processing limit, the number of events to process</source>
+				<target>Limit de traitement, le nombre d&apos;événements à traiter</target>
+			</trans-unit>
+			<trans-unit id="task.eventQueueWorkerTask.statusMsg" xml:space="preserve">
+				<source>Data update events to process: %1$d, Errors: %2$d. %3$d events will be processed per run.</source>
+				<target>Événements de mise à jour à traiter : %1$d, Erreurs: %2$d. %3$d événements sont traités par exécution.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_csh_pages.xlf
+++ b/Resources/Private/Language/fr.locallang_csh_pages.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
+	<file t3:id="1415814793" source-language="en" target-language="fr" datatype="plaintext" original="EXT:core/Resources/Private/Language/locallang_csh_pages.xlf" date="2020-12-1T15:22:32Z" product-name="context_help">
+		<header/>
+		<body>
+			<trans-unit id="no_search_sub_entries.description" resname="no_search_sub_entries.description">
+				<source>If enabled, this option includes the sub entries of this page in Solr index. (NOTE: Value=0 means enabled in this view.)</source>
+				<target>Si activée, cette option inclue les sous-entrées de cette page dans l'index Solr. (NOTE : Valeur=0 signifie activé dans cette vue.)</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_mod.xlf
+++ b/Resources/Private/Language/fr.locallang_mod.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2014-06-02T11:48:40Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Apache Solr</source>
+				<target>Apache Solr</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Administrate solr</source>
+				<target>Administrer solr</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>This module provides submodules to maintain solr functionality.</source>
+				<target>Ce module fourni les sous-modules pour maintenir le fonctionnement de solr.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_mod_coreoptimize.xlf
+++ b/Resources/Private/Language/fr.locallang_mod_coreoptimize.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2014-06-02T11:48:40Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Core Optimization</source>
+				<target>Optimisation noyau</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Maintain synonyms and stopwords</source>
+				<target>Maintenance des synonymes et mots ignorés</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>This module allows you to optimize the cores, you can maintain synonyms and stopwords to improve the search results.</source>
+				<target>Ce module vous permet d'optimiser les noyaux, de maintenir les synonymes et les mots ignorés pour améliorer les résultats de recherche.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_mod_indexadmin.xlf
+++ b/Resources/Private/Language/fr.locallang_mod_indexadmin.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2014-06-02T11:48:40Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Index Administration</source>
+				<target>Administration de l&apos;Index</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Administrate your solr system</source>
+				<target>Administrer votre system solr</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>This module allows you to do admin operations on the index (e.g. clear the index queue or clean the solr server).</source>
+				<target>Ce module vous permet d&apos;effectuer des opérations d'administration sur l&apos;index (ex. nettoyer la file d&apos;indexation ou nettoyer le serveur solr).</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_mod_indexqueue.xlf
+++ b/Resources/Private/Language/fr.locallang_mod_indexqueue.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2014-06-02T11:48:40Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Index Queue</source>
+				<target>File d&apos;Indexation</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Allows to check the status of the index queue</source>
+				<target>Permet de vérifier l&apos;état de la file d&apos;indexation</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>This module allows you to check the state of the index queue and reQueue items.</source>
+				<target>Ce module vous permet de vérifier l&apos;état de la file d&apos;indexation et d&apos;y remettre des éléments.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_mod_info.xlf
+++ b/Resources/Private/Language/fr.locallang_mod_info.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2014-06-02T11:48:40Z" product-name="solr">
+		<header/>
+		<body>
+			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
+				<source>Info</source>
+				<target>Info</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
+				<source>Get information from your search usage and data</source>
+				<target>Obtenir des information d&apos;usage et sur les données de recherche</target>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
+				<source>This module allows you to get information (statistics, used fields, connection details) from the core.</source>
+				<target>Ce module vous permet d&apos;obtenir des informations (statistiques, champs utilisés, détails de connexion) depuis le noyau.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_tca.xlf
+++ b/Resources/Private/Language/fr.locallang_tca.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2020-12-01T11:42:09Z">
+		<header>
+			<generator>LFEditor</generator>
+		</header>
+		<body>
+
+			<trans-unit id="pages.no_search_sub_entries" xml:space="preserve">
+				<source>Include sub entries in Search</source>
+				<target>Inclure les sous-entrées dans la recherche</target>
+			</trans-unit>
+
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
# What this pr does

Adds missing translations for French and normalize some terms likes "Index Queue" to "File d'indexation" instead of "File d'attente de l'index" or "File d'attente d'indexation".

Also fixes some other small mistakes.

# How to test

Using a clean setup (no var/labels folder), activate and download French for backend. Change your user to French. Check that pages.no_search_sub_entries field has its label and description translated. In the module bar, check module names are in French. In about module, check the module and submodules information are translated. Explore the SOLR module and find no word in English. If found, the text is not found in translation files.

Fixes: #3983

### Maintainers notes:

- [x] port into main branch
