### PR TITLE
[BUGFIX] Prevent exception in queue module when no site can be determined

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -318,11 +318,13 @@ class IndexQueueModuleController extends AbstractModuleController
     protected function getIndexQueues(): array
     {
         $queues = [];
-        $configuration = $this->selectedSite->getSolrConfiguration();
-        foreach ($configuration->getEnabledIndexQueueConfigurationNames() as $indexingConfiguration) {
-            $indexQueueClass = $configuration->getIndexQueueClassByConfigurationName($indexingConfiguration);
-            if (!isset($queues[$indexQueueClass])) {
-                $queues[$indexQueueClass] = GeneralUtility::makeInstance($indexQueueClass);
+        $configuration = $this->selectedSite?->getSolrConfiguration();
+        if ($configuration) {
+            foreach ($configuration->getEnabledIndexQueueConfigurationNames() as $indexingConfiguration) {
+                $indexQueueClass = $configuration->getIndexQueueClassByConfigurationName($indexingConfiguration);
+                if (!isset($queues[$indexQueueClass])) {
+                    $queues[$indexQueueClass] = GeneralUtility::makeInstance($indexQueueClass);
+                }
             }
         }
 

--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -318,13 +318,14 @@ class IndexQueueModuleController extends AbstractModuleController
     protected function getIndexQueues(): array
     {
         $queues = [];
-        $configuration = $this->selectedSite?->getSolrConfiguration();
-        if ($configuration) {
-            foreach ($configuration->getEnabledIndexQueueConfigurationNames() as $indexingConfiguration) {
-                $indexQueueClass = $configuration->getIndexQueueClassByConfigurationName($indexingConfiguration);
-                if (!isset($queues[$indexQueueClass])) {
-                    $queues[$indexQueueClass] = GeneralUtility::makeInstance($indexQueueClass);
-                }
+        if ($this->selectedSite === null) {
+            return [];
+        }
+        $configuration = $this->selectedSite->getSolrConfiguration();
+        foreach ($configuration->getEnabledIndexQueueConfigurationNames() as $indexingConfiguration) {
+            $indexQueueClass = $configuration->getIndexQueueClassByConfigurationName($indexingConfiguration);
+            if (!isset($queues[$indexQueueClass])) {
+                $queues[$indexQueueClass] = GeneralUtility::makeInstance($indexQueueClass);
             }
         }
 


### PR DESCRIPTION
# What this pr does

When having more than one site the cannot be determined if the page root is selected. This patch makes the selectedSite truely optional

# How to test

Have more than one site, e.g. a minimal, non-assigned autogenerated site.
Have no page in a site selected in the page tree (e.g. root page)
Open queue module