### PR TITLE
[BUGFIX] Solves PHP Warning: Undefined array key "label".

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -87,7 +87,7 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             }
 
             $field = $sortingOptions['field'];
-            $label = $sortingOptions['label'];
+            $label = $sortingOptions['label'] ?? '';
 
             $isResetOption = $field === 'relevance';
 


### PR DESCRIPTION
If the label of a sorting field only consists of a stdWrap, the key “label” is not present, only “label.”.

# What this pr does

Removes possible flooded TYPO3 log messages.

# How to test

Create a simple sorting field with a label using stdWrap.

```
plugin.tx_solr {
  search {
    sorting = 1
    sorting {
      options >
      options {
        isnew {
          label.data = LLL:EXT:extension/Resources/Private/Language/locallang.xlf:solr.sorting.isnew
          field = sort_isnew_boolS
        }
      }
    }
  }
}
```

Fixes: #3997 
