### PR TITLE
[BUGFIX] Improve autosuggest_controller focus behavior

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -11,19 +11,19 @@ function SuggestController() {
                 $formAutoComplete = $('body');
             }
 
-            $form.find('.tx-solr-suggest-focus').focus();
-
             // when no specific container found, use the form as container
             if ($searchBox.length === 0) {
                 $searchBox = $form;
             }
             $searchBox.css('position', 'relative');
 
+            $form.find('.tx-solr-suggest-focus').focus();
+
             // Prevent submit of empty search form
             $form.on('submit', function (e) {
-                if ($form.find('.tx-solr-suggest').val() === '') {
+                if ($form.find('.tx-solr-suggest-focus').val() === '') {
                     e.preventDefault();
-                    $form.find('.tx-solr-suggest').focus();
+                    $form.find('.tx-solr-suggest-focus').focus();
                 }
             });
 


### PR DESCRIPTION
# What this pr does

`suggest_controller.js` adds an autofocus on form submit to all forms with an autosuggest input containing `.tx-solr-suggest`. We have a form that contains an autosuggest input field and multiple other facets to filter for values. If you leave the search input empty and add activate some other facet filters, you can't submit the form. 

This pull request changes the submit event listener, to check for `.tx-solr-suggest-focus` instead of `.tx-solr-suggest` which is more intuitive, as it's already used for the initial focus made by `$form.find('.tx-solr-suggest-focus').focus();`.

# How to test

Create an autosuggest searchfield and remove the `.tx-solr-suggest-focus` CSS class.

Fixes: #4004
