### PR TITLE
Be able to disable tracking of last searches

### DIFF
--- a/Classes/Domain/Search/LastSearches/LastSearchesService.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesService.php
@@ -83,9 +83,11 @@ class LastSearchesService
             case 'global':
                 $this->lastSearchesRepository->add($keywords, $this->configuration->getSearchLastSearchesLimit());
                 break;
+            case 'disabled':
+                break;
             default:
                 throw new UnexpectedValueException(
-                    'Unknown mode for plugin.tx_solr.search.lastSearches.mode, valid modes are "user" or "global".',
+                    'Unknown mode for plugin.tx_solr.search.lastSearches.mode, valid modes are "user", "global" or "disabled".',
                     1342456570
                 );
         }

--- a/Classes/Search/LastSearchesComponent.php
+++ b/Classes/Search/LastSearchesComponent.php
@@ -46,7 +46,7 @@ class LastSearchesComponent
 
         $query = $resultSet->getUsedSearchRequest()->getRawUserQuery();
 
-        if (!empty($query)) {
+        if (!empty($query) && $event->getTypoScriptConfiguration()->getSearchLastSearchesMode() !== 'disabled') {
             $lastSearchesService = $this->getLastSearchesService($resultSet);
             $lastSearchesService->addToLastSearches($query);
         }

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -981,7 +981,7 @@ class TypoScriptConfiguration
      *
      * plugin.tx_solr.search.lastSearches.mode
      */
-    public function getSearchLastSearchesMode(string $defaultIfEmpty = 'user'): string
+    public function getSearchLastSearchesMode(string $defaultIfEmpty = 'disabled'): string
     {
         $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.lastSearches.mode', $defaultIfEmpty);
         return (string)$result;

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -198,7 +198,7 @@ plugin.tx_solr {
     lastSearches = 0
     lastSearches {
       limit = 10
-      // tracking mode "user" or "global"
+      // tracking mode "user", "global" or "disabled"
       mode = user
     }
 

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -199,7 +199,7 @@ plugin.tx_solr {
     lastSearches {
       limit = 10
       // tracking mode "user", "global" or "disabled"
-      mode = user
+      mode = disabled
     }
 
     frequentSearches = 0

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -622,7 +622,7 @@ lastSearches.mode
 :Type: String
 :TS Path: plugin.tx_solr.search.lastSearches.mode
 :Since: 1.3-dkd
-:Default: user
+:Default: disabled
 :Options: user, global, disabled
 
 If mode is user, keywords will get stored into the session. If mode is global keywords will get stored into the database. If mode is disabled, then keywords are not stored in the database.

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -623,9 +623,9 @@ lastSearches.mode
 :TS Path: plugin.tx_solr.search.lastSearches.mode
 :Since: 1.3-dkd
 :Default: user
-:Options: user, global
+:Options: user, global, disabled
 
-If mode is user, keywords will get stored into the session. If mode is global keywords will get stored into the database.
+If mode is user, keywords will get stored into the session. If mode is global keywords will get stored into the database. If mode is disabled, then keywords are not stored in the database.
 
 frequentSearches
 ----------------


### PR DESCRIPTION
# What this pr does

It introduces `plugin.tx_solr.search.lastSearches.mode = disabled` and in the 2nd commit set it to be new default

# How to test

* Set the TypoScript.
* Make a search, that returns a result
* See no tracked keywords in database 

Fixes: #4003