### PR TITLE
[BUGFIX] Fix debug output if response body is read once stream

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -167,7 +167,8 @@ class PageIndexerRequest
         $headers = $this->getHeaders();
         $rawResponse = $this->getUrl($url, $headers, $this->timeout);
         // convert JSON response to response object properties
-        $decodedResponse = $response->getResultsFromJson($rawResponse->getBody()->getContents());
+        $responseString = $rawResponse->getBody()->getContents();
+        $decodedResponse = $response->getResultsFromJson($responseString);
 
         if ($decodedResponse === null) {
             $this->logger->error(
@@ -177,7 +178,7 @@ class PageIndexerRequest
                     'request url' => $url,
                     'request headers' => $headers,
                     'response headers' => $rawResponse->getHeaders(),
-                    'raw response body' => $rawResponse->getBody()->getContents(),
+                    'raw response body' => $responseString,
                 ]
             );
 


### PR DESCRIPTION
# Problem:

We had the problem that the requests where cached by staticfilecache.
But we could not find any hint about that in the logs. 

Because the log would only show an empty body.

That is because the body was already read in the lines above the log message.
And it was a read once stream. (read more about read once streams: https://stackoverflow.com/a/6518288/5440709 )

# Solution:

Our solution is to keep the body in a variable so if there is a Problem we can send the body to the log message.

@dkd-kaehm 