### PR TITLE
BUG [4026] treat non-overlayed mount points as valid

### DIFF
--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -110,7 +110,7 @@ class Page extends AbstractInitializer
         );
 
         foreach ($mountPoints as $mountPoint) {
-            if (!empty($mountPoint['mountPageOverlayed']) && !$this->isMountPointValid($mountPoint)) {
+            if (!$this->isMountPointValid($mountPoint)) {
                 continue;
             }
 
@@ -161,7 +161,7 @@ class Page extends AbstractInitializer
     {
         $isValidMountPage = true;
 
-        if (empty($mountPoint['mountPageSource'])) {
+        if (!empty($mountPoint['mountPageOverlayed']) && empty($mountPoint['mountPageSource'])) {
             $isValidMountPage = false;
 
             $flashMessage = GeneralUtility::makeInstance(
@@ -174,7 +174,7 @@ class Page extends AbstractInitializer
             $this->flashMessageQueue->addMessage($flashMessage);
         }
 
-        if (!$this->mountedPageExists($mountPoint['mountPageSource'])) {
+        if (!empty($mountPoint['mountPageOverlayed']) && !$this->mountedPageExists($mountPoint['mountPageSource'])) {
             $isValidMountPage = false;
 
             $flashMessage = GeneralUtility::makeInstance(

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -110,7 +110,7 @@ class Page extends AbstractInitializer
         );
 
         foreach ($mountPoints as $mountPoint) {
-            if (!$this->isMountPointValid($mountPoint)) {
+            if (!empty($mountPoint['mountPageOverlayed']) && !$this->isMountPointValid($mountPoint)) {
                 continue;
             }
 
@@ -122,6 +122,7 @@ class Page extends AbstractInitializer
                 // The page itself has its own content, which is handled like standard page.
                 $indexQueue = GeneralUtility::makeInstance(Queue::class);
                 $indexQueue->updateItem($this->type, $mountPoint['uid']);
+                $mountPointsInitialized = true;
             }
 
             // This can happen when the mount point does not show the content of the

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.csv
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/can_add_mount_pages.csv
@@ -2,7 +2,7 @@
 "pages",
 ,"uid","pid","is_siteroot","doktype","mount_pid","mount_pid_ol","slug","title"
 ,10,1,0,7,2,0,"/mount-point","Mount Point"
-,40,1,0,7,0,0,"/invalid-mount-point","Invalid Mount Point"
+,40,1,0,7,0,1,"/invalid-mount-point","Invalid Mount Point"
 ,2,0,1,1,0,0,"/","Mounted"
 ,20,2,0,1,0,0,"/child-of-mounter","Child of Mounter"
 

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -106,7 +106,7 @@ class PageTest extends IntegrationTestBase
         $this->assertEmptyQueue();
         $this->initializeAllPageIndexQueues();
 
-        $this->assertItemsInQueue(5);
+        $this->assertItemsInQueue(4);
 
         // @todo: verify, is this really as expected? since mount_pid_ol is not set
         // in the case when mount_pid_ol is set 4 pages get added
@@ -240,7 +240,7 @@ class PageTest extends IntegrationTestBase
         $this->assertEmptyQueue();
         $this->initializeAllPageIndexQueues();
 
-        $this->assertItemsInQueue(5); // The root page of "testtwo.site aka integration_tree_two" is included.
+        $this->assertItemsInQueue(4); // The root page of "testtwo.site aka integration_tree_two" is included.
 
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier('solr.queue.initializer');


### PR DESCRIPTION
# What this pr does

Allows non-overlayed mount points to be valid

# How to test

Please add a testing instruction here

Fixes: #4026
