### PR TITLE
[BUGFIX] Add empty array defaults in SearchFormViewHelper

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -145,8 +145,8 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         if ($this->getTypoScriptConfiguration()->getSearchKeepExistingParametersForNewSearches()) {
             $request = $this->renderingContext->getRequest();
             $pluginNamespace = $this->getTypoScriptConfiguration()->getSearchPluginNamespace();
-            $arguments = $request->getQueryParams()[$pluginNamespace];
-            ArrayUtility::mergeRecursiveWithOverrule($arguments, $request->getParsedBody()[$pluginNamespace]);
+            $arguments = $request->getQueryParams()[$pluginNamespace] ?? [];
+            ArrayUtility::mergeRecursiveWithOverrule($arguments, $request->getParsedBody()[$pluginNamespace] ?? []);
 
             unset($arguments['q'], $arguments['id'], $arguments['L']);
             $searchParameters = $this->translateSearchParametersToInputTagAttributes($arguments);


### PR DESCRIPTION
# What this pr does

Adds empty array defaults in SearchFormViewHelper::getExistingSearchParameters to prevent TYPO3 TypeError.

# How to test

Setup ext:solr with "keepExistingParametersForNewSearches = 1"

Fixes: #4040
