### PR TITLE
[TASK] Use Attributes for PHPUnit tests

### DIFF
--- a/Tests/Integration/Access/RootlineTest.php
+++ b/Tests/Integration/Access/RootlineTest.php
@@ -6,15 +6,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Access;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class RootlineTest
  */
 class RootlineTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAccessRootlineByPageId()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/user_protected_page.csv');

--- a/Tests/Integration/Backend/SettingsPreviewOnPluginsTest.php
+++ b/Tests/Integration/Backend/SettingsPreviewOnPluginsTest.php
@@ -4,6 +4,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Backend;
 
 use ApacheSolrForTypo3\Solr\Backend\SettingsPreviewOnPlugins;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent;
 use TYPO3\CMS\Backend\View\PageLayoutContext;
@@ -62,9 +63,7 @@ class SettingsPreviewOnPluginsTest extends IntegrationTestBase
         $GLOBALS['LANG'] = $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function printsPreviewOnExtSolrPluginsCorrectly()
     {
         $settingsPreviewOnPlugins = new SettingsPreviewOnPlugins(

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -20,6 +20,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -58,10 +60,9 @@ class ConnectionManagerTest extends IntegrationTestBase
      *  ——[ 1] First site
      *  |
      *  ——[111] Second site
-     *
-     * @test
-     * @dataProvider canFindSolrConnectionsByRootPageIdDataProvider
      */
+    #[DataProvider('canFindSolrConnectionsByRootPageIdDataProvider')]
+    #[Test]
     public function canFindSolrConnectionsByRootPageId(int $rootPageId, string $siteName, string $expectedSolrHost): void
     {
         $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
@@ -103,10 +104,9 @@ class ConnectionManagerTest extends IntegrationTestBase
      *      —— [31] Subpage 1 of Detached
      *      |
      *      —— [32] Subpage 2 of Detached
-     *
-     * @test
-     * @dataProvider canFindSolrConnectionsByPageIdDataProvider
      */
+    #[DataProvider('canFindSolrConnectionsByPageIdDataProvider')]
+    #[Test]
     public function canFindSolrConnectionsByPageId(int $pageId, string $siteName, string $expectedSolrHost): void
     {
         $this->mergeSiteConfiguration($siteName, ['solr_host_read' => $expectedSolrHost]);
@@ -157,9 +157,8 @@ class ConnectionManagerTest extends IntegrationTestBase
      * [0]
      *  |
      *  ——[ 3] Detached and non Root Page-Tree
-     *
-     * @test
      */
+    #[Test]
     public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByRootPageId()
     {
         $this->setupNotFullyConfiguredSite();
@@ -183,9 +182,8 @@ class ConnectionManagerTest extends IntegrationTestBase
      *       —— [31] Subpage 1 of Detached
      *       |
      *       —— [32] Subpage 2 of Detached
-     *
-     * @test
      */
+    #[Test]
     public function exceptionIsThrownForUnAvailableSolrConnectionOnGetConnectionByPageId()
     {
         $this->setupNotFullyConfiguredSite();
@@ -212,9 +210,8 @@ class ConnectionManagerTest extends IntegrationTestBase
      *     ——[ 1] Page (Root)
      *         |
      *         ——[14] Mount Point 1 (to [24] to show contents from)
-     *
-     * @test
      */
+    #[Test]
     public function canFindSolrConnectionForMountedPageIfMountPointIsGiven()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/connection_for_mounted_page.csv');

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -19,6 +19,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Relation;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Traversable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -37,10 +39,8 @@ class RelationTest extends IntegrationTestBase
         '../vendor/apache-solr-for-typo3/solr/Tests/Integration/Fixtures/Extensions/fake_extension',
     ];
 
-    /**
-     * @test
-     * @dataProvider fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn
-     */
+    #[DataProvider('fixturesProviderForFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn')]
+    #[Test]
     public function canFallbackToPagesTableIfPagesLanguageOverlayTCAHasNoDefinitionForLocalColumn(string $fixtureName): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/' . $fixtureName);
@@ -61,10 +61,8 @@ class RelationTest extends IntegrationTestBase
             => ['solr_relation_can_get_related_items_using_original_uid_if_sys_lang_overlay_has_no_tca.csv'];
     }
 
-    /**
-     * @test
-     * @dataProvider canResolveOneToOneRelationDataProvider
-     */
+    #[DataProvider('canResolveOneToOneRelationDataProvider')]
+    #[Test]
     public function canResolveOneToOneRelation(string $expected, array $config): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/solr_relation_can_resolve_one_to_one_relations.csv');
@@ -109,10 +107,8 @@ class RelationTest extends IntegrationTestBase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider canResolveMToNRelationDataProvider
-     */
+    #[DataProvider('canResolveMToNRelationDataProvider')]
+    #[Test]
     public function canResolveMToNRelation(string $expected, string $table, int $recordUid, array $config): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/solr_relation_can_resolve_m_to_n_relations.csv');
@@ -219,10 +215,8 @@ class RelationTest extends IntegrationTestBase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider canResolveOneToNRelationDataProvider
-     */
+    #[DataProvider('canResolveOneToNRelationDataProvider')]
+    #[Test]
     public function canResolveOneToNRelation(string $expected, string $table, int $recordUid, array $config): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/solr_relation_can_resolve_one_to_n_relations.csv');

--- a/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Mvc\Backend\Service\ModuleDataStorageService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -68,9 +69,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTestBase
         return $controller;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testReloadIndexConfigurationAction()
     {
         /** @var SiteRepository $siteRepository */
@@ -84,9 +83,7 @@ class IndexAdministrationModuleControllerTest extends IntegrationTestBase
         $controller->reloadIndexConfigurationAction();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testEmptyIndexAction()
     {
         /** @var SiteRepository $siteRepository */

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -20,6 +20,9 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 use ApacheSolrForTypo3\Solr\Controller\SearchController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use DOMDocument;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\Response;
@@ -83,10 +86,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canShowSearchFormViaPlugin(): void
     {
         $response = $this->executeFrontendSubRequest($this->getPreparedRequest(2022));
@@ -94,10 +95,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canShowSearchForm(): void
     {
         $response = $this->executeFrontendSubRequest($this->getPreparedRequest());
@@ -105,10 +104,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('id="tx-solr-search-form-pi-results"', $content, 'Response did not contain search css selector');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canSearchForPrices(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -123,10 +120,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('pages/2/0/0/0', $result, 'Could not find page 2 in result set');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDoAPaginatedSearch(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -175,10 +170,8 @@ class SearchControllerTest extends IntegrationTestBase
         $this->assertContainerByIdContains('<option selected="selected" value="10">10</option>', $resultPage, 'results-per-page');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canGetADidYouMeanProposalForATypo(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -202,10 +195,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('shoes', $resultPage1, 'Could not find shoes in response');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canAutoCorrectATypo(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -233,10 +224,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('Showing results for &quot;shoes&quot;', $resultPage1, 'Could not find correction message');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderAFacetWithFluid(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -268,12 +257,9 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     *
-     * @dataProvider canRenderSpeakingFacetUrlsDataProvider
-     */
+    #[DataProvider('canRenderSpeakingFacetUrlsDataProvider')]
+    #[Group('frontend')]
+    #[Test]
     public function canRenderSpeakingFacetUrls(int $enableRouteEnhancer, int $expectedMatchesDefaultUrl, int $expectedMatchesSpeakingUrl): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -348,10 +334,8 @@ class SearchControllerTest extends IntegrationTestBase
         ];
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDoAnInitialEmptySearchWithoutResults(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -379,10 +363,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialEmptyQuery was set to false');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDoAnInitialEmptySearchWithResults(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -410,10 +392,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialEmptyQuery was set to true');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDoAnInitialSearchWithoutResults(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -441,10 +421,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringNotContainsString('results-entry', $resultPage1, 'No results should be visible since showResultsOfInitialQuery was set to false');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDoAnInitialSearchWithResults(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -472,10 +450,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('results-entry', $resultPage1, 'Results should be visible since showResultsOfInitialQuery was set to true');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function removeOptionLinkWillBeShownWhenFacetWasSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -505,10 +481,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function removeOptionLinkWillBeShownWhenAFacetOptionLeadsToAZeroResults(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -537,10 +511,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('remove-facet-option', $resultPage1, 'No link to remove facet option found');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canFilterOnPageSections(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -563,10 +535,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('Found 2 results', $resultPage1, 'No link to remove facet option found');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function exceptionWillBeThrownWhenAWrongTemplateIsConfiguredForTheFacet(): void
     {
         // we expected that an exception will be thrown when a facet is rendered
@@ -598,10 +568,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderAScoreAnalysisWhenBackendUserIsLoggedIn(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -620,10 +588,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('document-score-analysis', $resultPage1, 'No score analysis in response');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canSortFacetsByLex(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -677,10 +643,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canSortFacetsByOptionCountWhenNothingIsConfigured(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -733,10 +697,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderQueryGroupFacet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -832,10 +794,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderHierarchicalFacet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -854,10 +814,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canFacetOnHierarchicalFacetItem(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -876,10 +834,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('tx_solr%5Bfilter%5D%5B0%5D=pageHierarchy%3A%2F1%2F2%2F&amp;tx_solr%5Bq%5D=%2A', $resultPage1, 'Result page did not contain hierarchical facet link');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canFacetOnHierarchicalTextCategory(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_render_path_facet_with_search_controller.csv');
@@ -928,10 +884,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('Found 1 result', $resultPage1, 'Assert to only find one result after faceting');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canDefineAManualSortOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -983,10 +937,8 @@ class SearchControllerTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canSeeTheParsedQueryWhenABackendUserIsLoggedIn(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1019,16 +971,15 @@ class SearchControllerTest extends IntegrationTestBase
     /**
      * @param string $action
      * @param array $getArguments
-     * @dataProvider frontendWillRenderErrorMessageIfSolrNotAvailableDataProvider
-     * @test
-     * @group frontend
-     *
-     * Notes:
-     *   Fits removed frontendWillRenderErrorMessageForSolrNotAvailableAction() test case as well.
-     *   Removed code: https://github.com/TYPO3-Solr/ext-solr/blob/03080d4d55eeb9d50b15348f445d23e57e34e461/Tests/Integration/Controller/SearchControllerTest.php#L729-L747
      *
      * @todo: See: https://github.com/TYPO3/testing-framework/issues/324
      */
+    #[DataProvider('frontendWillRenderErrorMessageIfSolrNotAvailableDataProvider')]
+    #[Group('frontend
+Notes:
+  Fits removed frontendWillRenderErrorMessageForSolrNotAvailableAction() test case as well.
+  Removed code: https://github.com/TYPO3-Solr/ext-solr/blob/03080d4d55eeb9d50b15348f445d23e57e34e461/Tests/Integration/Controller/SearchControllerTest.php#L729-L747')]
+    #[Test]
     public function frontendWillRenderErrorMessageIfSolrNotAvailable(string $action, array $getArguments): void
     {
         $this->mergeSiteConfiguration(
@@ -1052,11 +1003,11 @@ class SearchControllerTest extends IntegrationTestBase
     }
 
     /**
-     * @test
-     * @group frontend
      * @todo: https://github.com/TYPO3-Solr/ext-solr/issues/3160
      *       The session must be shared between both requests.
      */
+    #[Group('frontend')]
+    #[Test]
     public function canShowLastSearchesFromSessionInResponse()
     {
         self::markTestIncomplete(
@@ -1090,10 +1041,8 @@ class SearchControllerTest extends IntegrationTestBase
         $this->assertContainerByIdContains('>shoe</a>', $resultSearch2, 'tx-solr-lastsearches');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canShowLastSearchesFromDatabaseInResponse(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1122,10 +1071,8 @@ class SearchControllerTest extends IntegrationTestBase
         $this->assertContainerByIdContains('>shoe</a>', $resultSearch2, 'tx-solr-lastsearches');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canNotStoreQueyStringInLastSearchesWhenQueryDoesNotReturnAResult(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1155,10 +1102,8 @@ class SearchControllerTest extends IntegrationTestBase
         $this->assertContainerByIdNotContains('>nothingwillbefound</a>', $resultSearch2, 'tx-solr-lastsearches');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canOverwriteAFilterWithTheFlexformSettings(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1179,10 +1124,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('Displaying results 1 to 4 of 4', $resultSearch);
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderDateRangeFacet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1209,10 +1152,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('facet-type-dateRange', $resultSearch);
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderASecondFacetOnTheTypeField(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1245,10 +1186,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('id="facettype"', $resultSearch);
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canSortByMetric(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1290,13 +1229,11 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertTrue($isPid2OptionBefore1Option);
     }
 
-    /**
-     * @test
-     * @group frontend
-     * Notes:
-     *   Fits removed canRenderSearchFormOnly() test case as well.
-     *     Removed code: https://github.com/TYPO3-Solr/ext-solr/blob/03080d4d55eeb9d50b15348f445d23e57e34e461/Tests/Integration/Controller/SearchControllerTest.php#L1053-L1062
-     */
+    #[Group('frontend
+Notes:
+  Fits removed canRenderSearchFormOnly() test case as well.
+    Removed code: https://github.com/TYPO3-Solr/ext-solr/blob/03080d4d55eeb9d50b15348f445d23e57e34e461/Tests/Integration/Controller/SearchControllerTest.php#L1053-L1062')]
+    #[Test]
     public function formActionIsRenderingTheForm(): void
     {
         $connection = $this->getConnectionPool()->getConnectionForTable('tt_content');
@@ -1315,10 +1252,10 @@ class SearchControllerTest extends IntegrationTestBase
     }
 
     /**
-     * @test
-     * @group frontend
      * @todo : https://github.com/TYPO3-Solr/ext-solr/issues/3166
      */
+    #[Group('frontend')]
+    #[Test]
     public function searchingAndRenderingFrequentSearchesIsShowingTheTermAsFrequentSearch(): void
     {
         self::markTestIncomplete('See: https://github.com/TYPO3-Solr/ext-solr/issues/3166');
@@ -1340,10 +1277,8 @@ class SearchControllerTest extends IntegrationTestBase
         $this->assertContainerByIdContains('>shoes</a>', $resultPage, 'tx-solr-frequent-searches');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderDetailAction(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -1362,10 +1297,9 @@ class SearchControllerTest extends IntegrationTestBase
 
     /**
      * The template root path is configured in the typoscript template to point to another folder-
-     *
-     * @test
-     * @group frontend
      */
+    #[Group('frontend')]
+    #[Test]
     public function canOverrideTemplatesAndPartialsViaTypoScriptSetup(): void
     {
         $this->addTypoScriptToTemplateRecord(
@@ -1389,10 +1323,9 @@ class SearchControllerTest extends IntegrationTestBase
 
     /**
      * The template root path is configured in the typoscript template to point to another folder
-     *
-     * @test
-     * @group frontend
      */
+    #[Group('frontend')]
+    #[Test]
     public function canOverrideTemplatesAndPartialsViaTypoScriptConstants(): void
     {
         $this->addTypoScriptConstantsToTemplateRecord(
@@ -1414,10 +1347,8 @@ class SearchControllerTest extends IntegrationTestBase
         self::assertStringContainsString('<h1>From custom "RelevanceBar" partial</h1>', $result, 'Can not overwrite partial path');
     }
 
-    /**
-     * @test
-     * @group frontend
-     */
+    #[Group('frontend')]
+    #[Test]
     public function canPassCustomSettingsToView(): void
     {
         $this->addTypoScriptToTemplateRecord(
@@ -1443,10 +1374,9 @@ class SearchControllerTest extends IntegrationTestBase
 
     /**
      * Only the entry template points to a different file.
-     *
-     * @test
-     * @group frontend
      */
+    #[Group('frontend')]
+    #[Test]
     public function canRenderAsUserObjectWithCustomEntryTemplateInTypoScript(): void
     {
         $this->addTypoScriptToTemplateRecord(

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Controller;
 
 use ApacheSolrForTypo3\Solr\Controller\SuggestController;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 
@@ -24,8 +26,8 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
  * Integration testcase to test for {@link SuggestController}
  *
  * @author Timo Hund
- * @group frontend
  */
+#[Group('frontend')]
 class SuggestControllerTest extends IntegrationTestBase
 {
     protected function setUp(): void
@@ -54,9 +56,7 @@ class SuggestControllerTest extends IntegrationTestBase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDoABasicSuggest()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -68,9 +68,7 @@ class SuggestControllerTest extends IntegrationTestBase
         self::assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDoABasicSuggestWithoutCallback()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
@@ -82,9 +80,7 @@ class SuggestControllerTest extends IntegrationTestBase
         self::assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSuggestWithUriSpecialChars()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/suggest_with_uri_special_chars.csv');

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -20,6 +20,8 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Environment\CliEnvironment;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -66,10 +68,8 @@ class IndexServiceTest extends IntegrationTestBase
         ];
     }
 
-    /**
-     * @dataProvider canResolveBaseAsPrefixDataProvider
-     * @test
-     */
+    #[DataProvider('canResolveBaseAsPrefixDataProvider')]
+    #[Test]
     public function canResolveBaseAsPrefix(string $absRefPrefix, string $expectedUrl)
     {
         $this->cleanUpSolrServerAndAssertEmpty();

--- a/Tests/Integration/Domain/Index/PageIndexer/PageUriBuilderTest.php
+++ b/Tests/Integration/Domain/Index/PageIndexer/PageUriBuilderTest.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Index\PageIndexer;
 use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\PageUriBuilder;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -38,9 +39,7 @@ class PageUriBuilderTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pageIndexingUriCanBeModifiedViaEventListener(): void
     {
         $subject = GeneralUtility::makeInstance(PageUriBuilder::class);

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Event\IndexQueue\AfterRecordsForIndexQueueItemsHaveBeenRetrievedEvent;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -38,9 +39,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUpdateHasIndexingPropertiesFlagByItemUid()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/update_has_indexing_properties_flag.csv');
@@ -61,9 +60,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertFalse($queueItem->hasIndexingProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deleteItemDeletesItemForEverySite()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
@@ -74,9 +71,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertSame(4, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type and uid');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDeleteItemByPassingTypeOnly()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
@@ -87,9 +82,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertSame(3, $queueItemRepository->count(), 'Unexpected amount of items in the index queue after deletion by type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCountItems()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
@@ -100,9 +93,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertSame(1, $queueItemRepository->countItems([], ['pages'], [], [], [4713]), 'Unexpected amount of counted pages and uids');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindItems()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
@@ -115,9 +106,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertSame('pages', $firstItem->getType(), 'First item has unexpected type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindItemsAndModifyViaEventListener(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_and_news_queueitems.csv');
@@ -140,9 +129,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         self::assertCount(0, $items);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function indexingPropertyIsKeptWhenItIsReferencedToAnotherQueueItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_keep_indexing_properties.csv');
@@ -180,9 +167,7 @@ class QueueItemRepositoryTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFlushErrorByItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_error_by_item.csv');

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\ApacheSolrDocu
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Repository;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
@@ -49,9 +50,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindByPageIdAndByLanguageId()
     {
         $apacheSolrDocumentsCollection = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId(3, 0);
@@ -61,9 +60,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
         self::assertInstanceOf(Document::class, $apacheSolrDocumentsCollection[0], 'ApacheSolrDocumentRepository returned not an array of type Document.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnEmptyCollectionIfNoConnectionToSolrServerIsEstablished()
     {
         $apacheSolrDocumentsCollection = $this->apacheSolrDocumentRepository->findByPageIdAndByLanguageId(3, 777);

--- a/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\LastSearches;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class LastSearchesRepositoryTest extends IntegrationTestBase
@@ -30,18 +31,14 @@ class LastSearchesRepositoryTest extends IntegrationTestBase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/last_searches.csv');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindAllKeywords(): void
     {
         $actual = $this->lastSearchesRepository->findAllKeywords();
         self::assertSame(['4', '3', '2', '1', '0'], $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addWillInsertNewRowIfLastSearchesLimitIsNotExceeded(): void
     {
         $this->lastSearchesRepository->add('5', 6);
@@ -50,9 +47,7 @@ class LastSearchesRepositoryTest extends IntegrationTestBase
         self::assertSame(['5', '4', '3', '2', '1', '0'], $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addWillUpdateOldestRowIfLastSearchesLimitIsExceeded(): void
     {
         $this->lastSearchesRepository->add('5', 5);
@@ -61,9 +56,7 @@ class LastSearchesRepositoryTest extends IntegrationTestBase
         self::assertSame(['5', '4', '3', '2', '1'], $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lastUpdatedRowIsOnFirstPosition(): void
     {
         $this->lastSearchesRepository->add('1', 5);

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -23,14 +23,13 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
 class ResultSetReconstitutionProcessorTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canApplyRenderingInstructionsOnOptions()
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -78,9 +77,7 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTestBase
         self::assertSame('Pages', $option1->getLabel(), 'Rendering instructions have not been applied on the facet options');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function labelCanBeUsedAsCObject()
     {
         $this->writeDefaultSolrTestSiteConfiguration();

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -24,6 +24,8 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use ApacheSolrForTypo3\Solr\Util;
+use PHPUnit\Framework\Attributes\Test;
+use stdClass;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,9 +48,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetDocumentById(): void
     {
         // trigger a search
@@ -70,9 +70,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         self::assertSame($document->getTitle(), 'Root of Testpage testone.site aka integration_tree_one', 'Could not get document from solr by id');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetVariants(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
@@ -118,9 +116,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetCaseSensitiveVariants(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
@@ -186,9 +182,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetZeroResultsWithVariantsOnEmptyIndex(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../../../Controller/Fixtures/indexing_data.csv');
@@ -210,9 +204,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         self::assertSame(0, count($searchResults), 'There should zero results when the index is empty');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cantGetHiddenElementWithoutPermissions(): void
     {
         $this->importFrontendRestrictedPageScenario();
@@ -226,9 +218,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         self::assertSame(2, count($searchResults), 'We should only see two documents because the restricted element should be filtered out');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHiddenElementWithPermissions(): void
     {
         $this->importFrontendRestrictedPageScenario();
@@ -271,7 +261,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
         $searchRequest->setPage(1);
 
         // Simulate something as we still have some $GLOBALS[TSFE] dependency
-        $GLOBALS['TSFE'] = new \stdClass();
+        $GLOBALS['TSFE'] = new stdClass();
         $GLOBALS['TSFE']->id = 1;
         $GLOBALS['TSFE']->fe_user = new FrontendUserAuthentication();
         $GLOBALS['TSFE']->fe_user->initializeUserSessionManager();

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -17,14 +17,13 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\StatisticsRepo
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class StatisticsRepositoryTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTopKeywordsWithHits()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
@@ -42,9 +41,7 @@ class StatisticsRepositoryTest extends IntegrationTestBase
         self::assertSame($expectedResult, $topHits);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTopKeywordsWithoutHits()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
@@ -62,9 +59,7 @@ class StatisticsRepositoryTest extends IntegrationTestBase
         self::assertSame($expectedResult, $topHits);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTopKeywordsWithoutHitsNoResult()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
@@ -80,9 +75,7 @@ class StatisticsRepositoryTest extends IntegrationTestBase
         self::assertSame($expectedResult, $topHits);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchStatisticsNoResult()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
@@ -98,9 +91,7 @@ class StatisticsRepositoryTest extends IntegrationTestBase
         self::assertSame($expectedResult, $topHits);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSaveStatisticsRecord()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');

--- a/Tests/Integration/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Integration/Domain/Site/SiteHashServiceTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Site;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -42,10 +44,8 @@ class SiteHashServiceTest extends IntegrationTestBase
         yield 'currentSiteOnly' => ['__current_site', 'testone.site'];
     }
 
-    /**
-     * @dataProvider canResolveSiteHashAllowedSitesDataProvider
-     * @test
-     */
+    #[DataProvider('canResolveSiteHashAllowedSitesDataProvider')]
+    #[Test]
     public function canResolveSiteHashAllowedSites($allowedSitesConfiguration, $expectedAllowedSites)
     {
         $siteHashService = GeneralUtility::makeInstance(SiteHashService::class);

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -40,18 +41,14 @@ class SiteRepositoryTest extends IntegrationTestBase
         $this->siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAllSites()
     {
         $sites = $this->siteRepository->getAvailableSites();
         self::assertSame(2, count($sites), 'Expected to retrieve two sites from default tests setup. Note: The third site is not enabled for EXT:solr.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAllPagesFromSite()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_all_pages_from_sites.csv');
@@ -59,18 +56,14 @@ class SiteRepositoryTest extends IntegrationTestBase
         self::assertSame([1, 2, 21, 22, 3, 30], $site->getPages(), 'Can not get all pages from site');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByRootPageIdExistingRoot()
     {
         $site = $this->siteRepository->getSiteByRootPageId(1);
         self::assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from root page');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByRootPageIdNonExistingRoot()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -78,9 +71,7 @@ class SiteRepositoryTest extends IntegrationTestBase
         $siteRepository->getSiteByRootPageId(42);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByPageIdExistingPage()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_site_by_page_id.csv');
@@ -88,9 +79,7 @@ class SiteRepositoryTest extends IntegrationTestBase
         self::assertContainsOnlyInstancesOf(Site::class, [$site], 'Could not retrieve site from page');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByPageIdNonExistingPage()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -98,9 +87,7 @@ class SiteRepositoryTest extends IntegrationTestBase
         $this->siteRepository->getSiteByPageId(42);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteWithDomainFromSiteConfiguration()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_site_by_page_id.csv');

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -34,9 +35,7 @@ class SiteTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetDefaultLanguage()
     {
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
@@ -45,9 +44,7 @@ class SiteTest extends IntegrationTestBase
         self::assertEquals(0, $site->getDefaultLanguageId(), 'Could not get default language from site');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateInstanceWithRootSiteUidOK()
     {
         /** @var SiteRepository $siteRepository */
@@ -56,9 +53,7 @@ class SiteTest extends IntegrationTestBase
         self::assertEquals(1, $site->getRootPageId());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateInstanceWithRootSiteUidNOK()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -67,9 +62,7 @@ class SiteTest extends IntegrationTestBase
         $site = $siteRepository->getSiteByRootPageId(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateInstanceWithNonRootSiteUidOK()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_create_instance_with_non_root_site.csv');
@@ -80,9 +73,7 @@ class SiteTest extends IntegrationTestBase
         $siteRepository->getSiteByRootPageId(151);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateInstanceWithNonRootSiteUidNOK()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_create_instance_with_non_root_site.csv');
@@ -93,9 +84,7 @@ class SiteTest extends IntegrationTestBase
         $siteRepository->getSiteByRootPageId(152);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAvailableLanguageIds()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_translations_for_root_site.csv');

--- a/Tests/Integration/Extbase/PersistenceEventListenerTest.php
+++ b/Tests/Integration/Extbase/PersistenceEventListenerTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\FakeExtension\Domain\Model\Foo;
 use ApacheSolrForTypo3\FakeExtension\Domain\Repository\FooRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -47,9 +48,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function newEntityIsAddedToIndexQueue()
     {
         $object = new Foo();
@@ -61,9 +60,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         self::assertTrue($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 1));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function newHiddenEntityIsNotAddedToIndexQueue()
     {
         $object = new Foo();
@@ -76,9 +73,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 1));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updatedEntityIsUpdatedInIndexQueue()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/update_items.csv');
@@ -99,9 +94,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         self::assertSame($currentTimestamp, $item->getChanged());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function softDeletedEntityIsRemovedFromIndexQueue()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/delete_items.csv');
@@ -113,9 +106,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 3));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deletedEntityIsRemovedFromIndexQueue()
     {
         unset($GLOBALS['TCA']['tx_fakeextension_domain_model_foo']['ctrl']['delete']);
@@ -128,9 +119,7 @@ class PersistenceEventListenerTest extends IntegrationTestBase
         self::assertFalse($this->indexQueue->containsItem('tx_fakeextension_domain_model_foo', 3));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updatedEntityTurnedHiddenIsRemovedFromIndexQueue()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/hidden_items.csv');

--- a/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
+++ b/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\FieldProcessor;
 
 use ApacheSolrForTypo3\Solr\FieldProcessor\CategoryUidToHierarchy;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -26,9 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CategoryUidToHierarchyTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canConvertToCategoryIdToHierarchy()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_category.csv');

--- a/Tests/Integration/Fixtures/Extensions/fake_extension3/Configuration/TCA/Overrides/fake_extension3_pages_tca.php
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension3/Configuration/TCA/Overrides/fake_extension3_pages_tca.php
@@ -1,5 +1,7 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 $additionalColumns = [
     'page_relations' => [
         'exclude' => 1,
@@ -37,4 +39,4 @@ $additionalColumns = [
     ],
 ];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
+ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);

--- a/Tests/Integration/FrontendEnvironment/TsfeTest.php
+++ b/Tests/Integration/FrontendEnvironment/TsfeTest.php
@@ -4,15 +4,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\FrontendEnvironment;
 
 use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class TsfeTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function initializeTsfeWithNoDefaultPageAndPageErrorHandlerDoNotThrowAnError()
     {
         self::markTestSkipped('Since TSFE is isolated/capsuled, no exceptions are thrown or delegated to else where.
@@ -55,9 +54,7 @@ class TsfeTest extends IntegrationTestBase
         $tsfeManager->getTsfeByPageIdAndLanguageId(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitializeTsfeForPageWithDifferentFeGroupsSettings()
     {
         $this->writeDefaultSolrTestSiteConfiguration();

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\Connection;
@@ -167,9 +168,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function queueItemStaysWhenOverlayIsSetToHidden(): void
     {
         $this->prepareQueueItemStaysWhenOverlayIsSetToHidden();
@@ -178,9 +177,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function queueItemStaysWhenOverlayIsSetToHiddenInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -205,9 +202,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 2, ['hidden' => 1], $this->dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueAPageAndRemoveItWithTheGarbageCollector(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/subpage.csv');
@@ -227,9 +222,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet(): void
     {
         $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSet();
@@ -239,9 +232,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -282,9 +273,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 2, $changeSet, $dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages(): void
     {
         $this->prepareCanCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpages();
@@ -294,9 +283,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageFromSubPagesWhenPageIsSetToHiddenAndExtendToSubPagesIsSetForMultipleSubpagesInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -338,9 +325,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->garbageCollector->processDatamap_afterDatabaseOperations('update', 'pages', 2, $changeSet, $dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageIfPageTreeIsMoved(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_collect_garbage_if_page_tree_is_moved.csv');
@@ -364,9 +349,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertSolrContainsDocumentCount(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageIfPageTreeIsMovedToSysfolderWithDisabledOptionIncludeSubEntriesInSearch(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_collect_garbage_if_page_tree_is_moved.csv');
@@ -389,9 +372,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertSolrContainsDocumentCount(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCollectGarbageIfPageTreeIsMovedButStaysOnSamePage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_collect_garbage_if_page_tree_is_moved.csv');
@@ -415,9 +396,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertSolrContainsDocumentCount(3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveDeletedContentElement(): void
     {
         $this->prepareCanRemoveDeletedContentElement();
@@ -440,9 +419,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveDeletedContentElementInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -479,9 +456,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->dataHandler->process_datamap();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveHiddenContentElement(): void
     {
         $data = ['tt_content' => ['88' => ['hidden' => 1]]];
@@ -506,9 +481,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveHiddenContentElementInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -525,9 +498,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyEventQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveContentElementWithEndTimeSetToPast(): void
     {
         $timeStampInPast = time() - (60 * 60 * 24);
@@ -549,9 +520,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveContentElementWithEndTimeSetToPastInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -569,9 +538,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyEventQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotRemoveUpdatedContentElementWithNotSetEndTime(): void
     {
         $data = ['tt_content' => ['88' => ['bodytext' => 'Updated! Will stay after update!' ]]];
@@ -595,9 +562,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('Updated! Will stay after update!', $solrContent, 'solr did not remove content hidden by endtime in past');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotRemoveUpdatedContentElementWithNotSetEndTimeInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -614,9 +579,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyEventQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveContentElementWithStartDateSetToFuture(): void
     {
         $timestampInFuture = time() +  (60 * 60 * 24);
@@ -637,9 +600,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('will stay!', $solrContent, 'solr did not contain rendered page content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveContentElementWithStartDateSetToFutureInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -691,9 +652,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->dataHandler->clear_cacheCmd('all');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenPageIsHidden(): void
     {
         $dataMap = ['pages' => ['2' => ['hidden' => 1]]];
@@ -720,9 +679,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenPageIsHiddenInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -736,9 +693,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenPageIsDeleted(): void
     {
         $cmd = ['pages' => [2 => ['delete' => 1 ]]];
@@ -765,9 +720,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertStringContainsString('"numFound":1', $solrContent, 'Expected to have two documents in the index');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenPageIsDeletedInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -781,9 +734,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenContentElementOnAlreadyDeletedPageIsDeleted(): void
     {
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);
@@ -802,9 +753,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertEquals(234, $queueItemUid);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenContentElementOnNonExistingPageIsDeleted(): void
     {
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);
@@ -821,9 +770,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertEquals(123, $queueItemUid);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageWhenContentElementOnAlreadyDeletedSiteIsDeleted(): void
     {
         // simulate that site root is deleted
@@ -872,9 +819,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->dataHandler->clear_cacheCmd('all');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTriggerHookAfterRecordDeletion(): void
     {
         $this->prepareCanTriggerHookAfterRecordDeletion();
@@ -890,9 +835,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessGarbageCollector'] = [];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTriggerHookAfterRecordDeletionInDelayedProcessingMode(): void
     {
         /** @var TestGarbageCollectorPostProcessor $hook */

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Page\CacheHashCalculator;
@@ -50,9 +51,7 @@ class PageIndexerTest extends IntegrationTestBase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndexPageIntoSolr(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -82,9 +81,7 @@ class PageIndexerTest extends IntegrationTestBase
         self::assertStringContainsString('"custom_stringS":"my text"', $solrContent, 'Document does not contains value build with typoscript');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndexPageWithCustomPageTypeIntoSolr(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -119,9 +116,8 @@ class PageIndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexTranslatedPageToPageRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
@@ -162,9 +158,8 @@ class PageIndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexPageToCategoryRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
@@ -194,9 +189,7 @@ class PageIndexerTest extends IntegrationTestBase
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndexPageIntoSolrWithAdditionalFields(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_with_additional_fields_into_solr.csv');
@@ -228,9 +221,7 @@ class PageIndexerTest extends IntegrationTestBase
         self::assertStringContainsString('"additional_custom_stringS":"my text"', $solrContent, 'Document does not contains value from index.additionFields');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndexPageIntoSolrWithAdditionalFieldsFromRootLine(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_overwrite_configuration_in_rootline.csv');
@@ -256,9 +247,7 @@ class PageIndexerTest extends IntegrationTestBase
         self::assertStringContainsString('"additional_stringS":"from rootline"', $solrContent, 'Document does not contain custom field from rootline');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canExecutePostProcessor(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -275,9 +264,7 @@ class PageIndexerTest extends IntegrationTestBase
         self::assertStringContainsString('"postProcessorField_stringS":"postprocessed"', $solrContent, 'Field from post processor was not added');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canExecuteAdditionalPageIndexer(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_into_solr.csv');
@@ -316,9 +303,8 @@ class PageIndexerTest extends IntegrationTestBase
      *  ——[ 1] Page (Root)
      *  |
      *  ——[14] Mount Point (to [24] to show contents from)
-     *
-     * @test
      */
+    #[Test]
     public function canIndexMountedPage(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids'] = 1;
@@ -352,8 +338,8 @@ class PageIndexerTest extends IntegrationTestBase
      *  ——[ 2] Page (Root)
      *  |
      *  ——[24] Mount Point (to [24] to show contents from)
-     * @test
      */
+    #[Test]
     public function canIndexMultipleMountedPage(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -376,9 +362,8 @@ class PageIndexerTest extends IntegrationTestBase
     /**
      * This Test should test, that TYPO3 CMS on FE does not die if page is not available.
      * If something goes wrong the exception must be thrown instead of dying, to make marking the items as failed possible.
-     *
-     * @test
      */
+    #[Test]
     public function phpProcessDoesNotDieIfPageIsNotAvailable(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/does_not_die_if_page_not_available.csv');

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -21,6 +21,8 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Server\RequestHandlerInterface;
 use Traversable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -84,9 +86,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue a custom record with MM relations.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithMMRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -113,10 +114,8 @@ class IndexerTest extends IntegrationTestBase
         yield 'without_l_parameter_and_content_fallback' => ['can_index_custom_translated_record_without_l_param_and_content_fallback.csv'];
     }
 
-    /**
-     * @dataProvider getTranslatedRecordDataProvider
-     * @test
-     */
+    #[DataProvider('getTranslatedRecordDataProvider')]
+    #[Test]
     public function testCanIndexTranslatedCustomRecord(string $fixture): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -158,9 +157,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue a custom record with ordered MM relations.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithMMRelationsInTheExpectedOrder(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -193,9 +191,9 @@ class IndexerTest extends IntegrationTestBase
     /**
      * This testcase should check if we can queue a custom record with MM relations.
      *
-     * @test
      * @todo: this test might not be working as it does not check for L parameters. Should be revised
      */
+    #[Test]
     public function canIndexTranslatedItemWithMMRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -219,9 +217,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue a custom record with multiple MM relations.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexMultipleMMRelatedItems(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -246,9 +243,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue a custom record with MM relations and respect the additionalWhere clause.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithMMRelationAndAdditionalWhere(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -269,9 +265,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase should check if we can queue a custom record with MM relations and respect the additionalWhere clause.
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithMMRelationToATranslatedPage(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -297,9 +292,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase is used to check if direct relations can be resolved with the RELATION configuration
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithDirectRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -323,9 +317,8 @@ class IndexerTest extends IntegrationTestBase
 
     /**
      * This testcase is used to check if multiple direct relations can be resolved with the RELATION configuration
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithMultipleDirectRelation(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -361,9 +354,8 @@ class IndexerTest extends IntegrationTestBase
     /**
      * This testcase is used to check if direct relations can be resolved with the RELATION configuration
      * and could be limited with an additionalWhere clause at the same time
-     *
-     * @test
      */
+    #[Test]
     public function canIndexItemWithDirectRelationAndAdditionalWhere(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -382,9 +374,7 @@ class IndexerTest extends IntegrationTestBase
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseConfigurationFromTemplateInRootLine(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -403,9 +393,7 @@ class IndexerTest extends IntegrationTestBase
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAdditionalDocumentsViaPsr14EventListener(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/sites_setup_and_data_set/01_integration_tree_one.csv');
@@ -422,9 +410,7 @@ class IndexerTest extends IntegrationTestBase
         self::assertEquals(['can-be-an-alternative-record' => 'additional-test-document'], $result[1]->getFields());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanIndexCustomRecordOutsideOfSiteRoot(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -443,9 +429,7 @@ class IndexerTest extends IntegrationTestBase
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanIndexCustomRecordOutsideOfSiteRootWithTemplate(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -481,9 +465,7 @@ class IndexerTest extends IntegrationTestBase
         return $result;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSolrConnectionsByItemReturnsNoDefaultConnectionIfRootPageIsHideDefaultLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_with_rootPage_set_to_hide_default_language.csv');
@@ -504,9 +486,7 @@ class IndexerTest extends IntegrationTestBase
         self::assertArrayNotHasKey(0, $result, 'Expect, that there is no solr connection returned for default language,');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSolrConnectionsByItemReturnsNoDefaultConnectionDefaultLanguageIsHiddenInSiteConfig(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -529,9 +509,7 @@ class IndexerTest extends IntegrationTestBase
         self::assertArrayNotHasKey(0, $result, 'Expect, that there is no solr connection returned for default language,');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSolrConnectionsByItemReturnsProperItemInNestedSite(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -98,9 +99,8 @@ class PageTest extends IntegrationTestBase
      *      ------- 10 (Mounted)
      *                        |
      *                         ------------ 20 (Childpage of mountpoint)
-     *
-     * @test
      */
+    #[Test]
     public function initializerIsFillingQueueWithMountPages()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_add_mount_pages.csv');
@@ -132,9 +132,8 @@ class PageTest extends IntegrationTestBase
      *      ——[ 1] Page (Root)
      *          |
      *          ——[14] Mounted Page (to [24] to show contents from)
-     *
-     * @test
      */
+    #[Test]
     public function initializerIsFillingQueueWithMountedNonRootPages()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/mounted_shared_non_root_page_from_different_tree_can_be_indexed.csv');
@@ -164,9 +163,8 @@ class PageTest extends IntegrationTestBase
      *      ——[ 1] Page (Root)
      *          |
      *          ——[14] Mount Point (to [24] to show contents from)
-     *
-     * @test
      */
+    #[Test]
     public function initializerIsFillingQueueWithMountedRootPages()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/mounted_shared_root_page_from_different_tree_can_be_indexed.csv');
@@ -203,9 +201,8 @@ class PageTest extends IntegrationTestBase
      *      ——[ 111] Page2 (Root)
      *          |
      *          ——[34] Mount Point 2 (to [24] to show contents from)
-     *
-     * @test
      */
+    #[Test]
     public function initializerIsFillingQueuesWithMultipleSitesMounted()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/mounted_shared_page_from_multiple_trees_can_be_queued.csv');
@@ -236,9 +233,8 @@ class PageTest extends IntegrationTestBase
     /**
      * Check if invalid mount page is ignored and messages were added to the flash
      * message queue
-     *
-     * @test
      */
+    #[Test]
     public function initializerAddsInfoMessagesAboutInvalidMountPages()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_add_mount_pages.csv');
@@ -268,8 +264,8 @@ class PageTest extends IntegrationTestBase
      *      |       ——[3] 2-nd level Subpage                                   (included in index)
      *      |
      *      ——[ 111] Root of Testpage testtwo.site aka integration_tree_two    (included in index)
-     * @test
      */
+    #[Test]
     public function initializerDoesNotIgnoreSubPagesOfRestrictedByAdditionalWhereClauseParents()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/initializer_does_not_ignore_sub_pages_of_restricted_by_additionalWhereClause_parents.csv');

--- a/Tests/Integration/IndexQueue/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/PageIndexerTest.php
@@ -21,6 +21,8 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
@@ -64,10 +66,9 @@ class PageIndexerTest extends IntegrationTestBase
      * @param int $expectedNumFound
      * @param array $expectedAccessFieldValues
      * @param array $expectedContents
-     *
-     * @test
-     * @dataProvider canIndexPageWithAccessProtectedContentIntoSolrDataProvider
      */
+    #[DataProvider('canIndexPageWithAccessProtectedContentIntoSolrDataProvider')]
+    #[Test]
     public function canIndexPageWithAccessProtectedContentIntoSolr(
         string $fixture,
         int $expectedNumFound,

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -65,9 +66,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertItemsInQueue(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function preFilledQueueContainsRootPageAfterInitialize()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_one_item.csv');
@@ -84,9 +83,7 @@ class QueueTest extends IntegrationTestBase
         self::assertFalse($this->indexQueue->containsItem('pages', 4711));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addingTheSameItemTwiceWillOnlyProduceOneQueueItem()
     {
         $this->assertEmptyQueue();
@@ -100,9 +97,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertItemsInQueue(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDeleteItemsByType()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_with_multiple_types.csv');
@@ -115,9 +110,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertEmptyQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unExistingRecordIsNotAddedToTheQueue()
     {
         $this->assertEmptyQueue();
@@ -129,9 +122,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertEmptyQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNotAddUnAllowedPageType()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_not_add_unallowed_pagetype.csv');
@@ -145,9 +136,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertEmptyQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mountPagesAreOnlyAddedOnceAfterInitialize()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/queue_initialization_with_mount_pages.csv');
@@ -161,9 +150,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertItemsInQueue(4);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddCustomPageTypeToTheQueue()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/custom_page_doktype.csv');
@@ -202,9 +189,7 @@ class QueueTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetStatisticsWithTotalItemCount()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_in_multiple_sites.csv');
@@ -215,9 +200,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(1, $itemCount, 'Unexpected item count for the first site');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetStatisticsBySiteWithPendingItems()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_in_multiple_sites.csv');
@@ -232,9 +215,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(0, $itemCount, 'After updating a remaining item no remaining item should be left');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitializeMultipleSites()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages_in_multiple_sites.csv');
@@ -266,9 +247,7 @@ class QueueTest extends IntegrationTestBase
         $this->assertItemsInQueue(4);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetStatistics()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/subpages_with_filled_indexqueue.csv');
@@ -281,9 +260,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(1, $statistics->getPendingCount(), 'Can not get pending processed items from queue');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetStatisticsByCustomIndexingConfigurationName()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/subpages_with_filled_indexqueue_multiple_indexing_configurations.csv');
@@ -302,9 +279,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(0, $notExistingIndexingConfStatistic->getPendingCount(), 'Can not get pending processed items from queue for not existing indexing configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastIndexNonExistingRoot()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -313,9 +288,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($lastIndexTime, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastIndexRootExists()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -324,9 +297,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($lastIndexTime, 1489507800);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastIndexedItemIdNonExistingRoot()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -335,9 +306,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($lastIndexedItemIdUid, 0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastIndexedItemIdRootExists()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -346,9 +315,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($lastIndexedItemIdUid, 4713);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedWithItemAndEmptyMessage()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_with_one_error.csv');
@@ -359,9 +326,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($processedItem->getErrors(), '1');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedWithItemAndMessage()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_with_one_error.csv');
@@ -372,9 +337,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($processedItem->getErrors(), 'Error during indexing canMarkItemAsFailedWithItemAndMessage');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedWithUidAndEmptyMessage()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items_with_one_error.csv');
@@ -384,9 +347,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($item->getErrors(), '1');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedWithUidAndMessage()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -396,9 +357,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($item->getErrors(), 'Error during indexing canMarkItemAsFailedWithUidAndMessage');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedNonexistingUid()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -408,9 +367,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($item, null);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkItemAsFailedNonExistingItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -421,9 +378,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($processedItem, null);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUpdateIndexTimeByItemNonExistingItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -432,9 +387,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($item, null);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUpdateIndexTimeByItemExistingItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexqueue_items.csv');
@@ -446,9 +399,7 @@ class QueueTest extends IntegrationTestBase
         self::assertEquals($lastestUpdatedItem, 4711);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFlushAllErrors()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');
@@ -471,9 +422,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(0, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFlushErrorsBySite()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');
@@ -496,9 +445,7 @@ class QueueTest extends IntegrationTestBase
         self::assertSame(1, count($errorsForSecondSite), 'Unexpected amount of errors for the second site after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFlushErrorByItem()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_flush_errors.csv');

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -29,6 +29,8 @@ use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\SkippedWithMessageException;
 use Psr\Log\LogLevel;
 use Traversable;
@@ -166,8 +168,8 @@ class RecordMonitorTest extends IntegrationTestBase
      * AND mount_pid_ol=1)) AND doktype = 7 AND no_search = 0 AND pages' at line 1" (228 chars)
      *
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/155
-     * @test
      */
+    #[Test]
     public function canUpdateRootPageRecordWithoutSQLErrorFromMountPages(): void
     {
         throw new SkippedWithMessageException('Skipping canUpdateRootPageRecordWithoutSQLErrorFromMountPages');
@@ -201,8 +203,8 @@ class RecordMonitorTest extends IntegrationTestBase
      * Regression test for issue #48. Indexing of new records will crash if the name of the Indexing
      * Queue Configuration is different from tablename
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/48
-     * @test
      */
+    #[Test]
     public function canUseCorrectIndexingConfigurationForANewNonPagesRecord(): void
     {
         $this->prepareCanUseCorrectIndexingConfigurationForANewNonPagesRecord();
@@ -220,9 +222,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseCorrectIndexingConfigurationForANewNonPagesRecordInDelayedProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -246,9 +246,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIgnoreCorrectIndexingConfigurationForANewNonPagesRecordInNoProcessingMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 2]);
@@ -308,9 +306,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved(): void
     {
         $this->prepareCanQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemoved();
@@ -320,9 +316,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenExtendToSubPagesWasSetAndHiddenFlagWasRemovedInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -359,9 +353,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 17, $changeSet, $dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved(): void
     {
         $this->prepareCanQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemoved();
@@ -371,9 +363,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenHiddenFlagIsSetAndExtendToSubPagesFlagWasRemovedInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -409,9 +399,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 17, $changeSet, $this->dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved(): void
     {
         $this->prepareCanQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemoved();
@@ -421,9 +409,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueSubPagesWhenHiddenAndExtendToSubPagesFlagsWereRemovedInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -459,9 +445,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 17, $changeSet, $this->dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function queueIsNotFilledWhenItemIsSetToHidden(): void
     {
         $this->prepareQueueIsNotFilledWhenItemIsSetToHidden();
@@ -469,9 +453,7 @@ class RecordMonitorTest extends IntegrationTestBase
         // we assert that the index queue is still empty because the page was only set to hidden
         $this->assertEmptyIndexQueue();
     }
-    /**
-     * @test
-     */
+    #[Test]
     public function queueIsNotFilledWhenItemIsSetToHiddenInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -507,9 +489,8 @@ class RecordMonitorTest extends IntegrationTestBase
 
     /**
      * When a record without pid is processed a warning should be logged
-     *
-     * @test
      */
+    #[Test]
     public function logMessageIsCreatedWhenRecordWithoutPidIsCreated(): void
     {
         $loggerMock = $this->getMockBuilder(SolrLogManager::class)
@@ -582,9 +563,8 @@ class RecordMonitorTest extends IntegrationTestBase
 
     /**
      * This testcase checks, that a queue item will be removed when an unexisting record was updated
-     *
-     * @test
      */
+    #[Test]
     public function queueEntryIsRemovedWhenUnExistingRecordWasUpdated(): void
     {
         $this->prepareQueueEntryIsRemovedWhenUnExistingRecordWasUpdated();
@@ -592,9 +572,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function queueEntryIsRemovedWhenUnExistingRecordWasUpdatedInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -643,8 +621,8 @@ class RecordMonitorTest extends IntegrationTestBase
 
     /**
      * @see https://github.com/TYPO3-Solr/ext-solr/issues/639
-     * @test
      */
+    #[Test]
     public function canUseCorrectIndexingConfigurationForANewCustomPageTypeRecord(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/custom_page_doktype.csv');
@@ -714,9 +692,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueUpdatePagesWithCustomPageType(): void
     {
         $this->prepareCanQueueUpdatePagesWithCustomPageType();
@@ -734,9 +710,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canQueueUpdatePagesWithCustomPageTypeInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -803,9 +777,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations('update', 'pages', 8, $changeSet, $dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandePageTreeMovement(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_page_tree_movement.csv');
@@ -820,9 +792,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(4);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandePageTreeMovementIfPageTreeIsMovedToSysfolderWithDisabledOptionIncludeSubEntriesInSearch(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_page_tree_movement.csv');
@@ -837,9 +807,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandePageTreeMovementIfPageTreeIsMounted(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_mounted_page_tree_movement.csv');
@@ -854,9 +822,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mountPointIsOnlyAddedOnceForEachTree(): void
     {
         $data = $this->prepareMountPointIsOnlyAddedOnceForEachTree();
@@ -876,9 +842,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mountPointIsOnlyAddedOnceForEachTreeInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -939,9 +903,7 @@ class RecordMonitorTest extends IntegrationTestBase
         return $data;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function localizedPageIsAddedToTheQueue(): void
     {
         $this->prepareLocalizedPageIsAddedToTheQueue();
@@ -957,9 +919,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function localizedPageIsAddedToTheQueueInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1009,9 +969,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function queueItemStaysWhenOverlayIsSetToHidden(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/queue_entry_stays_when_overlay_set_to_hidden.csv');
@@ -1042,9 +1000,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function localizedPageIsNotAddedToTheQueueWhenL10ParentIsHidden(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/localized_page_with_hidden_parent.csv');
@@ -1065,9 +1021,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pageIsQueuedWhenContentElementIsChanged(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/change_content_element.csv');
@@ -1093,9 +1047,7 @@ class RecordMonitorTest extends IntegrationTestBase
         self::assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pageIsQueuedWhenTranslatedContentElementIsChanged(): void
     {
         $this->preparePageIsQueuedWhenTranslatedContentElementIsChanged();
@@ -1103,9 +1055,7 @@ class RecordMonitorTest extends IntegrationTestBase
         self::assertSame('pages', $firstQueueItem->getType(), 'First queue item has unexpected type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pageIsQueuedWhenTranslatedContentElementIsChangedInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1147,18 +1097,14 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForTitle();
         $this->assertIndexQueueContainsItemAmount(5);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRootPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1203,9 +1149,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1234,18 +1178,14 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle(): void
     {
         $this->prepareUpdateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitle();
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForTitleInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1290,18 +1230,14 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->prepareUpdateRootPageWithRecursiveUpdateFieldsConfiguredForDokType();
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRootPageWithRecursiveUpdateFieldsConfiguredForDokTypeInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1346,9 +1282,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1377,9 +1311,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubSubChildPageWithRecursiveUpdateFieldsConfiguredForDokType(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1408,9 +1340,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRootPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1434,18 +1364,14 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubChildPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->prepareUpdateSubChildPageWithoutRecursiveUpdateFieldsConfigured();
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubChildPageWithoutRecursiveUpdateFieldsConfiguredInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1485,9 +1411,7 @@ class RecordMonitorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateSubSubChildPageWithoutRecursiveUpdateFieldsConfigured(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1524,12 +1448,11 @@ class RecordMonitorTest extends IntegrationTestBase
     }
 
     /**
-     * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
-     * @test
-     *
      * @param int $uid
      * @param int $root
      */
+    #[DataProvider('updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider')]
+    #[Test]
     public function updateRecordOutsideSiteRootWithAdditionalWhereClause(int $uid, int $root): void
     {
         $this->prepareUpdateRecordOutsideSiteRootWithAdditionalWhereClause($uid);
@@ -1540,12 +1463,11 @@ class RecordMonitorTest extends IntegrationTestBase
     }
 
     /**
-     * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
-     * @test
-     *
      * @param int $uid
      * @param int $root
      */
+    #[DataProvider('updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider')]
+    #[Test]
     public function updateRecordOutsideSiteRootWithAdditionalWhereClauseInDelayedMode(int $uid, int $root): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1613,9 +1535,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordOutsideSiteRoot(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/update_record_outside_siteroot.csv');
@@ -1653,18 +1573,14 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordOutsideSiteRootReferencedInTwoSites(): void
     {
         $this->prepareUpdateRecordOutsideSiteRootReferencedInTwoSites();
         $this->assertIndexQueueContainsItemAmount(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordOutsideSiteRootReferencedInTwoSitesInDelayedMode(): void
     {
         $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
@@ -1732,9 +1648,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordOutsideSiteRootLocatedInOtherSite(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/update_record_outside_siteroot_from_other_siteroot.csv');
@@ -1783,9 +1697,7 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordMonitoringTablesConfiguredDefault(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_subpages.csv');
@@ -1809,18 +1721,14 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordMonitoringTablesConfiguredNotForTableBeingUpdated(): void
     {
         $this->prepareUpdateRecordMonitoringTablesTests(0, 'tt_content');
         $this->assertEmptyIndexQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordMonitoringTablesConfiguredNotForTableBeingUpdatedInDelayedMode(): void
     {
         $this->prepareUpdateRecordMonitoringTablesTests(1, 'tt_content');
@@ -1829,18 +1737,14 @@ class RecordMonitorTest extends IntegrationTestBase
         $this->assertEmptyEventQueue();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordMonitoringTablesConfiguredForTableBeingUpdated(): void
     {
         $this->prepareUpdateRecordMonitoringTablesTests(0, 'pages, tt_content');
         $this->assertIndexQueueContainsItemAmount(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updateRecordMonitoringTablesConfiguredForTableBeingUpdatedInDelayedMode(): void
     {
         $this->assertEmptyIndexQueue();
@@ -1892,9 +1796,8 @@ class RecordMonitorTest extends IntegrationTestBase
 
     /**
      * This testcase checks if we can create a new testpage on the root level without any errors.
-     *
-     * @test
      */
+    #[Test]
     public function canCreateSiteOneRootLevel(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_can_create_new_page.csv');
@@ -1910,9 +1813,8 @@ class RecordMonitorTest extends IntegrationTestBase
 
     /**
      * This testcase checks if we can create a new testpage on the root level without any errors.
-     *
-     * @test
      */
+    #[Test]
     public function canCreateSubPageBelowSiteRoot(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/recordmonitor_can_create_new_page.csv');
@@ -1930,8 +1832,8 @@ class RecordMonitorTest extends IntegrationTestBase
      * Tests if updates on access restricted pages lead to index queue updates
      *
      * https://github.com/TYPO3-Solr/ext-solr/issues/3225
-     * @test
      */
+    #[Test]
     public function canQueueAccessRestrictedPageOnPageUpdate(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/update_access_restricted_page.csv');

--- a/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
+++ b/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\AccessFilterPluginInstalledStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -35,9 +36,7 @@ class AccessFilterPluginInstalledStatusTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGreenAccessFilterStatus(): void
     {
         /** @var AccessFilterPluginInstalledStatus $accessFilterStatus */

--- a/Tests/Integration/Report/SchemaStatusTest.php
+++ b/Tests/Integration/Report/SchemaStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SchemaStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -35,9 +36,7 @@ class SchemaStatusTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAGreenSchemaStatusAgainstTestServer(): void
     {
         /** @var SchemaStatus $schemaStatus */

--- a/Tests/Integration/Report/SiteHandlingStatusTest.php
+++ b/Tests/Integration/Report/SiteHandlingStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SiteHandlingStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -29,9 +30,7 @@ use TYPO3\CMS\Reports\Status;
  */
 class SiteHandlingStatusTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function allStatusChecksShouldBeOkForFirstTestSite(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -46,9 +45,7 @@ class SiteHandlingStatusTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function statusCheckShouldFailIfSchemeIsNotDefined(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -70,9 +67,7 @@ class SiteHandlingStatusTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function statusCheckShouldFailIfAuthorityIsNotDefined(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -94,9 +89,7 @@ class SiteHandlingStatusTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function statusCheckShouldFailIfBaseIsSetWrongInLanguages(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrConfigStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -35,9 +36,7 @@ class SolrConfigStatusTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAGreenSolrConfigStatusAgainstTestServer(): void
     {
         /** @var SolrConfigStatus $schemaStatus */

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrConfigurationStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -41,9 +42,7 @@ class SolrConfigurationStatusTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGreenReportAgainstTestServer(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_green_solr_configuration_status_report.csv');
@@ -64,9 +63,7 @@ class SolrConfigurationStatusTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDetectMissingRootPage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_detect_missing_rootpage.csv');
@@ -81,9 +78,7 @@ class SolrConfigurationStatusTest extends IntegrationTestBase
         self::assertStringContainsString('No sites', $firstViolation->getValue(), 'Did not get a no sites found violation');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDetectIndexingDisabled(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_detect_indexing_disabled.csv');

--- a/Tests/Integration/Report/SolrStatusTest.php
+++ b/Tests/Integration/Report/SolrStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -29,9 +30,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SolrStatusTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function allStatusChecksShouldBeOkForValidSolrConnection(): void
     {
         $this->writeDefaultSolrTestSiteConfiguration();
@@ -44,9 +43,7 @@ class SolrStatusTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function allStatusChecksShouldFailForInvalidSolrConnection(): void
     {
         $this->writeDefaultSolrTestSiteConfigurationForHostAndPort(null, 'invalid', 4711);

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrVersionStatus;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Reports\Status;
@@ -36,9 +37,7 @@ class SolrVersionStatusTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAGreenSolrConfigStatusAgainstTestServer(): void
     {
         /** @var SolrVersionStatus $solrVersionStatus */

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -27,6 +27,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -54,9 +55,7 @@ class SearchTest extends IntegrationTestBase
         $this->cleanUpSolrServerAndAssertEmpty();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSearchForADocument(): void
     {
         $this->cleanUpSolrServerAndAssertEmpty();
@@ -77,9 +76,7 @@ class SearchTest extends IntegrationTestBase
         self::assertStringContainsString('"title":"Hello Search Test"', $rawResponse, 'Could not index document into solr');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHighlightTerms(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
@@ -144,9 +141,7 @@ class SearchTest extends IntegrationTestBase
         self::assertTrue((strlen($highlightString2) > strlen($highlightString3)));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function implicitPhraseSearchingBoostsDocsWithOccurringPhrase(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
@@ -178,9 +173,7 @@ class SearchTest extends IntegrationTestBase
         self::assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Unexpected score calculation. Document');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
@@ -248,11 +241,7 @@ class SearchTest extends IntegrationTestBase
         self::assertSame(3, $parsedDatasByPhraseSlop[2]->response->docs[7]->getUid(), 'Phrase slop setting does not work as expected.');
     }
 
-    /**
-     * @test
-     *
-     * Bigram Phrase
-     */
+    #[Test]
     public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByBigramPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search_bigram.csv');
@@ -334,11 +323,7 @@ class SearchTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     *
-     * Trigram Phrase
-     */
+    #[Test]
     public function implicitPhraseSearchSloppyPhraseBoostCanBeAdjustedByTrigramPhraseSlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search_trigram.csv');
@@ -417,16 +402,14 @@ class SearchTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function explicitPhraseSearchMatchesMorePrecise(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->fillIndexForPhraseSearchTests();
 
-        /** @var \ApacheSolrForTypo3\Solr\Search $searchInstance */
+        /** @var Search $searchInstance */
         $searchInstance = GeneralUtility::makeInstance(Search::class);
 
         $query = $this->getSearchQueryForSolr();
@@ -441,9 +424,7 @@ class SearchTest extends IntegrationTestBase
         self::assertSame('Hello World for phrase searching', $parsedData->response->docs[0]->getTitle(), 'Document containing "Hello World for phrase searching" should be found on explicit(surrounded with double quotes) phrase searching.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function explicitPhraseSearchPrecisionCanBeAdjustedByQuerySlop(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/phrase_search.csv');

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConfigurationPageResolverTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetClosestPageIdWithActiveTemplate()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_get_closest_template_page_id.csv');

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Configuration;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -37,9 +38,7 @@ class TypoScriptConfigurationTest extends IntegrationTestBase
         parent::setUp();
     }
 
-    /**
-    * @test
-    */
+    #[Test]
     public function testCanUsePlainValuesFromConfiguration()
     {
         $configuration = [

--- a/Tests/Integration/System/Environment/CliEnvironmentTest.php
+++ b/Tests/Integration/System/Environment/CliEnvironmentTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Environment;
 use ApacheSolrForTypo3\Solr\System\Environment\CliEnvironment;
 use ApacheSolrForTypo3\Solr\System\Environment\WebRootAllReadyDefinedException;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -27,9 +28,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CliEnvironmentTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitialize()
     {
         self::assertFalse(defined('TYPO3_PATH_WEB'));
@@ -43,9 +42,7 @@ class CliEnvironmentTest extends IntegrationTestBase
         $cliEnvironment->restore();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNotInitializeTwiceWithTwoInstances()
     {
         $this->expectException(WebRootAllReadyDefinedException::class);
@@ -58,9 +55,7 @@ class CliEnvironmentTest extends IntegrationTestBase
         $cliEnvironment2->initialize('/var/otherwww');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitializeTwiceWhenUsedAsSingleton()
     {
         $cliEnvironment = GeneralUtility::makeInstance(CliEnvironment::class);

--- a/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
+++ b/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\Pages;
 
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -35,9 +36,7 @@ class PagesRepositoryTest extends IntegrationTestBase
         $this->repository = GeneralUtility::makeInstance(PagesRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindAllRootPages()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
@@ -56,29 +55,7 @@ class PagesRepositoryTest extends IntegrationTestBase
         self::assertEquals($expectedResult, $result);
     }
 
-    /**
-     * @test
-     *
-     * There is following scenario:
-     *
-     * [0]
-     * |
-     * ——[ 1] Page (Root)
-     * |   |
-     * |   ——[14] Mount Point 1 (to [24] to show contents from) <—— Try to find this
-     * |
-     * ——[ 3] Page2 (Root)
-     * |  |
-     * |   ——[34] Mount Point 2 (to [25] to show contents from) <—— Try to find this
-     * |
-     * ——[20] Shared-Pages (Folder: Not root)
-     * |   |
-     * |   ——[24] FirstShared
-     * |       |
-     * |       ——[25] first subpage from FirstShared
-     * |       |
-     * |       ——[26] second subpage from FirstShared
-     */
+    #[Test]
     public function canfindMountPointPagesByRootLineParentPageIdsIfMountedPagesIsOutsideOfTheSite()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_find_mount_pages_in_rootline.csv');

--- a/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemCategor
 
 use ApacheSolrForTypo3\Solr\System\Records\SystemCategory\SystemCategoryRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -26,9 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SystemCategoryRepositoryTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindOneByParentCategory()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_category.csv');

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemTemplat
 
 use ApacheSolrForTypo3\Solr\System\Records\SystemTemplate\SystemTemplateRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SystemTemplateRepositoryTest extends IntegrationTestBase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canFindOneClosestPageIdWithActiveTemplateByRootLine()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_template.csv');

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\PingFailedException;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception as MockObjectException;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Curl;
@@ -69,10 +71,8 @@ class SolrAdminServiceTest extends IntegrationTestBase
         //yield '/' => ['baseWord' => '/', 'synonyms' => ['slash']]
     }
 
-    /**
-     * @dataProvider synonymDataProvider
-     * @test
-     */
+    #[DataProvider('synonymDataProvider')]
+    #[Test]
     public function canAddAndDeleteSynonym(string $baseWord, array $synonyms = [])
     {
         $this->solrAdminService->deleteSynonym($baseWord);
@@ -102,11 +102,10 @@ class SolrAdminServiceTest extends IntegrationTestBase
     }
 
     /**
-     * @test
-     * @dataProvider stopWordDataProvider
-     *
      * @throws InvalidArgumentException
      */
+    #[DataProvider('stopWordDataProvider')]
+    #[Test]
     public function canAddStopWord(string $stopWord): void
     {
         $stopWords = $this->solrAdminService->getStopWords();
@@ -129,18 +128,15 @@ class SolrAdminServiceTest extends IntegrationTestBase
 
     /**
      * Check if the default stopswords are stored in the solr server.
-     *
-     * @test
      */
+    #[Test]
     public function containsDefaultStopWord()
     {
         $stopWordsInSolr = $this->solrAdminService->getStopWords();
         self::assertContains('and', $stopWordsInSolr, 'Default stopword and was not present');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSystemInformation()
     {
         $informationResponse = $this->solrAdminService->getSystemInformation();
@@ -148,10 +144,9 @@ class SolrAdminServiceTest extends IntegrationTestBase
     }
 
     /**
-     * @test
-     *
      * @throws PingFailedException
      */
+    #[Test]
     public function canGetPingRoundtrimRunTime()
     {
         $pingRuntime = $this->solrAdminService->getPingRoundTripRuntime();
@@ -159,9 +154,7 @@ class SolrAdminServiceTest extends IntegrationTestBase
         self::assertTrue(is_float($pingRuntime), 'Ping runtime should be an integer');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSolrServiceVersion()
     {
         $solrServerVersion = $this->solrAdminService->getSolrServerVersion();
@@ -169,18 +162,14 @@ class SolrAdminServiceTest extends IntegrationTestBase
         self::assertTrue($isVersionHigherSix, 'Expecting to run on version larger then 6.0.0');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReloadCore()
     {
         $result = $this->solrAdminService->reloadCore();
         self::assertSame(200, $result->getHttpStatus(), 'Reload core did not responde with a 200 ok status');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetPluginsInformation()
     {
         $result = $this->solrAdminService->getPluginsInformation();
@@ -189,10 +178,9 @@ class SolrAdminServiceTest extends IntegrationTestBase
     }
 
     /**
-     * @test
-     *
      * @throws MockObjectException
      */
+    #[Test]
     public function canParseLanguageFromSchema()
     {
         /** @var EventDispatcher $eventDispatcher */

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Solr\Service;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ExtractingQuery;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
@@ -60,9 +61,7 @@ class SolrWriteServiceTest extends IntegrationTestBase
         $this->solrWriteService = GeneralUtility::makeInstance(SolrWriteService::class, $client);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canExtractByQuery(): void
     {
         $testFilePath = __DIR__ . '/Fixtures/testpdf.pdf';

--- a/Tests/Integration/System/Solr/SolrConnectionTest.php
+++ b/Tests/Integration/System/Solr/SolrConnectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -73,9 +74,7 @@ class SolrConnectionTest extends IntegrationTestBase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function typo3sHttpSettingsAreRecognizedByClient()
     {
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] = 0.0001;

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\Scheduler;
@@ -50,9 +51,7 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
         $extConf->set('solr', ['monitoringType' => 1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canProcessEventQueueItems(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_process_event_queue.csv');
@@ -69,9 +68,7 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
         self::assertEmpty($this->eventQueue->getEventQueueItems(null, false));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleErroneousEventQueueItems(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_erroneous_event_queue_items.csv');

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -47,9 +48,7 @@ class IndexQueueWorkerTaskTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAdditionalInformationFromTask()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_trigger_frontend_calls_for_page_index.csv');

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\Task\ReIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -86,9 +87,9 @@ class ReIndexTaskTest extends IntegrationTestBase
     }
 
     /**
-     * @test
      * @throws Exception
      */
+    #[Test]
     public function testIfTheQueueIsFilledAfterTaskWasRunning()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_reindex_task_fill_queue.csv');
@@ -104,9 +105,9 @@ class ReIndexTaskTest extends IntegrationTestBase
     }
 
     /**
-     * @test
      * @throws Exception
      */
+    #[Test]
     public function testCanGetAdditionalInformationFromTask()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_reindex_task_fill_queue.csv');
@@ -123,9 +124,9 @@ class ReIndexTaskTest extends IntegrationTestBase
     }
 
     /**
-     * @test
      * @throws Exception
      */
+    #[Test]
     public function solrIsEmptyAfterCleanup()
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_reindex_task_fill_queue.csv');

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -16,6 +16,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for AbstractIndexer
@@ -24,9 +25,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
  */
 class AbstractIndexerTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testTypeIsNotAllowedOverride()
     {
         self::assertFalse(AbstractIndexer::isAllowedToOverrideField('type'), 'Type is allowed to override');

--- a/Tests/Unit/Access/RootlineElementTest.php
+++ b/Tests/Unit/Access/RootlineElementTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Access;
 
 use ApacheSolrForTypo3\Solr\Access\RootlineElement;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -106,10 +108,9 @@ class RootlineElementTest extends SetUpUnitTestCase
      * @param array $expectedGroups
      * @param int|null $expectedPageId
      * @param string $expectedToString
-     * @dataProvider validRootLineRePresentations
-     *
-     * @test
      */
+    #[DataProvider('validRootLineRePresentations')]
+    #[Test]
     public function canParse($stringRepresentation, $expectedType, $expectedGroups, $expectedPageId, $expectedToString)
     {
         $rootLine = new RootlineElement($stringRepresentation);

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Access;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -33,10 +35,8 @@ class RootlineTest extends SetUpUnitTestCase
         yield 'mixed' => ['rootLineString' => '35:1/c:0', 'expectedGroups' => [0, 1]];
     }
 
-    /**
-     * @test
-     * @dataProvider rootLineDataProvider
-     */
+    #[DataProvider('rootLineDataProvider')]
+    #[Test]
     public function canParse(string $rootLineString, $expectedGroups)
     {
         $rootline = new Rootline($rootLineString);

--- a/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
+++ b/Tests/Unit/Backend/SettingsPreviewOnPluginsTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Backend;
 
 use ApacheSolrForTypo3\Solr\Backend\SettingsPreviewOnPlugins;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent;
 use TYPO3\CMS\Backend\View\PageLayoutContext;
@@ -38,9 +39,7 @@ class SettingsPreviewOnPluginsTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotPrintPreviewOnNonExtSolrPlugins()
     {
         $settingPreviewMock = $this->getMockOfSettingsPreviewOnPlugins(['getPreviewContent']);

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -21,6 +21,8 @@ use ApacheSolrForTypo3\Solr\Exception\InvalidConnectionException;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
@@ -120,10 +122,9 @@ class ConnectionManagerTest extends SetUpUnitTestCase
 
     /**
      * Tests the connect
-     *
-     * @dataProvider connectDataProvider
-     * @test
      */
+    #[DataProvider('connectDataProvider')]
+    #[Test]
     public function canConnect(
         string $scheme,
         string $host,

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Classification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -32,9 +34,7 @@ class ClassificationTest extends SetUpContentObject
         return Classification::class;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canClassifyContent()
     {
         $content = 'i like TYPO3 more then joomla';
@@ -71,10 +71,8 @@ class ClassificationTest extends SetUpContentObject
         ];
     }
 
-    /**
-     * @dataProvider excludePatternDataProvider
-     * @test
-     */
+    #[DataProvider('excludePatternDataProvider')]
+    #[Test]
     public function canExcludePatterns($input, $expectedOutput)
     {
         $this->contentObjectRenderer->start(['content' => $input]);

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests for the SOLR_MULTIVALUE cObj.
@@ -31,9 +32,7 @@ class MultivalueTest extends SetUpContentObject
         return Multivalue::class;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertsCommaSeparatedListFromRecordToSerializedArrayOfTrimmedValues()
     {
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
@@ -52,9 +51,7 @@ class MultivalueTest extends SetUpContentObject
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertsCommaSeparatedListFromValueToSerializedArrayOfTrimmedValues()
     {
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Controller\Backend\Search\IndexAdministrationModuleC
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Core\Client\Endpoint;
 
@@ -40,9 +41,7 @@ class IndexAdministrationModuleControllerTest extends AbstractModuleController
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testReloadIndexConfigurationAction(): void
     {
         $responseMock = $this->createMock(ResponseAdapter::class);

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatisticsReposito
 use ApacheSolrForTypo3\Solr\Event\IndexQueue\AfterIndexQueueItemHasBeenMarkedForReindexingEvent;
 use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
@@ -69,18 +70,14 @@ class IndexQueueModuleControllerTest extends AbstractModuleController
         $this->indexQueueMock->expects(self::once())->method('updateOrAddItemForAllRelatedRootPages')->with($type, $uid)->willReturn(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function requeueDocumentActionIsTriggeringReIndexOnIndexQueue(): void
     {
         $this->assertQueueUpdateIsTriggeredFor('pages', 4711);
         $this->controller->requeueDocumentAction('pages', 4711);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hookIsTriggeredWhenRegistered(): void
     {
         $this->eventDispatcher->addListener(function (AfterIndexQueueItemHasBeenMarkedForReindexingEvent $event) {

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -18,15 +18,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Classification;
 use ApacheSolrForTypo3\Solr\Domain\Index\Classification\Classification;
 use ApacheSolrForTypo3\Solr\Domain\Index\Classification\ClassificationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class ClassificationServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetMatchingClassifications()
     {
         $matchPatterns = ['smartphones', 'handy', 'smartphone', 'mobile', 'mobilephone'];
@@ -52,9 +51,7 @@ class ClassificationServiceTest extends SetUpUnitTestCase
         self::assertSame(['mobilephone'], $matches, 'Unexpected matched classification');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMatchWildCards()
     {
         $matchPatterns = ['\ssmart[a-z]*\s'];

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 
@@ -52,9 +53,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eventsAreTriggered(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
@@ -81,9 +80,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         $indexService->indexItems(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testConfigurationIsNotFetchedWhenProgressIsCalculated(): void
     {
         $this->siteMock->expects(self::never())->method('getSolrConfiguration');
@@ -101,9 +98,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         self::assertEquals(50, $progress);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testServerHostIsRestoredInCaseOfAnException(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
@@ -144,9 +139,7 @@ class IndexServiceTest extends SetUpUnitTestCase
         $indexService->indexItems(2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testDomainIsUsedFromSiteObject(): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/Domain/Index/PageIndexer/PageUriBuilderTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/PageUriBuilderTest.php
@@ -8,6 +8,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\PageUriBuilder;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Routing\RouterInterface;
@@ -17,9 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class PageUriBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testPageIndexingUriFromPageItemAndLanguageId(): void
     {
         $pageRecord = ['uid' => 55];
@@ -34,9 +33,7 @@ class PageUriBuilderTest extends SetUpUnitTestCase
         $uriBuilder->getPageIndexingUriFromPageItemAndLanguageId($itemMock, 2, 'foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canOverrideHost(): void
     {
         $pageRecord = ['uid' => 55];
@@ -52,9 +49,7 @@ class PageUriBuilderTest extends SetUpUnitTestCase
         self::assertSame('http://www.secondsite.de/en/test', $uri, 'Solr site strategy generated unexpected uri');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canOverrideScheme(): void
     {
         $pageRecord = ['uid' => 55];

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTestBase.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/AbstractStrategyTestBase.php
@@ -22,6 +22,8 @@ use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 
@@ -38,10 +40,8 @@ abstract class AbstractStrategyTestBase extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     * @dataProvider canDeleteRecordInAllSolrConnectionsDataProvider
-     */
+    #[DataProvider('canDeleteRecordInAllSolrConnectionsDataProvider')]
+    #[Test]
     public function canDeleteRecordInAllSolrConnections(int $status, bool $commit): void
     {
         $query = 'type:tx_fakeextension_foo AND uid:123 AND siteHash:#siteHash#';

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -45,9 +45,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class QueueInitializerServiceTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function allIndexConfigurationsAreUsedWhenWildcardIsPassed(): void
     {
         $queueMock = $this->createMock(Queue::class);

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -45,9 +46,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getResponsibleRootPageIdsMergesRootLineAndTypoScriptReferences(): void
     {
         $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
@@ -62,9 +61,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         self::assertEquals([222, 333, 444], $resolvedRootPages, $message);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getResponsibleRootPageIdsIgnoresPageFromRootLineThatIsNoSiteRoot(): void
     {
         $this->rootPageResolver->expects(self::once())->method('getRootPageIdByTableAndUid')->willReturn(222);
@@ -79,9 +76,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         self::assertEquals([333, 444], $resolvedRootPages, $message);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIsRootPageIdWithPageIdZero(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
@@ -92,9 +87,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         self::assertFalse($rootPage);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIsRootPageWithPageIdMinusOne(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)
@@ -105,9 +98,7 @@ class RootPageResolverTest extends SetUpUnitTestCase
         self::assertFalse($rootPage);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIsRootPageIdWithUnknownPageId(): void
     {
         $this->rootPageResolver = $this->getMockBuilder(RootPageResolver::class)

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\Statistic;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\Statistic\QueueStatistic;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class QueueStatisticTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetFailedPercentage()
     {
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);
@@ -39,9 +38,7 @@ class QueueStatisticTest extends SetUpUnitTestCase
         self::assertSame(25.0, $statistic->getPendingPercentage(), 'Can not calculate pending percentage');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetZeroPercentagesWhenEmpty()
     {
         $statistic = GeneralUtility::makeInstance(QueueStatistic::class);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -96,9 +97,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             ->willReturn([self::DUMMY_PAGE_ID]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleContentElementUpdateTriggersSinglePageProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -178,9 +177,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleContentElementUpdate(123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleContentElementUpdateTriggersInvalidPageProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -235,9 +232,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleContentElementUpdate(123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleContentElementDeletionTriggersPageUpdate(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -258,9 +253,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleContentElementDeletion(123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handlePageUpdateTriggersSinglePageProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -350,9 +343,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             ->willReturn(true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handlePageUpdateTriggersRecursivePageProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -420,9 +411,8 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
     /**
      * Tests if the processing of a page with no connection to a valid root page
      * triggers just the mount page updater
-     *
-     * @test
      */
+    #[Test]
     public function handlePageUpdateTriggersUnconnectedPageProcessing(): void
     {
         $dummyPageRecord = [
@@ -453,9 +443,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handlePageUpdate($dummyPageRecord['uid']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleRecordUpdateTriggersRecordProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -527,9 +515,8 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
     /**
      * Tests if the processing of a record that couldn't be found in database
      * triggers the removal from index and queue
-     *
-     * @test
      */
+    #[Test]
     public function handleRecordUpdateTriggersInvalidRecordProcessing(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -577,9 +564,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleRecordUpdateTriggersMultipleRootPagesRecordProcessing(): void
     {
         $dummyRecord = [
@@ -634,9 +619,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleVersionSwapAppliesPageChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -678,9 +661,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleVersionSwap($dummyPageRecord['uid'], 'pages');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleVersionSwapAppliesContentElementChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -723,9 +704,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleVersionSwap($dummyRecordId, 'tt_content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleVersionSwapAppliesInvalidPageChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -767,9 +746,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleVersionSwap($dummyPageRecord['uid'], 'pages');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleVersionSwapAppliesRecordChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -821,9 +798,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleVersionSwap($dummyRecord['uid'], 'tx_foo_bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleVersionSwapAppliesInvalidRecordChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -870,9 +845,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleVersionSwap($dummyRecord['uid'], 'tx_foo_bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleMovedPageAppliesPageChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();
@@ -914,9 +887,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $this->dataUpdateHandler->handleMovedPage($dummyPageRecord['uid']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handleMovedRecordAppliesRecordChangesToQueue(): void
     {
         $this->initRootPageResolverForValidDummyRootPage();

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Delay
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Events\DelayedProcessingQueuingFinishedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -34,9 +35,7 @@ class DelayedProcessingEventListenerTest extends SetUpEventListener
      */
     protected AbstractBaseEventListener $listener;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleEvents(): void
     {
         $this->extensionConfigurationMock
@@ -66,9 +65,7 @@ class DelayedProcessingEventListenerTest extends SetUpEventListener
         self::assertEquals($event, $dispatchedEvent->getDataUpdateEvent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSkipEventHandlingIfDisabled(): void
     {
         $this->extensionConfigurationMock

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/SetUpProcessingFinishedEvent.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Ev
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Abstract testcase for the processing finished events
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 abstract class SetUpProcessingFinishedEvent extends SetUpUnitTestCase
 {
     protected const EVENT_CLASS = 'stdClass';
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetAndReturnProcessedEvent(): void
     {
         $processedEvent = new RecordUpdatedEvent(123, 'tx_foo_bar');

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
@@ -28,6 +28,8 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedE
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwappedEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\StoppableEventInterface;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -55,10 +57,8 @@ class ImmediateProcessingEventListenerTest extends SetUpEventListener
         parent::setUp();
     }
 
-    /**
-     * @test
-     * @dataProvider canHandleEventsDataProvider
-     */
+    #[DataProvider('canHandleEventsDataProvider')]
+    #[Test]
     public function canHandleEvents(
         string $eventClass,
         string $handlerClass,
@@ -75,10 +75,8 @@ class ImmediateProcessingEventListenerTest extends SetUpEventListener
         $this->checkEventHandling($event, $handlerClass, $eventHandled);
     }
 
-    /**
-     * @test
-     * @dataProvider canHandleEventsDataProvider
-     */
+    #[DataProvider('canHandleEventsDataProvider')]
+    #[Test]
     public function canHandleEventsIfHandlingInactiveButForced(
         string $eventClass,
         string $handlerClass,

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Ev
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the NoProcessingEventListener
@@ -31,9 +32,7 @@ class NoProcessingEventListenerTest extends SetUpEventListener
      */
     protected AbstractBaseEventListener $listener;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleEvents(): void
     {
         $this->extensionConfigurationMock
@@ -46,9 +45,7 @@ class NoProcessingEventListenerTest extends SetUpEventListener
         self::assertTrue($event->isPropagationStopped());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSkipEventHandlingIfDisabled(): void
     {
         $this->extensionConfigurationMock

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/SetUpEventListener.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Ev
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\AbstractBaseEventListener;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -54,9 +56,7 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
      */
     abstract protected function initListener(): AbstractBaseEventListener;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicateActiveMonitoring(): void
     {
         $this->extensionConfigurationMock
@@ -70,10 +70,9 @@ abstract class SetUpEventListener extends SetUpUnitTestCase
 
     /**
      * @param int $currentType
-     *
-     * @test
-     * @dataProvider inactiveMonitoringDataProvider
      */
+    #[DataProvider('inactiveMonitoringDataProvider')]
+    #[Test]
     public function canIndicateInactiveMonitoring(int $currentType): void
     {
         $this->extensionConfigurationMock

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -16,6 +16,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Events;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\ContentElementDeletedEvent;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the ContentElementDeletedEvent
@@ -27,36 +28,28 @@ class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
     protected const EVENT_CLASS = ContentElementDeletedEvent::class;
     protected const EVENT_TEST_TABLE = 'tt_content';
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitAndReturnFields(): void
     {
         $event = new ContentElementDeletedEvent(123);
         self::assertEmpty($event->getFields());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canForceTable(): void
     {
         $event = new ContentElementDeletedEvent(123);
         self::assertEquals('tt_content', $event->getTable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicatePageUpdate(): void
     {
         $event = new ContentElementDeletedEvent(123);
         self::assertFalse($event->isPageUpdate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicateContentElementUpdate(): void
     {
         $event = new ContentElementDeletedEvent(123);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -16,6 +16,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Events;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\PageMovedEvent;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the PageMovedEvent
@@ -27,36 +28,28 @@ class PageMovedEventTest extends SetUpDataUpdateEvent
     protected const EVENT_CLASS = PageMovedEvent::class;
     protected const EVENT_TEST_TABLE = 'pages';
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitAndReturnFields(): void
     {
         $event = new PageMovedEvent(123);
         self::assertEmpty($event->getFields());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canForceTable(): void
     {
         $event = new PageMovedEvent(123);
         self::assertEquals('pages', $event->getTable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicatePageUpdate(): void
     {
         $event = new PageMovedEvent(123);
         self::assertTrue($event->isPageUpdate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicateContentElementUpdate(): void
     {
         $event = new PageMovedEvent(123);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Index\Queue\UpdateHandler\Ev
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the RecordGarbageCheckEvent
@@ -29,10 +30,9 @@ class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';
 
     /**
-     * @test
-     *
      * @return AbstractDataUpdateEvent
      */
+    #[Test]
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
     {
         /** @var RecordGarbageCheckEvent $event */
@@ -44,9 +44,7 @@ class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
         return $event;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitAndReturnFrontendGroupsRemovedFlag(): void
     {
         $event = new RecordGarbageCheckEvent(123, 'tx_foo_bar', [], true);

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/SetUpDataUpdateEvent.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\AbstractDataUpdateEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Abstract testcase for the data update events
@@ -30,9 +31,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
     protected const EVENT_CLASS = AbstractDataUpdateEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitAndReturnBasicProperties(): AbstractDataUpdateEvent
     {
         $eventClass = static::EVENT_CLASS;
@@ -49,9 +48,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         return $event;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canInitAndReturnFields(): void
     {
         $eventClass = static::EVENT_CLASS;
@@ -60,9 +57,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         self::assertEquals($fields, $event->getFields());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicatePageUpdate(): void
     {
         $eventClass = static::EVENT_CLASS;
@@ -76,9 +71,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         self::assertTrue($event->isPageUpdate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIndicateContentElementUpdate(): void
     {
         $eventClass = static::EVENT_CLASS;
@@ -90,9 +83,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         self::assertTrue($event->isContentElementUpdate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkAndIndicateStoppedProcessing(): void
     {
         $eventClass = static::EVENT_CLASS;
@@ -105,9 +96,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         self::assertFalse($event->isPropagationStopped());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkAndIndicateForcedProcessing(): void
     {
         $eventClass = static::EVENT_CLASS;
@@ -120,9 +109,7 @@ abstract class SetUpDataUpdateEvent extends SetUpUnitTestCase
         self::assertFalse($event->isImmediateProcessingForced());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCleanEventOnSerialization(): void
     {
         $fields = [

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\PageStrategy;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\RecordStrategy;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,18 +47,14 @@ class GarbageHandlerTest extends SetUpUpdateHandler
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectGarbageTriggersGarbageCollectionForPages(): void
     {
         $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
         $this->garbageHandler->collectGarbage('pages', 123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectGarbageTriggersGarbageCollectionForRecords(): void
     {
         $this->initGarbageCollectionExpectations(RecordStrategy::class, 'tx_foo_bar', 789);
@@ -85,18 +82,14 @@ class GarbageHandlerTest extends SetUpUpdateHandler
             );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handlePageMovementTriggersGarbageCollectionAndReindexing(): void
     {
         $this->initGarbageCollectionExpectations(PageStrategy::class, 'pages', 123);
         $this->garbageHandler->handlePageMovement(123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function performRecordGarbageCheckTriggersRecordGarbageCollection(): void
     {
         $dummyRecord = [
@@ -140,9 +133,7 @@ class GarbageHandlerTest extends SetUpUpdateHandler
         $this->garbageHandler->performRecordGarbageCheck($dummyRecord['uid'], 'tx_foo_bar', [], true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function performRecordGarbageCheckTriggersPageGarbageCollection(): void
     {
         $dummyPageRecord = [
@@ -194,9 +185,7 @@ class GarbageHandlerTest extends SetUpUpdateHandler
         $this->garbageHandler->performRecordGarbageCheck($dummyPageRecord['uid'], 'pages', ['hidden' => 1], true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRecordWithFieldRelevantForGarbageCollectionDeterminesFields(): void
     {
         $GLOBALS['TCA']['tx_foo_bar'] = ['columns' => []];

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -66,9 +67,7 @@ class BuilderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildApacheSolrDocumentFromEmptyPage(): void
     {
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
@@ -86,9 +85,7 @@ class BuilderTest extends SetUpUnitTestCase
         self::assertSame('siteHash/pages/4711', $document['id'], 'Builder did not use documentId from mock');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetKeywordsForApacheSolrDocument(): void
     {
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
@@ -105,9 +102,7 @@ class BuilderTest extends SetUpUnitTestCase
         self::assertSame($document['keywords'], ['foo', 'bar'], 'Could not set keywords from page document');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetEndtimeForApacheSolrDocument(): void
     {
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
@@ -124,9 +119,7 @@ class BuilderTest extends SetUpUnitTestCase
         self::assertSame($document['endtime'], 1234, 'Could not set endtime from page document');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetTagFieldsForApacheSolrDocument(): void
     {
         $fakePage = $this->createMock(TypoScriptFrontendController::class);
@@ -143,9 +136,7 @@ class BuilderTest extends SetUpUnitTestCase
         self::assertSame($document['tagsH1'], 'Fake H1 content', 'Could not assign extracted h1 heading to solr document');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildFromRecord(): void
     {
         $fakeRecord = ['uid' => 4711, 'pid' => 88, 'type' => 'news'];

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -26,6 +26,8 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use stdClass;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -48,9 +50,7 @@ class RepositoryTest extends SetUpUnitTestCase
      */
     protected $mockedAsSingletonSite;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOneByPageIdAndByLanguageIdReturnsFirstFoundDocument()
     {
         $apacheSolrDocumentCollection = [new Document(), new Document()];
@@ -71,9 +71,7 @@ class RepositoryTest extends SetUpUnitTestCase
         self::assertSame($apacheSolrDocumentCollection[0], $apacheSolrDocumentRepository->findOneByPageIdAndByLanguageId(0, 0));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByPageIdAndByLanguageIdReturnsEmptyCollectionIfConnectionToSolrServerCanNotBeEstablished()
     {
         $apacheSolrDocumentRepository = $this->getAccessibleMock(
@@ -92,9 +90,7 @@ class RepositoryTest extends SetUpUnitTestCase
         self::assertEmpty($apacheSolrDocumentCollection);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByPageIdAndByLanguageIdReturnsResultFromSearch()
     {
         $solrConnectionMock = $this->createMock(SolrConnection::class);
@@ -108,9 +104,9 @@ class RepositoryTest extends SetUpUnitTestCase
 
         $testDocuments = [new Document(), new Document()];
 
-        $parsedData = new \stdClass();
+        $parsedData = new stdClass();
         // @extensionScannerIgnoreLine
-        $parsedData->response = new \stdClass();
+        $parsedData->response = new stdClass();
         // @extensionScannerIgnoreLine
         $parsedData->response->docs = $testDocuments;
         $fakeResponse = $this->createMock(ResponseAdapter::class);

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\FrequentSearches\FrequentSearchesServi
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\Frontend\AbstractFrontend;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
@@ -62,9 +63,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cachedResultIsUsedWhenIdentifierIsPresent(): void
     {
         $fakeConfiguration = [];
@@ -77,9 +76,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
         self::assertSame('term a', $frequentTerms[0], 'Could not get frequent terms from service');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function databaseResultIsUsedWhenNoCachedResultIsPresent(): void
     {
         $fakeConfiguration = [

--- a/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
+++ b/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Highlight;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Highlight\SiteHighlighterUrlModifier;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -56,10 +58,8 @@ class SiteHighlighterUrlModifierTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider canModifyDataProvider
-     * @test
-     */
+    #[DataProvider('canModifyDataProvider')]
+    #[Test]
     public function canModify($inputUrl, $keywords, $no_cache, $keepCHash, $expectedResult)
     {
         $siteHighlightingModifier = new SiteHighlighterUrlModifier();

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\LastSearches;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class LastSearchesRepositoryTest extends SetUpUnitTestCase
@@ -31,9 +32,7 @@ class LastSearchesRepositoryTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findAllKeywordsWillDecoteKeywordsAsHTMLEntities(): void
     {
         $givenKeywords = [

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\LastSearches\LastSearchesService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class LastSearchesServiceTest extends SetUpUnitTestCase
@@ -48,9 +49,7 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastSearchesFromSessionInUserMode(): void
     {
         $fakedLastSearchesInSession = ['first search', 'second search'];
@@ -67,9 +66,7 @@ class LastSearchesServiceTest extends SetUpUnitTestCase
         self::assertSame($fakedLastSearchesInSession, array_reverse($lastSearches), 'Did not get last searches from session in user mode');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLastSearchesFromDatabaseInGlobalMode(): void
     {
         $fakedLastSearchesFromRepository = [

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\Helper;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -47,10 +49,8 @@ class EscapeHelperTest extends SetUpUnitTestCase
         yield 'combined quoted phrase mixed with escape character' => ['input' => '"hello world" or (planet)', 'expectedOutput' => '"hello world" or \(planet\)'];
     }
 
-    /**
-     * @dataProvider escapeQueryDataProvider
-     * @test
-     */
+    #[DataProvider('escapeQueryDataProvider')]
+    #[Test]
     public function canEscapeAsExpected($input, $expectedOutput)
     {
         $escapeHelper = new EscapeService();

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
@@ -17,15 +17,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilde
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\BigramPhraseFields;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class BigramPhraseFieldsTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function buildFromEmptyStringCreatesEmptyArrayOnBuild()
     {
         $bigramPhraseFields = BigramPhraseFields::fromString('');

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
@@ -18,15 +18,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilde
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Grouping;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class GroupingTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildSortingFromConfiguration()
     {
         $typoScriptConfiguration = new TypoScriptConfiguration(

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
@@ -17,15 +17,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Query\ParameterBuilde
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class QueryFieldsTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildFromString()
     {
         $input = 'one^10.0,two^20.0,three^5.0';

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -37,6 +37,9 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\QueryType\Select\RequestBuilder;
 use Traversable;
@@ -79,36 +82,28 @@ class QueryBuilderTest extends SetUpUnitTestCase
         return $query;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchQueryPassesQueryString(): void
     {
         $query = $this->builder->buildSearchQuery('one');
         self::assertSame('one', (string)$query->getQuery(), 'Query has unexpected value, when casted to string');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchQueryPassesDefaultPerPage(): void
     {
         $query = $this->builder->buildSearchQuery('one');
         self::assertSame(10, $query->getRows(), 'Query was not created with default perPage value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchQueryPassesCustomPerPage(): void
     {
         $query = $this->builder->buildSearchQuery('one', 22);
         self::assertSame(22, $query->getRows(), 'Query was not created with default perPage value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchQueryInitializesQueryFieldsFromConfiguration(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
@@ -116,9 +111,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('title^10.0 content^123.0', $this->getAllQueryParameters($query)['qf'], 'The queryFields have not been initialized as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchQueryInitializesTrigramPhraseFields(): void
     {
         $this->configurationMock->expects(self::once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);
@@ -128,9 +121,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^10.0', $this->getAllQueryParameters($query)['pf3'], 'The trigramPhraseFields have not been initialized as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchIsSettingWildCardQueryOnInitializeWithEmptyQuery(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchInitializeWithEmptyQuery')->willReturn(true);
@@ -138,9 +129,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchIsSettingWildCardQueryOnInitializeWithAllowEmptyQuery(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryAllowEmptyQuery')->willReturn(true);
@@ -148,9 +137,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('*:*', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchIsSettingQuerystringForConfiguredInitialQuery(): void
     {
         $this->configurationMock->expects(self::exactly(2))->method('getSearchInitializeWithQuery')->willReturn('myinitialsearch');
@@ -158,9 +145,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('myinitialsearch', $this->getAllQueryParameters($query)['q.alt'], 'The alterativeQuery has not been initialized from a configured initial query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchIsSettingConfiguredAdditionalFilters(): void
     {
         $this->configurationMock->expects(self::any())->method('getSearchQueryFilterConfiguration')->willReturn(['noPage' => '-type:pages']);
@@ -172,19 +157,15 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('-type:pages', $filterValue, 'First filter has unexpected value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildSearchIsSettingNoAlternativeQueryByDefault(): void
     {
         $query = $this->builder->buildSearchQuery('initializeWithEmpty');
         self::assertArrayNotHasKey('q.alt', $this->getAllQueryParameters($query), 'The alterativeQuery is not null when nothing was set');
     }
 
-    /**
-     * @test
-     * @dataProvider buildSearchIsRespectingPageSectionFiltersDataProvider
-     */
+    #[DataProvider('buildSearchIsRespectingPageSectionFiltersDataProvider')]
+    #[Test]
     public function buildSearchIsRespectingPageSectionFilters(
         array $rootLines,
         array $filterConfiguration,
@@ -267,9 +248,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canEnableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -282,9 +261,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(200, $queryParameters['hl.fragsize'], 'hl.fragsize was not set to the default value of 200');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDisableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -302,9 +279,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('hl', $queryParameters, 'Could not disable highlighting');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetHighlightingFieldList(): void
     {
         $fakeConfigurationArray = [];
@@ -323,9 +298,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('title', $queryParameters['hl.fl'], 'Can set highlighting field list');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canPassCustomWrapForHighlighting(): void
     {
         $fakeConfigurationArray = [];
@@ -344,9 +317,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed(): void
     {
         $fakeConfigurationArray = [];
@@ -369,9 +340,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseFastVectorHighlighting(): void
     {
         $fakeConfigurationArray = [];
@@ -389,9 +358,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18(): void
     {
         $fakeConfigurationArray = [];
@@ -409,18 +376,14 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('false', $queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQueryString(): void
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');
         self::assertSame('i like solr', $query->getQuery(), 'Can not set and get query string');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetPage(): void
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');
@@ -429,9 +392,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(10, $query->getStart(), 'Can not set and get page');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noFiltersAreSetAfterInitialization(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -439,9 +400,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('fq', $queryParameters, 'Query already contains filters after intialization.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addsCorrectAccessFilterForAnonymousUser(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -451,9 +410,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('{!typo3access}-1,0', $queryParameters['fq'], 'Accessfilter was not applied');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function grantsAccessToGroupZeroIfNoGroupsProvided(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -463,9 +420,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('{!typo3access}0', $queryParameters['fq'], 'Changed accessfilter was not applied');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function grantsAccessToGroupZeroIfZeroNotProvided(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -475,9 +430,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('{!typo3access}0,5', $queryParameters['fq'], 'Access filter was not applied as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filtersDuplicateAccessGroups(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -487,9 +440,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('{!typo3access}0,1', $queryParameters['fq'], 'Access filter was not applied as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function allowsOnlyOneAccessFilter(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -501,12 +452,8 @@ class QueryBuilderTest extends SetUpUnitTestCase
     }
 
     // TODO if user is in group -2 (logged in), disallow access to group -1
-
     // grouping
-
-    /**
-     * @test
-     */
+    #[Test]
     public function groupingIsNotActiveAfterInitialization(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -520,9 +467,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settingGroupingTrueActivatesGrouping()
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -543,10 +488,8 @@ class QueryBuilderTest extends SetUpUnitTestCase
         return $query;
     }
 
-    /**
-     * @test
-     * @depends settingGroupingTrueActivatesGrouping
-     */
+    #[Depends('settingGroupingTrueActivatesGrouping')]
+    #[Test]
     public function settingGroupingFalseDeactivatesGrouping(SearchQuery $query): void
     {
         $grouping = new Grouping(false);
@@ -560,9 +503,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetNumberOfGroups(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -570,9 +511,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertTrue($query->getGrouping()->getNumberOfGroups(), 'Could not set and get number of groups');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddGroupField(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -581,9 +520,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['category_s'], $query->getGrouping()->getFields(), 'groupFields has unexpected state after adding a group field');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroupSorting(): void
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -596,9 +533,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('price_f author_s', $queryParameters['group.sort'], 'Can not get groupSortings after adding');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetNumberOfResultsByGroup(): void
     {
         $query = $this->getInitializedTestSearchQuery('group test');
@@ -612,9 +547,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(22, $queryParameters['group.limit'], 'Can not set number of results per group');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddGroupQuery(): void
     {
         $query = $this->getInitializedTestSearchQuery('group test');
@@ -624,9 +557,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['price:[* TO 500]'], $query->getGrouping()->getQueries(), 'Could not retrieve group queries after adding one');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetQueryFieldsAsStringWhenPassedFromConfiguration(): void
     {
         $input = 'content^10, title^5';
@@ -640,9 +571,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($output, $expectedOutput, 'Passed and retrieved query fields are not the same');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnEmptyStringAsQueryFieldStringWhenNothingWasPassed(): void
     {
         $fakeConfigurationArray = [];
@@ -655,9 +584,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($output, $expectedOutput, 'Unexpected output from getQueryFieldsAsString when no configuration was passed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetMinimumMatch(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -674,9 +601,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertEmpty($queryParameters['mm']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBoostFunction(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -695,9 +620,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertEmpty($queryParameters['bf'], 'bf parameter should be null after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBoostQuery(): void
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -712,9 +635,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('bq', $queryParameters, 'bq parameter should be null after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnFieldListWhenConfigurationWithReturnFieldsWasPassed(): void
     {
         $input = 'abstract, price';
@@ -726,9 +647,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('abstract,price', $queryParameters['fl'], 'Did not parse returnsFields as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnDefaultFieldListWhenNoConfigurationWasPassed(): void
     {
         $fakeConfigurationArray = [];
@@ -738,9 +657,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('*,score', $queryParameters['fl'], 'Did not parse returnsFields as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddReturnField(): void
     {
         $fakeConfigurationArray = [];
@@ -753,9 +670,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('url,title', $queryParameters['fl'], 'Added return field was not in the list of valid fields');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveReturnField(): void
     {
         $fakeConfigurationArray = [];
@@ -769,12 +684,10 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('title,url', $queryParameters['fl'], 'content was not remove from the fieldList');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canEnableFaceting(): void
     {
-        /** @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
+        /** @var SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
         $faceting = new Faceting(true);
         $this->builder->startFrom($query)->useFaceting($faceting);
@@ -782,9 +695,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('true', $queryParameters['facet'], 'Enable faceting did not set the "facet" query parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDisableFaceting()
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -807,9 +718,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('f.title.facet.sort', $queryParameters, 'Facet sorting parameter should also be removed after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddFacetField()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -829,9 +738,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['color_s', 'price_f'], $queryParameters['facet.field'], 'facet.field should not be empty after adding a few fields.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetFacetFields()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -849,9 +756,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['lastname_s', 'role_s'], $queryParameters['facet.field'], 'Could not use setFields to pass facet fields');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseFacetMinCountFromConfiguration()
     {
         $input = 10;
@@ -868,9 +773,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(10, $queryParameters['facet.mincount'], 'Can not use facet.minimumCount from configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseFacetSortByFromConfiguration()
     {
         $input = 'alpha';
@@ -887,12 +790,10 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('index', $queryParameters['facet.sort'], 'Can not use facet.sort from configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetSpellChecking()
     {
-        /** @var \ApacheSolrForTypo3\Solr\Domain\Search\Query\SearchQuery $query */
+        /** @var SearchQuery $query */
         $query = $this->getInitializedTestSearchQuery();
 
         $spellchecking = Spellchecking::getEmpty();
@@ -911,9 +812,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('spellcheck.maxCollationTries', $queryParameters, 'spellcheck.maxCollationTries was not unsetted');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noSiteHashFilterIsSetWhenWildcardIsPassed()
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -929,9 +828,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('fq', $queryParameters, 'The filters should be empty when a wildcard sitehash was passed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filterIsAddedWhenAllowedSiteIsPassed()
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -949,9 +846,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertEquals('siteHash:"dsada43242342342"', $queryParameters['fq'], 'Unexpected siteHashFilter was added to the query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTestNumberOfSuggestionsToTryFromConfiguration()
     {
         $input = 9;
@@ -969,9 +864,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($input, $queryParameters['spellcheck.maxCollationTries'], 'Could not set spellcheck.maxCollationTries as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseConfiguredVariantsFieldWhenVariantsAreActive()
     {
         $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
@@ -985,9 +878,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('{!collapse field=myField}', $queryParameters['fq'], 'Collapse filter query was not created');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseConfiguredVariantsExpandAndRowCount()
     {
         $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
@@ -1004,9 +895,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(10, $queryParameters['expand.rows'], 'Expand.rows argument of query was not set to true with configured expand.rows');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function expandRowsIsNotSetWhenExpandIsInactive()
     {
         $fakeConfigurationArray = ['plugin.' => ['tx_solr.' => ['search.' => ['variants' => 1]]]];
@@ -1021,9 +910,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('expand.rows', $queryParameters, 'Expand.rows should not be set when expand is set to false');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function variantsAreDisabledWhenNothingWasConfigured()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -1032,9 +919,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('fq', $queryParameters, 'No filter query should be generated when field collapsing is disbled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canConvertQueryToString()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -1045,9 +930,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('test', $queryToString, 'Could not convert query to string');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddAndRemoveFilters()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -1080,9 +963,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('fq', $parameters, 'Could not remove filters from query object by filter key');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveFilterByValue()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -1098,9 +979,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('fq', $parameters, 'Filters are not empty after removing the last one');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseFilterIgnoreSecondePassedFilterWithSameKey()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -1112,9 +991,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('foo:bar', $parameters['fq'], 'Unexpected filter query was added');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetAndUnSetQueryType()
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -1132,9 +1009,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('qt', $queryParameters, 'The qt parameter was expected to be null after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetOperator()
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -1155,9 +1030,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertEmpty($queryParameters['q.op'], 'The queryParameter q.op should be null because operator was resetted');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetAlternativeQuery()
     {
         // check initial value
@@ -1177,9 +1050,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('q.alt', $queryParameters, 'We expect alternative query is null after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetOmitHeaders()
     {
         // check initial value
@@ -1198,9 +1069,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('false', $queryParameters['omitHeader'], 'The queryParameter omitHeader should be null because it was resetted');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetReturnFields()
     {
         // check initial value
@@ -1219,9 +1088,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content,title', $queryParameters['fl'], 'Can not set fieldList from array');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetSorting()
     {
         // check initial value
@@ -1246,9 +1113,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('sort', $queryParameters, 'Sorting should be null after reset');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQueryElevation()
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -1277,9 +1142,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('*,score', $queryParameters['fl']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function forceElevationIsFalseWhenForcingToFalse()
     {
         $query = $this->getInitializedTestSearchQuery('test');
@@ -1306,9 +1169,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('forceElevation', $queryParameters);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildExpectedQueryUrlFromCombinedQuery()
     {
         $faceting = new Faceting(true);
@@ -1346,9 +1207,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('qf', $parameters, 'No query fields have been set');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQueryFieldsFromString()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1360,9 +1219,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^100.0 title^10.0', $parameters['qf'], 'Can not set and get query fields');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQueryFields()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1385,9 +1242,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^9.0', $parameters['qf'], 'qf parameter not set in QueryParameters');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetPhraseFieldsFromString()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1397,9 +1252,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^100.0 title^10.0', $parameters['pf'], 'Can not set and get phrase fields');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetPhraseFields()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1423,9 +1276,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^9.0', $parameters['pf']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function phraseFieldsAreNotSetInUrlQueryIfPhraseSearchIsDisabled()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1438,9 +1289,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('pf', $parameters, 'pf parameter must be empty(not set) if phrase search is disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function phraseFieldsAreSetInUrlQueryIfPhraseSearchIsEnabled()
     {
         $fakeConfigurationArray = [];
@@ -1456,9 +1305,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddPhraseFieldsFromConfiguration()
     {
         $fakeConfigurationArray = [];
@@ -1472,9 +1319,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^22.0 title^11.0', $parameters['pf'], 'pf parameters must be set if phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bigramPhraseFieldsAreNotSetInUrlQueryIfBigramPhraseSearchIsDisabled()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar baz');
@@ -1486,9 +1331,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('pf2', $parameters, 'pf2 parameter must be empty(not set) if phrase search is disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddBigramFieldsWhenBigramPhraseIsEnabled()
     {
         $fakeConfigurationArray = [];
@@ -1504,9 +1347,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^11.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddBigramFieldsFromConfiguration()
     {
         $fakeConfigurationArray = [];
@@ -1520,9 +1361,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^12.0 title^14.0', $parameters['pf2'], 'pf2 parameters must be set if bigram phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function trigramPhraseFieldsAreNotSetInUrlQueryIfTrigramPhraseSearchIsDisabled()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar baz foobar barbaz');
@@ -1534,9 +1373,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('pf3', $parameters, 'pf3 parameter must be empty(not set) if phrase search is disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function trigramPhraseFieldsAreSetInUrlQueryIfTrigramPhraseSearchIsEnabled()
     {
         $fakeConfigurationArray = [];
@@ -1551,9 +1388,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^10.0 title^11.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddTrigramFieldsFromConfiguration()
     {
         $fakeConfigurationArray = [];
@@ -1565,9 +1400,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('content^12.0 title^14.0', $parameters['pf3'], 'pf3 parameters must be set if trigram phrase search is enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDebugMode()
     {
         $query = $this->getInitializedTestSearchQuery();
@@ -1588,9 +1421,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('echoParams', $parameter, 'Can not unset debug mode');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addingQueriesToGroupingAddsToRightGroupingParameter()
     {
         $query = $this->getInitializedTestSearchQuery('group test');
@@ -1603,9 +1434,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['price:[* TO 500]', 'someField:someValue'], $parameters['group.query'], 'Could not add group queries properly');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addingSortingsToGroupingAddsToRightGroupingParameter()
     {
         $query = $this->getInitializedTestSearchQuery('group test');
@@ -1617,9 +1446,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('price_f title desc', $parameters['group.sort'], 'Could not add group sortings properly');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addingFieldsToGroupingAddsToRightGroupingParameter()
     {
         $query = $this->getInitializedTestSearchQuery('group test');
@@ -1631,9 +1458,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame(['price_f', 'category_s'], $parameters['group.field'], 'Could not add group fields properly');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canDisablingGroupingRemoveTheGroupSorting()
     {
         $query = $this->getInitializedTestSearchQuery('foo bar');
@@ -1664,9 +1489,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('group.ngroups', $parameters, 'Grouping parameters should be removed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildSuggestQuery()
     {
         $this->configurationMock
@@ -1686,9 +1509,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         self::assertSame('foo', $queryParameters['facet.prefix'], 'Passed query string is not used as facet.prefix argument');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function alternativeQueryIsWildCardQueryForSuggestQuery()
     {
         $this->configurationMock

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\SuggestQuery;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class
@@ -28,9 +29,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class SuggestQueryTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testSuggestQueryDoesNotUseFieldCollapsing()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['variants'] = 1;
@@ -45,9 +44,7 @@ class SuggestQueryTest extends SetUpUnitTestCase
         self::assertNull($suggestQuery->getFilterQuery('fieldCollapsing'), 'Collapsing should never be active for a suggest query, even when active');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSuggestQueryUsesFilterList()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);
@@ -59,9 +56,7 @@ class SuggestQueryTest extends SetUpUnitTestCase
         self::assertSame('+type:pages', $queryParameters['fq'], 'Filter was not added to the suggest query parameters');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSuggestQueryDoesNotErrorOnEmptyKeywords()
     {
         $fakeConfiguration = new TypoScriptConfiguration([]);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\DefaultFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class DefaultFacetQueryBuilderTest
@@ -39,9 +40,8 @@ class DefaultFacetQueryBuilderTest extends SetUpUnitTestCase
      *       }
      *    }
      * }
-     *
-     * @test
      */
+    #[Test]
     public function testWhenKeepAllOptionsOnSelectionIsNotConfiguredNoExcludeTagIsAdded()
     {
         $fakeConfigurationArray = [];

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\DefaultUrlDecoder;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class DefaultUrlEncoderTest
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class DefaultUrlDecoderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canDecode()
     {
         $value = 'a + b';

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\FacetCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class FacetCollectionTest
@@ -27,9 +28,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class FacetCollectionTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddAndRetrieveFacetByKey()
     {
         $facetCollection = new FacetCollection();
@@ -44,9 +43,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
         self::assertEquals($brandFacet, $facetCollection['brand']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddAndRetrieveFacetByPosition()
     {
         $facetCollection = new FacetCollection();
@@ -61,9 +58,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
         self::assertEquals($brandFacet, $facetCollection->getByPosition(1));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRetrieveFacetOfCollectionCopyByKey()
     {
         $facetCollection = new FacetCollection();
@@ -79,9 +74,7 @@ class FacetCollectionTest extends SetUpUnitTestCase
         self::assertEquals($brandFacet, $leftFacetCollection['brand']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRetrieveFacetOfCollectionCopyByPosition()
     {
         $facetCollection = new FacetCollection();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\TestPackage\TestPackage;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -48,9 +49,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
         return $facetRegistry;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registeredPackageClassCanBeRetrievedByType(): void
     {
         $facetType = 'myType';
@@ -63,9 +62,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
         self::assertEquals($packageObject, $facetRegistry->getPackage($facetType));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registerParserClassThrowsExceptionIfClassDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -74,9 +71,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
         $facetParserRegistry->registerPackage($this->getUniqueId(), 'unknown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registerParserClassThrowsExceptionIfClassDoesNotImplementFacetPackageInterface(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -86,9 +81,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
         $facetParserRegistry->registerPackage($className, 'unknown');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registerReturnsDefaultPackageForUnknownFacetType(): void
     {
         $optionsFacetPackage = new OptionsPackage();
@@ -96,9 +89,7 @@ class FacetRegistryTest extends SetUpUnitTestCase
         self::assertEquals($optionsFacetPackage, $facetParserRegistry->getPackage('unknownType'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRegisterDifferentDefaultPackage(): void
     {
         $packageObject = new TestPackage();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacetParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -29,9 +31,7 @@ use Traversable;
  */
 class HierarchyFacetParserTest extends SetUpFacetParser
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsCreated(): void
     {
         $facetConfiguration = [
@@ -87,10 +87,8 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataProviderForDeepMoreThen10DoesNotBreakHierarchyFacet
-     */
+    #[DataProvider('dataProviderForDeepMoreThen10DoesNotBreakHierarchyFacet')]
+    #[Test]
     public function deepMoreThen10DoesNotBreakHierarchyFacet(array $facetConfiguration, string $fixtureFile)
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse(
@@ -122,9 +120,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         $this->assertNoNodeHasMoreThanOneChildInTheHierarchy($node->getChildNodes()->getByPosition(0));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function selectedOptionWithSlashInTitleOnHierarchicalFacetDoesNotBreakTheFacet()
     {
         $facetConfiguration = [
@@ -164,9 +160,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         self::assertSame(1, $facetOption->getChildNodes()->count(), 'Selected facet-option with slash in title/name breaks the Hierarchical facets.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsNotActive(): void
     {
         $facetConfiguration = [
@@ -187,9 +181,7 @@ class HierarchyFacetParserTest extends SetUpFacetParser
         self::assertFalse($facet->getIsUsed());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsActive(): void
     {
         $facetConfiguration = [

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyUrlDecoder;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -36,9 +37,7 @@ class HierarchyUrlDecoderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseHierarchy3LevelQuery()
     {
         $expected = '"2-sport/skateboarding/street/"';
@@ -47,9 +46,7 @@ class HierarchyUrlDecoderTest extends SetUpUnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseHierarchy3LevelQueryAndEscapedSlashes()
     {
         $expected = '"2-sport/skateboarding\\\\/snowboarding/street/"';
@@ -58,9 +55,7 @@ class HierarchyUrlDecoderTest extends SetUpUnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseHierarchy2LevelQuery()
     {
         $expected = '"1-sport/skateboarding/"';
@@ -69,9 +64,7 @@ class HierarchyUrlDecoderTest extends SetUpUnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseHierarchy1LevelQuery()
     {
         $expected = '"0-sport/"';

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\HierarchyFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase to test the Node class
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class NodeTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHasParentNode()
     {
         $facetMock = $this->createMock(HierarchyFacet::class);
@@ -42,9 +41,7 @@ class NodeTest extends SetUpUnitTestCase
         self::assertSame($parentNode, $node->getParentNode(), 'Node did not return assigend parent node');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHasChildNodeSelectedReturnFalseWhenNoChildNodeWasAssigned()
     {
         $facetMock = $this->createMock(HierarchyFacet::class);
@@ -53,9 +50,7 @@ class NodeTest extends SetUpUnitTestCase
         self::assertFalse($node->getHasChildNodeSelected(), 'Node without childnodes should not indicate that it as a selected child node');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHasChildNodeSelectedReturnFalseWhenNoSelectedChildNodeWasAssigned()
     {
         $facetMock = $this->createMock(HierarchyFacet::class);
@@ -67,9 +62,7 @@ class NodeTest extends SetUpUnitTestCase
         self::assertFalse($node->getHasChildNodeSelected(), 'Node with only unselected childnodes should not indicate that it has a selected child node');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHasChildNodeSelectedReturnTrueWhenSelectedChildNodeWasAssigned()
     {
         $facetMock = $this->createMock(HierarchyFacet::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -34,9 +35,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetManualSortedCopy()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
@@ -58,9 +57,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
         self::assertSame($red, $sortedOptions->getByPosition(2), 'First sorted item was not blue');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLabelPrefixes()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
@@ -83,9 +80,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
         self::assertSame(['r', 'p', 'l'], $labelPrefixes, 'Can not get expected label prefixes');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetByLowercaseLabelPrefix()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
@@ -112,9 +107,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
         self::assertCount(3, $optionsStartingWithR, 'Unexpected amount of options starting with r');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetByLowercaseLabelPrefixWithMultiByteCharacter()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
@@ -131,9 +124,7 @@ class OptionCollectionTest extends SetUpUnitTestCase
         self::assertCount(1, $optionsStartingWithO, 'Unexpected amount of options starting with ø');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetByValueAfterManualSorting()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
@@ -18,12 +18,11 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacetParser;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class OptionsFacetParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canListFloatValuesAsOptionsFromSolrResponse(): void
     {
         $responseAdapter = new ResponseAdapter(

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -27,9 +29,7 @@ use Traversable;
  */
 class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildSortParameter()
     {
         /**
@@ -69,9 +69,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildLimitParameter()
     {
         /**
@@ -105,9 +103,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildLimitParameterFromGlobalSetting()
     {
         /**
@@ -144,9 +140,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildMincountParameter()
     {
         /**
@@ -187,10 +181,8 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         yield ['configuredMinimumCount' => null, 'expectedMinimumCount' => 1];
     }
 
-    /**
-     * @dataProvider getGlobalMinimumCountValue
-     * @test
-     */
+    #[DataProvider('getGlobalMinimumCountValue')]
+    #[Test]
     public function canBuildMincountParameterFromGlobalSetting($configuredMinimumCount, $expectedMinimumCount)
     {
         /**
@@ -227,9 +219,7 @@ class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildMetricsParameter()
     {
         /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -19,6 +19,8 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -36,9 +38,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTitleFromOptionsFacet()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -46,9 +46,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from options facet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddOptionsToFacet()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -65,9 +63,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         self::assertEquals(1, $optionsFacet->getOptions()->getCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDefaultPartialName()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -76,9 +72,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         self::assertEquals('Options', $queryGroupFacet->getPartialName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCustomPartialName()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -87,9 +81,7 @@ class OptionsFacetTest extends SetUpUnitTestCase
         self::assertEquals('MyPartial', $queryGroupFacet->getPartialName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getType()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -107,10 +99,8 @@ class OptionsFacetTest extends SetUpUnitTestCase
         yield '0' => ['0', false];
     }
 
-    /**
-     * @dataProvider getIncludeInAvailableFacetsDataProvider
-     * @test
-     */
+    #[DataProvider('getIncludeInAvailableFacetsDataProvider')]
+    #[Test]
     public function getIncludeInAvailableFacetsCastsSettingsToBoolProperly(
         null|int|string $includeInAvailableFacetsConfiguration,
         bool $expectedResult,

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGrou
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test for the QueryGroupFacet options collection
@@ -28,9 +29,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class OptionCollectionTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetManualSortedCopy()
     {
         $searchResultSetMock = $this->createMock(SearchResultSet::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacetParser;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class QueryGroupFacetParserTest
@@ -69,9 +70,7 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
         return $searchResultSet;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsCreated()
     {
         $facetConfiguration = [
@@ -99,9 +98,7 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
         self::assertInstanceOf(QueryGroupFacet::class, $facet);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsNotActive()
     {
         $facetConfiguration = [
@@ -130,9 +127,7 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
         self::assertFalse($facet->getIsUsed());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsActive()
     {
         $facetConfiguration = [
@@ -161,9 +156,7 @@ class QueryGroupFacetParserTest extends SetUpFacetParser
         self::assertTrue($facet->getIsUsed());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function optionIsActive()
     {
         $facetConfiguration = [

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Opti
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the dateRange queryBuilder
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildQueryGroupFacetWithKeepAllOptionsOnSelection()
     {
         /**
@@ -68,9 +67,7 @@ class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildQueryGroupFacetWithKeepAllFacetsOnSelection()
     {
         /**
@@ -120,9 +117,7 @@ class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
         self::assertSame($expectedFacetParameters, $facetParameters, 'Can not build facet parameters as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuild()
     {
         /**

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGrou
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGroup\QueryGroupFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -40,9 +41,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTitleFromOptionsFacet()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -50,9 +49,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
         self::assertSame('myTitle', $optionsFacet->getLabel(), 'Could not get title from queryGroup facet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddOptionsToFacet()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -69,9 +66,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
         self::assertEquals(1, $queryGroupFacet->getOptions()->getCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDefaultPartialName()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -80,9 +75,7 @@ class QueryGroupFacetTest extends SetUpUnitTestCase
         self::assertEquals('Options', $queryGroupFacet->getPartialName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCustomPartialName()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacetParser;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class DateRangeFacetParserTest
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacet
  */
 class DateRangeFacetParserTest extends SetUpFacetParser
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsCreated()
     {
         $facetConfiguration = [

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the dateRange queryBuilder
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class DateRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuild()
     {
         $fakeFacetConfiguration = [

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -22,15 +22,14 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use DateTime;
 use Error;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class DateRangeTest
  */
 class DateRangeTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleHalfOpenDateRanges()
     {
         $dateTime = new DateTime('2021-07-20 16:04:21.000000');

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\DateRange\DateRangeUrlDecoder;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -37,9 +38,7 @@ class DateRangeUrlDecoderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseDateRangeQuery()
     {
         $expected = '[2010-01-01T00:00:00Z TO 2010-01-31T23:59:59Z]';
@@ -47,9 +46,7 @@ class DateRangeUrlDecoderTest extends SetUpUnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseMinOpenDateRangeQuery()
     {
         $expected = '[* TO 2010-01-31T23:59:59Z]';
@@ -57,9 +54,7 @@ class DateRangeUrlDecoderTest extends SetUpUnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseMaxOpenDateRangeQuery()
     {
         $expected = '[2010-01-01T00:00:00Z TO *]';

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
@@ -20,6 +20,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacetParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\SetUpFacetParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -70,9 +72,7 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
         return $facet;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetIsCreated()
     {
         $facetConfiguration = $this->getPageIdFacetConfiguration();
@@ -103,10 +103,9 @@ class NumericRangeFacetParserTest extends SetUpFacetParser
 
     /**
      * Test the parsing of the active range values
-     *
-     * @dataProvider canParseActiveFacetValuesProvider
-     * @test
      */
+    #[DataProvider('canParseActiveFacetValuesProvider')]
+    #[Test]
     public function canParseActiveFacetValues(int $startRequested, int $endRequested): void
     {
         $facetConfiguration = $this->getPageIdFacetConfiguration();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeFacetQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the numericRange queryBuilder
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class NumericRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuild()
     {
         $fakeFacetConfiguration = [

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rang
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RangeBased\NumericRange\NumericRangeUrlDecoder;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -56,13 +58,13 @@ class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
     /**
      * Test the filter decoding
      *
-     * @dataProvider rangeQueryParsingDataProvider
-     * @test
      *
      * @param string $firstValue
      * @param string $secondValue
      * @param string $expectedResult
      */
+    #[DataProvider('rangeQueryParsingDataProvider')]
+    #[Test]
     public function canParseRangeQuery(string $firstValue, string $secondValue, string $expectedResult)
     {
         $actual = $this->rangeParser->decode($firstValue . '-' . $secondValue);
@@ -71,9 +73,8 @@ class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
 
     /**
      * Test the handling of invalid parameters
-     *
-     * @test
      */
+    #[Test]
     public function canHandleInvalidParameters()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Rend
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RenderingInstructions\FormatDate;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -31,9 +32,9 @@ class FormatDateTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
      * @throws Exception
      */
+    #[Test]
     public function canFormatUsingDefaultFormat()
     {
         $processingInstruction = new FormatDate();
@@ -42,10 +43,9 @@ class FormatDateTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function canPassCustomOutputFormat()
     {
         $processingInstruction = new FormatDate();
@@ -54,10 +54,9 @@ class FormatDateTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function canParseTimestampAsInputValue()
     {
         $processingInstruction = new FormatDate();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\RequirementsService;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -35,9 +36,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRequirementsMetReturnTrueWhenNothingConfigured()
     {
         $facet = $this->createMock(OptionsFacet::class);
@@ -45,9 +44,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertTrue($service->getAllRequirementsMet($facet), 'Facet without any requirements should met all requirements');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsFalseWhenARequirementIsNotMet()
     {
         $resultSet = new SearchResultSet();
@@ -69,9 +66,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement is not met');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsTrueWhenRequirementIsMet()
     {
         $resultSet = new SearchResultSet();
@@ -98,9 +93,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color option is present, but is indicated to not be met');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsTrueWhenRequirementIsMetForMultipleFacets()
     {
         $resultSet = new SearchResultSet();
@@ -135,9 +128,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertTrue($service->getAllRequirementsMet($categoryFacet), 'Requirement should be met, because color and size option is present, but is indicated to not be met');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsFalseWhenOnlyOneConfiguredRequirementIsMet()
     {
         $resultSet = new SearchResultSet();
@@ -169,9 +160,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met since the matchesSize requirement is not met.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsFalseWhenRequiredFacetHasADifferentValue()
     {
         $resultSet = new SearchResultSet();
@@ -197,9 +186,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the facet has not the require value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllRequirementsMetIsReturnsFalseIfRequiredFacetValueIsNotSelected()
     {
         $resultSet = new SearchResultSet();
@@ -225,9 +212,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         self::assertFalse($service->getAllRequirementsMet($categoryFacet), 'Requirement should not be met because the required option is not selected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionIsThrownForRequirementWithNotExistingFacet()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -248,9 +233,7 @@ class RequirementsServiceTest extends SetUpUnitTestCase
         $service->getAllRequirementsMet($categoryFacet);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNegateRequirementsResult()
     {
         $resultSet = new SearchResultSet();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -19,6 +19,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\SortingExpression;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -79,9 +81,9 @@ class SortingExpressionTest extends SetUpUnitTestCase
      * @param string $direction
      * @param bool $isJson
      * @param string $expectedResult
-     * @dataProvider canBuildSortExpressionDataProvider
-     * @test
      */
+    #[DataProvider('canBuildSortExpressionDataProvider')]
+    #[Test]
     public function canBuildSortExpression($sorting, string $direction, bool $isJson, string $expectedResult)
     {
         $expression = new SortingExpression();

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\UrlFacetContainer;
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcases for the url data bag
@@ -53,9 +54,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         ],
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFilterIndexFacetsParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
@@ -63,9 +62,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFilterAssocFacetsParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(
@@ -76,9 +73,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveAllIndexFacetsParameter()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
@@ -87,9 +82,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(0, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveAllAssocFacetsParameter()
     {
         $urlFacetBack = new UrlFacetContainer(
@@ -102,9 +95,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(0, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveAllFacetsParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
@@ -113,9 +104,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(1, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveAllAssocFacetsParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(
@@ -128,9 +117,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(1, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveASingleFacetParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
@@ -139,9 +126,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(3, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveASingleAssocFacetParameterByName()
     {
         $urlFacetBack = new UrlFacetContainer(
@@ -153,18 +138,14 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(3, $urlFacetBack->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function keepOrderingOfIndexParameters()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
         self::assertEquals(['pages', 'example', 'news'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSortIndexParameters()
     {
         $urlFacetBack = new UrlFacetContainer(new ArrayAccessor($this->indexParameters));
@@ -172,9 +153,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         self::assertEquals(['example', 'news', 'pages'], $urlFacetBack->getActiveFacetValuesByName('type'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function didNotKeepOrderingOfAssocParameters()
     {
         $urlFacetBack = new UrlFacetContainer(
@@ -188,9 +167,7 @@ class UrlFacetContainerTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assocParametersSortedByDefault()
     {
         $urlFacetBack = new UrlFacetContainer(

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Grouping;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\Group;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupCollection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the GroupCollection class
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class GroupCollectionTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetByGroupName()
     {
         $groupA = new Group('type');
@@ -44,9 +43,7 @@ class GroupCollectionTest extends SetUpUnitTestCase
         self::assertNull($groupCollection->getByName('unexisting'), 'Could not get groupByName');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroupNames()
     {
         $groupA = new Group('type');
@@ -61,9 +58,7 @@ class GroupCollectionTest extends SetUpUnitTestCase
         self::assertSame(['type', 'color', 'price'], $groupCollection->getGroupNames(), 'Could not get groupNames');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHasWithName()
     {
         $groupA = new Group('price');

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the Group class
@@ -52,49 +53,37 @@ class GroupItemTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetMaximumScore()
     {
         self::assertSame(99.0, $this->groupItem->getMaximumScore(), 'Unexpected maximumScore');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetStart()
     {
         self::assertSame(1, $this->groupItem->getStart(), 'Unexpected start');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetNumFound()
     {
         self::assertSame(12, $this->groupItem->getAllResultCount(), 'Unexpected numFound');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroupValue()
     {
         self::assertSame('pages', $this->groupItem->getGroupValue(), 'Unexpected groupValue');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroup()
     {
         self::assertSame($this->parentGroup, $this->groupItem->getGroup(), 'Unexpected parentGroup');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchResults()
     {
         self::assertSame(0, $this->groupItem->getSearchResults()->getCount());

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the Group class
@@ -28,9 +29,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class GroupTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanGroupName()
     {
         $group = new Group('typeGroup');
@@ -40,18 +39,14 @@ class GroupTest extends SetUpUnitTestCase
         self::assertSame('changedTypeGroup', $group->getGroupName(), 'Can not getGroupName from group');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroupItemsReturnEmptyCollection()
     {
         $group = new Group('typeGroup');
         self::assertSame(0, $group->getGroupItems()->getCount(), 'Can not get empty groupItem collection');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetResultsPerPage()
     {
         $group = new Group('typeGroup', 22);
@@ -61,9 +56,7 @@ class GroupTest extends SetUpUnitTestCase
         self::assertSame(11, $group->getResultsPerPage(), 'Can not get results per page');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetGroupItems()
     {
         $group = new Group('typeGroup', 10);
@@ -83,9 +76,7 @@ class GroupTest extends SetUpUnitTestCase
         self::assertSame($groupItems, $group->getGroupItems(), 'Can not get group items from group');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddGroupItem()
     {
         $group = new Group('typeGroup', 10);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Component\Grouping;
 
@@ -42,9 +43,7 @@ class DefaultParserTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parseWillCreateResultCollectionFromSolrResponse(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
@@ -57,9 +56,7 @@ class DefaultParserTest extends SetUpUnitTestCase
         self::assertCount(3, $parsedResultSet->getSearchResults());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnsResultSetWithResultCount(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
@@ -72,9 +69,7 @@ class DefaultParserTest extends SetUpUnitTestCase
         self::assertSame(10, $parsedResultSet->getAllResultCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parseWillSetMaximumScore(): void
     {
         $fakeResultSet = $this->getMockBuilder(SearchResultSet::class)->onlyMethods(['getResponse'])->getMock();
@@ -87,9 +82,7 @@ class DefaultParserTest extends SetUpUnitTestCase
         self::assertSame(3.1, $parsedResultSet->getMaximumScore());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseReturnsFalseWhenGroupingIsEnabled(): void
     {
         $requestMock = $this->createMock(SearchRequest::class);
@@ -105,9 +98,7 @@ class DefaultParserTest extends SetUpUnitTestCase
         self::assertFalse($this->parser->canParse($fakeResultSet));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseReturnsTrueWhenGroupingIsDisabled(): void
     {
         $requestMock = $this->createMock(SearchRequest::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase to test the GroupedResultsParser.
@@ -30,9 +31,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class GroupedResultsParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canParsedQueryGroupResult()
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -61,9 +60,7 @@ class GroupedResultsParserTest extends SetUpUnitTestCase
         self::assertSame(3, $queryGroup->getCount(), 'Unexpected amount of groups in parsing result');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParsedQueryFieldResult()
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result\Pars
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\ResultParserRegistry;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the ResultParserRegistryTest.
@@ -37,9 +38,7 @@ class ResultParserRegistryTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRegisterAndRetrieveParserWithAHigherPriority()
     {
         $fakeResultSet = $this->createMock(SearchResultSet::class);
@@ -48,9 +47,7 @@ class ResultParserRegistryTest extends SetUpUnitTestCase
         self::assertInstanceOf(TestResultParser::class, $retrievedParser, 'Did not retrieve register custom parser with higher priority');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasParser()
     {
         $this->registry->registerParser(TestResultParser::class, 200);

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\Group;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Grouping\GroupCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultCollection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the SearchResultCollection.
@@ -38,17 +39,13 @@ class SearchResultCollectionTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getHasGroupsReturnsFalseByDefault()
     {
         self::assertFalse($this->searchResultCollection->getHasGroups());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getHasGroupsReturnsTrueWhenGroupsExist()
     {
         $groupA = new Group('foo');
@@ -56,9 +53,7 @@ class SearchResultCollectionTest extends SetUpUnitTestCase
         self::assertTrue($this->searchResultCollection->getHasGroups());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetAndGetGroupCollection()
     {
         $groupCollection = new GroupCollection();

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Result;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the SearchResult.
@@ -44,9 +45,7 @@ class SearchResultTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetId(): void
     {
         self::assertSame(
@@ -56,9 +55,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetScore(): void
     {
         self::assertSame(
@@ -68,9 +65,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetContent(): void
     {
         self::assertSame(
@@ -80,9 +75,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetType(): void
     {
         self::assertSame(
@@ -92,9 +85,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTitle(): void
     {
         self::assertSame(
@@ -104,9 +95,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetUrl(): void
     {
         self::assertSame(
@@ -116,9 +105,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIsElevated(): void
     {
         self::assertTrue(
@@ -127,9 +114,7 @@ class SearchResultTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOnUnexistingFieldReturnsNull(): void
     {
         self::assertNull(

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -48,9 +49,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         return $searchResultSet;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteSpellCheckingModelsFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck.json');
@@ -66,9 +65,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertTrue($searchResultSet->getHasSpellCheckingSuggestions());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteFacetModelFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_one_fields_facet.json');
@@ -94,9 +91,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(1, $searchResultSet->getFacets());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteJsonFacetModelFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_jsonfacets.json');
@@ -130,9 +125,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame(19, $optionFacet->getOptions()->getByPosition(0)->getDocumentCount(), 'Custom type facet count not correct');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteFacetModelsFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -163,9 +156,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(2, $searchResultSet->getFacets());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSkipOptionsMarkedAsExcludeValue(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -196,9 +187,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('event', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Skipping configured value not working as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetRequirementsMetToFalseOnFacetThatMissesARequirement(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -239,9 +228,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertFalse($firstFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetRequirementsMetToTrueOnFacetThatFullFillsARequirement(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -289,9 +276,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertTrue($secondFacet->getAllRequirementsMet(), 'Unexpected state of allRequirementsMet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -322,9 +307,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('event', $option2->getValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrderWhenReversOrderIsApplied(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -356,9 +339,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('page', $option2->getValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrderWhenManualSortOrderIsApplied(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -390,9 +371,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('page', $option2->getValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteFacetModelsWithSameFieldNameFromResponse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -430,9 +409,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(2, $facets->getByPosition(0)->getOptions());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReconstituteUsedFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -482,9 +459,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertFalse($facet2->getIsUsed());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMarkUsedOptionAsSelected(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -526,9 +501,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(1, $facets->getUsed(), 'and also "type" is the only used facet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function includeIsUsedFacetsCanBeSetToFalse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -565,9 +538,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(0, $facets->getUsed(), 'we should have 0 used facets because type has configuration includeInUsedFacets=0');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetConfiguredFacetNotInResponseAsUnavailableFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -609,9 +580,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $this->asserttrue($firstOption->getSelected());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTwoUsedFacetOptions(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_two_used_facets.json');
@@ -656,9 +625,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertTrue($firstOption->getSelected());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyFacetsAreNotReconstitutedWhenDisabled(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -690,9 +657,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(1, $facets, 'we have two facets at all');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyFacetIsKeptWhenNothingIsConfiguredGloballyButKeepingIsEnabledOnFacetLevel(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -724,9 +689,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(2, $facets, 'we have two facets at all');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function includeInAvailableFacetsCanBeSetToFalse(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -754,9 +717,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(0, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function includeInAvailableFacetsCanBeSetToTrue(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_used_facet.json');
@@ -784,9 +745,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(1, $facets->getAvailable(), 'but non is available, the first is set to includeInAvailableFacets=0');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function labelCanBeConfiguredAsAPlainText(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
@@ -812,9 +771,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('My Type with special rendering', $facet->getLabel(), 'Could not get label for facet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnsCorrectSetUpFacetTypeForAQueryGroupFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
@@ -855,9 +812,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(3, $facet->getOptions());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrderForQueryGroupFacet(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
@@ -902,9 +857,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrderForQueryGroupFacetWithManualSortOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
@@ -950,9 +903,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('old', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOptionsInExpectedOrderForQueryGroupFacetWithReversOrder(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
@@ -998,9 +949,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('month', $thirdValue, 'Could not get values in expected order from QueryGroupFacet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnsResultSetWithConfiguredSortingOptions(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');
@@ -1031,9 +980,7 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertTrue($searchResultSet->getSortings()->getHasSelected(), 'The sorting by "relevance/score" is active but not marked as selected.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnSortingsAndMarkedSelectedAsActive(): void
     {
         $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_query_fields_facets.json');

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Solarium\Component\Grouping;
@@ -60,9 +61,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchIsNotTriggeredWhenEmptySearchDisabledAndEmptyQueryWasPassed(): void
     {
         $searchRequest = new SearchRequest();
@@ -72,9 +71,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
         self::assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchIsNotTriggeredWhenEmptyQueryWasPassedAndEmptySearchWasDisabled(): void
     {
         $searchRequest = new SearchRequest();
@@ -84,9 +81,7 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
         self::assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateGroups(): void
     {
         // source: http://solr-ddev-site.ddev.site:8983/solr/core_en/select

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -31,6 +31,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
@@ -75,9 +76,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSearchIfFiredWithInitializedQuery(): void
     {
         // we expect the ->search method on the Search object will be called once
@@ -94,9 +93,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
-    /**
-    * @test
-    */
+    #[Test]
     public function testOffsetIsPassedAsExpectedWhenSearchWasPaginated(): void
     {
         $fakeResponse = $this->createMock(ResponseAdapter::class);
@@ -110,9 +107,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testComponentAsEventListenerGetsInitialized(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchConfiguration')->willReturn([]);
@@ -133,9 +128,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         self::assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRegisterSearchResultSetProcessor(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchQueryReturnFieldsAsArray')->willReturn(['*']);
@@ -163,9 +156,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         self::assertSame('PAGES', $firstResult->getType(), 'Could not get modified type from result');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAdditionalFiltersGetPassedToTheQuery(): void
     {
         $fakeResponse = $this->createMock(ResponseAdapter::class);
@@ -186,9 +177,7 @@ class SearchResultSetTest extends SetUpUnitTestCase
         self::assertSame(count($resultSet->getUsedQuery()->getFilterQueries()), 1, 'There should be one registered filter in the query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testExpandedDocumentsGetAddedWhenVariantsAreConfigured(): void
     {
         // we fake that collapsing is enabled

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
@@ -18,15 +18,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Sorting;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\SortingHelper;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class SortingHelperTest
  */
 class SortingHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSortFieldFromUrlParameter()
     {
         $sortConfiguration = [
@@ -45,9 +44,7 @@ class SortingHelperTest extends SetUpUnitTestCase
         self::assertSame('sortTitle desc, type asc', $sortField);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canThrowExceptionForUnconfiguredSorting()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Sorting\Sorting;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
@@ -51,50 +52,38 @@ class SortingTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNotCreateWhenInvalidDirectionIsPassed()
     {
         $this->expectException(InvalidArgumentException::class);
         new Sorting($this->resultSetMock, 'Color', 'color_s', 'invalid direction', 'the color', false, false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetName()
     {
         self::assertSame('Price', $this->sorting->getName(), 'Could not get name from sorting');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLabel()
     {
         self::assertSame('the príce', $this->sorting->getLabel(), 'Could not get label from sorting');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetField()
     {
         self::assertSame('price_f', $this->sorting->getField(), 'Could not get field from sorting');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetDirection()
     {
         self::assertSame('asc', $this->sorting->getDirection(), 'Could not get direction');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetOppositeDirection()
     {
         self::assertSame('desc', $this->sorting->getOppositeDirection(), 'Could not get opposite direction');
@@ -103,25 +92,19 @@ class SortingTest extends SetUpUnitTestCase
         self::assertSame('asc', $descSorting->getOppositeDirection(), 'Could not get opposite direction');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGetIsAsDirection()
     {
         self::assertTrue($this->sorting->getIsAscDirection(), 'Sorting direction was not handled as ascending');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGetIsDescDirection()
     {
         self::assertFalse($this->sorting->getIsDescDirection(), 'Sorting should be indicated to not be descending');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIsResetOption()
     {
         self::assertFalse($this->sorting->getIsResetOption(), 'Sorting options should not be a reset option');

--- a/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
+++ b/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\Score;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Score\ScoreCalculationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Schmidt <timo.schmidt@dkd.de>
@@ -34,9 +35,7 @@ class ScoreCalculationServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetRenderedScoreAnalysis()
     {
         $fakeDebugData = self::getFixtureContentByName('fakeSolrDebugData.txt');

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -39,9 +40,7 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testPageIsResettedWhenValidResultsPerPageValueWasPassed(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')
@@ -59,9 +58,7 @@ class SearchRequestBuilderTest extends SetUpUnitTestCase
         self::assertSame($request->getPage(), null, 'Page was not resetted.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testPerPageValueIsNotSetInSession(): void
     {
         $this->configurationMock->expects(self::once())->method('getSearchResultsPerPageSwitchOptionsAsArray')

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Schmidt <timo.schmidt@dkd.de>
@@ -35,17 +36,13 @@ class SearchRequestTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetPageIsNullWhenNothingWasPassed()
     {
         self::assertNull($this->searchRequest->getPage(), 'Page was expected to be null');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanMerge()
     {
         $this->searchRequest = new SearchRequest(['tx_solr' => ['page' => 2]]);
@@ -55,9 +52,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame(8, $this->searchRequest->getPage(), 'Page was not properly merged');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetActiveFilterNames()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
@@ -65,9 +60,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertEquals(['type'], $request->getActiveFacetNames());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetRawQueryString()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
@@ -75,9 +68,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertEquals('typo3', $request->getRawUserQuery());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQueryString()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -85,9 +76,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertEquals(['tx_solr' => ['q' => 'foobar']], $data, 'The argument container did not contain the expected argument');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddOneFacet()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -97,9 +86,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddManyFacets()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -111,9 +98,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments, 'Adding a facet did not product the expected structure');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canAddFacetsAndQuery()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -126,9 +111,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments, 'Could not set a query and add a facet at the same time');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReset()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -137,9 +120,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments, 'Could not reset arguments');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetCopyForSubRequest()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -157,9 +138,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments, 'Could not reset arguments');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nonPersistentArgumentsGetLostForSubRequest()
     {
         $request = $this->getSearchRequestFromQueryString('');
@@ -177,27 +156,21 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame($arguments, $expectedArguments);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetContextSystemLanguageUidPassedOnCreation()
     {
         $request = new SearchRequest([], 111, 4711);
         self::assertSame($request->getContextSystemLanguageUid(), 4711, 'Can get initial passed sys_language_uid');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetContextPageUidPassedOnCreation()
     {
         $request = new SearchRequest([], 111, 4711);
         self::assertSame($request->getContextPageUid(), 111, 'Can get initial passed page_uid');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveFacetValue()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages';
@@ -208,9 +181,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertFalse($request->getHasFacetValue('type', 'pages'), 'Could not remove facet value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetFacetValues()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Anews';
@@ -218,9 +189,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertEquals(['pages', 'news'], $request->getActiveFacetValuesByName('type'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveAllFacets()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents';
@@ -230,9 +199,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame(0, $request->getActiveFacetCount(), 'Expected to have no active facets');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveFacetsByName()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bfilter%5D%5B0%5D=type%253Apages&tx_solr%5Bfilter%5D%5B1%5D=type%253Aevents&tx_solr%5Bfilter%5D%5B2%5D=created%253A1-4';
@@ -242,9 +209,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame(1, $request->getActiveFacetCount(), 'Only 1 facet should remain active');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSortingField()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
@@ -254,9 +219,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame('asc', $request->getSortingDirection(), 'Expected sorting direction was asc');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemoveSorting()
     {
         $query = 'tx_solr%5Bq%5D=typo3&tx_solr%5Bsort%5D=title asc';
@@ -273,9 +236,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertFalse(isset($requestAsArray['tx_solr']['sort']), 'Sorting was set but was not expected to be set');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetSorting()
     {
         $query = 'tx_solr%5Bq%5D=typo3';
@@ -286,27 +247,21 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertTrue($request->getHasSorting(), 'Passed query has no sorting');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetHighestGroupItemPageWhenNoPageWasPassed()
     {
         $request = $this->getSearchRequestFromQueryString('');
         self::assertSame(1, $request->getHighestGroupPage(), 'Can not get highest group item page when no group page was passed');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetInitialGroupItemPage()
     {
         $request = $this->getSearchRequestFromQueryString('');
         self::assertSame(1, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not get initial group item page');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetGroupItemPage()
     {
         $query = 'tx_solr%5Bq%5D=typo3';
@@ -316,9 +271,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame(2, $request->getGroupItemPage('typeGroup', 'pages'), 'Can not set and get groupItemPage');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetGroupItemPageForQuery()
     {
         $query = 'tx_solr%5Bq%5D=typo3';
@@ -328,9 +281,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertSame(3, $request->getGroupItemPage('pidGroup', 'pid:[0 to 5]'), 'Can not set and get groupItemPage for a query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canResetAllGroupItemPages()
     {
         $query = 'tx_solr%5Bq%5D=typo3';
@@ -346,18 +297,14 @@ class SearchRequestTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('groupPage', $requestArguments['tx_solr'], 'Expected to have two group pages registered');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoDifferentRequestsHaveADifferentId()
     {
         $newSearchRequest = new SearchRequest();
         self::assertNotEquals($newSearchRequest->getId(), $this->searchRequest->getId(), 'Two different requests seem to have the same id');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setPerPageWillMarkedTheRequestAsChanged()
     {
         self::assertFalse($this->searchRequest->getStateChanged());
@@ -377,9 +324,7 @@ class SearchRequestTest extends SetUpUnitTestCase
         return $request;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetContextTypoScriptConfigurationPassedOnCreation()
     {
         $typoScriptConfiguration = $this->createMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -77,9 +78,7 @@ class StatisticsWriterProcessorTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canWriteExpectedStatisticsData()
     {
         $fakeTSFE = $this->createMock(TypoScriptFrontendController::class);

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -32,6 +32,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
@@ -74,9 +75,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         $this->suggestQueryMock->expects(self::any())->method('getQuery')->willReturn($queryString);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSuggestionsWithoutTopResults(): void
     {
         // the query string is used as prefix but no real query string is passed.
@@ -104,9 +103,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedSuggestions, $suggestions, 'Suggest response did not contain expected content');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleInvalidSyntaxInAdditionalFilters(): void
     {
         $this->assertNoSearchWillBeTriggered();
@@ -144,9 +141,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyJsonIsReturnedWhenSolrHasNoSuggestions(): void
     {
         $this->configurationMock->expects(self::never())->method('getSuggestShowTopResults');
@@ -161,9 +156,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSuggestionsWithTopResults(): void
     {
         $this->configurationMock->expects(self::once())->method('getSuggestShowTopResults')->willReturn(true);

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Yaml\Yaml;
@@ -53,9 +54,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addFacetLinkIsCalledWithSubstitutedArguments(): void
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -71,9 +70,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'foo', 'bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addFacetLinkWillAddAdditionalConfiguredArguments(): void
     {
         $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0:option###']], 'foo' => '###foo###'];
@@ -124,9 +121,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         self::assertEquals('/index.php?id=1&filter=option%3Avalue&foo=bar', $linkBuilderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered(): void
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -150,9 +145,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'red');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function targetPageUidIsPassedWhenSortingIsAdded(): void
     {
         $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
@@ -189,9 +182,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         self::assertEquals('/index.php?id=1&' . urlencode('tx_solr[sort]') . '=' . urlencode('title desc'), $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetRemoveFacetOptionUri(): void
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -218,9 +209,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         $this->searchUrlBuilder->getRemoveFacetValueUri($previousRequest, 'type', 'pages');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetRemoveFacetUri(): void
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -251,9 +240,8 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
 
     /**
      * When a page for a group was set, this should be resetted when a facet is selected.
-     *
-     * @test
      */
+    #[Test]
     public function addFacetUriRemovesPreviousGroupPage(): void
     {
         $configurationMock = $this->createMock(TypoScriptConfiguration::class);
@@ -290,9 +278,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         self::assertSame('/index.php?id=1&tx_solr[filter][0]=type:pages', urldecode($uri), 'Unexpected uri generated');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetGroupPageForQueryGroup(): void
     {
         $expectedArguments = [
@@ -357,10 +343,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
     /*
      * Unit tests for router behaviour
      */
-
-    /**
-     * @test
-     */
+    #[Test]
     public function siteConfigurationModifyUriTest(): void
     {
         $configuration = Yaml::parse(self::getFixtureContentByName('siteConfiguration.yaml'));
@@ -413,9 +396,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         self::assertEquals($linkBuilderResult, $uri);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function siteConfigurationModifyUriKeepUnmappedFilterTest(): void
     {
         $configuration = Yaml::parse(self::getFixtureContentByName('siteConfiguration.yaml'));
@@ -471,9 +452,7 @@ class SearchUriBuilderTest extends SetUpUnitTestCase
         self::assertEquals($linkBuilderResult, $uri);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uriErrorsResultInNonMappedProcessing(): void
     {
         $configuration = Yaml::parse(self::getFixtureContentByName('siteConfiguration.yaml'));

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\UriInterface;
 use Traversable;
 use TYPO3\CMS\Core\Site\Entity\Site;
@@ -41,10 +43,8 @@ class SiteHashServiceTest extends SetUpUnitTestCase
         yield 'nullIsFallingBackToCurrentSiteOnly' => [null, 'solrtesta.local'];
     }
 
-    /**
-     * @dataProvider canResolveSiteHashAllowedSitesDataProvider
-     * @test
-     */
+    #[DataProvider('canResolveSiteHashAllowedSitesDataProvider')]
+    #[Test]
     public function canResolveSiteHashAllowedSites($allowedSitesConfiguration, $expectedAllowedSites)
     {
         $siteLanguageMock = $this->createMock(SiteLanguage::class);
@@ -78,9 +78,7 @@ class SiteHashServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedAllowedSites, $allowedSites, 'resolveSiteHashAllowedSites did not return expected allowed sites');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSiteHashForDomain()
     {
         $oldKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'];

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -55,9 +56,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByRootPageId(): void
     {
         $this->fakeEmptyCache();
@@ -69,9 +68,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         self::assertInstanceOf(Site::class, $site);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSiteByPageId(): void
     {
         $this->fakeEmptyCache();
@@ -84,9 +81,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         self::assertInstanceOf(Site::class, $site);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetFirstAvailableSite(): void
     {
         $this->fakeEmptyCache();
@@ -103,9 +98,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         self::assertInstanceOf(Site::class, $site);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAvailableSites(): void
     {
         $this->fakeEmptyCache();
@@ -120,9 +113,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         self::assertCount(2, $sites, 'We expect to have two sites with two languages');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAllLanguages(): void
     {
         $this->fakeEmptyCache();

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\Event\Variants\AfterVariantIdWasBuiltEvent;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
 
@@ -32,9 +33,7 @@ use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
  */
 class IdBuilderTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildVariantId(): void
     {
         $build = new IdBuilder(new NoopEventDispatcher());
@@ -42,9 +41,7 @@ class IdBuilderTest extends SetUpUnitTestCase
         self::assertSame('c523304ea47711019595d2bb352b623d1db40427/pages/4711', $variantId);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUseCustomEventListener(): void
     {
         $eventDispatcher = new MockEventDispatcher();

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
 
 use ApacheSolrForTypo3\Solr\FieldProcessor\PathToHierarchy;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * tests the path to hierarchy processing
@@ -36,9 +37,7 @@ class PathToHierarchyTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBuildSolrHierarchyString()
     {
         self::assertEquals(

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
 use ApacheSolrForTypo3\Solr\FieldProcessor\Service;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * tests the processing Service class
@@ -45,9 +46,7 @@ class ServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function transformsStringToUppercaseOnSingleValuedField()
     {
         $this->documentMock->setField('stringField', 'stringvalue');
@@ -61,9 +60,7 @@ class ServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function transformsStringToUppercaseOnMultiValuedField()
     {
         $this->documentMock->addField('stringField', 'stringvalue_1');
@@ -78,9 +75,7 @@ class ServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function transformsUnixTimestampToIsoDateOnSingleValuedField()
     {
         $this->documentMock->setField(
@@ -97,9 +92,7 @@ class ServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function transformsUnixTimestampToIsoDateOnMultiValuedField()
     {
         $this->documentMock->addField(
@@ -120,9 +113,7 @@ class ServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function customFieldProcessorTurnsFooIntoBar()
     {
         $this->documentMock->setField('stringField', 'foo');

--- a/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
+++ b/Tests/Unit/FrontendEnvironment/TypoScriptTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\FrontendEnvironment\TypoScript;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -42,9 +43,7 @@ class TypoScriptTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getConfigurationFromPageIdReturnsCachedConfiguration(): void
     {
         $pageId = 12;

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -21,8 +21,10 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbag
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use ReflectionObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -76,9 +78,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_preProcessUHandlesRecordDeletion(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -97,9 +97,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         self::assertEquals(123, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_preProcessIgnoresDraftWorkspace(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -111,9 +109,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         $this->garbageCollector->processCmdmap_preProcess('delete', 'pages', 123, '', $dataHandlerMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessHandlesPageMovement(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -133,9 +129,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         self::assertEquals(1011, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessIgnoresPageMovementInDraftWorkspace(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -148,9 +142,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         $this->garbageCollector->processCmdmap_postProcess('move', 'pages', 1011, '', $dataHandlerMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processDatamap_preProcessFieldArrayStoresRecordData(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -190,7 +182,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
 
         $this->garbageCollector->processDatamap_preProcessFieldArray([], 'tx_foo_bar', 123, $dataHandlerMock);
 
-        $objectReflection = new \ReflectionObject($this->garbageCollector);
+        $objectReflection = new ReflectionObject($this->garbageCollector);
         $property = $objectReflection->getProperty('trackedRecords');
         $property->setAccessible(true);
         $trackedRecords = $property->getValue($this->garbageCollector);
@@ -198,9 +190,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         self::assertEquals($dummyRecord, $trackedRecords['tx_foo_bar'][123]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processDatamap_afterDatabaseOperationsTriggersRecordGarbageCheck(): void
     {
         $GLOBALS['TCA']['tx_foo_bar']['ctrl']['enablecolumns']['fe_group'] = 'fe_group';
@@ -250,9 +240,7 @@ class GarbageCollectorTest extends SetUpUnitTestCase
         self::assertTrue($dispatchedEvent->frontendGroupsRemoved());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectGarbageTriggersGarbageCollection(): void
     {
         $this->garbageHandlerMock

--- a/Tests/Unit/HtmlContentExtractorTest.php
+++ b/Tests/Unit/HtmlContentExtractorTest.php
@@ -16,6 +16,8 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 use ApacheSolrForTypo3\Solr\HtmlContentExtractor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -25,9 +27,7 @@ use Traversable;
  */
 class HtmlContentExtractorTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetTagContent(): void
     {
         $extractor = new HtmlContentExtractor(self::getFixtureContentByName('fixture2.html'));
@@ -69,10 +69,8 @@ class HtmlContentExtractorTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getIndexableContentDataProvider
-     * @test
-     */
+    #[DataProvider('getIndexableContentDataProvider')]
+    #[Test]
     public function canUnifyWhitespacesInIndexableContent($websiteContent, $expectedIndexableContent): void
     {
         $extractor = new HtmlContentExtractor($websiteContent);

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use UnexpectedValueException;
 
@@ -32,9 +34,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isSerializedValueCanHandleCustomContentElements(): void
     {
         $indexingConfiguration = [
@@ -55,9 +55,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
         self::assertFalse(AbstractIndexer::isSerializedValue($indexingConfiguration, 'notConfigured_stringM'), 'Non configured fields should allways be unserialized');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isSerializedValueCanHandleCustomInvalidSerializedValueDetector(): void
     {
         // register invalid detector
@@ -73,9 +71,7 @@ class AbstractIndexerTest extends SetUpUnitTestCase
         AbstractIndexer::isSerializedValue($indexingConfiguration, 'topic_stringM');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isSerializedValueCanHandleCustomValidSerializedValueDetector(): void
     {
         // register invalid detector
@@ -99,9 +95,9 @@ class AbstractIndexerTest extends SetUpUnitTestCase
 
     /**
      * Test that field values can be resolved
-     * @test
-     * @dataProvider indexingDataProvider
      */
+    #[DataProvider('indexingDataProvider')]
+    #[Test]
     public function resolveFieldValue(array $indexingConfiguration, string $solrFieldName, array $data, $expectedValue): void
     {
         $subject = new class () extends AbstractIndexer {};

--- a/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/ManagerTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
 
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\Manager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -34,22 +36,18 @@ class ManagerTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveActionReturnsNullWhenNoHandlerIsRegistered()
     {
         $handler = $this->manager->resolveAction('foo');
         self::assertNull($handler, 'Unregistered action should return null when it will be resolved');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionIsThrownWhenInvalidActionHandlerIsRetrieved()
     {
         Manager::registerFrontendHelper('test', InvalidFakeHelper::class);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $message = InvalidFakeHelper::class . ' is not an implementation of ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\FrontendHelper';
         $this->expectExceptionMessage($message);
         $handler = $this->manager->resolveAction('test');

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -32,7 +32,10 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use Closure;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
 use TYPO3\CMS\Core\Tests\Unit\Fixtures\EventDispatcher\MockEventDispatcher;
@@ -54,10 +57,9 @@ class IndexerTest extends SetUpUnitTestCase
     /**
      * @param int $httpStatus
      * @param bool $itemIndexed
-     *
-     * @test
-     * @dataProvider canTriggerIndexingAndIndicateIndexStatusDataProvider
      */
+    #[DataProvider('canTriggerIndexingAndIndicateIndexStatusDataProvider')]
+    #[Test]
     public function canTriggerIndexingAndIndicateIndexStatus(int $httpStatus, bool $itemIndexed): void
     {
         $writeServiceMock = $this->createMock(SolrWriteService::class);
@@ -142,11 +144,9 @@ class IndexerTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider canGetAdditionalDocumentsDataProvider
-     */
-    public function canGetAdditionalDocuments(\Closure|null $listener, ?string $expectedException, int $expectedResultCount): void
+    #[DataProvider('canGetAdditionalDocumentsDataProvider')]
+    #[Test]
+    public function canGetAdditionalDocuments(Closure|null $listener, ?string $expectedException, int $expectedResultCount): void
     {
         $indexer = $this->getAccessibleMock(
             Indexer::class,
@@ -229,9 +229,9 @@ class IndexerTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
      * @skip
      */
+    #[Test]
     public function indexerAlwaysInitializesTSFE(): void
     {
         self::markTestIncomplete('API has been changed, the test case must be moved, since it is still relevant.');

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -25,9 +27,7 @@ use Traversable;
  */
 class ItemTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetErrors()
     {
         $metaData = ['errors' => 'error during index'];
@@ -38,9 +38,7 @@ class ItemTest extends SetUpUnitTestCase
         self::assertSame('error during index', $errors, 'Can not get errors from queue item');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetType()
     {
         $metaData = ['item_type' => 'pages'];
@@ -58,19 +56,15 @@ class ItemTest extends SetUpUnitTestCase
         yield 'blocked item' => [['item_type' => 'pages', 'indexed' => 5, 'changed' => 4, 'errors' => 'Something bad happened'], Item::STATE_BLOCKED];
     }
 
-    /**
-     * @dataProvider getStateDataProvider
-     * @test
-     */
+    #[DataProvider('getStateDataProvider')]
+    #[Test]
     public function canGetState($metaData, $expectedState)
     {
         $item = new Item($metaData, [], null, $this->createMock(QueueItemRepository::class));
         self::assertSame($expectedState, $item->getState(), 'Can not get state from item as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testHasErrors()
     {
         $item = new Item([], [], null, $this->createMock(QueueItemRepository::class));
@@ -80,9 +74,7 @@ class ItemTest extends SetUpUnitTestCase
         self::assertTrue($item->getHasErrors(), 'Item with errors was not indicated to have errors');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testHasIndexingProperties()
     {
         $item = new Item([], [], null, $this->createMock(QueueItemRepository::class));

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -33,9 +34,7 @@ use TYPO3\CMS\Core\Http\RequestFactory;
  */
 class PageIndexerRequestTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function authenticatesValidRequest()
     {
         $jsonEncodedParameters = json_encode([
@@ -48,9 +47,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertTrue($request->isAuthenticated());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotAuthenticateInvalidRequest()
     {
         $jsonEncodedParameters = json_encode([
@@ -63,9 +60,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertFalse($request->isAuthenticated());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function usesUniqueIdFromHeader()
     {
         $id = uniqid();
@@ -77,9 +72,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertEquals($id, $request->getRequestId());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sendCreatesExpectedResponse()
     {
         $testParameters = json_encode(['requestId' => '581f76be71f60']);
@@ -99,9 +92,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertSame($response->getRequestId(), '581f76be71f60', 'Response did not contain expected requestId');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sendThrowsExceptionOnIsMismatch()
     {
         $testParameters = json_encode(['requestId' => 'wrongId']);
@@ -118,9 +109,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $requestMock->send('http://7.6.local.typo3.org/about/typo3/');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sendThrowsExceptionWhenInvalidJsonIsReturned()
     {
         $testParameters = json_encode(['requestId' => 'wrongId']);
@@ -136,9 +125,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $requestMock->send('http://7.6.local.typo3.org/about/typo3/');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetTimeOutFromPHPConfiguration()
     {
         $initialTimeout = ini_get('default_socket_timeout');
@@ -149,9 +136,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         ini_set('default_socket_timeout', $initialTimeout);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSendRequestToSslSite()
     {
         $testParameters = json_encode(['requestId' => '581f76be71f60']);
@@ -165,9 +150,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $requestMock->send('https://7.6.local.typo3.org/about/typo3/');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function authenticationHeaderIsSetWhenUsernameAndPasswordHaveBeenPassed()
     {
         /** @var MockObject|RequestFactory $requestFactoryMock */
@@ -195,9 +178,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $pageIndexerRequest->send('https://7.6.local.typo3.org/about/typo3/');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetParameter()
     {
         $pageIndexerRequest = $this->getPageIndexerRequest();
@@ -210,9 +191,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         self::assertSame(4711, $pageIndexerRequest->getParameter('test'), 'Could not get parameter foo after setting it');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetUserAgent()
     {
         $pageIndexerRequest = $this->getPageIndexerRequest();

--- a/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerResponseTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue;
 
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -28,9 +29,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PageIndexerResponseTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getResultReturnsSingleResult()
     {
         $action = 'testAction';
@@ -42,9 +41,7 @@ class PageIndexerResponseTest extends SetUpUnitTestCase
         self::assertEquals($result, $request->getActionResult($action));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getResultReturnsAllResults()
     {
         $request = GeneralUtility::makeInstance(PageIndexerResponse::class);

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
@@ -75,9 +76,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         return $pageIndexer;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testIndexPageItemIsSendingFrontendRequestsToExpectedUrls(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solr'] = [];

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwapp
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -74,9 +75,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_preProcessUHandlesDeletedContentElements(): void
     {
         $dispatchedEvent = null;
@@ -93,9 +92,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(123, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_preProcessIgnoresDraftWorkspace(): void
     {
         $GLOBALS['BE_USER']->workspace = 1;
@@ -105,9 +102,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         $this->recordMonitor->processCmdmap_preProcess('delete', 'tt_content', 123);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfPageRecord(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -126,9 +121,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(4711, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessUpdatesQueueItemForVersionSwapOfRecord(): void
     {
         $dispatchedEvent = null;
@@ -145,9 +138,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(888, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecord(): void
     {
         $dispatchedEvent = null;
@@ -164,9 +155,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(4711, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfPageRecordInDraftWorkspace(): void
     {
         $GLOBALS['BE_USER']->workspace = 1;
@@ -177,9 +166,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         $this->recordMonitor->processCmdmap_postProcess('move', 'pages', 4711, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCmdmap_postProcessUpdatesQueueItemForMoveOfRecord(): void
     {
         $dispatchedEvent = null;
@@ -196,10 +183,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(888, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     * For more infos, please refer https://github.com/TYPO3-Solr/ext-solr/pull/2836
-     */
+    #[Test]
     public function processDatamap_afterDatabaseOperationsUsesAlreadyResolvedNextAutoIncrementValueForNewStatus(): void
     {
         $dataHandlerMock = $this->createMock(DataHandler::class);
@@ -218,10 +202,7 @@ class RecordMonitorTest extends SetUpUnitTestCase
         self::assertEquals(4711, $dispatchedEvent->getUid());
     }
 
-    /**
-     * @test
-     * For more infos, please refer https://github.com/TYPO3-Solr/ext-solr/pull/2836
-     */
+    #[Test]
     public function processDatamap_afterDatabaseOperationsUsesNotYetResolvedNextAutoIncrementValueForNewStatus(): void
     {
         $newId = 'NEW1';

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -22,6 +22,8 @@ use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -39,6 +41,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
+#[CoversClass(\ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::class)]
 class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
 {
     protected RoutingService|MockObject $routingServiceMock;
@@ -72,10 +75,7 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::process
-     */
+    #[Test]
     public function missingEnhancerHasNoEffectTest(): void
     {
         $serverRequest = new ServerRequest(
@@ -130,10 +130,7 @@ class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Middleware\SolrRoutingMiddleware::process
-     */
+    #[Test]
     public function enhancerInactiveDuringIndexingTest(): void
     {
         $serverRequest = new ServerRequest(

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Report;
 
 use ApacheSolrForTypo3\Solr\Report\SolrConfigurationStatus;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Reports\Status;
@@ -46,9 +47,7 @@ class SolrConfigurationStatusTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetEmptyResultWhenEverythingIsOK(): void
     {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];
@@ -64,9 +63,7 @@ class SolrConfigurationStatusTest extends SetUpUnitTestCase
         $this->report->getStatus();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetViolationWhenSolrIsEnabledButIndexingNot(): void
     {
         $fakedRootPages =  [1 => ['uid' => 1, 'title' => 'My Siteroot']];

--- a/Tests/Unit/Routing/RoutingServiceTest.php
+++ b/Tests/Unit/Routing/RoutingServiceTest.php
@@ -19,6 +19,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Routing;
 
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -30,6 +32,7 @@ use TYPO3\CMS\Core\Site\Entity\Site;
  *
  * @author Lars Tode <lars.tode@dkd.de>
  */
+#[CoversClass(\ApacheSolrForTypo3\Solr\Routing\RoutingService::class)]
 class RoutingServiceTest extends SetUpUnitTestCase
 {
     /**
@@ -47,10 +50,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::getDefaultMultiValueSeparator
-     */
+    #[Test]
     public function defaultValueSeparatorIsAvailableTest()
     {
         $routingService = new RoutingService([]);
@@ -61,10 +61,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::getDefaultMultiValueSeparator
-     */
+    #[Test]
     public function canOverrideValueSeparatorTest()
     {
         $routingService = new RoutingService(
@@ -79,10 +76,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::facetsToString
-     */
+    #[Test]
     public function combinedFacetsAreInAlphabeticOrderTest()
     {
         $routingService = new RoutingService([]);
@@ -93,10 +87,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::facetsToString
-     */
+    #[Test]
     public function combiningFacetsUsingCustomSeparatorTest()
     {
         $routingService = new RoutingService(
@@ -111,10 +102,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::convertStringIntoUri
-     */
+    #[Test]
     public function canConvertStringToUriTest()
     {
         $routingService = new RoutingService();
@@ -137,10 +125,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         return $routingService;
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::concatQueryParameter
-     */
+    #[Test]
     public function testDeflateFilterQueryParameterTest()
     {
         $routingService = $this->getRoutingService();
@@ -180,10 +165,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::inflateQueryParameter
-     */
+    #[Test]
     public function testInflateFilterQueryParameterTest()
     {
         $routingService = $this->getRoutingService();
@@ -223,10 +205,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::maskQueryParameters
-     */
+    #[Test]
     public function testIfFilterParametersCanBeMaskedTest()
     {
         $routingService = $this->getRoutingService();
@@ -262,10 +241,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::maskQueryParameters
-     */
+    #[Test]
     public function testIfFilterParametersCanBeUnmaskedTest()
     {
         $routingService = $this->getRoutingService();
@@ -301,10 +277,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::addPathArgumentsToQuery
-     */
+    #[Test]
     public function testIfPathParametersMovedInfoQueryParameters()
     {
         $uri = new Uri('http://domain.example/');
@@ -332,10 +305,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::addPathArgumentsToQuery
-     */
+    #[Test]
     public function testIfMultiplePathParametersMovedInfoQueryParameters()
     {
         $uri = new Uri('http://domain.example/');
@@ -363,10 +333,7 @@ class RoutingServiceTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @covers \ApacheSolrForTypo3\Solr\Routing\RoutingService::addPathArgumentsToQuery
-     */
+    #[Test]
     public function testIfMultiplePathParametersAndMaskedParametersMovedInfoQueryParameters()
     {
         $uri = new Uri('http://domain.example/candy?taste=sweet,sour');

--- a/Tests/Unit/Search/ElevationComponentTest.php
+++ b/Tests/Unit/Search/ElevationComponentTest.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Search\ElevationComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Elevation class
@@ -32,9 +33,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class ElevationComponentTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canModifyQuery(): void
     {
         $query = $this->createMock(Query::class);

--- a/Tests/Unit/Search/FacetingComponentTest.php
+++ b/Tests/Unit/Search/FacetingComponentTest.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\Search\FacetingComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\QueryType\Select\RequestBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -79,9 +80,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *        field = type
      *     }
      *  }
-     *
-     * @test
      */
+    #[Test]
     public function testCanAddASimpleFacet(): void
     {
         $fakeConfigurationArray = [];
@@ -114,9 +114,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *        sortBy = index
      *     }
      *  }
-     *
-     * @test
      */
+    #[Test]
     public function testCanAddSortByIndexArgument(): void
     {
         $fakeConfigurationArray = [];
@@ -148,9 +147,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *        sortBy = count
      *     }
      *  }
-     *
-     * @test
      */
+    #[Test]
     public function testCanAddSortByCountArgument(): void
     {
         $fakeConfigurationArray = [];
@@ -189,9 +187,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *       }
      *    }
      * }
-     *
-     * @test
      */
+    #[Test]
     public function testCanHandleKeepAllFacetsOnSelectionOnAllFacetWhenGloballyConfigured(): void
     {
         $fakeConfigurationArray = [];
@@ -233,9 +230,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *       }
      *    }
      * }
-     *
-     * @test
      */
+    #[Test]
     public function testExcludeTagsAreEmptyWhenKeepAllFacetsOnSelectionIsNotSet(): void
     {
         $fakeConfigurationArray = [];
@@ -278,9 +274,8 @@ class FacetingComponentTest extends SetUpUnitTestCase
      *       }
      *    }
      * }
-     *
-     * @test
      */
+    #[Test]
     public function testCanHandleKeepAllOptionsOnSelectionForASingleFacet(): void
     {
         $fakeConfigurationArray = [];
@@ -308,9 +303,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('color', $jsonData->color->field, 'Query string did not contain expected snipped');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanHandleCombinationOfKeepAllFacetsOnSelectionAndKeepAllOptionsOnSelection(): void
     {
         $fakeConfigurationArray = [];
@@ -346,9 +339,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanHandleCombinationOfKeepAllFacetsOnSelectionAndKeepAllOptionsOnSelectionAndCountAllFacetsForSelection(): void
     {
         $fakeConfigurationArray = [];
@@ -386,9 +377,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('color', $jsonData->color->field, 'Did not build json field properly');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanAddQueryFilters(): void
     {
         $fakeConfigurationArray = [];
@@ -419,9 +408,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanAddQueryFiltersWithKeepAllOptionsOnSelectionFacet(): void
     {
         $fakeConfigurationArray = [];
@@ -452,9 +439,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanAddQueryFiltersWithGlobalKeepAllOptionsOnSelection(): void
     {
         $fakeConfigurationArray = [];
@@ -485,9 +470,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'][1], 'Did not build filter query from type');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanAddExcludeTagWithAdditionalExcludeTagConfiguration(): void
     {
         $fakeConfigurationArray = [];
@@ -519,9 +502,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('{!tag=type}(type:"product")', $queryParameter['fq'], 'Did not build filter query from color');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanAddQueryFiltersContainingPlusSign(): void
     {
         $fakeArguments = [
@@ -560,9 +541,7 @@ class FacetingComponentTest extends SetUpUnitTestCase
         self::assertEquals('{!tag=something2}(something2:"A B")', $queryParameter['fq'][2], 'Can handle %20 as space');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFiltersByFacetNameCanHandleAssocUrlParameterStyle(): void
     {
         $facetingModifierStub = new class ($this->createMock(FacetRegistry::class)) extends FacetingComponent {

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\Search\RelevanceComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Solarium\QueryType\Select\RequestBuilder;
 
 /**
@@ -45,9 +46,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         return $request->getParams();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetQuerySlop(): void
     {
         $searchConfiguration = [
@@ -83,9 +82,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame(2, $this->getQueryParameters($query)['qs'], 'querySlop was not applied as qs parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function querySlopIsNotSetWhenPhraseIsDisabled(): void
     {
         $searchConfiguration = [
@@ -120,9 +117,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('qs', $this->getQueryParameters($query), 'querySlop should still be null because phrase is disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetSlop(): void
     {
         $searchConfiguration = [
@@ -158,9 +153,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame(3, $this->getQueryParameters($query)['ps'], 'slop was not applied as qs parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function slopIsNullWhenPhraseIsDisabled()
     {
         $searchConfiguration = [
@@ -195,9 +188,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('ps', $this->getQueryParameters($query), 'PhraseSlop should be null, when phrase is disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBigramPhraseSlop(): void
     {
         $searchConfiguration = [
@@ -233,9 +224,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame(4, $this->getQueryParameters($query)['ps2'], 'slop was not applied as qs parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNotSetBigramPhraseSlopWhenBigramPhraseIsDisabled(): void
     {
         $searchConfiguration = [
@@ -270,9 +259,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('ps2', $this->getQueryParameters($query), 'ps2 parameter should be empty because bigramPhrases are disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetTrigramPhraseSlop(): void
     {
         $searchConfiguration = [
@@ -308,9 +295,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame(4, $this->getQueryParameters($query)['ps3'], 'slop was not applied as qs parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNotSetTrigramPhraseSlopWhenBigramPhraseIsDisabled(): void
     {
         $searchConfiguration = [
@@ -346,9 +331,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertArrayNotHasKey('ps3', $this->getQueryParameters($query), 'ps3 parameter should be empty because bigramPhrases are disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetTieParameter(): void
     {
         $searchConfiguration = [
@@ -380,9 +363,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame((float)'0.78', $this->getQueryParameters($query)['tie'], 'tieParameter was not applied as tie parameter');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBoostQuery(): void
     {
         $searchConfiguration = [
@@ -415,9 +396,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame('type:pages^100', $this->getQueryParameters($query)['bq'], 'Configured boostQuery was not applied');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBoostQueries(): void
     {
         $searchConfiguration = [
@@ -454,9 +433,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame('type:tx_solr_file^400', $this->getQueryParameters($query)['bq'][1], 'Configured boostQuery was not applied');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetBoostFunction(): void
     {
         $searchConfiguration = [
@@ -489,9 +466,7 @@ class RelevanceComponentTest extends SetUpUnitTestCase
         self::assertSame('sum(clicks)^100', $this->getQueryParameters($query)['bf'], 'Configured boostFunction was not applied');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetMinimumMatch(): void
     {
         $searchConfiguration = [

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\Search\SortingComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -57,9 +58,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortingFromUrlIsNotAppliedWhenSortingIsDisabled(): void
     {
         $event = new AfterSearchQueryHasBeenPreparedEvent($this->query, $this->searchRequestMock, $this->createMock(Search::class), $this->createMock(TypoScriptConfiguration::class));
@@ -68,9 +67,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         self::assertSame([], $event->getQuery()->getSorts(), 'No sorting should be present in query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validSortingFromUrlIsApplied(): void
     {
         $configuration = $this->createMock(TypoScriptConfiguration::class);
@@ -90,9 +87,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         self::assertSame(['sortTitle' => 'asc'], $this->query->getSorts(), 'Sorting was not applied in the query as expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidSortingFromUrlIsNotApplied(): void
     {
         $configuration = $this->createMock(TypoScriptConfiguration::class);
@@ -112,9 +107,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         self::assertSame([], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByIsApplied(): void
     {
         $configuration = $this->createMock(TypoScriptConfiguration::class);
@@ -129,9 +122,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         self::assertSame(['price' => 'desc'], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function urlSortingHasPrioriy(): void
     {
         $configuration = $this->createMock(TypoScriptConfiguration::class);
@@ -154,9 +145,7 @@ class SortingComponentTest extends SetUpUnitTestCase
         self::assertSame(['sortTitle' =>  'asc'], $this->query->getSorts(), 'No sorting should be present in query');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function querySortingHasPriorityWhenSortingIsDisabled(): void
     {
         $configuration = $this->createMock(TypoScriptConfiguration::class);

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrReadService;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SearchTest extends SetUpUnitTestCase
@@ -55,9 +56,7 @@ class SearchTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canPassLimit()
     {
         $query = new SearchQuery();
@@ -72,9 +71,7 @@ class SearchTest extends SetUpUnitTestCase
         $this->search->search($query, 0, $limit);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canKeepLimitWhenNullWasPassedAsLimit()
     {
         $query = new SearchQuery();

--- a/Tests/Unit/SetUpUnitTestCase.php
+++ b/Tests/Unit/SetUpUnitTestCase.php
@@ -15,8 +15,11 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionObject;
+use RuntimeException;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -100,7 +103,7 @@ abstract class SetUpUnitTestCase extends UnitTestCase
      */
     protected function callInaccessibleMethod($object, $name, ...$arguments)
     {
-        $reflectionObject = new \ReflectionObject($object);
+        $reflectionObject = new ReflectionObject($object);
         $reflectionMethod = $reflectionObject->getMethod($name);
         $reflectionMethod->setAccessible(true);
         return $reflectionMethod->invokeArgs($object, $arguments);
@@ -115,16 +118,16 @@ abstract class SetUpUnitTestCase extends UnitTestCase
      * @param object $target The instance which needs the dependency
      * @param string $name Name of the property to be injected
      * @param mixed $dependency The dependency to inject – usually an object but can also be any other type
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     protected function inject($target, $name, $dependency)
     {
         if (!is_object($target)) {
-            throw new \InvalidArgumentException('Wrong type for argument $target, must be object.', 1476107338);
+            throw new InvalidArgumentException('Wrong type for argument $target, must be object.', 1476107338);
         }
 
-        $objectReflection = new \ReflectionObject($target);
+        $objectReflection = new ReflectionObject($target);
         $methodNamePart = strtoupper($name[0]) . substr($name, 1);
         if ($objectReflection->hasMethod('set' . $methodNamePart)) {
             $methodName = 'set' . $methodNamePart;
@@ -137,7 +140,7 @@ abstract class SetUpUnitTestCase extends UnitTestCase
             $property->setAccessible(true);
             $property->setValue($target, $dependency);
         } else {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Could not inject ' . $name . ' into object of type ' . get_class($target),
                 1476107339
             );

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Cache;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
@@ -46,9 +47,7 @@ class TwoLevelCacheTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOnSecondaryCacheIsNeverCalledWhenValueIsPresentInFirstLevelCache(): void
     {
         $this->secondLevelCacheMock->expects(self::never())->method('get');
@@ -63,9 +62,9 @@ class TwoLevelCacheTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
      * @throws NoSuchCacheException
      */
+    #[Test]
     public function canHandleInvalidCacheIdentifierOnSet(): void
     {
         $cacheBackendMock = $this->createMock(BackendInterface::class);
@@ -77,9 +76,9 @@ class TwoLevelCacheTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
      * @throws NoSuchCacheException
      */
+    #[Test]
     public function canHandleInvalidCacheIdentifierOnGet(): void
     {
         $cacheBackendMock = $this->createMock(BackendInterface::class);

--- a/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 
@@ -36,11 +37,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testGetIsUseConfigurationFromClosestTemplateEnabled(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();
@@ -52,11 +52,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testIsGetUseConfigurationTrackRecordsOutsideSiterootEnabled(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();
@@ -68,11 +67,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredKnownTable(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();
@@ -86,11 +84,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredUnknownTable(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();
@@ -104,11 +101,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testIsGetIsUseConfigurationMonitorTablesConfiguredEmptyList(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();
@@ -121,11 +117,10 @@ class ExtensionConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
+    #[Test]
     public function testIsGetIsSelfSignedCertificatesEnabled(): void
     {
         $defaultConfiguration = new ExtensionConfiguration();

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Record;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase to check if the configuration object can be used as expected
@@ -41,18 +42,14 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetValueByPath()
     {
         $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
         self::assertSame('SOLR_CONTENT', $this->configuration->getValueByPath($testPath), 'Could not get configuration value by path');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetObjectByPath()
     {
         $testPath = 'plugin.tx_solr.index.queue.tt_news.fields.content';
@@ -64,9 +61,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertSame($expectedResult, $this->configuration->getObjectByPath($testPath), 'Could not get configuration object by path');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canShowEvenIfEmptyFallBackToGlobalSetting()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -113,10 +108,10 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
      * @deprecated queue.[indexConfig].table is deprecated and will be removed in v13. As soon as setting is removed this
      *             test must be removed too. For now this test ensures that 'table' and 'type' are supported.
      */
+    #[Test]
     public function canGetIndexQueueTableOrFallbackToConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -140,9 +135,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueTypeOrFallbackToConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -166,9 +159,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertSame($customTableExpected, 'tx_model_custom', 'Usage of custom table tx_model_custom was expected');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueConfigurationNames()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -198,9 +189,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertContains('custom', $enabledIndexQueueNames, 'Pages was no enabled index queue configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueConfigurationRecursiveUpdateFields()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -253,9 +242,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['title' => 'title', 'subtitle' => 'subtitle'], $configuration->getIndexQueueConfigurationRecursiveUpdateFields('custom'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetInitialPagesAdditionalWhereClause()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -278,9 +265,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('', $configuration->getInitialPagesAdditionalWhereClause('notconfigured'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAdditionalWhereClause()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -303,9 +288,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('', $configuration->getIndexQueueAdditionalWhereClauseByConfigurationName('notconfigured'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueConfigurationNamesByTableName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -330,9 +313,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['tx_model_news', 'custom_two'], $configuration->getIndexQueueConfigurationNamesByTableName('tx_model_news'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueInitializerClassByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -354,9 +335,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('CustomInitializer', $configuration->getIndexQueueInitializerClassByConfigurationName('custom_one'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueClassByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -378,9 +357,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('CustomQueue', $configuration->getIndexQueueClassByConfigurationName('custom_one'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueMonitoredTables()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -409,9 +386,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['tx_model_news', 'tx_model_bar', 'pages'], $monitoredTables);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueIsMonitoredTable()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -444,9 +419,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertTrue($configuration->getIndexQueueIsMonitoredTable('tx_model_news'), 'tx_model_news was expected to be monitored');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLoggingEnableStateForIndexQueueByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -470,9 +443,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetLoggingEnableStateForIndexQueueByConfigurationNameByFallingBack()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -497,9 +468,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexFieldsConfigurationByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -520,9 +489,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueMappedFieldNamesByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -545,9 +512,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['sortSubTitle_stringS', 'subTitle_stringM'], $mappedFieldNames);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexAdditionalFieldsConfiguration()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -564,9 +529,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['additional_sortSubTitle_stringS' => 'subtitle'], $retrievedConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexMappedAdditionalFieldNames()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -583,9 +546,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['additional_sortSubTitle_stringS'], $retrievedConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueIndexerByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -602,9 +563,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertSame('Foobar', $configuredIndexer, 'Retrieved unexpected indexer from typoscript configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueueIndexerConfigurationByConfigurationName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -622,9 +581,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertSame(['configuration' => 'test'], $configuredIndexer, 'Retrieved unexpected indexer configuration from typoscript configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetIndexQueuePagesExcludeContentByClassArray()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -641,9 +598,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['excludeClass'], $excludeClasses, 'Can not get exclude patterns from configuration');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetSearchQueryFilterConfiguration()
     {
         $configuration = new TypoScriptConfiguration([]);
@@ -652,9 +607,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['foo'], $configuration->getSearchQueryFilterConfiguration());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRemovePageSectionFilter()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -674,9 +627,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals([], $configuration->getSearchQueryFilterConfiguration());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removePageSectionFilterIsKeepingOtherFilters()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -696,9 +647,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['type:pages'], $configuration->getSearchQueryFilterConfiguration());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchQueryReturnFieldsAsArrayNoConfig()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -712,9 +661,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals([], $configuration->GetSearchQueryReturnFieldsAsArray());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchQueryReturnFieldsAsArrayWithConfig()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -729,9 +676,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(['foo', 'bar'], $configuration->GetSearchQueryReturnFieldsAsArray());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchSortingDefaultOrderBySortOptionNameIsFallingBackToDefaultSortOrder()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -754,9 +699,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('desc', $retrievedSorting);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchSortingDefaultOrderBySortOptionName()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -780,9 +723,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('asc', $retrievedSorting);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchSortingDefaultOrderBySortOptionNameInLowerCase()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -805,9 +746,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals('desc', $retrievedSorting);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchGroupingHighestGroupResultsLimit()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -834,9 +773,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(5, $highestResultsPerGroup, 'Can not get highest result per group value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchGroupingHighestGroupResultsLimitAsGlobalFallback()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -863,9 +800,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertEquals(8, $highestResultsPerGroup, 'Can not get highest result per group value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSearchGroupingWhenDisabled()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [
@@ -888,9 +823,7 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertFalse($configuration->getIsSearchGroupingEnabled(), 'Expected grouping to be disabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetGroupingAllowGetParameterSwitch()
     {
         $fakeConfigurationArray = [
@@ -914,18 +847,14 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         self::assertTrue($configuration->getIsGroupingGetParameterSwitchEnabled(), 'Expected allowGetParameterSwitch to be enabled');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSearchAdditionalPersistentArgumentNamesReturnsEmptyArrayWhenNothingIsConfigured()
     {
         $configuration = new TypoScriptConfiguration([]);
         self::assertSame([], $configuration->getSearchAdditionalPersistentArgumentNames(), 'Expected to get an empty array, when nothing configured');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetAdditionalPersistentArgumentNames()
     {
         $fakeConfigurationArray['plugin.']['tx_solr.'] = [

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -19,6 +19,7 @@ namespace  ApacheSolrForTypo3\Solr\Tests\Unit\System\ContentObject;
 
 use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -48,9 +49,7 @@ class ContentObjectServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRenderSingleContentObjectByArrayAndKey()
     {
         $fakeStdWrapConfiguration = [
@@ -66,9 +65,7 @@ class ContentObjectServiceTest extends SetUpUnitTestCase
         $this->contentObjectService->renderSingleContentObjectByArrayAndKey($fakeStdWrapConfiguration, 'field');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSingleContentObjectByArrayAndKeyWillReturnNameWhenConfigIsNotAnArray()
     {
         $fakeStdWrapConfiguration = [

--- a/Tests/Unit/System/Data/DateTimeTest.php
+++ b/Tests/Unit/System/Data/DateTimeTest.php
@@ -17,27 +17,25 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Data;
 
 use ApacheSolrForTypo3\Solr\System\Data\DateTime;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class DateTimeTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanWrapDateTimeAndConvertToString()
     {
-        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone('UTC'));
+        $proxy = new DateTime('2003-12-13T18:30:02Z', new DateTimeZone('UTC'));
         self::assertSame('2003-12-13T18:30:02+0000', (string)$proxy);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanDispatchCallToUnderlyingDateTime()
     {
-        $proxy = new DateTime('2003-12-13T18:30:02Z', new \DateTimeZone('UTC'));
+        $proxy = new DateTime('2003-12-13T18:30:02Z', new DateTimeZone('UTC'));
         self::assertSame('2003-12-13T18:30:02+0000', $proxy->format(\DateTime::ISO8601));
     }
 }

--- a/Tests/Unit/System/DateTime/FormatServiceTest.php
+++ b/Tests/Unit/System/DateTime/FormatServiceTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\DateTime;
 
 use ApacheSolrForTypo3\Solr\System\DateTime\FormatService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for FormatService
@@ -37,129 +38,97 @@ class FormatServiceTest extends SetUpUnitTestCase
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] = 'Y-m-d';
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFormatLegalDate()
     {
         self::assertSame('2017-02-16', $this->formatService->format('2017-02-16'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFormatIllegalDate()
     {
         self::assertSame('20170216', $this->formatService->format('20170216'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFormatLegalDateOtherInputFormat()
     {
         self::assertSame('2017-02-16', $this->formatService->format('02-16-2017', 'm-d-Y'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFormatIllegalDateOtherInputFormat()
     {
         self::assertSame('02162017', $this->formatService->format('02162017', 'm-d-Y'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToIsoLegalDate()
     {
         self::assertSame('2017-02-16T20:13:57Z', $this->formatService->TimestampToIso(1487272437));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToIsoIllegalDate()
     {
         self::assertEquals('1970-01-01T00:59:59Z', $this->formatService->TimestampToIso(-1));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToIsoNull()
     {
         self::assertEquals('1970-01-01T01:00:00Z', $this->formatService->TimestampToIso(null));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsoToTimestampLegalDate()
     {
         self::assertEquals(1487272437, $this->formatService->IsoToTimestamp('2017-02-16T20:13:57Z'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsoToTimestampIllegalDate()
     {
         self::assertEquals(0, $this->formatService->IsoToTimestamp('02-16-2017T20:13:57Z'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsoToTimestampEpoch()
     {
         self::assertEquals(0, $this->formatService->IsoToTimestamp('1970-01-01T00:00:00'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToUtcIsoLegalDate()
     {
         self::assertEquals('2017-02-16T19:13:57Z', $this->formatService->timestampToUtcIso(1487272437));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToUtcIsoIllegalDate()
     {
         self::assertEquals('1969-12-31T23:59:59Z', $this->formatService->timestampToUtcIso(-1));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canTimestampToUtcIsoNull()
     {
         self::assertEquals('1970-01-01T00:00:00Z', $this->formatService->timestampToUtcIso(null));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUtcIsoToTimestampLegalDate()
     {
         self::assertEquals(1487276037, $this->formatService->utcIsoToTimestamp('2017-02-16T20:13:57Z'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUtcIsoToTimestampIllegalDate()
     {
         self::assertEquals(0, $this->formatService->utcIsoToTimestamp('02-16-2017T20:13:57Z'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUtcIsoToTimestampEpoch()
     {
         self::assertEquals(0, $this->formatService->utcIsoToTimestamp('1970-01-01T00:00:00'));

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Logging;
 
 use ApacheSolrForTypo3\Solr\System\Logging\DebugWriter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LogLevel;
 
 /**
@@ -26,9 +27,7 @@ use Psr\Log\LogLevel;
  */
 class DebugWriterTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testDebugMessageIsWrittenForMessageFromSolr(): void
     {
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
@@ -40,9 +39,7 @@ class DebugWriterTest extends SetUpUnitTestCase
         $logWriter->write(LogLevel::INFO, 'test');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testDebugMessageIsNotWrittenWhenDevIpMaskIsNotMatching(): void
     {
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();
@@ -54,9 +51,7 @@ class DebugWriterTest extends SetUpUnitTestCase
         $logWriter->write(LogLevel::INFO, 'test');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testDebugMessageIsNotWrittenWhenDebugOutputIsDisabled(): void
     {
         $logWriter = $this->getMockBuilder(DebugWriter::class)->onlyMethods(['getIsAllowedByDevIPMask', 'getIsdebugOutputEnabled', 'writeDebugMessage'])->getMock();

--- a/Tests/Unit/System/Page/RootlineTest.php
+++ b/Tests/Unit/System/Page/RootlineTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Page;
 
 use ApacheSolrForTypo3\Solr\System\Page\Rootline;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the ArrayAccessor helper class.
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class RootlineTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getRootPageIdReturnUidOfRootPage()
     {
         $testRootLineArray = [
@@ -40,27 +39,21 @@ class RootlineTest extends SetUpUnitTestCase
         self::assertSame(1, $rootline->getRootPageId(), 'GetRootPageId does not return expected root page id');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRootPageIdReturnsZeroWhenNoSiteRootIsPresent()
     {
         $rootline = new Rootline([]);
         self::assertSame(0, $rootline->getRootPageId(), 'Expecting null when no rootline given');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getHasRootPageReturnsFalseOnEmptyRootLine()
     {
         $rootline = new Rootline([]);
         self::assertFalse($rootline->getHasRootPage(), 'Expecting false when no rootline given');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getHasRootPageRturnsTrueWithGivenRootLine()
     {
         $testRootLineArray = [
@@ -73,9 +66,7 @@ class RootlineTest extends SetUpUnitTestCase
         self::assertTrue($rootline->getHasRootPage(), 'Expecting true when rootline with rootpage given');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetParentPageIds()
     {
         $testRootLineArray = [

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -20,6 +20,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Service;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Service\ConfigurationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
@@ -64,10 +66,8 @@ class ConfigurationServiceTest extends SetUpUnitTestCase
         yield ['title', '\(1\+1\)\:2', '\(1\+1\)\:2'];
     }
 
-    /**
-     * @dataProvider escapeFilterDataProvider
-     * @test
-     */
+    #[DataProvider('escapeFilterDataProvider')]
+    #[Test]
     public function isFlexFormFilterEscaped(string $filterField, $filterValue, string $expectedFilterString): void
     {
         $fakeFlexFormArrayData = [
@@ -101,10 +101,8 @@ class ConfigurationServiceTest extends SetUpUnitTestCase
         yield ['title', 'test', 'title:test'];
     }
 
-    /**
-     * @dataProvider overrideFilterDataProvider
-     * @test
-     */
+    #[DataProvider('overrideFilterDataProvider')]
+    #[Test]
     public function canOverrideConfigurationWithFlexFormSettings(
         string $filterField,
         $filterValue,

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Session;
 
 use ApacheSolrForTypo3\Solr\System\Session\FrontendUserSession;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
@@ -41,18 +42,14 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getEmptyArrayWhenNoLastSearchesInSession(): void
     {
         $lastSearches = $this->session->getLastSearches();
         self::assertSame([], $lastSearches, 'Expected to get an empty lastSearches array');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sessionDataWillBeRetrievedFromSessionForLastSearches(): void
     {
         $fakeSessionData = ['foo', 'bar'];
@@ -60,9 +57,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
         self::assertSame($fakeSessionData, $this->session->getLastSearches(), 'Session data from fe_user was not returned from session');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetLastSearchesInSession(): void
     {
         $lastSearches = ['TYPO3', 'solr'];
@@ -70,25 +65,19 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
         $this->session->setLastSearches($lastSearches);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getHasPerPageReturnsFalseWhenNothingIsSet(): void
     {
         self::assertFalse($this->session->getHasPerPage(), 'Has per page should be false');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPerPageReturnsZeroWhenNothingIsSet(): void
     {
         self::assertSame(0, $this->session->getPerPage(), 'Expected to get 0 when nothing was set');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPerPageFromSessionData(): void
     {
         $fakeSessionData = 12;
@@ -96,9 +85,7 @@ class FrontendUserSessionTest extends SetUpUnitTestCase
         self::assertSame(12, $this->session->getPerPage(), 'Could not get per page from session data');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetPerPageInSessionData(): void
     {
         $lastSearches = 45;

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Schema\Schema;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the SchemaParser class.
@@ -26,9 +27,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class SchemaParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseLanguage()
     {
         $parser = new SchemaParser();
@@ -36,9 +35,7 @@ class SchemaParserTest extends SetUpUnitTestCase
         self::assertSame('core_de', $schema->getManagedResourceId(), 'Could not parse id of managed resources from schema response.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseName()
     {
         $parser = new SchemaParser();
@@ -46,9 +43,7 @@ class SchemaParserTest extends SetUpUnitTestCase
         self::assertSame('tx_solr-6-0-0--20161122', $schema->getName(), 'Could not parser name from schema response');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReturnEmptySchemaWhenNoSchemaPropertyInResponse()
     {
         $parser = new SchemaParser();

--- a/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\StopWordParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for StopWordParser
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class StopWordParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseStopWords()
     {
         $parser = new StopWordParser();

--- a/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for StopWordParser
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class SynonymParserTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canParseSynonyms()
     {
         $parser = new SynonymParser();

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Endpoint;
@@ -51,9 +52,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         $this->adminService = $this->getMockBuilder(SolrAdminService::class)->setConstructorArgs([$this->clientMock])->onlyMethods(['_sendRawGet'])->getMock();
         parent::setUp();
     }
-    /**
-     * @test
-     */
+    #[Test]
     public function getLukeMetaDataIsSendingRequestToExpectedUrl(): void
     {
         $fakedLukeResponse = $this->createMock(ResponseAdapter::class);
@@ -63,9 +62,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         self::assertSame($fakedLukeResponse, $result, 'Could not get expected result from getLukeMetaData');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPluginsInformation(): void
     {
         $fakePluginsResponse = $this->createMock(ResponseAdapter::class);
@@ -74,9 +71,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         self::assertSame($fakePluginsResponse, $result, 'Could not get expected result from getPluginsInformation');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSystemInformation(): void
     {
         $fakeSystemInformationResponse = $this->createMock(ResponseAdapter::class);
@@ -85,9 +80,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         self::assertSame($fakeSystemInformationResponse, $result, 'Could not get expected result from getSystemInformation');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSolrServerVersion(): void
     {
         $fakeRawResponse = new stdClass();
@@ -102,9 +95,7 @@ class SolrAdminServiceTest extends SetUpUnitTestCase
         self::assertSame('6.2.1', $result, 'Can not get solr version from faked response');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetSolrConfigNameFromFakedXmlResponse(): void
     {
         $fakeTestSchema = self::getFixtureContentByName('solrconfig.xml');

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -23,6 +23,8 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrInternalServerErrorException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Request;
@@ -55,9 +57,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pingIsOnlyDoingOnePingCallWhenCacheIsEnabled()
     {
         // we fake a 200 OK response and expect that
@@ -67,9 +67,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
         $this->service->ping();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pingIsOnlyDoingManyPingCallsWhenCacheIsDisabled()
     {
         // we fake a 200 OK response and expect that
@@ -79,9 +77,7 @@ class SolrReadServiceTest extends SetUpUnitTestCase
         $this->service->ping(false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchMethodIsTriggeringGetRequest()
     {
         $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);
@@ -102,10 +98,8 @@ class SolrReadServiceTest extends SetUpUnitTestCase
         yield 'Other unspecific error' => ['exceptionClass' => SolrCommunicationException::class, 555];
     }
 
-    /**
-     * @dataProvider readServiceExceptionDataProvider
-     * @test
-     */
+    #[DataProvider('readServiceExceptionDataProvider')]
+    #[Test]
     public function searchThrowsExpectedExceptionForStatusCode(
         string $exceptionClass,
         int $statusCode

--- a/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Service;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Response;
@@ -47,9 +48,7 @@ class SolrWriteServiceTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canRunOptimizeIndex(): void
     {
         $this->responseMock->expects(self::once())->method('getStatusCode')->willReturn(200);

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -22,6 +22,8 @@ use ApacheSolrForTypo3\Solr\System\Solr\Parser\StopWordParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception as MockObjectException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
@@ -87,10 +89,9 @@ class SolrConnectionTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws MockObjectException
      */
+    #[Test]
     public function authenticationIsNotTriggeredWithoutUsername(): void
     {
         $endpointMock = $this->createMock(Endpoint::class);
@@ -109,10 +110,9 @@ class SolrConnectionTest extends SetUpUnitTestCase
     }
 
     /**
-     * @test
-     *
      * @throws MockObjectException
      */
+    #[Test]
     public function authenticationIsTriggeredWhenUsernameIsPassed(): void
     {
         $endpointMock = $this->createMock(Endpoint::class);
@@ -137,11 +137,10 @@ class SolrConnectionTest extends SetUpUnitTestCase
     }
 
     /**
-     * @dataProvider coreNameDataProvider
-     * @test
-     *
      * @throws MockObjectException
      */
+    #[DataProvider('coreNameDataProvider')]
+    #[Test]
     public function canGetCoreName(string $path, string $core, string $expectedCoreName): void
     {
         $fakeConfiguration = $this->createMock(TypoScriptConfiguration::class);
@@ -159,10 +158,8 @@ class SolrConnectionTest extends SetUpUnitTestCase
         yield ['path' => '/somewherelese/', 'core' => 'corename', 'expectedCoreBasePath' => '/somewherelese'];
     }
 
-    /**
-     * @dataProvider coreBasePathDataProvider
-     * @test
-     */
+    #[DataProvider('coreBasePathDataProvider')]
+    #[Test]
     public function canGetCoreBasePath(string $path, string $core, string $expectedCoreBasePath): void
     {
         $readEndpoint = new Endpoint(
@@ -173,9 +170,7 @@ class SolrConnectionTest extends SetUpUnitTestCase
         self::assertSame($expectedCoreBasePath, $solrService->getReadService()->getPrimaryEndpoint()->getPath());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function coreBaseUriContainsAllSegments(): void
     {
         $readEndpoint = new Endpoint([

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -18,6 +18,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\TCA;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\DateTimeAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -31,9 +32,8 @@ class TCAServiceTest extends SetUpUnitTestCase
 {
     /**
      * When a deleted record is passed (has 1 in the TCA deleted field, this should be detected).
-     *
-     * @test
      */
+    #[Test]
     public function getIsEnabledRecordDetectDeletedRecord()
     {
         $fakeTCA = [
@@ -56,9 +56,8 @@ class TCAServiceTest extends SetUpUnitTestCase
 
     /**
      * When a record is passed that is not deleted we should detect that.
-     *
-     * @test
      */
+    #[Test]
     public function getIsEnabledRecordDetectNonDeletedRecord()
     {
         $fakeTCA = [
@@ -81,9 +80,8 @@ class TCAServiceTest extends SetUpUnitTestCase
 
     /**
      * When a page record is passed with the field no_search = 1 it should be detected is invisible
-     *
-     * @test
      */
+    #[Test]
     public function getIsEnabledRecordDetectsPageConfiguredWithNoSearch()
     {
         $fakeTCA = [
@@ -106,9 +104,8 @@ class TCAServiceTest extends SetUpUnitTestCase
 
     /**
      * When a page record is passed with the field no_search = 1 it should be detected is invisible
-     *
-     * @test
      */
+    #[Test]
     public function getIsEnabledRecordEmptyRecord()
     {
         $fakeTCA = [
@@ -127,9 +124,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($isVisible);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEndTimeInPastCanDetectedEndtimeThatIsInPast()
     {
         $fakeTCA = [
@@ -153,9 +148,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertTrue($isEndTimeInPast, 'Endtime in past was not detected as endtime in past');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEndTimeInPastCanDetectedEndtimeThatIsNotInPast()
     {
         $fakeTCA = [
@@ -179,9 +172,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($isEndTimeInPast, 'Endtime in future, was detected as endtime in past');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEndTimeInPastCanDetectedEndtimeIsEmpty()
     {
         $fakeTCA = [
@@ -206,9 +197,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($isEndTimeInPast, 'Not set endtime(default 0), was detected as endtime in past.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isStartTimeInFutureCanDetectedStartTimeInFuture()
     {
         $fakeTCA = [
@@ -232,9 +221,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertTrue($isStartTimeInFuture, 'Starttime in future was not detected as start time in future');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isStartTimeInFutureCanDetectedStartTimeNotInFuture()
     {
         $fakeTCA = [
@@ -258,9 +245,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($isStartTimeInFuture, 'Start time in past was detected as starttime in future');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isHiddenCanDetectHiddenRecord()
     {
         $fakeTCA = [
@@ -282,9 +267,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertTrue($isHidden, 'Page was expected to be hidden');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isHiddenCanDetectNonHiddenRecord()
     {
         $fakeTCA = [
@@ -306,9 +289,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($isHidden, 'Page was not expected to be hidden');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canNormalizeFrontendGroupField()
     {
         $fakeTCA = [
@@ -328,9 +309,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertSame($normalizedRecord['fe_groups'], '0', 'Empty fe_group field was not normalized to 0');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVisibilityAffectingFieldsByTableCanReturnDefaultFieldsWhenNoTCAIsConfigured()
     {
         $tcaService = new TCAService([]);
@@ -340,9 +319,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertStringContainsString('no_search', $visibilityFields, 'Expected to have no_search as visibility affecting field as default for pages');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVisibilityAffectingFieldsByTableCanReturnUidAndPidForNormalRecordTable()
     {
         $tcaService = new TCAService([]);
@@ -350,9 +327,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertEquals('uid, pid', $visibilityFields, 'TCA Service should return uid and pid of visibility affecting fields for record table where no TCA is configured');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVisibilityAffectingFieldsByTableCanReturnConfiguredDeleteField()
     {
         $fakeTCA = [
@@ -368,9 +343,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertStringContainsString('deleted', $visibilityFields, 'The deleted field should be retrieved as visibility affecting field');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVisibilityAffectingFieldsByTableCanReturnConfiguredEnableConfiguredEnabledColumnFields()
     {
         $fakeTCA = [
@@ -388,9 +361,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertStringContainsString('fe_groups', $visibilityFields, 'The field fe_groups should be retrieved as visbility affecting field');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTranslationOriginalUid()
     {
         $fakeTCA = [
@@ -408,9 +379,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertSame(999, $l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTranslationOriginalUidReturnsNullWhenFieldIsEmpty()
     {
         $fakeTCA = [
@@ -428,9 +397,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTranslationOriginalUidReturnsNullWhenPointerFieldIsNotConfigured()
     {
         $tcaService = new TCAService([]);
@@ -439,9 +406,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertNull($l10nParentUid, 'l10nParentUid should be null when the data is not set in the record');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isLocalizedRecord()
     {
         $fakeTCA = [
@@ -459,9 +424,7 @@ class TCAServiceTest extends SetUpUnitTestCase
         self::assertFalse($tcaService->isLocalizedRecord('tx_domain_model_faketable_withouttca', ['l10n_parent' => 9999]), 'Item without tca should not be indicated as translation');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTranslationOriginalUidIfTranslated()
     {
         $fakeTCA = [

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Url;
 
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
 /**
@@ -54,10 +56,8 @@ class UrlHelperTest extends SetUpUnitTestCase
             'expectedUrl' => '/index.php?foo%5B1%5D=bar&cHash=ddd&id=1',
         ];
     }
-    /**
-     * @dataProvider withoutQueryParameter
-     * @test
-     */
+    #[DataProvider('withoutQueryParameter')]
+    #[Test]
     public function testCanRemoveQueryParameter($input, $queryParameterToRemove, $expectedUrl)
     {
         $urlHelper = new UrlHelper($input);
@@ -86,11 +86,11 @@ class UrlHelperTest extends SetUpUnitTestCase
     }
 
     /**
-     * @dataProvider getUrl
-     * @test
      * @param string $inputUrl
      * @param string $expectedOutputUrl
      */
+    #[DataProvider('getUrl')]
+    #[Test]
     public function testGetUrl($inputUrl, $expectedOutputUrl)
     {
         $urlHelper = new UrlHelper($inputUrl);
@@ -103,45 +103,35 @@ class UrlHelperTest extends SetUpUnitTestCase
         yield 'withQuery' => ['http://www.site.de/en/test?id=1'];
         yield 'withQueries' => ['http://www.site.de/en/test?id=1&L=2'];
     }
-    /**
-     * @dataProvider unmodifiedUrl
-     */
+    #[DataProvider('unmodifiedUrl')]
     public function testGetUnmodifiedUrl($uri)
     {
         $urlHelper = new UrlHelper($uri);
         self::assertSame($uri, (string)$urlHelper, 'Could not get unmodified url');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifNoSchemeIsGivenGetSchemeReturnsAnEmptyString(): void
     {
         $urlHelper = new UrlHelper('www.google.de');
         self::assertSame('', $urlHelper->getScheme());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifNoPathIsGivenGetPathReturnsAnEmptyString(): void
     {
         $urlHelper = new UrlHelper('https://www.google.de');
         self::assertSame('', $urlHelper->getPath());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifNoPortIsGivenGetPortReturnsAnEmptyString(): void
     {
         $urlHelper = new UrlHelper('https://www.google.de');
         self::assertNull($urlHelper->getPort());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifNoHostIsGivenGetHostReturnsAnEmptyString(): void
     {
         $urlHelper = new UrlHelper('/my/path/to/a/site');

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -17,15 +17,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\UserFunctions;
 
 use ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
  */
 class FlexFormUserFunctionsTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function whenNoFacetsAreConfiguredAllSolrFieldsShouldBeAvailableAsFilter()
     {
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -45,9 +44,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertEquals(0, $parentInformation['items'][0][0] ?? null);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function labelIsUsedFromFacetWhenTheFacetIsConfiguredInTypoScript()
     {
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -72,9 +69,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertEquals('type (Facet Label: "The type")', $parentInformation['items']['type'][0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function duplicateFacetLabelDoesNotMakeFieldsDisappearingInFlexForms()
     {
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -105,9 +100,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertCount(2, $parentInformation['items']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function facetLabelIsShownTranslatedInBracketsSignsInFlexFormsIfTranslationIsAvailable()
     {
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -154,9 +147,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertEquals('someQuiteOther_field (Facet Label: "LLL:EXT:some_ext/locallang.xlf:not_existing_label")', $parentInformation['items']['someQuiteOther_field'][0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cObjectPathIsShownInBracketsSignsInFlexFormsIfcObjectIsUsed()
     {
         $flexFormUserFunctionsMock = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -183,9 +174,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertEquals('some_field (Facet Label: "cObject[...faceting.facets.someFacet.label]")', $parentInformation['items']['some_field'][0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function passingNullRowReturnsEmptyItems()
     {
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)
@@ -206,9 +195,7 @@ class FlexFormUserFunctionsTest extends SetUpUnitTestCase
         self::assertCount(0, $parentInformation['items']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetExpectedSelectOptions()
     {
         $userFunc = $this->getMockBuilder(FlexFormUserFunctions::class)

--- a/Tests/Unit/System/Util/ArrayAccessorTest.php
+++ b/Tests/Unit/System/Util/ArrayAccessorTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
 
 use ApacheSolrForTypo3\Solr\System\Util\ArrayAccessor;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the ArrayAccessor helper class.
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class ArrayAccessorTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGet()
     {
         $data = ['foo' => ['bla' => 1]];
@@ -44,9 +43,7 @@ class ArrayAccessorTest extends SetUpUnitTestCase
         self::assertNull($arrayAccessor->get('one:two:three:four'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetAndGet()
     {
         // can set and get a simple value
@@ -61,9 +58,7 @@ class ArrayAccessorTest extends SetUpUnitTestCase
         self::assertSame('test2', $arrayAccessor->get('one:two:three:four'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canReset()
     {
         $data = ['one' => ['two' => ['a' => 111, 'b' => 222]]];
@@ -78,9 +73,7 @@ class ArrayAccessorTest extends SetUpUnitTestCase
         self::assertSame(222, $arrayAccessor->get('one:two:b'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resetIsRemovingEmptyNodes()
     {
         $data = ['one' => ['two' => ['a' => 111, 'b' => 222]]];
@@ -96,9 +89,7 @@ class ArrayAccessorTest extends SetUpUnitTestCase
         self::assertSame(['b' => 222], $arrayAccessor->get('one:two'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resetIsRemovingSubNodesAndEmptyNodes()
     {
         $data = [

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Util;
 
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -34,9 +36,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFallbackToLanguageSpecificReadProperty()
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
@@ -50,9 +50,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
         self::assertSame('readcore', $property, 'Can not fallback to read property when write property is undefined');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canFallbackToGlobalPropertyWhenLanguageSpecificPropertyIsNotSet()
     {
         $languageConfiguration = ['solr_core_read' => 'readcore'];
@@ -97,10 +95,9 @@ class SiteUtilityTest extends SetUpUnitTestCase
 
     /**
      * solr_use_write_connection is functional
-     *
-     * @dataProvider writeConnectionTestsDataProvider
-     * @test
      */
+    #[DataProvider('writeConnectionTestsDataProvider')]
+    #[Test]
     public function solr_use_write_connectionSiteSettingInfluencesTheWriteConnection(string $expectedSolrHost, array $expectedSiteMockConfiguration)
     {
         $siteMock = $this->createMock(Site::class);
@@ -115,9 +112,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canLanguageSpecificConfigurationOverwriteGlobalConfiguration()
     {
         $languageConfiguration = ['solr_host_read' => 'readhost.local.de'];
@@ -133,9 +128,7 @@ class SiteUtilityTest extends SetUpUnitTestCase
         self::assertSame('readhost.local.de', $property, 'Can not fallback to read property when write property is undefined');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function specifiedDefaultValueIsReturnedByGetConnectionPropertyIfPropertyIsNotDefinedInConfiguration()
     {
         $languageMock = $this->createMock(SiteLanguage::class);
@@ -266,10 +259,9 @@ class SiteUtilityTest extends SetUpUnitTestCase
      * @param string $property
      * @param string $scope
      * @param mixed $expectedConfigurationValue
-     *
-     * @test
-     * @dataProvider siteConfigurationValueHandlingDataProvider
      */
+    #[DataProvider('siteConfigurationValueHandlingDataProvider')]
+    #[Test]
     public function canHandleSiteConfigurationValues(
         array $fakeConfiguration,
         string $property,

--- a/Tests/Unit/System/Validator/PathTest.php
+++ b/Tests/Unit/System/Validator/PathTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Validator;
 
 use ApacheSolrForTypo3\Solr\System\Validator\Path;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -26,9 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PathTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsValidSolrPathisValidPath()
     {
         $path = GeneralUtility::makeInstance(Path::class);
@@ -37,9 +36,7 @@ class PathTest extends SetUpUnitTestCase
         self::assertTrue($isValidPath);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsValidSolrPathEmptyString()
     {
         $path = GeneralUtility::makeInstance(Path::class);
@@ -48,9 +45,7 @@ class PathTest extends SetUpUnitTestCase
         self::assertFalse($isValidPath);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsValidSolrPathisInvalidPathButAppears()
     {
         $path = GeneralUtility::makeInstance(Path::class);
@@ -59,9 +54,7 @@ class PathTest extends SetUpUnitTestCase
         self::assertFalse($isValidPath);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canIsValidSolrPathisInvalidPath()
     {
         $path = GeneralUtility::makeInstance(Path::class);

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -21,6 +21,8 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\Execution;
@@ -51,9 +53,7 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canProcessEventQueue(): void
     {
         $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
@@ -102,9 +102,7 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
         self::assertTrue($dispatchedEvents[1] instanceof DelayedProcessingFinishedEvent);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canHandleErrors(): void
     {
         $eventQueueItemRepositoryMock = $this->createMock(EventQueueItemRepository::class);
@@ -132,7 +130,7 @@ class EventQueueWorkerTaskTest extends SetUpUnitTestCase
         $eventDispatcherMock
             ->expects(self::once())
             ->method('dispatch')
-            ->willThrowException(new \Exception('', 1641889238));
+            ->willThrowException(new Exception('', 1641889238));
 
         $solrLogManagerMock
             ->expects(self::once())

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 use ApacheSolrForTypo3\Solr\Task\IndexQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Core\Environment;
 
 /**
@@ -26,9 +27,7 @@ use TYPO3\CMS\Core\Core\Environment;
  */
 class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetWebRoot()
     {
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)
@@ -48,9 +47,7 @@ class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
         self::assertSame(Environment::getPublicPath() . '/../test/', $indexQueuerWorker->getWebRoot(), 'Could not use a marker in forced webroot');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
         $indexQueuerWorker = $this->getMockBuilder(IndexQueueWorkerTask::class)

--- a/Tests/Unit/Task/OptimizeIndexTaskTest.php
+++ b/Tests/Unit/Task/OptimizeIndexTaskTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 use ApacheSolrForTypo3\Solr\Task\OptimizeIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for OptimizeIndexTask
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class OptimizeIndexTaskTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
         /** @var OptimizeIndexTask $indexQueuerWorker */

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 
 use ApacheSolrForTypo3\Solr\Task\ReIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for ReIndexTask
@@ -25,9 +26,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
  */
 class ReIndexTaskTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable()
     {
         $indexQueuerWorker = $this->getMockBuilder(ReIndexTask::class)

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -17,6 +17,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -41,9 +43,7 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function changesNbspToSpace()
     {
         $content = '<!-- TYPO3SEARCH_begin -->In Olten&nbsp;ist<!-- TYPO3SEARCH_end -->';
@@ -55,9 +55,7 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canExcludeContentByClass()
     {
         $content = '<!-- TYPO3SEARCH_begin --><div class="typo3-search-exclude">Exclude content</div><p>Expected content</p><!-- TYPO3SEARCH_end -->';
@@ -70,9 +68,7 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function excludeContentKeepsEncodingForUmlaut()
     {
         $content = '<!-- TYPO3SEARCH_begin --><div class="typo3-search-exclude">Remove me</div><p>Was ein schöner Tag</p><!-- TYPO3SEARCH_end -->';
@@ -86,9 +82,7 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
         self::assertStringNotContainsString('Remove me', $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function excludeContentKeepsEncodingForEuroSign()
     {
         $content = '<!-- TYPO3SEARCH_begin --><div class="typo3-search-exclude">Remove me</div><p>100€</p><!-- TYPO3SEARCH_end -->';
@@ -138,10 +132,8 @@ class Typo3PageContentExtractorTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider canGetIndexableContentDataProvider
-     * @test
-     */
+    #[DataProvider('canGetIndexableContentDataProvider')]
+    #[Test]
     public function canGetIndexableContent($content, $expectedResult): void
     {
         $content = '<!-- TYPO3SEARCH_begin -->' . $content . '<!-- TYPO3SEARCH_end -->';

--- a/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Backend;
 
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Backend\IsStringViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class IsStringViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersThenChildIfStringIsGiven()
     {
         $arguments = [
@@ -40,9 +39,7 @@ class IsStringViewHelperTest extends SetUpUnitTestCase
         self::assertSame('thenResult', $result, 'thenClosure was not rendered');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersElseChildIfNotStringTypeIsGiven()
     {
         $arguments = [

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -24,6 +24,8 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\HighlightResultViewHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Traversable;
@@ -53,10 +55,8 @@ class HighlightingResultViewHelperTest extends SetUpUnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider canRenderCreateHighlightSnippedDataProvider
-     * @test
-     */
+    #[DataProvider('canRenderCreateHighlightSnippedDataProvider')]
+    #[Test]
     public function canRenderCreateHighlightSnipped(array $input, $expectedOutput, $configuredWrap)
     {
         /** @var RenderingContextInterface|MockObject $renderingContextMock */

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResult;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Document\RelevanceViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -26,9 +27,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RelevanceViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canCalculateRelevance()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);
@@ -47,9 +46,7 @@ class RelevanceViewHelperTest extends SetUpUnitTestCase
         self::assertEquals(10.0, $score, 'Unexpected score');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCalculateRelevanceFromPassedMaximumScore()
     {
         $resultSetMock = $this->createMock(SearchResultSet::class);

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Area\GroupViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -28,9 +29,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 class GroupViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canMakeOnlyExpectedFacetsAvailableInStaticContext()
     {
         $facetCollection = $this->getTestFacetCollection();
@@ -53,9 +52,7 @@ class GroupViewHelperTest extends SetUpUnitTestCase
         self::assertEquals(['color', 'brand'], $facetKeys);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMakeOnlyExpectedFacetsAvailableInstanceContext()
     {
         $facetCollection = $this->getTestFacetCollection();

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelFilterViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -28,9 +29,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 class LabelFilterViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canMakeOnlyExpectedFacetsAvailableInStaticContext(): void
     {
         $facet = $this->createMock(OptionsFacet::class);
@@ -64,9 +63,7 @@ class LabelFilterViewHelperTest extends SetUpUnitTestCase
         self::assertSame('Polar Blue', $optionCollection->getByPosition(0)->getLabel(), 'Filtered option has unexpected label');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canMakeOnlyExpectedFacetsAvailableInStaticContextWithMultiByteCharacters(): void
     {
         $facet = $this->createMock(OptionsFacet::class);

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -20,6 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\O
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Options\OptionsFacet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Facet\Options\Group\Prefix\LabelPrefixesViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
@@ -28,9 +29,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetPrefixesSortedByOrderInCollection()
     {
         $optionCollection = $this->getTestFacetOptionCollection();
@@ -47,9 +46,7 @@ class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
         self::assertSame(['r', 'p', 'l'], $prefixes, 'ViewHelper registers unexpected prefixes from passed options');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canGetPrefixesSortedAlphabeticalByLabel()
     {
         $optionCollection = $this->getTestFacetOptionCollection();

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Controller\SearchController;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\SearchFormViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
@@ -93,9 +94,7 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
         $this->uriBuilderMock->expects(self::once())->method('build')->willReturn('index.php?id=' . $pageUid);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSetTargetPageUidFromConfigurationWhenNullWasPassed()
     {
         $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(888);
@@ -106,9 +105,7 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canUsePassedPageUidWhenNoTargetPageIsConfigured()
     {
         $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(0);
@@ -119,9 +116,7 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function passedPageUidHasPriorityOverConfiguredTargetPageUid()
     {
         $this->typoScriptConfigurationMock->expects(self::any())->method('getSearchTargetPage')->willReturn(888);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\AddFacetItemViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -25,9 +26,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function addFacetItemWillUseUriBuilderAsExpected()
     {
         $facet = $this->getTestColorFacet();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveAllFacetsViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
@@ -30,9 +31,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setFacetItemWillUseUriBuilderAsExpected(): void
     {
         $mockedPreviousFakedRequest = $this->createMock(SearchRequest::class);

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetItemViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function removeFacetItemWillUseUriBuilderAsExpected()
     {
         $facet = $this->getTestColorFacet();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -25,9 +26,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class RemoveFacetViewHelperTest extends SetUpFacetItemViewHelper
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function removeFacetWillUseUriBuilderAsExpected()
     {
         $facet = $this->getTestColorFacet();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ViewHelpers\Uri\Facet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
 use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\SetFacetItemViewHelper;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -24,9 +25,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class SetFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setFacetItemWillUseUriBuilderAsExpected()
     {
         $facet = $this->getTestColorFacet();

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "require-dev": {
     "dg/bypass-finals": "^1.6",
-    "phpunit/phpunit": "^10.1",
+    "phpunit/phpunit": "^10.5",
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "~0.7.1",
     "typo3/testing-framework": "^8.0",


### PR DESCRIPTION
This change utilizes PHP8 attributes, which
is possible since PHPUnit 10, and the only way
to define Tests and DataProviders in PHPUnit 11.

Done via rector:

    return RectorConfig::configure()
        ->withSets([
            PHPUnitSetList::PHPUNIT_100,
        ])
        ->withImportNames();

Fixes: #4047
