### PR TITLE
[BUGFIX] Typecast $userGroup to integer

### DIFF
--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -62,7 +62,7 @@ class PageIndexer extends Indexer
         foreach ($systemLanguageUids as $systemLanguageUid) {
             $contentAccessGroups = $this->getAccessGroupsFromContent($item, $systemLanguageUid);
             foreach ($contentAccessGroups as $userGroup) {
-                $this->indexPage($item, $systemLanguageUid, $userGroup);
+                $this->indexPage($item, $systemLanguageUid, (int)$userGroup);
             }
         }
 


### PR DESCRIPTION
The 3rd argument of `PageIndexer::indexPage()` must be an integer or null, but under certein conditions, a string is passed (when page is access protected). 

This change ensures, that the 3rd argument for `indexPage()` function in `PageIndexer` is always an integer by typecasting the evaluated value.

Fixes: #3986
