### PR TITLE
[TASK] Call getLabelFromItemListMerged with the current row data

### DIFF
--- a/Classes/Backend/SettingsPreviewOnPlugins.php
+++ b/Classes/Backend/SettingsPreviewOnPlugins.php
@@ -149,7 +149,13 @@ class SettingsPreviewOnPlugins
      */
     protected function getPluginLabel(): string
     {
-        $label = BackendUtility::getLabelFromItemListMerged($this->pluginsTtContentRecord['pid'], 'tt_content', 'list_type', $this->pluginsTtContentRecord['list_type']);
+        $label = BackendUtility::getLabelFromItemListMerged(
+            $this->pluginsTtContentRecord['pid'],
+            'tt_content',
+            'list_type',
+            $this->pluginsTtContentRecord['list_type'],
+            $this->pluginsTtContentRecord
+        );
         if (!empty($label)) {
             $label = $this->getLanguageService()->sL($label);
         } else {


### PR DESCRIPTION
# What this pr does

This commit add the row information as 5th argument in the function call of 'BackendUtility::getLabelFromItemListMerged()'.

Even the argument is optional for this function, it becomes a kind of required in the following nested function calls within TYPO3.

# How to test

1. Install extension `gridelementsteam/gridelements`
2. Install extension `apache-solr-for-typo3/solr`
3. Add a page and place the search plugin into it
4. After saving and go back to the page module
5. There should not be any warnings be visible related to a missing pid

Fixes: #4080
