### PR TITLE
[BUGFIX] numeric facet range slider sends lot of requests to server

### DIFF
--- a/Resources/Public/JavaScript/facet_numericrange_controller.js
+++ b/Resources/Public/JavaScript/facet_numericrange_controller.js
@@ -33,10 +33,17 @@ function NumericRangeFacetController() {
                     if (isNaN(min)) { min = 0; }
                     if (isNaN(max)) { max = 0; }
 
+                    jQuery("#facet-" + facetName + "-value").html(min.toString() + "-" + max.toString());
+                },
+                stop: function (event, ui) {
+                    min = ui.values[0];
+                    max = ui.values[1];
+                    if (isNaN(min)) { min = 0; }
+                    if (isNaN(max)) { max = 0; }
+
                     url = urlTemplate.replace('___FROM___', min.toString());
                     url = url.replace('___TO___', max.toString());
                     _this.load(url);
-                    jQuery("#facet-" + facetName + "-value").html(min.toString() + "-" + max.toString());
                 }
             });
         });


### PR DESCRIPTION
Previously the numeric range slider updated the UI and the facet setting continously during sliding. This caused a lot of get requests to the server. This PR implents the desired beviour to send update requests only once the user releases the slider. The UI still gets updated continously by using the separate slide-event for that.

Fixes: https://github.com/TYPO3-Solr/ext-solr/issues/4082