### PR TITLE
[BUGFIX:P:11.5] Fix range string calculation in DateRange facet

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRange.php
+++ b/Classes/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRange.php
@@ -91,7 +91,7 @@ class DateRange extends AbstractRangeFacetItem
     protected function getRangeString(): string
     {
         $from = $this->startRequested === null ? '' : $this->startRequested->format('Ymd') . '0000';
-        $till = $this->endRequested === null ? '' : $this->endRequested->format('Ymd') . '0000';
+        $till = $this->endRequested === null ? '' : $this->endRequested->format('Ymd') . '2359';
         return $from . '-' . $till;
     }
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -53,7 +53,7 @@ class DateRangeFacetParserTest extends AbstractFacetParserTest
         self::assertSame($facet->getConfiguration(), $facetConfiguration['myCreated.'], 'Configuration was not passed to new facets');
         self::assertTrue($facet->getIsUsed());
 
-        self::assertEquals('201506020000-201706020000', $facet->getRange()->getLabel());
+        self::assertEquals('201506020000-201706022359', $facet->getRange()->getLabel());
         self::assertEquals(32, $facet->getRange()->getDocumentCount());
         self::assertCount(3, $facet->getRange()->getRangeCounts(), 'We expected that there are three count items attached');
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -68,7 +68,7 @@ class DateRangeTest extends UnitTest
                 $error->getMessage() . ' in ' . $error->getFile() . ':' . $error->getLine()
             );
         }
-        self::assertEquals('-202107200000', $dateRangeCollectionKeyOpenStart);
+        self::assertEquals('-202107202359', $dateRangeCollectionKeyOpenStart);
         self::assertEquals('202107200000-', $dateRangeCollectionKeyOpenEnd);
     }
 }


### PR DESCRIPTION
This change fixes the range string calculation, so items for the given date are included until 23:59 of the target end date.

Fixes: #4087
Ports: #4090