### PR TITLE
[FEATURE] Add flag to site config to skip DataHandler hooks

### DIFF
--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -189,6 +189,10 @@ class GarbageCollector implements SingletonInterface
             return;
         }
 
+        if (Util::skipHooksForRecord($table, $uid, $fields['pid'] ?? null)) {
+            return;
+        }
+
         $updatedRecord = $this->getGarbageHandler()->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
         if (empty($updatedRecord)) {
             return;

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -152,6 +152,10 @@ class RecordMonitor
             return;
         }
 
+        if (Util::skipHooksForRecord($table, (int)$recordUid, $recordPid)) {
+            return;
+        }
+
         if ($status === 'new' && !MathUtility::canBeInterpretedAsInteger($recordUid)) {
             if (isset($tceMain->substNEWwithIDs[$recordUid])) {
                 $recordUid = $tceMain->substNEWwithIDs[$recordUid];

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -87,6 +87,23 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_use_write_connection'] = 
     'displayCond' => 'FIELD:solr_enabled_read:=:1',
 ];
 
+$GLOBALS['SiteConfiguration']['site']['columns']['solr_skip_hooks'] = [
+    'label' => 'Disable TYPO3 hooks for this site',
+    'config' => [
+        'type' => 'check',
+        'renderType' => 'checkboxToggle',
+        'default' => 0,
+        'items' => [
+            [
+                'label' => '',
+                'labelChecked' => '',
+                'labelUnchecked' => '',
+            ],
+        ],
+    ],
+    'displayCond' => 'FIELD:solr_enabled_read:=:1',
+];
+
 // write TCA
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write'] = $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_read'];
 $GLOBALS['SiteConfiguration']['site']['columns']['solr_scheme_write']['displayCond'] = 'FIELD:solr_use_write_connection:=:1';
@@ -106,7 +123,7 @@ $GLOBALS['SiteConfiguration']['site']['columns']['solr_path_write']['displayCond
 $GLOBALS['SiteConfiguration']['site']['palettes']['solr_read']['showitem'] = 'solr_scheme_read, solr_port_read, --linebreak--, solr_host_read, solr_path_read';
 $GLOBALS['SiteConfiguration']['site']['palettes']['solr_write']['showitem'] = 'solr_scheme_write, solr_port_write, --linebreak--, solr_host_write, solr_path_write';
 
-$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;Solr,solr_enabled_read,--palette--;;solr_read, solr_use_write_connection,--palette--;;solr_write';
+$GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',--div--;Solr,solr_enabled_read,--palette--;;solr_read, solr_use_write_connection,--palette--;;solr_write,solr_skip_hooks';
 
 /**
  * Language specific core configuration


### PR DESCRIPTION
# What this pr does

Currently the 2 hooks of EXT:solr into DataHandler are fired for all sites, their pages and records. This is time consuming. Especially the RecordMonitor is taking up to 10s to do its thing.

# How to test

Add the flag `solr_skip_hooks` to a site config file and edit/save one of it's pages. Both GarbageCollector and RecordMonitor should skip their `processDatamap_afterDatabaseOperations` method.

Fixes: #4108

---

### Maintainers Notes:

- **Don't merge into release-12.0.x** 
