### PR TITLE
[FIX] deprecations in Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     needs: ci_bootstrapping
     continue-on-error: ${{ contains(matrix.TYPO3, '-dev') }}
     strategy:
-      matrix: ${{fromJson(needs.ci_bootstrapping.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.ci_bootstrapping.outputs.matrix) }}
     env:
       TYPO3_DATABASE_NAME: 'typo3_ci'
       TYPO3_DATABASE_HOST: '127.0.0.1'

--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -1,6 +1,6 @@
 FROM solr:9.6.1
-MAINTAINER dkd Internet Service GmbH <info@dkd.de>
-ENV TERM linux
+LABEL maintainer="dkd Internet Service GmbH info@dkd.de"
+ENV TERM=linux
 
 ARG SOLR_UNIX_UID="8983"
 ARG SOLR_UNIX_GID="8983"


### PR DESCRIPTION
Fixes deprecation notices in Dockerfile:

 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)