### PR TITLE
[BUGFIX] Ensure index document is deleted

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -185,7 +185,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
         }
 
         if ($pid === null) {
-            $this->removeFromIndexAndQueueWhenItemInQueue('pages', $uid);
+            $this->removeFromIndexAndQueue('pages', $uid);
             return;
         }
 
@@ -285,7 +285,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
             $this->mountPageUpdater->update($uid);
             $this->indexQueue->updateItem('pages', $uid);
         } else {
-            $this->removeFromIndexAndQueueWhenItemInQueue('pages', $uid);
+            $this->removeFromIndexAndQueue('pages', $uid);
         }
     }
 
@@ -308,7 +308,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
                 $this->indexQueue->updateItem($table, $uid);
             } else {
                 // TODO should be moved to garbage collector
-                $this->removeFromIndexAndQueueWhenItemInQueue($table, $uid);
+                $this->removeFromIndexAndQueue($table, $uid);
             }
         }
     }
@@ -325,9 +325,17 @@ class DataUpdateHandler extends AbstractUpdateHandler
      * Removes record from the index queue and from the solr index when the item is in the queue.
      *
      * @throws DBALException
+     * @deprecated DataUpdateHandler->removeFromIndexAndQueueWhenItemInQueue is deprecated and will be removed in v13.
+                   Use DataUpdateHandler->removeFromIndexAndQueue instead.
      */
     protected function removeFromIndexAndQueueWhenItemInQueue(string $recordTable, int $recordUid): void
     {
+        trigger_error(
+            'DataUpdateHandler->removeFromIndexAndQueueWhenItemInQueue is deprecated and will be removed in v13.'
+            . ' Use DataUpdateHandler->removeFromIndexAndQueue instead.',
+            E_USER_DEPRECATED
+        );
+
         if (!$this->indexQueue->containsItem($recordTable, $recordUid)) {
             return;
         }
@@ -401,7 +409,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
     protected function processRecord(string $recordTable, int $recordUid, array $rootPageIds): void
     {
         if (empty($rootPageIds)) {
-            $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+            $this->removeFromIndexAndQueue($recordTable, $recordUid);
             return;
         }
 
@@ -419,9 +427,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
 
             $record = $this->configurationAwareRecordService->getRecord($recordTable, $recordUid, $solrConfiguration);
             if (empty($record)) {
-                // TODO move this part to the garbage collector
-                // check if the item should be removed from the index because it no longer matches the conditions
-                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+                // skip processing, queue and index entry will be removed by garbage collection triggered via RecordGarbageCheckEvent
                 continue;
             }
             // Clear existing index queue items to prevent mount point duplicates.

--- a/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
@@ -120,8 +120,9 @@ class GarbageHandler extends AbstractUpdateHandler
     ): void {
         $record = $this->getRecordWithFieldRelevantForGarbageCollection($table, $uid);
 
-        // If no record could be found skip further processing
+        // If no record could be found, remove remains from index and queue
         if (empty($record)) {
+            $this->collectGarbage($table, $uid);
             return;
         }
 

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -20,9 +20,12 @@ use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Traversable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\Connection;
@@ -392,6 +395,110 @@ class GarbageCollectorTest extends IntegrationTestBase
         $this->dataHandler->process_cmdmap();
         $this->assertIndexQueueContainsItemAmount(4);
         $this->assertSolrContainsDocumentCount(3);
+    }
+
+    #[Test]
+    public function canCollectGarbageEvenIfNotInIndexQueue(): void
+    {
+        $this->prepareCanCollectGarbageEvenIfNotInIndexQueue();
+        $this->assertIndexQueueContainsItemAmount(0);
+        $this->assertSolrIsEmpty();
+    }
+
+    #[Test]
+    public function canCollectGarbageEvenIfNotInIndexQueueInDelayedProcessingMode(): void
+    {
+        $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
+        $this->prepareCanCollectGarbageEvenIfNotInIndexQueue();
+        $this->assertEventQueueContainsItemAmount(2);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(0);
+        $this->assertSolrIsEmpty();
+    }
+
+    protected function prepareCanCollectGarbageEvenIfNotInIndexQueue(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/subpage.csv');
+
+        $this->cleanUpSolrServerAndAssertEmpty();
+        $this->assertEmptyIndexQueue();
+        $this->addToQueueAndIndexRecord('pages', 2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(1);
+
+        // flush cache after preparing the environment to be sure no wrong version is cached
+        $cache = new TwoLevelCache('runtime');
+        $cache->flush();
+
+        // clear index queue, as we want to test if garbage collection works if record has no representation in queue
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_solr_indexqueue_item');
+        $connection->truncate('tx_solr_indexqueue_item');
+
+        $this->dataHandler->start(
+            ['pages' => [2 => ['hidden' => 1]]],
+            [],
+            $this->backendUser
+        );
+        $this->dataHandler->process_datamap();
+    }
+
+    #[Test]
+    #[DataProvider('canCollectGarbageOfDeletedRecordEvenIfNotInIndexQueueDataProvider')]
+    public function canCollectGarbageOfDeletedRecordEvenIfNotInIndexQueue(bool $forceHardDelete): void
+    {
+        $this->prepareCanCollectGarbageOfDeletedRecordEvenIfNotInIndexQueue($forceHardDelete);
+        $this->assertIndexQueueContainsItemAmount(0);
+        $this->assertSolrIsEmpty();
+    }
+
+    #[Test]
+    #[DataProvider('canCollectGarbageOfDeletedRecordEvenIfNotInIndexQueueDataProvider')]
+    public function canCollectGarbageOfDeletedRecordEvenIfNotInIndexQueueInDelayedProcessingMode(bool $forceHardDelete): void
+    {
+        $this->extensionConfiguration->set('solr', ['monitoringType' => 1]);
+        $this->prepareCanCollectGarbageOfDeletedRecordEvenIfNotInIndexQueue($forceHardDelete);
+        $this->assertEventQueueContainsItemAmount(1);
+        $this->processEventQueue();
+        $this->assertIndexQueueContainsItemAmount(0);
+        $this->assertSolrIsEmpty();
+    }
+
+    protected function prepareCanCollectGarbageOfDeletedRecordEvenIfNotInIndexQueue(bool $forceHardDelete): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/subpage.csv');
+
+        $this->cleanUpSolrServerAndAssertEmpty();
+        $this->assertEmptyIndexQueue();
+        $this->addToQueueAndIndexRecord('pages', 2);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(1);
+
+        // flush cache after preparing the environment to be sure no wrong version is cached
+        $cache = new TwoLevelCache('runtime');
+        $cache->flush();
+
+        // clear index queue, as we want to test if garbage collection works if record has no representation in queue
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_solr_indexqueue_item');
+        $connection->truncate('tx_solr_indexqueue_item');
+
+        if ($forceHardDelete) {
+            unset($GLOBALS['TCA']['pages']['ctrl']['delete']);
+        }
+
+        $this->dataHandler->start(
+            [],
+            ['pages' => [2 => ['delete' => 1 ]]],
+            $this->backendUser
+        );
+        $this->dataHandler->process_cmdmap();
+    }
+
+    public static function canCollectGarbageOfDeletedRecordEvenIfNotInIndexQueueDataProvider(): Traversable
+    {
+        yield 'Test soft delete' => [ false ];
+        yield 'Test hard delete' => [ true ];
     }
 
     #[Test]

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -186,29 +186,14 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         ];
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
 
-        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
-        $garbageHandlerMock
-            ->expects(self::once())
-            ->method('collectGarbage')
-            ->with(
-                'pages',
-                $dummyPageRecord['uid']
-            );
-        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
-
         $this->mountPagesUpdaterMock
             ->expects(self::once())
             ->method('update')
             ->with($dummyPageRecord['uid']);
 
         $this->indexQueueMock
-            ->expects(self::once())
-            ->method('containsItem')
-            ->with(
-                'pages',
-                $dummyPageRecord['uid']
-            )
-            ->willReturn(true);
+            ->expects(self::never())
+            ->method('containsItem');
 
         $this->typoScriptConfigurationMock
             ->expects(self::once())
@@ -524,16 +509,6 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             'pid' => self::DUMMY_PAGE_ID,
         ];
 
-        $garbageHandlerMock = $this->createMock(GarbageHandler::class);
-        $garbageHandlerMock
-            ->expects(self::once())
-            ->method('collectGarbage')
-            ->with(
-                'tx_foo_bar',
-                $dummyRecord['uid']
-            );
-        GeneralUtility::addInstance(GarbageHandler::class, $garbageHandlerMock);
-
         $this->typoScriptConfigurationMock
             ->expects(self::once())
             ->method('getIndexQueueIsMonitoredTable')
@@ -551,13 +526,8 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects(self::once())
-            ->method('containsItem')
-            ->with(
-                'tx_foo_bar',
-                $dummyRecord['uid']
-            )
-            ->willReturn(true);
+            ->expects(self::never())
+            ->method('containsItem');
 
         $this->dataUpdateHandler->handleRecordUpdate($dummyRecord['uid'], 'tx_foo_bar');
     }
@@ -723,13 +693,8 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects(self::once())
-            ->method('containsItem')
-            ->with(
-                'pages',
-                $dummyPageRecord['uid']
-            )
-            ->willReturn(true);
+            ->expects(self::never())
+            ->method('containsItem');
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock
@@ -822,13 +787,8 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         ->willReturn([]);
 
         $this->indexQueueMock
-            ->expects(self::once())
-            ->method('containsItem')
-            ->with(
-                'tx_foo_bar',
-                $dummyRecord['uid']
-            )
-            ->willReturn(true);
+            ->expects(self::never())
+            ->method('containsItem');
 
         $garbageHandlerMock = $this->createMock(GarbageHandler::class);
         $garbageHandlerMock


### PR DESCRIPTION
# What this pr does

If an index document has no representation in the index queue, EXT:solr fails to remove the item on deletions or updates of the corresponding record in TYPO3.

By adjusting the checks in the record monitor, garbage remover and update handler this issue is resolved. The
ConfigurationAwareRecordService is no longer using BackendUtility::getRecord() as this would return hidden records.

Resolves: #4107