### PR TITLE
Re-added template variables

### DIFF
--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -105,11 +105,26 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
         // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->add('q', $this->getQueryString());
         // @extensionScannerIgnoreLine
+        $this->getTemplateVariableContainer()->add('pageUid', $pageUid);
+        // @extensionScannerIgnoreLine
+        $this->getTemplateVariableContainer()->add(
+            'languageUid',
+            ($this->renderingContext->getRequest()->getAttribute('language')?->getLanguageId() ?? 0)
+        );
+        // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->add('existingParameters', $this->getExistingSearchParameters());
         // @extensionScannerIgnoreLine
+        // Added addPageAndLanguageId for compatibility
+        $this->getTemplateVariableContainer()->add('addPageAndLanguageId', false);
         $formContent = $this->renderChildren();
         // @extensionScannerIgnoreLine
+        $this->getTemplateVariableContainer()->remove('addPageAndLanguageId');
+        // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->remove('q');
+        // @extensionScannerIgnoreLine
+        $this->getTemplateVariableContainer()->remove('pageUid');
+        // @extensionScannerIgnoreLine
+        $this->getTemplateVariableContainer()->remove('languageUid');
         // @extensionScannerIgnoreLine
         $this->getTemplateVariableContainer()->remove('existingParameters');
 


### PR DESCRIPTION
# What this pr does

This PR re-introduces the template variables in the SearchFormViewHelper

# How to test

Check that variables are back in template. For instance by adding a <f:debug>{_all}</f:debug> to the Resources/Private/Partials/Search/Form.html template

Fixes: #4117
