### PR TITLE
[TASK] Enable dependabot for all supported branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,47 @@
 version: 2
 updates:
-  -
+  - &composer-solarium
     package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
     allow:
       - dependency-name: "solarium/solarium"
-  -
+    target-branch: "main"
+    commit-message:
+      prefix: "[TASK] 13.0.x-dev "
+  - &docker-apache-solr
     package-ecosystem: "docker"
     directory: "/Docker/SolrServer"
     schedule:
       interval: "daily"
+    target-branch: "main"
+    commit-message:
+      prefix: "[TASK] 13.0.x-dev "
+
+  # For release-12.0.x
+  - <<: *composer-solarium
+    target-branch: "release-12.0.x"
+    commit-message:
+      prefix: "[TASK] 12.0.x-dev "
+  - <<: *docker-apache-solr
+    target-branch: "release-12.0.x"
+    commit-message:
+      prefix: "[TASK] 12.0.x-dev "
+
+  # For release-11.6.x
+  - <<: *composer-solarium
+    target-branch: "release-11.6.x"
+    commit-message:
+      prefix: "[TASK] 11.6.x-dev "
+  - <<: *docker-apache-solr
+    target-branch: "release-11.6.x"
+    commit-message:
+      prefix: "[TASK] 11.6.x-dev "
+
+  # For release-11.5.x
+  # Apache Solr multiple versions not supported, but for 11.6.x
+  - <<: *composer-solarium
+    target-branch: "release-11.5.x"
+    commit-message:
+      prefix: "[TASK] 11.5.x-dev "


### PR DESCRIPTION
This change enables Dependabot for all supported branches, by trying  to consume dependabot settings 
[`target-branch`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch) together with  [`commit-message.prefix`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)

Fixes: #3168

---

## NOTE: 

This pull-request could be reverted, removed, or adapted after merging, if the setting will not work as expected:

* Create pull requests for solarium/solarium against
   - [ ] release-12.0.x
   - [ ] release-11.6.x
   - [ ] release-11.5.x
* Create pull requests for Dockerfile
   - [ ] release-11.6.x Apache Solr 9.6.1