### PR TITLE
[TASK] Enable dependabot for all supported branches: Use PHP platform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,6 @@ updates:
     directory: "/Docker/SolrServer"
     schedule:
       interval: "daily"
-
     target-branch: "release-11.6.x"
     commit-message:
       prefix: "[TASK] 11.6.x-dev "

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "config": {
+    "platform": {
+      "php": "8.2"
+    },
     "allow-plugins": true,
     "vendor-dir": ".Build/vendor",
     "bin-dir": ".Build/bin",


### PR DESCRIPTION
Dependabot requires `config.platform.php` in composer.json to work correctly.

This will avoid troubles like:

```
Problem 1
    - Root composer.json requires solarium/solarium 6.3.5 -> satisfiable by solarium/solarium[6.3.5].
    - solarium/solarium 6.3.5 requires php ^8.0 -> your php version (7.4.33) does not satisfy that requirement.

    - solarium/solarium 6.3.5 requires php ^8.0 -> your php version (7.4.33) does not satisfy that requirement.
```

Relates: #3168