### PR TITLE
Introduce method to remove the query-string from search-request

### DIFF
--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -445,6 +445,17 @@ class SearchRequest
     }
 
     /**
+     * Unsets the query string.
+     */
+    public function removeQueryString(): SearchRequest
+    {
+        $this->stateChanged = true;
+        $path = $this->prefixWithNamespace('q');
+        $this->argumentsAccessor->reset($path);
+        return $this;
+    }
+
+    /**
      * Returns the passed rawQueryString.
      */
     public function getRawUserQuery(): string


### PR DESCRIPTION
# What this PR does

This introduce a new method that removes the query-string from `SearchRequest`. Other active filters e.g. selected categories are not removed from `SearchRequest`.

This is especially usefull when `allowEmptyQuery` is set in TS-config:

```
plugin.tx_solr {
  search {
    query {
      allowEmptyQuery = 1
    }
}
```

# How to test

This can be used in a custom `ViewHelper`:

```php
class RemoveQueryViewHelper extends AbstractUriViewHelper
{

    /**
     * @param array $arguments
     * @param \Closure $renderChildrenClosure
     * @param RenderingContextInterface $renderingContext
     * @return string
     */
    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
    {
        $newRequest = static::getUsedSearchRequestFromRenderingContext($renderingContext)
            ->getCopyForSubRequest()
            ->removeQueryString();
        $uri = self::getSearchUriBuilder($renderingContext)->getCurrentSearchUri($newRequest);
        return $uri;
    }
}
```

Fixes: https://github.com/TYPO3-Solr/ext-solr/issues/4135
