### PR TITLE
Use PHP generator to prevent processing of all available site

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -146,9 +146,7 @@ abstract class AbstractModuleController extends ActionController
      */
     protected function initializeView($view): void
     {
-        $sites = $this->siteRepository->getAvailableSites();
-
-        $selectOtherPage = count($sites) > 0 || $this->selectedPageUID < 1;
+        $selectOtherPage = $this->siteRepository->hasAvailableSites() || $this->selectedPageUID < 1;
         $this->moduleTemplate->assign('showSelectOtherPage', $selectOtherPage);
         $this->moduleTemplate->assign('pageUID', $this->selectedPageUID);
         if ($this->selectedPageUID < 1) {

--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -124,9 +124,8 @@ abstract class AbstractModuleController extends ActionController
      */
     protected function autoSelectFirstSiteAndRootPageWhenOnlyOneSiteIsAvailable(): bool
     {
-        $solrConfiguredSites = $this->siteRepository->getAvailableSites();
         $availableSites = $this->siteFinder->getAllSites();
-        if (count($solrConfiguredSites) === 1 && count($availableSites) === 1) {
+        if (count($availableSites) === 1 && $this->siteRepository->hasExactlyOneAvailableSite()) {
             $this->selectedSite = $this->siteRepository->getFirstAvailableSite();
 
             // we only overwrite the selected pageUid when no id was passed

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -102,8 +102,12 @@ class SiteRepository
      */
     public function getFirstAvailableSite(bool $stopOnInvalidSite = false): ?Site
     {
-        $sites = $this->getAvailableSites($stopOnInvalidSite);
-        return array_shift($sites);
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        $site = $siteGenerator->current();
+
+        return $site instanceof Site ? $site : null;
     }
 
     /**
@@ -118,28 +122,93 @@ class SiteRepository
         $cacheId = 'SiteRepository' . '_' . 'getAvailableSites';
 
         $sites = $this->runtimeCache->get($cacheId);
-        if (!empty($sites)) {
+        if (is_array($sites) && $sites !== []) {
             return $sites;
         }
 
-        $sites = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        $sites = [];
+        foreach ($siteGenerator as $rootPage => $site) {
+            $sites[$rootPage] = $site;
+        }
         $this->runtimeCache->set($cacheId, $sites);
 
         return $sites;
     }
 
     /**
-     * Returns available TYPO3 sites
-     *
-     * @return Site[]
+     * Check, if there are any managed sites available
      *
      * @throws UnexpectedTYPO3SiteInitializationException
      */
-    protected function getAvailableTYPO3ManagedSites(bool $stopOnInvalidSite): array
+    public function hasAvailableSites(bool $stopOnInvalidSite = false): bool
     {
-        $typo3ManagedSolrSites = [];
-        $typo3Sites = $this->siteFinder->getAllSites();
-        foreach ($typo3Sites as $typo3Site) {
+        $cacheId = 'SiteRepository' . '_' . 'hasAvailableSites';
+
+        $hasSites = $this->runtimeCache->get($cacheId);
+        if (is_bool($hasSites)) {
+            return $hasSites;
+        }
+
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        $hasSites = ($site = $siteGenerator->current()) && $site instanceof Site;
+        $this->runtimeCache->set($cacheId, $hasSites);
+
+        return $hasSites;
+    }
+
+    /**
+     * Check, if there is exactly one managed site available
+     * Needed in AbstractModuleController::autoSelectFirstSiteAndRootPageWhenOnlyOneSiteIsAvailable
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    public function hasExactlyOneAvailableSite(bool $stopOnInvalidSite = false): bool
+    {
+        $cacheId = 'SiteRepository' . '_' . 'hasExactlyOneAvailableSite';
+
+        $hasExactlyOneSite = $this->runtimeCache->get($cacheId);
+        if (is_bool($hasExactlyOneSite)) {
+            return $hasExactlyOneSite;
+        }
+
+        if (!$this->hasAvailableSites($stopOnInvalidSite)) {
+            $this->runtimeCache->set($cacheId, false);
+            return false;
+        }
+
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        // We start with 1 here as we know from hasAvailableSites() above we have at least one site
+        $counter = 1;
+        foreach ($siteGenerator as $_) {
+            if ($counter > 1) {
+                $this->runtimeCache->set($cacheId, false);
+                return false;
+            }
+            $counter++;
+        }
+
+        $this->runtimeCache->set($cacheId, true);
+
+        return true;
+    }
+
+    /**
+     * Returns available TYPO3 sites
+     *
+     * @return Site[]|\Generator
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    protected function getAvailableTYPO3ManagedSites(bool $stopOnInvalidSite): \Generator
+    {
+        foreach ($this->siteFinder->getAllSites() as $typo3Site) {
             try {
                 $rootPageId = $typo3Site->getRootPageId();
                 if (isset($typo3ManagedSolrSites[$rootPageId])) {
@@ -148,7 +217,7 @@ class SiteRepository
                 }
                 $typo3ManagedSolrSite = $this->buildSite($rootPageId);
                 if ($typo3ManagedSolrSite->isEnabled()) {
-                    $typo3ManagedSolrSites[$rootPageId] = $typo3ManagedSolrSite;
+                    yield $rootPageId => $typo3ManagedSolrSite;
                 }
             } catch (Throwable $e) {
                 if ($stopOnInvalidSite) {
@@ -160,7 +229,6 @@ class SiteRepository
                 }
             }
         }
-        return $typo3ManagedSolrSites;
     }
 
     /**

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -130,8 +130,12 @@ class SiteRepository
         $siteGenerator->rewind();
 
         $sites = [];
-        foreach ($siteGenerator as $rootPage => $site) {
-            $sites[$rootPage] = $site;
+        foreach ($siteGenerator as $rootPageId => $site) {
+            if (isset($sites[$rootPageId])) {
+                //get each site only once
+                continue;
+            }
+            $sites[$rootPageId] = $site;
         }
         $this->runtimeCache->set($cacheId, $sites);
 
@@ -190,10 +194,6 @@ class SiteRepository
         foreach ($this->siteFinder->getAllSites() as $typo3Site) {
             try {
                 $rootPageId = $typo3Site->getRootPageId();
-                if (isset($typo3ManagedSolrSites[$rootPageId])) {
-                    //get each site only once
-                    continue;
-                }
                 $typo3ManagedSolrSite = $this->buildSite($rootPageId);
                 if ($typo3ManagedSolrSite->isEnabled()) {
                     yield $rootPageId => $typo3ManagedSolrSite;

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -145,20 +145,10 @@ class SiteRepository
      */
     public function hasAvailableSites(bool $stopOnInvalidSite = false): bool
     {
-        $cacheId = 'SiteRepository' . '_' . 'hasAvailableSites';
-
-        $hasSites = $this->runtimeCache->get($cacheId);
-        if (is_bool($hasSites)) {
-            return $hasSites;
-        }
-
         $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
         $siteGenerator->rewind();
 
-        $hasSites = ($site = $siteGenerator->current()) && $site instanceof Site;
-        $this->runtimeCache->set($cacheId, $hasSites);
-
-        return $hasSites;
+        return ($site = $siteGenerator->current()) && $site instanceof Site;
     }
 
     /**
@@ -169,15 +159,7 @@ class SiteRepository
      */
     public function hasExactlyOneAvailableSite(bool $stopOnInvalidSite = false): bool
     {
-        $cacheId = 'SiteRepository' . '_' . 'hasExactlyOneAvailableSite';
-
-        $hasExactlyOneSite = $this->runtimeCache->get($cacheId);
-        if (is_bool($hasExactlyOneSite)) {
-            return $hasExactlyOneSite;
-        }
-
         if (!$this->hasAvailableSites($stopOnInvalidSite)) {
-            $this->runtimeCache->set($cacheId, false);
             return false;
         }
 
@@ -188,13 +170,10 @@ class SiteRepository
         $counter = 1;
         foreach ($siteGenerator as $_) {
             if ($counter > 1) {
-                $this->runtimeCache->set($cacheId, false);
                 return false;
             }
             $counter++;
         }
-
-        $this->runtimeCache->set($cacheId, true);
 
         return true;
     }

--- a/Classes/Report/SiteHandlingStatus.php
+++ b/Classes/Report/SiteHandlingStatus.php
@@ -66,8 +66,7 @@ class SiteHandlingStatus extends AbstractSolrStatus
     public function getStatus(): array
     {
         $reports = [];
-        $sites = $this->siteRepository->getAvailableSites();
-        if (empty($sites)) {
+        if (!$this->siteRepository->hasAvailableSites()) {
             $reports[] = GeneralUtility::makeInstance(
                 Status::class,
                 self::TITLE_SITE_HANDLING_CONFIGURATION,
@@ -79,8 +78,7 @@ class SiteHandlingStatus extends AbstractSolrStatus
             return $reports;
         }
 
-        /** @var Site $site */
-        foreach ($sites as $site) {
+        foreach ($this->siteRepository->getAvailableSites() as $site) {
             if (!($site instanceof Site)) {
                 $reports[] = GeneralUtility::makeInstance(
                     Status::class,

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -24,14 +24,10 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\RequestInterface;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
-use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
 /**
  * Class SearchFormViewHelper
- *
- *
- * @property RenderingContext $renderingContext
  */
 class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
 {
@@ -87,7 +83,7 @@ class SearchFormViewHelper extends AbstractSolrFrontendTagBasedViewHelper
     public function render()
     {
         /** @var RequestInterface $request */
-        $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
+        $request = $this->renderingContext->getRequest();
         $this->uriBuilder->setRequest($request);
         $pageUid = $this->arguments['pageUid'] ?? null;
         if ($pageUid === null && !empty($this->getTypoScriptConfiguration()->getSearchTargetPage())) {

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -89,7 +89,6 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         $this->assertThatSitesAreCreatedWithPageIds([333], [
             0 => ['language' => 0],
         ]);
-        $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getFirstAvailableSite();
         self::assertInstanceOf(Site::class, $site);

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -64,7 +64,7 @@ class SearchFormViewHelperTest extends SetUpUnitTestCase
             new TemplatePaths()
         );
         $request = new Request((new ServerRequest())->withAttribute('extbase', new ExtbaseRequestParameters(SearchController::class)));
-        $renderingContext->setAttribute(ServerRequestInterface::class, $request);
+        $renderingContext->setRequest($request);
         $this->viewHelper->setRenderingContext($renderingContext);
         $this->viewHelper->expects(self::any())->method('getTypoScriptConfiguration')->willReturn($this->typoScriptConfigurationMock);
         $this->viewHelper->expects(self::any())->method('getTemplateVariableContainer')->willReturn($this->createMock(VariableProviderInterface::class));

--- a/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SearchFormViewHelperTest.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\ViewHelpers\SearchFormViewHelper;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request;


### PR DESCRIPTION
# What this pr does

Use PHP generator with yield to process just the available sites needed

# How to test

With over 300 root pages it needs over 30 seconds to build up all available sites. With help of a PHP generator we can stop processing all available sites if just the first site is requested. It's also helpful to just check, if there are available sites.

This should speed up performance a lot.