### PR TITLE
[BUGFIX] Convert getPageOverlay hook into PSR-14 Event

### DIFF
--- a/Classes/EventListener/PageIndexer/ExtendToSubpagesModifier.php
+++ b/Classes/EventListener/PageIndexer/ExtendToSubpagesModifier.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\EventListener\PageIndexer;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
+use TYPO3\CMS\Core\Domain\Access\RecordAccessGrantedEvent;
+
+/**
+ * Class ExtendToSubpagesModifier is responsible to modify page records so that when checking for
+ * access through fe groups no groups or extendToSubpages flag is found and thus access is granted.
+ */
+class ExtendToSubpagesModifier
+{
+    public function __invoke(RecordAccessGrantedEvent $event): void
+    {
+        if ($GLOBALS['TYPO3_REQUEST']->hasHeader(PageIndexerRequest::SOLR_INDEX_HEADER) && $event->getTable() === 'pages') {
+            $header = $GLOBALS['TYPO3_REQUEST']->getHeader(PageIndexerRequest::SOLR_INDEX_HEADER);
+
+            if (isset($header[0])) {
+                $headerDecoded = json_decode($header[0], true);
+                if (is_array($headerDecoded) && isset($headerDecoded['actions']) && $headerDecoded['actions'] === 'findUserGroups') {
+                    $record = $event->getRecord();
+                    $record['fe_group'] = '';
+                    $record['extendToSubpages'] = 1;
+
+                    $event->updateRecord($record);
+                }
+            }
+        }
+    }
+
+}

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -72,7 +72,6 @@ class UserGroupDetector implements
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_checkEnableFields'][__CLASS__] = UserGroupDetector::class . '->checkEnableFields';
 
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPage'][__CLASS__] = UserGroupDetector::class;
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPageOverlay'][__CLASS__] = UserGroupDetector::class;
 
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['postInit'][__CLASS__] = UserGroupDetector::class;
         $this->logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
@@ -138,6 +137,10 @@ class UserGroupDetector implements
      * @param array $pageInput Page record
      * @param int $lUid Overlay language ID
      * @param PageRepository $parent Parent \TYPO3\CMS\Core\Domain\Repository\PageRepository object
+     * @see This code is not invoked in version 12 - instead an PSR-14 event was introduced to handle
+     * this case. In version 13 this has been fixed - so leaving the code here for now.
+     * The hook invoking part has been removed
+     * @see https://github.com/TYPO3-Solr/ext-solr/issues/4151
      */
     public function getPageOverlay_preProcess(
         &$pageInput,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -273,6 +273,12 @@ services:
       - name: event.listener
         identifier: 'solr.index.PageIndexer.FrontendUserAuthenticator'
 
+  ApacheSolrForTypo3\Solr\EventListener\PageIndexer\ExtendToSubpagesModifier:
+    autowire: true
+    tags:
+      - name: event.listener
+        identifier: 'solr.index.PageIndexer.ExtendToSubpagesModifier'
+
   ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer:
     autowire: true
     tags:


### PR DESCRIPTION
# What this pr does

Converts getPageOverlay hook into PSR-14 Event

# How to test

Make page with no fe groups no groups or extendToSubpages flag is set and ensure that pages is properly indexed.

Fixes: #4151
