### PR TITLE
[BUGFIX] Make getHasChildNodeSelected recursive

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/Node.php
@@ -72,7 +72,7 @@ class Node extends AbstractOptionFacetItem
     {
         /** @var Node $childNode */
         foreach ($this->childNodes as $childNode) {
-            if ($childNode->getSelected()) {
+            if ($childNode->getSelected() || $childNode->getHasChildNodeSelected()) {
                 return true;
             }
         }


### PR DESCRIPTION
# What this pr does

Currently, the GetHasChildNodeSelected function in \ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\Node only checks whether a direct child is selected. With hierarchical filters, however, it makes sense to check whether any child is selected in this hierarchy branch. E.g. because this should be expanded in the frontend.
```html 
<f:if condition="{childNode.hasChildNodeSelected}">
  <f:variable name="detailsState" value="open" />
</f:if>
```


The PR implements this recursive check.

Fixes: #4155
