### PR TITLE
[BUGFIX] PhpStan Variable $parameters in empty() always exists and is not falsy

### DIFF
--- a/Classes/System/Url/UrlHelper.php
+++ b/Classes/System/Url/UrlHelper.php
@@ -48,10 +48,7 @@ class UrlHelper extends Uri
     {
         parse_str($this->query, $parameters);
         $parameters[$parameterName] = $value;
-        $query = '';
-        if (!empty($parameters)) {
-            $query = http_build_query($parameters);
-        }
+        $query = http_build_query($parameters);
         $query = $this->sanitizeQuery($query);
         $clonedObject = clone $this;
         $clonedObject->query = $query;


### PR DESCRIPTION
Fixes PhpStan-issue:

```
------ -----------------------------------------------------------------
  Line   Classes/System/Url/UrlHelper.php
 ------ -----------------------------------------------------------------
  52     Variable $parameters in empty() always exists and is not falsy.
 ------ -----------------------------------------------------------------
```