### PR TITLE
Update TxSolrSearch.rst

### DIFF
--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -241,7 +241,7 @@ Example (boosts tt_news documents by factor 10):
 
 .. code-block:: typoscript
 
-    plugin.tx_solr.search.query.boostQuery.boostNews = (type:tt_news)^10
+    plugin.tx_solr.search.query.boostQuery.boostNews = type:tt_news^10
 
 
 query.tieParameter


### PR DESCRIPTION
Fixed wrong syntax for query.boostQuery

Using brackets leads to a PHP warning: 
`Undefined array key 0 in /.../vendor/apache-solr-for-typo3/solr/Classes/Domain/Search/Score/ScoreCalculationService.php line 101`