### PR TITLE
[BUGFIX] Add StartTimeRestriction to ConfigurationAwareRecordService

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;
+use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -134,6 +135,7 @@ class ConfigurationAwareRecordService
         }
 
         $queryBuilder = $this->getQueryBuilderForTable($recordTable);
+        $queryBuilder->getRestrictions()->removeByType(StartTimeRestriction::class);
         $queryBuilder
             ->select('*')
             ->from($recordTable)


### PR DESCRIPTION
By fixing this issue (https://github.com/TYPO3-Solr/ext-solr/issues/4107), the ConfigurationAwareRecordService no longer uses BackendUtility::getRecord(). As a result, the default Restrictions are now applied to the query.

If you have an already published and indexed article and modify the startdate to schedule the article for future publication, the queue item will be deleted and not reinserted due to the StarttimeRestriction, which removes the item from the result list.

In EXT:solr v11, the behavior is different. After modifying the start date, the item will be deleted from tx_news_domain_model_news and reinserted for further indexing.

Relates: #4168
Fixes: #4176

---

### Todo

- [x] port into main branch
