### PR TITLE
Fix formatting and update Slack link on FAQ

### DIFF
--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -15,6 +15,7 @@ Are versions of EXT:solr compatible with TYPO3 ELTS versions?
 
 Yes, the updates will be available via EXT:solr ELTS regiment in EB program.
 For ELTS version of EXT:solr, you have following options:
+
 * visit https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/
 * or contact us via solr-eb-support@dkd.de
 * or call us +49 (0)69 - 2475218 0
@@ -45,7 +46,7 @@ Please send an email to the `TYPO3 security team <mailto:security@typo3.org>`_ w
 Is there some chat/irc channel for EXT:solr available?
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Join us on the official `Slack for TYPO3 <https://forger.typo3.org/slack>`_ and get answers related to EXT:solr in the #ext-solr channel immediately!
+Join us on the official `Slack for TYPO3 <https://typo3.slack.com/>`_ and get answers related to EXT:solr in the #ext-solr channel immediately!
 
 
 Which plugins(TYPO3 Frontend) are available?


### PR DESCRIPTION
# What this pr does

The list was not diplayed properly and the slack link wasn't redirecting. Tested the changes with: https://www.tutorialspoint.com/online_restructure_editor.php

# How to test

If you open this page:
https://docs.typo3.org/p/apache-solr-for-typo3/solr/11.0/en-us/FAQ/Index.html

You'll notice the broken list as first item. Also the slack link doesn't work.