### PR TITLE
[TASK] Upgrade typo3/testing-framework to dev-main 2024.10.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "phpunit/phpunit": "^11.4",
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "v0.8.0",
-    "typo3/testing-framework": "dev-main#47bf0daab24b4210221f46a1fde59b9c3e245e39",
+    "typo3/testing-framework": "dev-main#5787ec240dc634665e09fca500f307828dee07f1",
     "phpstan/phpstan": "^1.11",
     "phpstan/phpstan-phpunit": "^1.3"
   },


### PR DESCRIPTION
This change is required for deprecated DB configs, which are migrated in https://github.com/TYPO3/testing-framework/commit/0c5ee0bc307765f2d77f4847eb24b31ab592bf1c