### PR TITLE
[TASK] Adjust mount point indexing

### DIFF
--- a/Classes/Domain/Index/PageIndexer/PageUriBuilder.php
+++ b/Classes/Domain/Index/PageIndexer/PageUriBuilder.php
@@ -61,7 +61,14 @@ class PageUriBuilder
         int $language = 0,
         string $mountPointParameter = '',
     ): UriInterface {
-        $site = $this->siteFinder->getSiteByPageId($item->getRecordUid());
+        if ($item->hasIndexingProperty('isMountedPage')) {
+            $recordUid = (int)$item->getIndexingProperty('mountPageDestination');
+        } else {
+            $recordUid = $item->getRecordUid();
+        }
+
+        $site = $this->siteFinder->getSiteByPageId($recordUid);
+
         $parameters = [];
 
         if ($language > 0) {

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -95,8 +95,6 @@ class DataUpdateHandler extends AbstractUpdateHandler
 
     protected ?PagesRepository $pagesRepository;
 
-    protected SolrLogManager $logger;
-
     protected DataHandler $dataHandler;
 
     public function __construct(
@@ -110,16 +108,12 @@ class DataUpdateHandler extends AbstractUpdateHandler
         DataHandler $dataHandler,
         ?SolrLogManager $solrLogManager = null,
     ) {
-        parent::__construct($recordService, $frontendEnvironment, $tcaService, $indexQueue);
+        parent::__construct($recordService, $frontendEnvironment, $tcaService, $indexQueue, $solrLogManager);
 
         $this->mountPageUpdater = $mountPageUpdater;
         $this->rootPageResolver = $rootPageResolver;
         $this->pagesRepository = $pagesRepository;
         $this->dataHandler = $dataHandler;
-        $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(
-            SolrLogManager::class,
-            __CLASS__
-        );
     }
 
     /**

--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -148,7 +148,7 @@ class ConfigurationManager implements SingletonInterface
     }
 
     /**
-     * @return array{
+     * @return array|array{
      *    'uid': int,
      *    'pid': int,
      *    'tstamp': int,
@@ -198,6 +198,10 @@ class ConfigurationManager implements SingletonInterface
             '', // @todo: tag: MountPoint,
             $coreContext,
         );
+        $rootline = $rootlineUtility->get();
+        if ($rootline === []) {
+            return [];
+        }
 
         /** @var SysTemplateRepository $sysTemplateRepository */
         $sysTemplateRepository = GeneralUtility::makeInstance(
@@ -208,7 +212,7 @@ class ConfigurationManager implements SingletonInterface
         );
 
         return $sysTemplateRepository->getSysTemplateRowsByRootline(
-            $rootlineUtility->get(),
+            $rootline,
             $request
         );
     }

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -693,7 +693,7 @@ Yes. If user is not logged in one can redirect to a login page with the help of 
 
 The reason for that:
 
-With Typo3 10 and solr 11.0.1 it was possible for solr to read it's configuration from shortcut pages directly. With Typo3 11 and solr 11.5 these shortcuts are followed. And if the access to the destination of the shortcut is restricted, solr cannot read the configuration because solr is not logged in.
+With TYPO3 10 and solr 11.0.1 it was possible for solr to read it's configuration from shortcut pages directly. With TYPO3 11 and solr 11.5 these shortcuts are followed. And if the access to the destination of the shortcut is restricted, solr cannot read the configuration because solr is not logged in.
 
 The solution:
 
@@ -721,3 +721,13 @@ The container log did not contain any output relevant to the container quitting.
 Changing to Docker Desktop as provider keep the container alive.
 
 Relevant DDEV link: https://ddev.readthedocs.io/en/latest/users/providers/
+
+
+
+Can mount points be indexed?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Mount points are supported in general and the mounted pages will be indexed like standard pages.
+
+But there is a point to consider: Mounted pages from a pagetree without a site configuration cannot be indexed, in fact TYPO3 currently can't mount a page from a page tree without a site configuration and an exeception occurs.
+The behavior is intentionally designed this way in TYPO3 core, the background is that it is not possible to specify the languages of the mounted page tree without Site Configuration.

--- a/Documentation/Releases/solr-release-13-0.rst
+++ b/Documentation/Releases/solr-release-13-0.rst
@@ -5,15 +5,30 @@
 Releases 13.0
 =============
 
+
+Release 13.0.0-beta-1
+=====================
+
+This is a first beta release for TYPO3 13.4 LTS
+
+New in this release
+-------------------
+
+Adjust mount point indexing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mount point indexing and corresponding tests have been adjusted for TYPO3 13. Mount points are supported in general and the mounted pages will be indexed like standard pages.
+
+But there is a point to consider: Mounted pages from a pagetree without a site configuration cannot be indexed, in fact TYPO3 currently can't mount a page from a page tree without a site configuration and an exeception occurs.
+The behavior is intentionally designed this way in TYPO3 core, the background is that it is not possible to specify the languages of the mounted page tree without Site Configuration.
+
+.. note::
+   We require at least TYPO3 13.4.2, as this version contains some bugfixes that address problems with the determination of TypoScript and the site configuration of mounted pages.
+
 Release 13.0.0-alpha-1
 ======================
 
 This is a first alpha release for upcoming TYPO3 13 LTS
-
-Known Bugs
-----------
-
-*   Mount pages cannot be indexed, see `#4160 <https://github.com/TYPO3-Solr/ext-solr/issues/4160>`__
 
 New in this release
 -------------------

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -189,25 +189,27 @@ class ConnectionManagerTest extends IntegrationTestBase
      * ConnectionManager must use the connection for site(tree), where mount Point is defined.
      * There is following scenario:
      *
-     *     [0]
-     *     |
-     *     ——[20] Shared-Pages (Folder)
-     *     |   |
-     *     |   ——[24] FirstShared
-     *     |       |
-     *     |       ——[25] first sub page from FirstShared
-     *     |       |
-     *     |       ——[26] second sub page from FirstShared
-     *     |
-     *     ——[ 1] Page (Root)
-     *         |
-     *         ——[14] Mount Point 1 (to [24] to show contents from)
+     *  [0]
+     *   |
+     *   |—[211] Page3 (Root)
+     *   |  |
+     *   |   |—[24] FirstShared
+     *   |       |
+     *   |       |—[25] first sub page from FirstShared
+     *   |       |
+     *   |       |—[26] second sub page from FirstShared
+     *   |
+     *   |—[  1] Page (Root)
+     *   |   |
+     *   |   |—[14] Mount Point 1 (to [24] to show contents from)
+     *   |
+     *   |—[111] Page2 (Root)
+     *       |
+     *       |—[34] Mount Point 2 (to [24] to show contents from)
      */
     #[Test]
     public function canFindSolrConnectionForMountedPageIfMountPointIsGiven(): void
     {
-        self::markTestSkipped('@todo: Fix it. See: https://github.com/TYPO3-Solr/ext-solr/issues/4160');
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/connection_for_mounted_page.csv');
 
         $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -31,12 +31,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConnectionManagerTest extends IntegrationTestBase
 {
-    /**
-     * @inheritdoc
-     * @todo: Remove unnecessary fixtures and remove that property as intended.
-     */
-    protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/Tests/Integration/Fixtures/connection_basic.csv
+++ b/Tests/Integration/Fixtures/connection_basic.csv
@@ -18,28 +18,9 @@
 #
 "pages",
 ,"uid","pid","is_siteroot","doktype","mount_pid","mount_pid_ol","slug","title"
-,1,0,1,1,0,0,"/","First site"
 ,11,1,0,7,24,1,"/subpage","Subpage of first site"
-,111,0,1,1,0,0,"/","Second site"
 ,21,111,0,7,24,1,"/subpage","Subpage of second site"
 # detached and non Root Page-Tree
 ,3,0,0,1,0,0,"/","Detached and non Root Page-Tree"
 ,31,3,0,7,24,1,"/subpage","Subpage 1 of Detached"
 ,32,3,0,7,24,1,"/subpage-2","Subpage 2 of Detached"
-"sys_template",
-,"uid","pid","root","clear","sorting","config"
-,1,1,1,3,100,"
-page = PAGE
-page.typeNum = 0
-plugin.tx_solr {
-    enabled = 1
-}"
-,111,111,1,3,100,"
-page = PAGE
-page.typeNum = 0
-
-plugin.tx_solr {
-    enabled = 1
-}"
-
-

--- a/Tests/Integration/Fixtures/connection_for_mounted_page.csv
+++ b/Tests/Integration/Fixtures/connection_for_mounted_page.csv
@@ -2,75 +2,28 @@
 #
 #  [0]
 #   |
-#   ——[20] Shared-Pages (Folder: Not root)
+#   |—[211] Page3 (Root)
 #   |   |
-#   |   ——[24] FirstShared
+#   |   |—[24] FirstShared
 #   |       |
-#   |       ——[25] first sub page from FirstShared
+#   |       |—[25] first sub page from FirstShared
 #   |       |
-#   |       ——[26] second sub page from FirstShared
+#   |       |—[26] second sub page from FirstShared
 #   |
-#   ——[ 1] Page (Root)
+#   |—[  1] Page (Root)
 #   |   |
-#   |   ——[14] Mount Point 1 (to [24] to show contents from)
+#   |   |—[14] Mount Point 1 (to [24] to show contents from)
 #   |
-#   ——[ 2] Page2 (Root)
+#   |—[111] Page2 (Root)
 #       |
-#       ——[34] Mount Point 2 (to [24] to show contents from)
+#       |—[34] Mount Point 2 (to [24] to show contents from)
 "pages",
 ,"uid","pid","is_siteroot","doktype","mount_pid","mount_pid_ol","slug","title"
 # Shared Pages tree
-,20,0,0,254,0,0,"/","Shared-Pages"
-,24,20,0,1,0,0,"/first-shared","FirstShared (Not root)"
+,24,211,0,1,0,0,"/first-shared","FirstShared (Not root)"
 ,25,24,0,1,0,0,"/first-shared/first-subpage","first sub page from FirstShared (Not root)"
 ,26,24,0,1,0,0,"/first-shared/second-subpage","second sub page from FirstShared (Not root)"
 # Site tree
-,1,0,1,1,0,0,"/","Page (Root)"
 ,14,1,0,7,24,1,"/mount-point-1","Mount Point 1"
 # Second Site tree
-,2,0,1,1,0,0,"/","Second Site (Root)"
-,34,2,0,7,24,1,"/mount-point-2","Mount Point 2"
-"sys_template",
-,"uid","pid","root","clear","sorting","config"
-,1,1,1,3,100,"
-page = PAGE
-page.typeNum = 0
-config.index_enable = 1
-
-plugin.tx_solr {
-    enabled = 1
-
-    index {
-        fieldProcessingInstructions {
-            changed = timestampToIsoDate
-            created = timestampToIsoDate
-            endtime = timestampToUtcIsoDate
-            rootline = pageUidToHierarchy
-        }
-
-        queue {
-            // mapping tableName.fields.SolrFieldName => TableFieldName (+ cObj processing)
-            pages = 1
-            pages {
-                initialization = ApacheSolrForTypo3\Solr\IndexQueue\Initializer\Page
-
-                // allowed page types (doktype) when indexing records from pages
-                allowedPageTypes = 1,7
-
-                indexingPriority = 0
-
-                indexer = ApacheSolrForTypo3\Solr\IndexQueue\PageIndexer
-                indexer {
-                    // add options for the indexer here
-                }
-
-                // Only index standard pages and mount points that are not overlayed.
-                additionalWhereClause = (doktype = 1 OR (doktype=7 AND mount_pid_ol=0)) AND no_search = 0
-
-                fields {
-                    sortSubTitle_stringS = subtitle
-                }
-            }
-        }
-    }
-}"
+,34,111,0,7,24,1,"/mount-point-2","Mount Point 2"

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page_from_another_site.csv
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page_from_another_site.csv
@@ -1,15 +1,18 @@
 # There is following scenario:
 #
 #  [0]
+#   |
+#   |—[ 111] Page (Root Testpage 2)
+#   |   |
+#   |   |—[24] FirstShared
+#   |
 #   |—[ 1] Page (Root Testpage 1)
 #       |
 #       |—[14] Mount Point (to [24] to show contents from)
-#       |
-#       |—[24] FirstShared
 "pages",
 ,"uid","pid","is_siteroot","doktype","mount_pid","mount_pid_ol","slug","title"
 ,14,1,0,7,24,1,"/mount-point","Mount Point"
-,24,1,0,1,0,0,"/first-shared","FirstShared"
+,24,111,0,1,0,0,"/first-shared","FirstShared"
 "tt_content",
 ,"uid","pid","colPos","CType","bodytext"
 ,99,24,0,"text","Some Lorem Ipsum conteint!"

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.csv
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.csv
@@ -1,29 +1,34 @@
 # There is following scenario:
 #   [0]
 #    |
-#    ——[20] Shared-Pages (Not root)
+#    |—[111] 2nd page root
 #    |   |
-#    |   ——[44] FirstShared (Not root)
+#    |   |—[44] FirstShared (Not root)
 #    |
-#    ——[ 1] Page (Root)
+#    |—[ 1] Page (Root)
 #        |
-#        ——[14] Mount Point (to [44] to show contents from)
-#    |
-#    ——[ 2] Page (Root)
+#        |—[14] Mount Point (to [44] to show contents from)
 #        |
-#        ——[24] Mount Point (to [44] to show contents from)
+#        |—[24] Mount Point (to [44] to show contents from)
 "pages",
 ,"uid","pid","is_siteroot","doktype","mount_pid","mount_pid_ol","slug","title"
 # Site tree a
 ,14,1,0,7,44,1,"/mount-point","Mount Point"
 ,24,1,0,7,44,1,"/mount-point-2","Mount Point 2"
 # Shared Pages tree
-,20,0,0,254,0,0,"/shared-pages","Shared-Pages"
-,44,20,0,1,0,0,"/first-shared","FirstShared (Not root)"
+,44,111,0,1,0,0,"/first-shared","FirstShared (Not root)"
 "tt_content",
 ,"uid","pid","colPos","CType","bodytext"
 ,99,44,0,"text","Some Lorem Ipsum conteint!"
 "tx_solr_indexqueue_item",
 ,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
-,4711,1,"pages",44,"pages",1449151778,0,0,0,0,0
-,4712,1,"pages",44,"pages",1449151778,0,0,0,0,0
+,4711,1,"pages",14,"pages",1449151778,0,1,0,0,0
+,4712,1,"pages",24,"pages",1449151778,0,1,0,0,0
+"tx_solr_indexqueue_indexing_property",
+,"uid","root","item_id","property_key","property_value"
+,1,1,4711,"mountPageSource",44
+,2,1,4711,"mountPageDestination",14
+,3,1,4711,"isMountedPage",1
+,4,1,4712,"mountPageSource",44
+,5,1,4712,"mountPageDestination",24
+,6,1,4712,"isMountedPage",1

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.csv
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.csv
@@ -1,6 +1,6 @@
 "pages",
 ,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp"
-,2,1,1,1,"/","hello solr","the subtitle",1449151778,1449151778
+,2,1,1,1,"/hello-solr","hello solr","the subtitle",1449151778,1449151778
 "tx_solr_indexqueue_item",
 ,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
 ,4711,1,"pages",2,"pages",1449151778,0,0,0,0,0

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.csv
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.csv
@@ -1,3 +1,3 @@
 "tx_solr_indexqueue_item",
 ,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
-,4711,999,"pages",1636120156,"pages",1449151778,0,0,0,0,0
+,4711,1,"pages",1636120156,"pages",1449151778,0,0,0,0,0

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -337,7 +337,7 @@ class PageIndexerTest extends IntegrationTestBase
 
         $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_mounted_page_from_another_site.csv');
-        $this->addTypoScriptToTemplateRecord(111, 'config.index_enable = 1');
+        $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexQueuedPage();
 
         // we wait to make sure the document will be available in solr

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\DataUpdateHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\GarbageHandler;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
-use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
@@ -43,17 +42,12 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
 
     protected DataHandler|MockObject $dataHandlerMock;
 
-    protected SolrLogManager|MockObject $solrLogManagerMock;
-
-    protected MockObject|SolrLogManager $loggerMock;
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->mountPagesUpdaterMock = $this->createMock(MountPagesUpdater::class);
         $this->rootPageResolverMock = $this->createMock(RootPageResolver::class);
         $this->dataHandlerMock = $this->createMock(DataHandler::class);
-        $this->loggerMock = $this->createMock(SolrLogManager::class);
 
         $this->dataUpdateHandler = $this->getAccessibleMock(
             DataUpdateHandler::class,

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -44,6 +44,7 @@ class GarbageHandlerTest extends SetUpUpdateHandler
                 $this->frontendEnvironmentMock,
                 $this->tcaServiceMock,
                 $this->indexQueueMock,
+                $this->loggerMock,
             ],
         );
     }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/SetUpUpdateHandler.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/SetUpUpdateHandler.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\Configuratio
 use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
@@ -36,6 +37,7 @@ abstract class SetUpUpdateHandler extends SetUpUnitTestCase
     protected TCAService|MockObject $tcaServiceMock;
     protected Queue|MockObject $indexQueueMock;
     protected PagesRepository|MockObject $pagesRepositoryMock;
+    protected SolrLogManager|MockObject $loggerMock;
 
     protected function setUp(): void
     {
@@ -45,6 +47,7 @@ abstract class SetUpUpdateHandler extends SetUpUnitTestCase
         $this->indexQueueMock = $this->createMock(Queue::class);
         $this->pagesRepositoryMock = $this->createMock(PagesRepository::class);
         GeneralUtility::addInstance(PagesRepository::class, $this->pagesRepositoryMock);
+        $this->loggerMock = $this->createMock(SolrLogManager::class);
 
         $this->typoScriptConfigurationMock = $this->createMock(TypoScriptConfiguration::class);
         $this->frontendEnvironmentMock

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "ext-simplexml": "*",
     "solarium/solarium": "6.3.6",
     "typo3/cms-backend": "*",
-    "typo3/cms-core": "^v13.4",
+    "typo3/cms-core": "^v13.4.2",
     "typo3/cms-extbase": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-frontend": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'scheduler' => '',
-            'typo3' => '13.1.0-13.4.99',
+            'typo3' => '13.4.2-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Mount point indexing and corresponding tests have been adjusted for
TYPO3 13. Mount points are supported in general and the mounted pages
will be indexed like standard pages.

But there are some points to consider:

*   Cross-site mounts require that `config.index_enable = 1` is set
    in the pagetree of the mounted page, as TYPO3 loads the
    TypoScript of the mounted page.
    This is probably a bug in the TYPO3 core and may change, due to
    changes in RootlineUtility->generateRootlineCache() the mount page
    pid isn't used any more.
*   Pages in a pagetree without a site configuration cannot be
    indexed, in fact TYPO3 currently can't mount a page from a page
    tree without a site configuration and an exeception occurs.

Test procedure in PageIndexerTest has been improved and now uses
the PageUriBuilder to build the url to index, instead of building
the url in the test itself.

Resolves: https://github.com/TYPO3-Solr/ext-solr/issues/4160

---

*Caution*: Do not squash!