### PR TITLE
[BUGFIX] NPE in Index Queue module when no site is selected

### DIFF
--- a/Classes/Controller/Backend/Search/IndexQueueModuleController.php
+++ b/Classes/Controller/Backend/Search/IndexQueueModuleController.php
@@ -336,6 +336,10 @@ class IndexQueueModuleController extends AbstractModuleController
      */
     protected function getIndexQueues(): array
     {
+        if ($this->selectedSite === null) {
+            return [];
+        }
+
         $queues = [];
         $configuration = $this->selectedSite->getSolrConfiguration();
         foreach ($configuration->getEnabledIndexQueueConfigurationNames() as $indexingConfiguration) {


### PR DESCRIPTION
In multi site setups a null pointer exception is thrown when opening the Index Queue TYPO3 module without having a solr-enabled page selected in the page tree. The NPE is thrown in `::initializeAction()` before the original handling of the "no site selected" case in `::indexAction()`.

Fixes: 3ea271319 ("[TASK:BP:11.6] Consider queue initialization status")

# What this pr does

Brings back the existing "No site could be found."  error message to the Index Queue TYPO3 module.

# How to test

Open the Index Queue TYPO3 module in an PHP 8.2, TYPO3 v11.5.41, EXT:solr v11.6.0 installation, that contains at least two sites with solr enabled. Select the root page (imaginary page with uid=0) in the page tree.
