### PR TITLE
[FIX] Garbage collector does not get configuration

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Page\Rootline;
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
+use Doctrine\DBAL\Exception as DBALException;
 use RuntimeException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -58,8 +59,11 @@ class RootPageResolver implements SingletonInterface
      * if the pid is references in another site with additionalPageIds and returning those rootPageIds as well.
      * The result is cached by the caching framework.
      *
+     * @return int[]
+     *
      * @throws UnexpectedTYPO3SiteInitializationException
      * @throws RootPageRecordNotFoundException
+     * @throws DBALException
      */
     public function getResponsibleRootPageIds(string $table, int $uid): array
     {
@@ -118,6 +122,12 @@ class RootPageResolver implements SingletonInterface
 
     /**
      * Returns record of page for given conditions or empty array if nothing found.
+     *
+     * @return array{
+     *    'uid'?: int,
+     *    'pid'?: int,
+     *    'is_siteroot'?: int
+     * }
      */
     protected function getPageRecordByPageId(int $pageId, string $fieldList = 'is_siteroot'): array
     {
@@ -126,6 +136,8 @@ class RootPageResolver implements SingletonInterface
 
     /**
      * Determines the root page ID for a given page.
+     *
+     * @throws DBALException
      */
     public function getRootPageId(
         int $pageId = 0,
@@ -163,8 +175,11 @@ class RootPageResolver implements SingletonInterface
      * This method determines the responsible site roots for a record by getting the rootPage of the record and checking
      * if the pid is references in another site with additionalPageIds and returning those rootPageIds as well.
      *
+     * @return int[]
+     *
      * @throws UnexpectedTYPO3SiteInitializationException
      * @throws RootPageRecordNotFoundException
+     * @throws DBALException
      */
     protected function buildResponsibleRootPageIds(string $table, int $uid): array
     {
@@ -188,6 +203,8 @@ class RootPageResolver implements SingletonInterface
     /**
      * This method checks if the record is a pages record or another one and determines the rootPageId from the records
      * rootline.
+     *
+     * @throws DBALException
      */
     protected function getRootPageIdByTableAndUid(string $table, int $uid): int
     {
@@ -215,6 +232,8 @@ class RootPageResolver implements SingletonInterface
      * configuration of another site, if so we return the rootPageId of this site.
      * The result is cached by the caching framework.
      *
+     * @return int[]
+     *
      * @throws UnexpectedTYPO3SiteInitializationException
      */
     public function getAlternativeSiteRootPagesIds(string $table, int $uid, int $recordPageId): array
@@ -229,6 +248,8 @@ class RootPageResolver implements SingletonInterface
 
     /**
      * Retrieves an optimized array structure with the monitored pageId as key and the relevant site rootIds as value.
+     *
+     * @return array<int, int[]>
      *
      * @throws UnexpectedTYPO3SiteInitializationException
      */
@@ -249,6 +270,8 @@ class RootPageResolver implements SingletonInterface
     /**
      * This method builds an array with observer page id as key and rootPageIds as values to determine which root pages
      * are responsible for this record by referencing the pageId in additionalPageIds configuration.
+     *
+     * @return array<int, int[]>
      *
      * @throws UnexpectedTYPO3SiteInitializationException
      */

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -228,8 +228,6 @@ class Site
 
     /**
      * Gets the site's Solr TypoScript configuration (plugin.tx_solr.*)
-     *
-     * Purpose: Interface and Unit test mocking helper method.
      */
     public function getSolrConfiguration(): TypoScriptConfiguration
     {

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -21,7 +21,6 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageReso
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\FrontendEnvironment;
-use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
@@ -29,6 +28,7 @@ use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use Doctrine\DBAL\Exception as DBALException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -67,6 +67,7 @@ class SiteRepository
      *
      * @throws DBALException
      * @throws InvalidArgumentException
+     * @throws SiteNotFoundException
      */
     public function getSiteByPageId(int $pageId, string $mountPointIdentifier = ''): ?Site
     {
@@ -77,8 +78,8 @@ class SiteRepository
     /**
      * Gets the Site for a specific root page-id.
      *
-     * @throws DBALException
      * @throws InvalidArgumentException
+     * @throws SiteNotFoundException
      */
     public function getSiteByRootPageId(int $rootPageId): ?Site
     {
@@ -166,8 +167,8 @@ class SiteRepository
     /**
      * Creates an instance of the Site object.
      *
-     * @throws DBALException
      * @throws InvalidArgumentException
+     * @throws SiteNotFoundException
      */
     protected function buildSite(int $rootPageId): ?Site
     {
@@ -197,6 +198,11 @@ class SiteRepository
     /**
      * Validates given root page record, if it fits requirements.
      *
+     * @param array{
+     *    'uid'?: int,
+     *    'is_siteroot'?: int
+     * } $rootPageRecord
+     *
      * @throws InvalidArgumentException
      */
     protected function validateRootPageRecord(array $rootPageRecord): void
@@ -211,8 +217,12 @@ class SiteRepository
 
     /**
      * Builds a TYPO3 managed site with TypoScript configuration.
+     * @param array{
+     *    'uid': int,
+     *    'pid'?: int
+     * } $rootPageRecord
      *
-     * @throws DBALException
+     * @throws SiteNotFoundException
      */
     protected function buildTypo3ManagedSite(array $rootPageRecord): ?Site
     {

--- a/Classes/Report/SolrStatus.php
+++ b/Classes/Report/SolrStatus.php
@@ -111,7 +111,11 @@ class SolrStatus extends AbstractSolrStatus
         $this->responseStatus = ContextualFeedbackSeverity::OK;
 
         $solrAdmin = $this->connectionManager
-            ->getSolrConnectionForEndpoints($solrConnection['read'], $solrConnection['write'])
+            ->getSolrConnectionForEndpoints(
+                $solrConnection['read'],
+                $solrConnection['write'],
+                $site->getSolrConfiguration()
+            )
             ->getAdminService();
 
         $solrVersion = $this->checkSolrVersion($solrAdmin);

--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -148,6 +148,29 @@ class ConfigurationManager implements SingletonInterface
     }
 
     /**
+     * @return array{
+     *    'uid': int,
+     *    'pid': int,
+     *    'tstamp': int,
+     *    'crdate': int,
+     *    'deleted': int,
+     *    'hidden': int,
+     *    'starttime': int,
+     *    'endtime': int,
+     *    'sorting': int,
+     *    'description': string,
+     *    'tx_impexp_origuid': int,
+     *    'title': string,
+     *    'root': int,
+     *    'clear': int,
+     *    'constants': string,
+     *    'include_static_file': string,
+     *    'basedOn': string,
+     *    'includeStaticAfterBasedOn': int,
+     *    'config': string,
+     *    'static_file_mode': int,
+     * }
+     *
      * @throws DBALException
      */
     protected function getSysTemplateRowsForAssociatedContextPageId(ServerRequestInterface $request): array

--- a/Classes/System/Util/SiteUtility.php
+++ b/Classes/System/Util/SiteUtility.php
@@ -220,6 +220,10 @@ class SiteUtility
 
     /**
      * Takes a page record and checks whether the page is marked as root page.
+     *
+     * @param array{
+     *    'is_siteroot'?: int
+     * } $pageRecord
      */
     public static function isRootPage(array $pageRecord): bool
     {

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Definitions for modules provided by EXT:solr
  */

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -107,10 +107,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         );
     }
 
-    /**
-     * @param $amount
-     */
-    protected function assertIndexQueueContainsItemAmount($amount): void
+    protected function assertIndexQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->indexQueue->getAllItemsCount();
         self::assertEquals(
@@ -125,9 +122,6 @@ class GarbageCollectorTest extends IntegrationTestBase
         self::assertEquals(0, $this->eventQueue->count(), 'Event queue is not empty as expected');
     }
 
-    /**
-     * @param int $amount
-     */
     protected function assertEventQueueContainsItemAmount(int $amount): void
     {
         $itemsInQueue = $this->eventQueue->count();

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Exception\InvalidConnectionException;
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -141,7 +142,10 @@ class ConnectionManagerTest extends SetUpUnitTestCase
             ];
             $configuration['write'] = $configuration['read'];
 
-            $solrService = $this->connectionManager->getConnectionFromConfiguration($configuration);
+            $solrService = $this->connectionManager->getConnectionFromConfiguration(
+                $configuration,
+                $this->createMock(TypoScriptConfiguration::class)
+            );
             self::assertEquals($expectedConnectionString, $solrService->getReadService()->__toString());
         } catch (InvalidConnectionException $exception) {
             $exceptionOccurred = true;


### PR DESCRIPTION
Garbage collector and RecordMonitor triggered by RecordMonitor 
do not have infos about PID or Site. 
This change contains first step for refactoring of configuration retrieval. 
The delegation of TypoScriptConfiguration object, which will be moved to strict aggregation structure.

Fixes: #4203, #4207, #4208
Relates: #3995