### PR TITLE
[FEATURE:BP:12.0] Add timeframe filter to statistics module

### DIFF
--- a/Classes/Controller/Backend/Search/InfoModuleController.php
+++ b/Classes/Controller/Backend/Search/InfoModuleController.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Controller\Backend\Search;
 
 use ApacheSolrForTypo3\Solr\Api;
 use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Repository as ApacheSolrDocumentRepository;
+use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsFilterDto;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
@@ -51,16 +52,21 @@ class InfoModuleController extends AbstractModuleController
      *
      * @noinspection PhpUnused
      */
-    public function indexAction(): ResponseInterface
-    {
+    public function indexAction(
+        ?StatisticsFilterDto $statisticsFilter = null,
+        int $activeTabId = 0,
+        string $operation = '',
+    ): ResponseInterface {
         $this->initializeAction();
+
+        $this->moduleTemplate->assign('activeTabId', $activeTabId);
         if ($this->selectedSite === null) {
             $this->moduleTemplate->assign('can_not_proceed', true);
             return $this->moduleTemplate->renderResponse('Index');
         }
 
         $this->collectConnectionInfos();
-        $this->collectStatistics();
+        $this->collectStatistics($statisticsFilter, $operation);
         $this->collectIndexFieldsInfo();
         $this->collectIndexInspectorInfo();
 
@@ -133,65 +139,41 @@ class InfoModuleController extends AbstractModuleController
      *
      * @throws DBALException
      */
-    protected function collectStatistics(): void
+    protected function collectStatistics(?StatisticsFilterDto $statisticsFilterDto, string $operation): void
     {
-        $frameWorkConfiguration = $this->configurationManager->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT,
-            'solr'
-        );
-        $statisticsConfig = $frameWorkConfiguration['plugin.']['tx_solr.']['statistics.'] ?? [];
+        $statisticsFilter = $this->getStatisticsFilter($statisticsFilterDto, $operation);
 
-        $topHitsLimit = (int)($statisticsConfig['topHits.']['limit'] ?? 5);
-        $noHitsLimit = (int)($statisticsConfig['noHits.']['limit'] ?? 5);
-
-        $queriesDays = (int)($statisticsConfig['queries.']['days'] ?? 30);
-
-        $siteRootPageId = $this->selectedSite->getRootPageId();
         /** @var StatisticsRepository $statisticsRepository */
         $statisticsRepository = GeneralUtility::makeInstance(StatisticsRepository::class);
 
         $this->moduleTemplate->assign(
             'top_search_phrases',
-            $statisticsRepository->getTopKeyWordsWithHits(
-                $siteRootPageId,
-                (int)($statisticsConfig['topHits.']['days'] ?? 30),
-                $topHitsLimit
-            )
+            $statisticsRepository->getTopKeyWordsWithHits($statisticsFilter)
         );
         $this->moduleTemplate->assign(
             'top_search_phrases_without_hits',
-            $statisticsRepository->getTopKeyWordsWithoutHits(
-                $siteRootPageId,
-                (int)($statisticsConfig['noHits.']['days'] ?? 30),
-                $noHitsLimit
-            )
+            $statisticsRepository->getTopKeyWordsWithoutHits($statisticsFilter)
         );
         $this->moduleTemplate->assign(
             'search_phrases_statistics',
-            $statisticsRepository->getSearchStatistics(
-                $siteRootPageId,
-                $queriesDays,
-                (int)($statisticsConfig['queries.']['limit'] ?? 100)
-            )
+            $statisticsRepository->getSearchStatistics($statisticsFilter)
         );
 
         $labels = [];
         $data = [];
-        $chartData = $statisticsRepository->getQueriesOverTime(
-            $siteRootPageId,
-            $queriesDays,
-            86400
-        );
+        $chartData = $statisticsRepository->getQueriesOverTime($statisticsFilter, 86400);
+
         foreach ($chartData as $bucket) {
             // @todo Replace deprecated strftime in php 8.1. Suppress warning for now
             $labels[] = @strftime('%x', $bucket['timestamp']);
             $data[] = (int)$bucket['numQueries'];
         }
 
+        $this->moduleTemplate->assign('statisticsFilter', $statisticsFilter);
         $this->moduleTemplate->assign('queriesChartLabels', json_encode($labels));
         $this->moduleTemplate->assign('queriesChartData', json_encode($data));
-        $this->moduleTemplate->assign('topHitsLimit', $topHitsLimit);
-        $this->moduleTemplate->assign('noHitsLimit', $noHitsLimit);
+        $this->moduleTemplate->assign('topHitsLimit', $statisticsFilter->getTopHitsLimit());
+        $this->moduleTemplate->assign('noHitsLimit', $statisticsFilter->getNoHitsLimit());
     }
 
     /**
@@ -321,5 +303,21 @@ class InfoModuleController extends AbstractModuleController
             'numberOfTerms' => $lukeData->index->numTerms ?? 0,
             'numberOfFields' => count($fields),
         ];
+    }
+
+    protected function getStatisticsFilter(?StatisticsFilterDto $statisticsFilterDto, string $operation): StatisticsFilterDto
+    {
+        $frameWorkConfiguration = $this->configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT,
+            'solr'
+        );
+        $statisticsConfig = $frameWorkConfiguration['plugin.']['tx_solr.']['statistics.'] ?? [];
+
+        if ($statisticsFilterDto === null || $operation === 'reset-filters') {
+            $statisticsFilterDto = GeneralUtility::makeInstance(StatisticsFilterDto::class);
+        }
+
+        return $statisticsFilterDto->setFromTypoScriptConstants($statisticsConfig)
+            ->setSiteRootPageId($this->selectedSite->getRootPageId());
     }
 }

--- a/Classes/Domain/Search/Statistics/StatisticsFilterDto.php
+++ b/Classes/Domain/Search/Statistics/StatisticsFilterDto.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Statistics;
+
+use DateTime;
+
+final class StatisticsFilterDto
+{
+    /** typoscript constants */
+    private int $siteRootPageId = 0;
+    private int $topHitsLimit = 5;
+    private int $noHitsLimit = 5;
+    private int $queriesLimit = 100;
+    private int $topHitsDays = 30;
+    private int $noHitsDays = 30;
+    private int $queriesDays = 30;
+
+    /** Override properties */
+    private ?DateTime $startDate = null;
+    private ?DateTime $endDate = null;
+
+    public function __construct()
+    {
+        $this->startDate = DateTime::createFromFormat('U', (string)$this->getQueriesStartDate());
+        $this->endDate = DateTime::createFromFormat('U', (string)$this->getEndDateTimestamp());
+    }
+
+    public function setFromTypoScriptConstants(array $settings): StatisticsFilterDto
+    {
+        $this->topHitsLimit = (int)($settings['topHits.']['limit'] ?? 5);
+        $this->noHitsLimit = (int)($settings['noHits.']['limit'] ?? 5);
+        $this->queriesLimit = (int)($settings['queries.']['limit'] ?? 100);
+        $this->topHitsDays = (int)($settings['topHits.']['days'] ?? 30);
+        $this->noHitsDays = (int)($settings['noHits.']['days'] ?? 30);
+        $this->queriesDays = (int)($settings['queries.']['days'] ?? 30);
+
+        return $this;
+    }
+
+    public function setSiteRootPageId(int $siteRootPageId): StatisticsFilterDto
+    {
+        $this->siteRootPageId = $siteRootPageId;
+        return $this;
+    }
+
+    public function setStartDate(?DateTime $startDate): StatisticsFilterDto
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    public function setEndDate(?DateTime $endDate): StatisticsFilterDto
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    public function getTopHitsDays(): int
+    {
+        return $this->topHitsDays;
+    }
+
+    public function getNoHitsDays(): int
+    {
+        return $this->noHitsDays;
+    }
+
+    public function getQueriesDays(): int
+    {
+        return $this->queriesDays;
+    }
+
+    public function getSiteRootPageId(): int
+    {
+        return $this->siteRootPageId;
+    }
+
+    public function getTopHitsLimit(): int
+    {
+        return $this->topHitsLimit;
+    }
+
+    public function getNoHitsLimit(): int
+    {
+        return $this->noHitsLimit;
+    }
+
+    public function getQueriesLimit(): int
+    {
+        return $this->queriesLimit;
+    }
+
+    public function getStartDate(): ?DateTime
+    {
+        return $this->startDate;
+    }
+
+    public function getEndDate(): ?DateTime
+    {
+        return $this->endDate;
+    }
+
+    public function getTopHitsStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->topHitsDays);
+    }
+
+    public function getNoHitsStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->noHitsDays);
+    }
+
+    public function getQueriesStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->queriesDays);
+    }
+
+    /**
+     * End date can not be set by default in typoscript constants and is always now, so one override getter is enough
+     */
+    public function getEndDateTimestamp(): int
+    {
+        if ($this->endDate !== null) {
+            return $this->endDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays(0);
+    }
+
+    protected function getTimeStampSinceDays(int $days): int
+    {
+        $now = time();
+        return $now - 86400 * $days; // 86400 seconds/day
+    }
+}

--- a/Classes/Domain/Search/Statistics/StatisticsRepository.php
+++ b/Classes/Domain/Search/Statistics/StatisticsRepository.php
@@ -33,11 +33,14 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    public function getSearchStatistics(int $rootPageId, int $days = 30, int $limit = 10): array
+    public function getSearchStatistics(StatisticsFilterDto $statisticsFilterDto): array
     {
-        $now = time();
-        $timeStart = $now - 86400 * $days; // 86400 seconds/day
-        return $this->getPreparedQueryBuilderForSearchStatisticsAndTopKeywords($rootPageId, $timeStart, $limit)
+        return $this->getPreparedQueryBuilderForSearchStatisticsAndTopKeywords(
+            $statisticsFilterDto->getSiteRootPageId(),
+            $statisticsFilterDto->getQueriesStartDate(),
+            $statisticsFilterDto->getEndDateTimestamp(),
+            $statisticsFilterDto->getQueriesLimit()
+        )
             ->executeQuery()
             ->fetchAllAssociative();
     }
@@ -48,8 +51,12 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    protected function getPreparedQueryBuilderForSearchStatisticsAndTopKeywords(int $rootPageId, int $timeStart, int $limit): QueryBuilder
-    {
+    protected function getPreparedQueryBuilderForSearchStatisticsAndTopKeywords(
+        int $rootPageId,
+        int $timeStart,
+        int $timeEnd,
+        int $limit,
+    ): QueryBuilder {
         $countRows = $this->countByRootPageId($rootPageId);
         $queryBuilder = $this->getQueryBuilder();
         return $queryBuilder
@@ -60,6 +67,7 @@ class StatisticsRepository extends AbstractRepository
             ->from($this->table)
             ->andWhere(
                 $queryBuilder->expr()->gt('tstamp', $timeStart),
+                $queryBuilder->expr()->lt('tstamp', $timeEnd),
                 $queryBuilder->expr()->eq('root_pid', $rootPageId)
             )
             ->groupBy('keywords')
@@ -74,9 +82,14 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    public function getTopKeyWordsWithHits(int $rootPageId, int $days = 30, int $limit = 10): array
+    public function getTopKeyWordsWithHits(StatisticsFilterDto $filterDto): array
     {
-        return $this->getTopKeyWordsWithOrWithoutHits($rootPageId, $days, $limit);
+        return $this->getTopKeyWordsWithOrWithoutHits(
+            $filterDto->getSiteRootPageId(),
+            $filterDto->getTopHitsStartDate(),
+            $filterDto->getEndDateTimestamp(),
+            $filterDto->getTopHitsLimit()
+        );
     }
 
     /**
@@ -84,9 +97,15 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    public function getTopKeyWordsWithoutHits(int $rootPageId, int $days = 30, int $limit = 10): array
+    public function getTopKeyWordsWithoutHits(StatisticsFilterDto $filterDto): array
     {
-        return $this->getTopKeyWordsWithOrWithoutHits($rootPageId, $days, $limit, true);
+        return $this->getTopKeyWordsWithOrWithoutHits(
+            $filterDto->getSiteRootPageId(),
+            $filterDto->getNoHitsStartDate(),
+            $filterDto->getEndDateTimestamp(),
+            $filterDto->getNoHitsLimit(),
+            true
+        );
     }
 
     /**
@@ -94,12 +113,20 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    protected function getTopKeyWordsWithOrWithoutHits(int $rootPageId, int $days = 30, int $limit = 10, bool $withoutHits = false): array
-    {
-        $now = time();
-        $timeStart = $now - 86400 * $days; // 86400 seconds/day
+    protected function getTopKeyWordsWithOrWithoutHits(
+        int $rootPageId,
+        int $timeStart,
+        int $timeEnd,
+        int $limit = 10,
+        bool $withoutHits = false,
+    ): array {
+        $queryBuilder = $this->getPreparedQueryBuilderForSearchStatisticsAndTopKeywords(
+            $rootPageId,
+            $timeStart,
+            $timeEnd,
+            $limit
+        );
 
-        $queryBuilder = $this->getPreparedQueryBuilderForSearchStatisticsAndTopKeywords($rootPageId, $timeStart, $limit);
         // Check if we want without or with hits
         if ($withoutHits === true) {
             $queryBuilder->andWhere($queryBuilder->expr()->eq('num_found', 0));
@@ -117,12 +144,10 @@ class StatisticsRepository extends AbstractRepository
      *
      * @throws DBALException
      */
-    public function getQueriesOverTime(int $rootPageId, int $days = 30, int $bucketSeconds = 3600): array
+    public function getQueriesOverTime(StatisticsFilterDto $statisticsFilterDto, int $bucketSeconds = 3600): array
     {
-        $now = time();
-        $timeStart = $now - 86400 * $days; // 86400 seconds/day
-
         $queryBuilder = $this->getQueryBuilder();
+
         return $queryBuilder
             ->addSelectLiteral(
                 'FLOOR(tstamp/' . $bucketSeconds . ') AS bucket',
@@ -131,8 +156,9 @@ class StatisticsRepository extends AbstractRepository
             )
             ->from($this->table)
             ->andWhere(
-                $queryBuilder->expr()->gt('tstamp', $timeStart),
-                $queryBuilder->expr()->eq('root_pid', $rootPageId)
+                $queryBuilder->expr()->gt('tstamp', $statisticsFilterDto->getQueriesStartDate()),
+                $queryBuilder->expr()->lt('tstamp', $statisticsFilterDto->getEndDateTimestamp()),
+                $queryBuilder->expr()->eq('root_pid', $statisticsFilterDto->getSiteRootPageId())
             )
             ->groupBy('bucket', 'timestamp')
             ->orderBy('bucket', 'ASC')

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -373,6 +373,18 @@
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>
 			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter" xml:space="preserve">
+				<source>Filter</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.reset" xml:space="preserve">
+				<source>Reset</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.start" xml:space="preserve">
+				<source>Start</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.end" xml:space="preserve">
+				<source>End</source>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -7,49 +7,49 @@
     <div role="tabpanel">
         <ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-tab" data-store-last-tab="1">
             <li role="presentation" class="t3js-tabmenu-item nav-item">
-                <a href="#connections-tab" class="nav-link active" title="" aria-controls="tab-1" role="tab" data-bs-toggle="tab">
+                <a href="#connections-tab" class="nav-link{f:if(condition: '{activeTabId} == 0', then: ' active')}" title="" aria-controls="tab-1" role="tab" data-bs-toggle="tab">
                     Connections
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item ">
-                <a href="#statistics-tab" class="nav-link" title="" aria-controls="tab-3" role="tab" data-bs-toggle="tab">
+                <a href="#statistics-tab" class="nav-link{f:if(condition: '{activeTabId} == 1', then: ' active')}" title="" aria-controls="tab-3" role="tab" data-bs-toggle="tab">
                     Statistics
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item ">
-                <a href="#index_fields-tab" class="nav-link" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
+                <a href="#index_fields-tab" class="nav-link{f:if(condition: '{activeTabId} == 2', then: ' active')}" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
                     Index Fields
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item">
-                <a href="#index_inspector-tab" class="nav-link" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
+                <a href="#index_inspector-tab" class="nav-link{f:if(condition: '{activeTabId} == 3', then: ' active')}" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
                     Index Documents
                 </a>
             </li>
         </ul>
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane active" id="connections-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 0', then: ' active')}" id="connections-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="ConnectionInfos" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="statistics-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 1', then: ' active')}" id="statistics-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="Statistics" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="index_fields-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 2', then: ' active')}" id="index_fields-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="IndexFields" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="index_inspector-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 3', then: ' active')}" id="index_inspector-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="IndexInspector" arguments="{_all}"/>
@@ -108,13 +108,58 @@
 </f:section>
 
 <f:section name="Statistics">
-    <!-- TODO add buttons to select time frame [last 24h] [last 30 days] [all] -->
-
     <f:be.pageRenderer
         includeJavaScriptModules="{
             0: '@apache-solr-for-typo3/solr/SearchStatistics.js'
         }"
     />
+
+	<div class="row">
+		<div class="col-md-12">
+			<f:form action="index" object="{statisticsFilter}" name="statisticsFilter">
+				<div class="form-row">
+					<div class="form-group">
+						<label for="statisticsStartDate" class="form-label">{f:translate(key: 'solr.backend.search_statistics_module.filter.start')}</label>
+						<div class="input-group">
+							<f:form.textfield
+								property="startDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.startDate}')}"
+								id="statisticsStartDate"
+								additionalAttributes="{'autocomplete': 'off'}"
+								class="form-control form-control-clearable t3js-datetimepicker t3js-clearable"
+								data="{date-type: 'datetime'}"
+							/>
+							<label class="btn btn-default" for="statisticsStartDate">
+								<core:icon identifier="actions-calendar" />
+							</label>
+						</div>
+					</div>
+
+					<div class="form-group">
+						<label for="statisticsEndDate" class="form-label">{f:translate(key: 'solr.backend.search_statistics_module.filter.end')}</label>
+						<div class="input-group">
+							<f:form.textfield
+								property="endDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.endDate}')}"
+								id="statisticsEndDate"
+								additionalAttributes="{'autocomplete': 'off'}"
+								class="form-control form-control-clearable t3js-datetimepicker t3js-clearable"
+								data="{date-type: 'datetime'}"
+							/>
+							<label class="btn btn-default" for="statisticsEndDate">
+								<core:icon identifier="actions-calendar" />
+							</label>
+						</div>
+					</div>
+					<div class="form-group align-self-end">
+						<f:form.button type="submit" name="operation" value="filter" class="btn btn-default">{f:translate(key: 'solr.backend.search_statistics_module.filter')}</f:form.button>
+						<f:form.button type="submit" name="operation" value="reset-filters" class="btn btn-link">{f:translate(key: 'solr.backend.search_statistics_module.filter.reset')}</f:form.button>
+					</div>
+				</div>
+				<f:form.hidden name="activeTabId" value="1" />
+			</f:form>
+		</div>
+	</div>
 
     <div class="row">
         <div class="col-md-12">

--- a/Resources/Public/JavaScript/SearchStatistics.js
+++ b/Resources/Public/JavaScript/SearchStatistics.js
@@ -1,4 +1,6 @@
-import { Chart, registerables } from './Chart/chart.esm.js'
+import { Chart, registerables } from './Chart/chart.esm.js';
+import DateTimePicker from '@typo3/backend/date-time-picker.js';
+
 Chart.register(...registerables);
 
 const queriesOverTimeChartElement = document.getElementById('queriesOverTime');
@@ -58,3 +60,6 @@ new Chart(queriesOverTimeChartElement, {
     }
   }
 });
+
+document.querySelectorAll('.t3js-datetimepicker')
+  .forEach(datePickerElement => { DateTimePicker.initialize(datePickerElement) });

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -15,8 +15,10 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\Domain\Search\StatisticsRepository;
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsFilterDto;
 use ApacheSolrForTypo3\Solr\Domain\Search\Statistics\StatisticsRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use DateTime;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,11 +30,11 @@ class StatisticsRepositoryTest extends IntegrationTestBase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
         $fixtureTimestamp = 1471203378;
-        $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
+        $filterDto = self::getFilterDto(1, $fixtureTimestamp);
 
         /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
-        $topHits = $repository->getTopKeyWordsWithHits(1, $daysSinceFixture);
+        $topHits = $repository->getTopKeyWordsWithHits($filterDto);
         $expectedResult = [
             ['keywords' => 'content', 'count' => 2, 'hits' => '5.0000', 'percent' => '50.0000'],
             ['keywords' => 'typo3', 'count' => 1, 'hits' => '6.0000', 'percent' => '25.0000'],
@@ -46,11 +48,11 @@ class StatisticsRepositoryTest extends IntegrationTestBase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
         $fixtureTimestamp = 1471203378;
-        $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
+        $filterDto = self::getFilterDto(1, $fixtureTimestamp);
 
         /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
-        $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
+        $topHits = $repository->getTopKeyWordsWithoutHits($filterDto);
 
         $expectedResult = [
             ['keywords' => 'cms', 'count' => 1, 'hits' => '0.0000', 'percent' => '25.0000'],
@@ -64,11 +66,11 @@ class StatisticsRepositoryTest extends IntegrationTestBase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
         $fixtureTimestamp = 1480000000;
-        $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
+        $filterDto = self::getFilterDto(1, $fixtureTimestamp);
 
         /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
-        $topHits = $repository->getTopKeyWordsWithoutHits(1, $daysSinceFixture);
+        $topHits = $repository->getTopKeyWordsWithoutHits($filterDto);
 
         $expectedResult = [];
 
@@ -80,11 +82,11 @@ class StatisticsRepositoryTest extends IntegrationTestBase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/statistics.csv');
         $fixtureTimestamp = 1480000000;
-        $daysSinceFixture = self::getDaysSinceTimestamp($fixtureTimestamp) + 1;
+        $filterDto = self::getFilterDto(37, $fixtureTimestamp);
 
         /** @var StatisticsRepository $repository */
         $repository = GeneralUtility::makeInstance(StatisticsRepository::class);
-        $topHits = $repository->getSearchStatistics(37, $daysSinceFixture);
+        $topHits = $repository->getSearchStatistics($filterDto);
 
         $expectedResult = [];
 
@@ -123,13 +125,13 @@ class StatisticsRepositoryTest extends IntegrationTestBase
         self::assertEquals(5, $repository->countByRootPageId(1), 'Does not contain shortly inserted statistic record.');
     }
 
-    /**
-     * Helper method to calculate the number of days from now to a specific timestamp.
-     */
-    protected static function getDaysSinceTimestamp(int $timestamp): int
+    protected static function getFilterDto(int $rootPageId, int $sinceTimestamp): StatisticsFilterDto
     {
-        $secondsUntilNow = time() - $timestamp;
-        $days = floor($secondsUntilNow / (60 * 60 * 24));
-        return (int)$days;
+        $startDate = DateTime::createFromFormat('U', (string)$sinceTimestamp);
+        $filterDto = new StatisticsFilterDto();
+        $filterDto->setSiteRootPageId($rootPageId)
+            ->setFromTypoScriptConstants([])
+            ->setStartDate($startDate->modify('-1 day'));
+        return $filterDto;
     }
 }


### PR DESCRIPTION
# What this pr does
Backport for TYPO3v12

Adds a time frame filter in the statistics module.
Per default the typoscript constants are used, which are then overwritten by the selected timeframe.

# How to test

Go to the statistics module and select the desired timeframe

Fixes: #4228 