### PR TITLE
[FEATURE] Add timeframe filter to statistics module

### DIFF
--- a/Classes/Domain/Search/Statistics/StatisticsFilterDto.php
+++ b/Classes/Domain/Search/Statistics/StatisticsFilterDto.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApacheSolrForTypo3\Solr\Domain\Search\Statistics;
+
+use DateTime;
+
+final class StatisticsFilterDto
+{
+    /** typoscript constants */
+    private int $siteRootPageId = 0;
+    private int $topHitsLimit = 5;
+    private int $noHitsLimit = 5;
+    private int $queriesLimit = 100;
+    private int $topHitsDays = 30;
+    private int $noHitsDays = 30;
+    private int $queriesDays = 30;
+
+    /** Override properties */
+    private ?DateTime $startDate = null;
+    private ?DateTime $endDate = null;
+
+    public function __construct()
+    {
+        $this->startDate = DateTime::createFromFormat('U', (string)$this->getQueriesStartDate());
+        $this->endDate = DateTime::createFromFormat('U', (string)$this->getEndDateTimestamp());
+    }
+
+    public function setSiteRootPageId(int $siteRootPageId): StatisticsFilterDto
+    {
+        $this->siteRootPageId = $siteRootPageId;
+        return $this;
+    }
+
+    public function setStartDate(?DateTime $startDate): StatisticsFilterDto
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    public function setEndDate(?DateTime $endDate): StatisticsFilterDto
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    public function getTopHitsDays(): int
+    {
+        return $this->topHitsDays;
+    }
+
+    public function getNoHitsDays(): int
+    {
+        return $this->noHitsDays;
+    }
+
+    public function getQueriesDays(): int
+    {
+        return $this->queriesDays;
+    }
+
+    public function getSiteRootPageId(): int
+    {
+        return $this->siteRootPageId;
+    }
+
+    public function getTopHitsLimit(): int
+    {
+        return $this->topHitsLimit;
+    }
+
+    public function getNoHitsLimit(): int
+    {
+        return $this->noHitsLimit;
+    }
+
+    public function getQueriesLimit(): int
+    {
+        return $this->queriesLimit;
+    }
+
+    public function getStartDate(): ?DateTime
+    {
+        return $this->startDate;
+    }
+
+    public function getEndDate(): ?DateTime
+    {
+        return $this->endDate;
+    }
+
+    public function getTopHitsStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->topHitsDays);
+    }
+
+    public function getNoHitsStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->noHitsDays);
+    }
+
+    public function getQueriesStartDate(): int
+    {
+        if ($this->startDate !== null) {
+            return $this->startDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays($this->queriesDays);
+    }
+
+    /**
+     * End date can not be set by default in typoscript constants and is always now, so one override getter is enough
+     */
+    public function getEndDateTimestamp(): int
+    {
+        if ($this->endDate !== null) {
+            return $this->endDate->getTimestamp();
+        }
+
+        return $this->getTimeStampSinceDays(0);
+    }
+
+    protected function getTimeStampSinceDays(int $days): int
+    {
+        $now = time();
+        return $now - 86400 * $days; // 86400 seconds/day
+    }
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -373,6 +373,18 @@
 			<trans-unit id="solr.backend.search_statistics_module.search_phrases_header" xml:space="preserve">
 				<source>Search Phrase Statistics</source>
 			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter" xml:space="preserve">
+				<source>Filter</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.reset" xml:space="preserve">
+				<source>Reset</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.start" xml:space="preserve">
+				<source>Start</source>
+			</trans-unit>
+			<trans-unit id="solr.backend.search_statistics_module.filter.end" xml:space="preserve">
+				<source>End</source>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/InfoModule/Index.html
@@ -7,49 +7,49 @@
     <div role="tabpanel">
         <ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-tab" data-store-last-tab="1">
             <li role="presentation" class="t3js-tabmenu-item nav-item">
-                <a href="#connections-tab" class="nav-link active" title="" aria-controls="tab-1" role="tab" data-bs-toggle="tab">
+                <a href="#connections-tab" class="nav-link{f:if(condition: '{activeTabId} == 0', then: ' active')}" title="" aria-controls="tab-1" role="tab" data-bs-toggle="tab">
                     Connections
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item ">
-                <a href="#statistics-tab" class="nav-link" title="" aria-controls="tab-3" role="tab" data-bs-toggle="tab">
+                <a href="#statistics-tab" class="nav-link{f:if(condition: '{activeTabId} == 1', then: ' active')}" title="" aria-controls="tab-3" role="tab" data-bs-toggle="tab">
                     Statistics
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item ">
-                <a href="#index_fields-tab" class="nav-link" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
+                <a href="#index_fields-tab" class="nav-link{f:if(condition: '{activeTabId} == 2', then: ' active')}" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
                     Index Fields
                 </a>
             </li>
             <li role="presentation" class="t3js-tabmenu-item nav-item">
-                <a href="#index_inspector-tab" class="nav-link" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
+                <a href="#index_inspector-tab" class="nav-link{f:if(condition: '{activeTabId} == 3', then: ' active')}" title="" aria-controls="tab-2" role="tab" data-bs-toggle="tab">
                     Index Documents
                 </a>
             </li>
         </ul>
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane active" id="connections-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 0', then: ' active')}" id="connections-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="ConnectionInfos" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="statistics-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 1', then: ' active')}" id="statistics-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="Statistics" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="index_fields-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 2', then: ' active')}" id="index_fields-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="IndexFields" arguments="{_all}"/>
                     </div>
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="index_inspector-tab">
+            <div role="tabpanel" class="tab-pane{f:if(condition: '{activeTabId} == 3', then: ' active')}" id="index_inspector-tab">
                 <div class="panel panel-tab">
                     <div class="panel-body">
                         <f:render section="IndexInspector" arguments="{_all}"/>
@@ -108,13 +108,67 @@
 </f:section>
 
 <f:section name="Statistics">
-    <!-- TODO add buttons to select time frame [last 24h] [last 30 days] [all] -->
-
     <f:be.pageRenderer
             includeJsFiles="{
         0: '{f:uri.resource(path:\'JavaScript/SearchStatistics.js\')}'
     }"
+						includeRequireJsModules="{0: 'TYPO3/CMS/Backend/DateTimePicker'}"
     />
+
+	<div class="row">
+		<div class="col-md-12">
+			<f:form action="index" object="{statisticsFilter}" name="statisticsFilter">
+				<div class="row row-cols-auto align-items-end g-3">
+					<div class="col">
+						<label for="statisticsStartDate" class="form-label">{f:translate(key: 'solr.backend.search_statistics_module.filter.start')}</label>
+						<div class="input-group">
+							<f:form.textfield
+								name="startDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.startDate}')}"
+								id="statisticsStartDate"
+								additionalAttributes="{'autocomplete': 'off'}"
+								class="form-control t3js-datetimepicker t3js-clearable"
+								data="{date-type: 'datetime'}"
+							/>
+							<f:form.hidden
+								property="startDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.startDate}')}"
+							/>
+							<label class="mb-0 btn btn-default" for="statisticsStartDate">
+								<core:icon identifier="actions-calendar" />
+							</label>
+						</div>
+					</div>
+
+					<div class="col">
+						<label for="statisticsEndDate" class="form-label">{f:translate(key: 'solr.backend.search_statistics_module.filter.end')}</label>
+						<div class="input-group">
+							<f:form.textfield
+								name="endDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.endDate}')}"
+								id="statisticsEndDate"
+								additionalAttributes="{'autocomplete': 'off'}"
+								class="form-control t3js-datetimepicker t3js-clearable"
+								data="{date-type: 'datetime'}"
+							/>
+							<f:form.hidden
+								property="endDate"
+								value="{f:format.date(format:'c', date: '{statisticsFilter.endDate}')}"
+							/>
+							<label class="mb-0 btn btn-default" for="statisticsEndDate">
+								<core:icon identifier="actions-calendar" />
+							</label>
+						</div>
+					</div>
+					<div class="col">
+						<f:form.button type="submit" name="operation" value="filter" class="btn btn-light">{f:translate(key: 'solr.backend.search_statistics_module.filter')}</f:form.button>
+						<f:form.button type="submit" name="operation" value="reset-filters" class="btn btn-link">{f:translate(key: 'solr.backend.search_statistics_module.filter.reset')}</f:form.button>
+					</div>
+				</div>
+				<f:form.hidden name="activeTabId" value="1" />
+			</f:form>
+		</div>
+	</div>
 
     <div class="row">
         <div class="col-md-12">


### PR DESCRIPTION
Relates: #4228

# What this pr does

Backport for TYPO3v11

Adds a time frame filter in the statistics module.
Per default the typoscript constants are used, which are then overwritten by the selected timeframe.

# How to test

Go to the statistics module and select the desired timeframe

Fixes: #4228 
