### PR TITLE
[BUGFIX] Prevent error when overlay is not available

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -303,7 +303,15 @@ class Relation extends AbstractContentObject
         string $foreignTableName = ''
     ): array {
         if ($this->getLanguageUid() > 0 && !empty($foreignTableName)) {
-            $relatedRecord = $this->getFrontendOverlayService()->getOverlay($foreignTableName, $relatedRecord);
+            $overlayRelatedRecord = $this->getFrontendOverlayService($parentContentObject)->getOverlay($foreignTableName, $relatedRecord);
+        }
+
+        // sys_page->getLanguageOverlay() may return NULL if overlays were activated but no overlay 
+        // was found and LanguageAspect was NOT set to MIXED
+        //
+        // If so rely on original record data
+        if (is_array($overlayRelatedRecord)) {
+            $relatedRecord = $overlayRelatedRecord;
         }
 
         $contentObject = clone $parentContentObject;


### PR DESCRIPTION
This fixes:

Core: Error handler (BE): PHP Warning: Trying to access array offset on value of type null in /var/www/vendor/apache-solr-for-typo3/solr/Classes/ContentObject/Relation.php line 311

# What this pr does

Please add a description here

# How to test

Please add a testing instruction here

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
