### PR TITLE
[BUGFIX] Fix notice exception in ScoreCalculationService

### DIFF
--- a/Classes/Domain/Search/Score/ScoreCalculationService.php
+++ b/Classes/Domain/Search/Score/ScoreCalculationService.php
@@ -98,7 +98,7 @@ class ScoreCalculationService
                 $pattern = '/' . preg_quote($field, '/') . '\^([\d.]*)/';
                 $boostMatches = [];
                 preg_match_all($pattern, $queryFields, $boostMatches);
-                $boost = (float)$boostMatches[1][0];
+                $boost = (float)($boostMatches[1][0] ?? 0);
                 $highScores[$field] = new Score($boost, $field, $currentScoreValue, $searchTerm);
             }
         }


### PR DESCRIPTION
Fix exception
```
 Exception: PHP Warning: Undefined array key 0 in /var/www/html/vendor/apache-solr-for-typo3/solr/Classes/Domain/Search/Score/ScoreCalculationService.php line 101, in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php:141 - {"exception":"TYPO3\\CMS\\Core\\Error\\Exception: PHP Warning: Undefined array key 0 in /var/www/html/vendor/apache-solr-for-typo3/solr/Classes/Domain/Search/Score/ScoreCalculationService.php line 101
```

I don't know the internals of the code but got the issue at a client
