### PR TITLE
[FEATURE] Use PHP generator to prevent processing of all available site

### DIFF
--- a/Classes/Controller/Backend/Search/AbstractModuleController.php
+++ b/Classes/Controller/Backend/Search/AbstractModuleController.php
@@ -124,9 +124,8 @@ abstract class AbstractModuleController extends ActionController
      */
     protected function autoSelectFirstSiteAndRootPageWhenOnlyOneSiteIsAvailable(): bool
     {
-        $solrConfiguredSites = $this->siteRepository->getAvailableSites();
         $availableSites = $this->siteFinder->getAllSites();
-        if (count($solrConfiguredSites) === 1 && count($availableSites) === 1) {
+        if (count($availableSites) === 1 && $this->siteRepository->hasExactlyOneAvailableSite()) {
             $this->selectedSite = $this->siteRepository->getFirstAvailableSite();
 
             // we only overwrite the selected pageUid when no id was passed
@@ -147,9 +146,7 @@ abstract class AbstractModuleController extends ActionController
      */
     protected function initializeView($view): void
     {
-        $sites = $this->siteRepository->getAvailableSites();
-
-        $selectOtherPage = count($sites) > 0 || $this->selectedPageUID < 1;
+        $selectOtherPage = $this->siteRepository->hasAvailableSites() || $this->selectedPageUID < 1;
         $this->moduleTemplate->assign('showSelectOtherPage', $selectOtherPage);
         $this->moduleTemplate->assign('pageUID', $this->selectedPageUID);
         if ($this->selectedPageUID < 1) {

--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -103,8 +103,12 @@ class SiteRepository
      */
     public function getFirstAvailableSite(bool $stopOnInvalidSite = false): ?Site
     {
-        $sites = $this->getAvailableSites($stopOnInvalidSite);
-        return array_shift($sites);
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        $site = $siteGenerator->current();
+
+        return $site instanceof Site ? $site : null;
     }
 
     /**
@@ -119,37 +123,81 @@ class SiteRepository
         $cacheId = 'SiteRepository' . '_' . 'getAvailableSites';
 
         $sites = $this->runtimeCache->get($cacheId);
-        if (!empty($sites)) {
+        if (is_array($sites) && $sites !== []) {
             return $sites;
         }
 
-        $sites = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        $sites = [];
+        foreach ($siteGenerator as $rootPageId => $site) {
+            if (isset($sites[$rootPageId])) {
+                //get each site only once
+                continue;
+            }
+            $sites[$rootPageId] = $site;
+        }
         $this->runtimeCache->set($cacheId, $sites);
 
         return $sites;
     }
 
     /**
-     * Returns available TYPO3 sites
-     *
-     * @return Site[]
+     * Check, if there are any managed sites available
      *
      * @throws UnexpectedTYPO3SiteInitializationException
      */
-    protected function getAvailableTYPO3ManagedSites(bool $stopOnInvalidSite): array
+    public function hasAvailableSites(bool $stopOnInvalidSite = false): bool
     {
-        $typo3ManagedSolrSites = [];
-        $typo3Sites = $this->siteFinder->getAllSites();
-        foreach ($typo3Sites as $typo3Site) {
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        return ($site = $siteGenerator->current()) && $site instanceof Site;
+    }
+
+    /**
+     * Check, if there is exactly one managed site available
+     * Needed in AbstractModuleController::autoSelectFirstSiteAndRootPageWhenOnlyOneSiteIsAvailable
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    public function hasExactlyOneAvailableSite(bool $stopOnInvalidSite = false): bool
+    {
+        if (!$this->hasAvailableSites($stopOnInvalidSite)) {
+            return false;
+        }
+
+        $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
+        $siteGenerator->rewind();
+
+        // We start with 1 here as we know from hasAvailableSites() above we have at least one site
+        $counter = 1;
+        foreach ($siteGenerator as $_) {
+            if ($counter > 1) {
+                return false;
+            }
+            $counter++;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns available TYPO3 sites
+     *
+     * @return Site[]|\Generator
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    protected function getAvailableTYPO3ManagedSites(bool $stopOnInvalidSite): \Generator
+    {
+        foreach ($this->siteFinder->getAllSites() as $typo3Site) {
             try {
                 $rootPageId = $typo3Site->getRootPageId();
-                if (isset($typo3ManagedSolrSites[$rootPageId])) {
-                    //get each site only once
-                    continue;
-                }
                 $typo3ManagedSolrSite = $this->buildSite($rootPageId);
                 if ($typo3ManagedSolrSite->isEnabled()) {
-                    $typo3ManagedSolrSites[$rootPageId] = $typo3ManagedSolrSite;
+                    yield $rootPageId => $typo3ManagedSolrSite;
                 }
             } catch (Throwable $e) {
                 if ($stopOnInvalidSite) {
@@ -161,7 +209,6 @@ class SiteRepository
                 }
             }
         }
-        return $typo3ManagedSolrSites;
     }
 
     /**

--- a/Classes/Report/SiteHandlingStatus.php
+++ b/Classes/Report/SiteHandlingStatus.php
@@ -66,8 +66,7 @@ class SiteHandlingStatus extends AbstractSolrStatus
     public function getStatus(): array
     {
         $reports = [];
-        $sites = $this->siteRepository->getAvailableSites();
-        if (empty($sites)) {
+        if (!$this->siteRepository->hasAvailableSites()) {
             $reports[] = GeneralUtility::makeInstance(
                 Status::class,
                 self::TITLE_SITE_HANDLING_CONFIGURATION,
@@ -79,8 +78,7 @@ class SiteHandlingStatus extends AbstractSolrStatus
             return $reports;
         }
 
-        /** @var Site $site */
-        foreach ($sites as $site) {
+        foreach ($this->siteRepository->getAvailableSites() as $site) {
             if (!($site instanceof Site)) {
                 $reports[] = GeneralUtility::makeInstance(
                     Status::class,

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -89,7 +89,6 @@ class SiteRepositoryTest extends SetUpUnitTestCase
         $this->assertThatSitesAreCreatedWithPageIds([333], [
             0 => ['language' => 0],
         ]);
-        $this->assertCacheIsWritten();
 
         $site = $this->siteRepository->getFirstAvailableSite();
         self::assertInstanceOf(Site::class, $site);


### PR DESCRIPTION
Use PHP generator with yield to process just the available sites needed How to test

With over 300 root pages it needs over 30 seconds to build up all available sites. With help of a PHP generator we can stop processing all available sites if just the first site is requested. It's also helpful to just check, if there are available sites.

This should speed up performance a lot.

* Remove cache storing from <has> methods of SiteRepository
* Use hasAvailableSites in ModuleController
* Remove cache-set check from tests for SiteRepository
* Move check for duplicate sites to getAvailableSites. PhpStan

Fixes: #3939
Replaces: #4154