### PR TITLE
#4263 [FIX] - fixed ConfigurationAwareRecordService.php

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -123,9 +123,9 @@ class ConfigurationAwareRecordService
     protected function getRecordForIndexConfigurationIsValid(
         string $recordTable,
         int $recordUid,
-        string $recordWhereClause = '',
+        string $recordWhereClause = ''
     ): array {
-        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'runtime');
         $cacheId = md5('ConfigurationAwareRecordService' . ':' . 'getRecordIfIndexConfigurationIsValid' . ':' . $recordTable . ':' . $recordUid . ':' . $recordWhereClause);
 
         $row = $cache->get($cacheId);
@@ -133,27 +133,10 @@ class ConfigurationAwareRecordService
             return $row;
         }
 
-        $queryBuilder = $this->getQueryBuilderForTable($recordTable);
-        $queryBuilder
-            ->select('*')
-            ->from($recordTable)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid',
-                    $queryBuilder->createNamedParameter($recordUid, Connection::PARAM_INT)
-                )
-            );
-
-        if ($recordWhereClause !== '') {
-            $queryBuilder->andWhere(QueryHelper::stripLogicalOperatorPrefix($recordWhereClause));
-        }
-
-        $row = $queryBuilder->executeQuery()->fetchAssociative();
-        if ($row === false) {
-            $row = [];
-        }
+        $row = (array)BackendUtility::getRecord($recordTable, $recordUid, '*', $recordWhereClause);
         $cache->set($cacheId, $row);
-        return $row;
+
+        return $row ?? [];
     }
 
     /**


### PR DESCRIPTION
Related to issue 4263 : 

# What this pr does

just reverting the ConfigurationAwareRecordService::getRecordForIndexConfigurationIsValid() method to v11.5.2, relying on Backend::getRecord() method instead of using a queryBuilder() adding constraints preventing to retrieve a not-yet visible record. The issue could also be fixed by removing restrictions, for instance : $queryBuilder->getRestrictions()
    ->removeByType(StartTimeRestriction::class)

# How to test

cf related issue.

Fixes: #4263
