### PR TITLE
[FEATURE] Add an event for modifying the domain used for a site

### DIFF
--- a/Classes/Event/Site/AfterDomainHasBeenDeterminedForSiteEvent.php
+++ b/Classes/Event/Site/AfterDomainHasBeenDeterminedForSiteEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Event\Site;
+
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+/**
+ * This event is dispatched when determining which domain to use for a site
+ */
+final class AfterDomainHasBeenDeterminedForSiteEvent
+{
+    private string $domain;
+
+    private array $rootPageRecord;
+
+    private Site $typo3Site;
+
+    private ExtensionConfiguration $extensionConfiguration;
+
+    public function __construct(String $domain, array $rootPageRecord, Site $typo3Site, ExtensionConfiguration $extensionConfiguration)
+    {
+        $this->domain = $domain;
+        $this->rootPageRecord = $rootPageRecord;
+        $this->typo3Site = $typo3Site;
+        $this->extensionConfiguration = $extensionConfiguration;
+    }
+
+    public function getDomain(): String
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain)
+    {
+        $this->domain = $domain;
+    }
+
+    public function getRootPageRecord(): array
+    {
+        return $this->rootPageRecord;
+    }
+
+    public function getTypo3Site(): Site
+    {
+        return $this->typo3Site;
+    }
+
+    public function getExtensionConfiguration(): ExtensionConfiguration
+    {
+        return $this->extensionConfiguration;
+    }
+}

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -18,13 +18,18 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Site;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Site\Entity\Site as CoreSite;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Testcase to check if the SiteRepository class works as expected.
@@ -37,6 +42,7 @@ class SiteRepositoryTest extends SetUpUnitTestCase
     protected RootPageResolver|MockObject $rootPageResolverMock;
     protected SiteRepository|MockObject $siteRepository;
     protected SiteFinder|MockObject $siteFinderMock;
+    protected EventDispatcherInterface|MockObject $eventDispatcherMock;
 
     protected function setUp(): void
     {
@@ -47,7 +53,14 @@ class SiteRepositoryTest extends SetUpUnitTestCase
 
         // we mock buildSite to avoid the creation of real Site objects and pass all dependencies as mock
         $this->siteRepository = $this->getMockBuilder(SiteRepository::class)
-            ->setConstructorArgs([$this->rootPageResolverMock, $this->cacheMock, $this->siteFinderMock])
+            ->setConstructorArgs([
+                $this->rootPageResolverMock,
+                $this->cacheMock,
+                $this->siteFinderMock,
+                GeneralUtility::makeInstance(ExtensionConfiguration::class),
+                GeneralUtility::makeInstance(FrontendEnvironment::class),
+                new NoopEventDispatcher(),
+            ])
             ->onlyMethods(['buildSite'])
             ->getMock();
         parent::setUp();


### PR DESCRIPTION
When running the TYPO3 backend on a different domain the the TYPO3 frontend via a hostVariant it is impossible to get the correct domain in the backend. This has an impact on indexing, clearing the index, and much more. This event allows to modify the domain used for a site.

# What this pr does

Adds an event that allows to modify the domain used for a site.

# How to test

Use an EventListener to modify that domain.

Fixes: #4265