### PR TITLE
!!![TASK] Remove JSONP callback in suggest

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -37,7 +37,7 @@ class SuggestController extends AbstractBaseController
      *
      * @noinspection PhpUnused
      */
-    public function suggestAction(string $queryString, ?string $callback = null, ?array $additionalFilters = []): ResponseInterface
+    public function suggestAction(string $queryString, ?array $additionalFilters = []): ResponseInterface
     {
         // Get suggestions
         $rawQuery = htmlspecialchars(mb_strtolower(trim($queryString)));
@@ -64,9 +64,6 @@ class SuggestController extends AbstractBaseController
             $result = $suggestService->getSuggestions($searchRequest, $additionalFilters);
         } catch (SolrUnavailableException) {
             return $this->handleSolrUnavailable();
-        }
-        if ($callback) {
-            return $this->htmlResponse(htmlspecialchars($callback) . '(' . json_encode($result, JSON_UNESCAPED_SLASHES) . ')');
         }
         return $this->htmlResponse(json_encode($result, JSON_UNESCAPED_SLASHES));
     }

--- a/Configuration/TypoScript/Examples/Suggest/setup.typoscript
+++ b/Configuration/TypoScript/Examples/Suggest/setup.typoscript
@@ -7,7 +7,7 @@ tx_solr_suggest {
         disableAllHeaderCode = 1
         xhtml_cleaning = 0
         admPanel = 0
-        additionalHeaders.10.header = Content-type: application/javascript
+        additionalHeaders.10.header = Content-type: application/json
         no_cache = 0
         debug = 0
     }
@@ -22,10 +22,6 @@ tx_solr_suggest {
         action = suggest
     }
 }
-
-[request && traverse(request.getQueryParams(), 'tx_solr/callback') == '']
-    tx_solr_suggest.config.additionalHeaders.10.header = Content-type: application/json
-[global]
 
 # Enable suggest
 plugin.tx_solr {

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -93,6 +93,14 @@ Or do that in other ways to set the `solr.config.lib.enabled=true` to sys-props 
 
 
 
+!!![TASK] Remove JSONP callback in suggest
+------------------------------------------
+
+ by @bmack and @dkd-kaehm in `#4267 <https://github.com/TYPO3-Solr/ext-solr/pull/4267>`__
+
+  In own implementation of autosuggest JS parts with usage of JSONP, the action must be migrated to non-JSONP calls.
+
+
 Release 12.0.5
 ==============
 

--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -29,10 +29,7 @@ function SuggestController() {
 
             $form.find('.tx-solr-suggest').devbridgeAutocomplete({
                 serviceUrl: $form.data('suggest'),
-                dataType: 'jsonp',
-                ajaxSettings: {
-                    jsonp: "tx_solr[callback]"
-                },
+                dataType: 'json',
                 paramName: 'tx_solr[queryString]',
                 groupBy: 'category',
                 maxHeight: 1000,

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -60,18 +60,6 @@ class SuggestControllerTest extends IntegrationTestBase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
-        $result = (string)($this->executeFrontendSubRequestForSuggestQueryString('Sweat', 'rand')->getBody());
-
-        // we assume to get suggestions like Sweatshirt
-        self::assertStringContainsString('suggestions":{"sweatshirts":2}', $result, 'Response did not contain sweatshirt suggestions');
-    }
-
-    #[Test]
-    public function canDoABasicSuggestWithoutCallback(): void
-    {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
-        $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
-
         $result = (string)($this->executeFrontendSubRequestForSuggestQueryString('Sweat')->getBody());
 
         // we assume to get suggestions like Sweatshirt
@@ -112,13 +100,13 @@ class SuggestControllerTest extends IntegrationTestBase
 
     protected function expectSuggested(string $prefix, string $expected)
     {
-        $result = (string)($this->executeFrontendSubRequestForSuggestQueryString($prefix, 'rand')->getBody());
+        $result = (string)($this->executeFrontendSubRequestForSuggestQueryString($prefix)->getBody());
 
         //we assume to get suggestions like some/large/path
         self::assertStringContainsString($expected, $result, 'Response did not contain expected suggestions: ' . $expected);
     }
 
-    protected function executeFrontendSubRequestForSuggestQueryString(string $queryString, ?string $callback = null): ResponseInterface
+    protected function executeFrontendSubRequestForSuggestQueryString(string $queryString): ResponseInterface
     {
         $request = new InternalRequest('http://testone.site/en/');
         $request = $request
@@ -126,9 +114,6 @@ class SuggestControllerTest extends IntegrationTestBase
             ->withQueryParameter('type', '7384')
             ->withQueryParameter('tx_solr[queryString]', $queryString);
 
-        if ($callback !== null) {
-            $request = $request->withQueryParameter('tx_solr[callback]', $callback);
-        }
         return $this->executeFrontendSubRequest($request);
     }
 }


### PR DESCRIPTION
This change removes the callback logic
in the Suggest AJAX Call via JSONP, as JSONP
is known to be used to call untrusted third-party
code, and can thus be removed, as custom suggest
code is done anyway via custom JS implementations.

See https://en.wikipedia.org/wiki/JSONP#Security_concerns

Fixes: #2556
Ports: #4201