### PR TITLE
[FIX] Indexing fails with SOLR_* cObj in TypoScript

### DIFF
--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -151,11 +151,6 @@ class RootPageResolver implements SingletonInterface
         /** @var Rootline $rootLine */
         $rootLine = GeneralUtility::makeInstance(Rootline::class);
 
-        // frontend
-        if (!empty($GLOBALS['TSFE']->rootLine)) {
-            $rootLine->setRootLineArray($GLOBALS['TSFE']->rootLine);
-        }
-
         // fallback, backend
         if ($forceFallback || !$rootLine->getHasRootPage()) {
             /** @var RootlineUtility $rootlineUtility */


### PR DESCRIPTION
TYPO3 BE context properties from `$GLOBALS['TYPO3_REQUEST']` is used on actions  from TYPO3 BE modules.
Most probably no usage of `$GLOBALS['TYPO3_REQUEST']` in EXT:solr context required at all,  but leaving it for possible page-indexing context, which it is just fine to use original TYPO3 core bootstrapped FE stack.

Fixes: #4221
Relates: #3995