### PR TITLE
[FIX] missing TypoScript configuration on RecordMonitor stack

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -80,6 +80,8 @@ class SolrConnection
      *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     *
+     * @noinspection PhpInternalEntityUsedInspection
      */
     public function __construct(
         Endpoint $readEndpoint,
@@ -167,7 +169,11 @@ class SolrConnection
         $endpointKey = 'read';
         $client = $this->getClient($endpointKey);
         $this->initializeClient($client, $endpointKey);
-        return GeneralUtility::makeInstance(SolrReadService::class, $client);
+        return GeneralUtility::makeInstance(
+            SolrReadService::class,
+            $client,
+            $this->configuration,
+        );
     }
 
     /**
@@ -190,7 +196,11 @@ class SolrConnection
         $endpointKey = 'write';
         $client = $this->getClient($endpointKey);
         $this->initializeClient($client, $endpointKey);
-        return GeneralUtility::makeInstance(SolrWriteService::class, $client);
+        return GeneralUtility::makeInstance(
+            SolrWriteService::class,
+            $client,
+            $this->configuration,
+        );
     }
 
     /**


### PR DESCRIPTION
By editing records in BE TypoScript settings are not resolvable due of  missing propagation of `TypoScriptConfiguration` object on
* `\ApacheSolrForTypo3\Solr\System\Solr\SolrConnection::buildReadService()`
* `\ApacheSolrForTypo3\Solr\System\Solr\SolrConnection::buildWriteService()`

Relates: #3995