### PR TITLE
Release 13.0.0

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -69,4 +69,3 @@ and many more by searching for "solr" in the TYPO3 Extension Repository (TER).
    :hidden:
 
    Sitemap
-   genindex

--- a/Documentation/Releases/solr-release-13-0.rst
+++ b/Documentation/Releases/solr-release-13-0.rst
@@ -5,13 +5,18 @@ Releases 13.0
 =============
 
 
-Release 13.0.0-beta-1
-=====================
+Release 13.0.0
+==============
 
-This is a first beta release for TYPO3 13.4 LTS
+This is a new major release for TYPO3 13.4 LTS.
 
 New in this release
 -------------------
+
+!!! Upgrade to Apache Solr 9.7.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This release requires Apache Solr v 9.7.0+.
 
 Adjust mount point indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,61 +29,94 @@ The behavior is intentionally designed this way in TYPO3 core, the background is
 .. note::
    We require at least TYPO3 13.4.2, as this version contains some bugfixes that address problems with the determination of TypoScript and the site configuration of mounted pages.
 
-Release 13.0.0-alpha-1
-======================
-
-This is a first alpha release for upcoming TYPO3 13 LTS
-
-New in this release
--------------------
-
-!!! Upgrade to Apache Solr 9.7.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This release requires Apache Solr v 9.7.0+.
-
 All Changes
 -----------
 
-*  [TASK] Use request object to retrieve query params instead of _GET by @sfroemkenjw in `#4045 <https://github.com/TYPO3-Solr/ext-solr/pull/4045>`_
-*  [TASK] Use Attributes for PHPUnit tests by @bmack in `#4048 <https://github.com/TYPO3-Solr/ext-solr/pull/4048>`_
-*  [TASK] Update PHP-Stan to at least 1.11.* by @sfroemkenjw in `#4055 <https://github.com/TYPO3-Solr/ext-solr/pull/4055>`_
-*  [TASK] Apply and repair rector refactorings by @sfroemkenjw in `#4049 <https://github.com/TYPO3-Solr/ext-solr/pull/4049>`_
-*  [TASK] Migrate requireJS to ES6. Solr BE Modal JS by @sfroemkenjw in `#4057 <https://github.com/TYPO3-Solr/ext-solr/pull/4057>`_
-*  [TASK] Apache Solr 9.6 compatibility by @dkd-friedrich in `#4056 <https://github.com/TYPO3-Solr/ext-solr/pull/4056>`_
-*  [TASK] Use new template module API by @sfroemkenjw in `#4054 <https://github.com/TYPO3-Solr/ext-solr/pull/4054>`_
-*  [FEATURE] Add contentObjectData to searchController by @spoonerWeb in `#4059 <https://github.com/TYPO3-Solr/ext-solr/pull/4059>`_
-*  [BUGFIX] Add empty array as fallback if null by @spoonerWeb in `#4061 <https://github.com/TYPO3-Solr/ext-solr/pull/4061>`_
-*  [BUGFIX] Add empty array defaults in SearchFormViewHelper by @hnadler in `#4042 <https://github.com/TYPO3-Solr/ext-solr/pull/4042>`_
-*  [TASK] Integrate content of Module layout into WithPageTree by @sfroemkenjw in `#4066 <https://github.com/TYPO3-Solr/ext-solr/pull/4066>`_
-*  [TASK] Repair statistics chart because of CSP in Solr Info module by @sfroemkenjw in `#4068 <https://github.com/TYPO3-Solr/ext-solr/pull/4068>`_
-*  [FEATURE:BP:12] Be able to disable tracking of last searches by @dkd-kaehm in `#4064 <https://github.com/TYPO3-Solr/ext-solr/pull/4064>`_
-*  [TASK] Add access plugin tests by @dkd-friedrich in `#4069 <https://github.com/TYPO3-Solr/ext-solr/pull/4069>`_
-*  [TASK] Update authors by @sfroemkenjw in `#4071 <https://github.com/TYPO3-Solr/ext-solr/pull/4071>`_
-*  [TASK] Remove content stream usage by @dkd-friedrich in `#4073 <https://github.com/TYPO3-Solr/ext-solr/pull/4073>`_
-*  [BUGFIX] Fix synonym and stop word upload by @dkd-friedrich in `#4074 <https://github.com/TYPO3-Solr/ext-solr/pull/4074>`_
-*  [TASK] Call getLabelFromItemListMerged with the current row data by @3l73 in `#4081 <https://github.com/TYPO3-Solr/ext-solr/pull/4081>`_
-*  [BUGFIX] numeric facet range slider sends lot of requests to server by @hvomlehn-sds in `#4084 <https://github.com/TYPO3-Solr/ext-solr/pull/4084>`_
-*  [BUGFIX] Typecast $userGroup to integer by @derhansen in `#4079 <https://github.com/TYPO3-Solr/ext-solr/pull/4079>`_
-*  [TASK] Remove getIsSiteManagedSite as all site are managed now by @sfroemkenjw in `#4070 <https://github.com/TYPO3-Solr/ext-solr/pull/4070>`_
-*  [BUG] #4026 treat non-overlayed mount points as valid by @derMatze82 in `#4029 <https://github.com/TYPO3-Solr/ext-solr/pull/4029>`_
-*  [TASK] New Crowdin updates by @dkd-kaehm in `#4094 <https://github.com/TYPO3-Solr/ext-solr/pull/4094>`_
-*  [BUGFIX] Fix range string calculation in DateRange facet by @derhansen in `#4090 <https://github.com/TYPO3-Solr/ext-solr/pull/4090>`_
-*  [FIX:12] scheduler task "Optimize index of a site" is not functional by @dkd-kaehm in `#4104 <https://github.com/TYPO3-Solr/ext-solr/pull/4104>`_
-*  [TASK] Apache Solr 9.6.1 compatibility by @dkd-kaehm in `#4106 <https://github.com/TYPO3-Solr/ext-solr/pull/4106>`_
-*  [FIX] tests for TYPO3 13 @ 2024.07.02 by @dkd-kaehm in `#4098 <https://github.com/TYPO3-Solr/ext-solr/pull/4098>`_
-*  [FIX] deprecations for Fluid viewHelpers and stack by @dkd-kaehm in `#4140 <https://github.com/TYPO3-Solr/ext-solr/pull/4140>`_
-*  [FIX] Integration\\Extbase\\PersistenceEventListenerTest errors by @dkd-kaehm in `#4142 <https://github.com/TYPO3-Solr/ext-solr/pull/4142>`_
-*  [TASK] TYPO3 13 dev-main 2024.09.13 compatibility:: Tests by @dkd-kaehm in `#4153 <https://github.com/TYPO3-Solr/ext-solr/pull/4153>`_
-*  [TASK] TYPO3 13 compatibility 2024.09.19 by @dkd-kaehm in `#4159 <https://github.com/TYPO3-Solr/ext-solr/pull/4159>`_
-*  [FIX] Tests for TYPO3 dev-main @2024.09.23 by @dkd-kaehm in `#4163 <https://github.com/TYPO3-Solr/ext-solr/pull/4163>`_
-*  [BUGFIX] Failed to resolve module specifier '@apache-solr-for-typo3/solr//FormModal.js' by @dkd-kaehm in `#4166 <https://github.com/TYPO3-Solr/ext-solr/pull/4166>`_
-*  [BUGFIX] @typo3/backend/tree/page-tree-element does not work in BE-Modules by @dkd-kaehm in `#4167 <https://github.com/TYPO3-Solr/ext-solr/pull/4167>`_
-*  [FIX] access restrictions stack for TYPO3 13 by @dkd-kaehm in `#4172 <https://github.com/TYPO3-Solr/ext-solr/pull/4172>`_
-*  [TASK] Adapt simulated environment for TYPO3 13 by @dkd-friedrich in `#4164 <https://github.com/TYPO3-Solr/ext-solr/pull/4164>`_
-*  [DOCS] Update TxSolrSearch.rst by @seirerman in `#4162 <https://github.com/TYPO3-Solr/ext-solr/pull/4162>`_
-*  [TASK] Update dependencies by @dkd-kaehm in `#4177 <https://github.com/TYPO3-Solr/ext-solr/pull/4177>`_
-*  [TASK] fix CS issues for newest typo3/coding-standards by @dkd-kaehm in `#4177 <https://github.com/TYPO3-Solr/ext-solr/pull/4177>`_
+- [TASK] Prepare main branch for TYPO3 13 by Rafael Kähm `(eaec73806) <https://github.com/TYPO3-Solr/ext-solr/commit/eaec73806>`_
+- [TASK] Set Apache Solr configsets to ext_solr_13_0_0 2024.05.13 by Rafael Kähm `(460f919be) <https://github.com/TYPO3-Solr/ext-solr/commit/460f919be>`_
+- [BUGFIX] Fix TYPO3 coding standards by Rafael Kähm `(80cfe91dc) <https://github.com/TYPO3-Solr/ext-solr/commit/80cfe91dc>`_
+- [TASK] Simple blocker:: come through `typo3 extension:setup` command by Rafael Kähm `(12de6ef21) <https://github.com/TYPO3-Solr/ext-solr/commit/12de6ef21>`_
+- [BUGFIX] Set solr configSet to ext_solr_13_0_0 by Thomas Löffler `(c3c317ffe) <https://github.com/TYPO3-Solr/ext-solr/commit/c3c317ffe>`_
+- [TASK] Update navigationComponent for page tree in v13 by Thomas Löffler `(64673fd0f) <https://github.com/TYPO3-Solr/ext-solr/commit/64673fd0f>`_
+- [TASK] Adapt Unit Tests for TYPO3 v13 by Benni Mack `(c0baedbaa) <https://github.com/TYPO3-Solr/ext-solr/commit/c0baedbaa>`_
+- !!![TASK] Change default to not track last searches by Christoph Lehmann `(e1f607a88) <https://github.com/TYPO3-Solr/ext-solr/commit/e1f607a88>`_
+- [TASK] Beautify backend modules for v13 by Thomas Löffler `(e51bd8286) <https://github.com/TYPO3-Solr/ext-solr/commit/e51bd8286>`_
+- [TASK] Adapt Unit Tests for TYPO3 v13 by Benni Mack `(1c3c35105) <https://github.com/TYPO3-Solr/ext-solr/commit/1c3c35105>`_
+- [TASK] Make TSFE resolving work again by Benni Mack `(6e2b3f3b4) <https://github.com/TYPO3-Solr/ext-solr/commit/6e2b3f3b4>`_
+- [TASK] Clean up usages of TSFE mocking by Benni Mack `(87630a289) <https://github.com/TYPO3-Solr/ext-solr/commit/87630a289>`_
+- [BUGFIX] Fix remaining integration tests by Benni Mack `(f859f0c5b) <https://github.com/TYPO3-Solr/ext-solr/commit/f859f0c5b>`_
+- [TASK] fix PhpStan errors for TYPO3 13 by Rafael Kähm `(89d9f0d27) <https://github.com/TYPO3-Solr/ext-solr/commit/89d9f0d27>`_
+- [TASK] Disable progress % within Github Actions by Rafael Kähm `(396396979) <https://github.com/TYPO3-Solr/ext-solr/commit/396396979>`_
+- [TASK] Run tests daily by Rafael Kähm `(a81626723) <https://github.com/TYPO3-Solr/ext-solr/commit/a81626723>`_
+- [FIX] tests for TYPO3 13 @ 2024.07.02 by Rafael Kähm `(20b35ea21) <https://github.com/TYPO3-Solr/ext-solr/commit/20b35ea21>`_
+- [FIX] tests for TYPO3 13 @ 2024.07.09 by Rafael Kähm `(c02a3ebbc) <https://github.com/TYPO3-Solr/ext-solr/commit/c02a3ebbc>`_
+- [FIX] Integration\SearchTest for TYPO3 13 by Rafael Kähm `(3415e9871) <https://github.com/TYPO3-Solr/ext-solr/commit/3415e9871>`_
+- [FIX] require PHP 8.2 for TER version by Rafael Kähm `(3d1092b84) <https://github.com/TYPO3-Solr/ext-solr/commit/3d1092b84>`_
+- [FIX] Dependabot not working by Rafael Kähm `(dfcdd98bb) <https://github.com/TYPO3-Solr/ext-solr/commit/dfcdd98bb>`_
+- [TASK] Don't store build solrci-image longer as 1 days by Rafael Kähm `(ed561a654) <https://github.com/TYPO3-Solr/ext-solr/commit/ed561a654>`_
+- [FIX] GitHub scheduled Actions for daily tests by Rafael Kähm `(556b5d3df) <https://github.com/TYPO3-Solr/ext-solr/commit/556b5d3df>`_
+- [FIX] deprecations for Fluid viewHelpers and stack by Rafael Kähm `(216319eed) <https://github.com/TYPO3-Solr/ext-solr/commit/216319eed>`_
+- [FIX] Integration\Extbase\PersistenceEventListenerTest errors by Rafael Kähm `(97156bf19) <https://github.com/TYPO3-Solr/ext-solr/commit/97156bf19>`_
+- [FIX] Restore BE Modules functionality for TYPO3 13 by Rafael Kähm `(cdd979018) <https://github.com/TYPO3-Solr/ext-solr/commit/cdd979018>`_
+- [TASK] migrate to typo3fluid/fluid v4 as required by TYPO3 13 by Rafael Kähm `(064ce710d) <https://github.com/TYPO3-Solr/ext-solr/commit/064ce710d>`_
+- [TASK] Remove deprecated queue.[indexConfig].table TypoScript setting by Rafael Kähm `(1a426a6dc) <https://github.com/TYPO3-Solr/ext-solr/commit/1a426a6dc>`_
+- [FIX] Translation handling by delegating requered context objects/values by Rafael Kähm `(c3d9db33b) <https://github.com/TYPO3-Solr/ext-solr/commit/c3d9db33b>`_
+- [FIX] follow-up for removed queue.[indexConfig].table TypoScript setting by Rafael Kähm `(7fee9368e) <https://github.com/TYPO3-Solr/ext-solr/commit/7fee9368e>`_
+- [FIX] wrong Schema version in status checks by Rafael Kähm `(590b34e8d) <https://github.com/TYPO3-Solr/ext-solr/commit/590b34e8d>`_
+- [TASK] skip tests for mount-pages temporary #4160 by Rafael Kähm `(32906dccf) <https://github.com/TYPO3-Solr/ext-solr/commit/32906dccf>`_
+- [TASK] skip tests for acces restrictions stack temporary #4161 by Rafael Kähm `(f8eeaad03) <https://github.com/TYPO3-Solr/ext-solr/commit/f8eeaad03>`_
+- [BUGFIX] PhpStan Variable $parameters in empty() always exists and is not falsy by Rafael Kähm `(2a8596519) <https://github.com/TYPO3-Solr/ext-solr/commit/2a8596519>`_
+- [FIX] Tests for TYPO3 dev-main @2024.09.23 by Rafael Kähm `(ff7e038f7) <https://github.com/TYPO3-Solr/ext-solr/commit/ff7e038f7>`_
+- [BUGFIX] Failed to resolve module specifier '@apache-solr-for-typo3/solr//FormModal.js' by Rafael Kähm `(3c86a707f) <https://github.com/TYPO3-Solr/ext-solr/commit/3c86a707f>`_
+- [BUGFIX] `@typo3/backend/tree/page-tree-element` does not work in BE-Modules by Rafael Kähm `(111f68404) <https://github.com/TYPO3-Solr/ext-solr/commit/111f68404>`_
+- [FIX] access restrictions stack for TYPO3 13 by Rafael Kähm `(dc7162b25) <https://github.com/TYPO3-Solr/ext-solr/commit/dc7162b25>`_
+- [FIX] `#[Group('frontend')]` attribute has comment in SearchControllerTest by Rafael Kähm `(0514886b4) <https://github.com/TYPO3-Solr/ext-solr/commit/0514886b4>`_
+- [TASK] Adjust configuration check and fallbacks in MultiValue CO by Markus Friedrich `(ea883ce33) <https://github.com/TYPO3-Solr/ext-solr/commit/ea883ce33>`_
+- [TASK] Adapt simulated environment for TYPO3 13 by Markus Friedrich `(fb9fdd8c8) <https://github.com/TYPO3-Solr/ext-solr/commit/fb9fdd8c8>`_
+- Update TxSolrSearch.rst by Florian Seirer `(f8d330082) <https://github.com/TYPO3-Solr/ext-solr/commit/f8d330082>`_
+- [TASK] Update dependencies by Rafael Kähm `(01e5387c0) <https://github.com/TYPO3-Solr/ext-solr/commit/01e5387c0>`_
+- [TASK] fix CS issues for newest typo3/coding-standards by Rafael Kähm `(8c1e28850) <https://github.com/TYPO3-Solr/ext-solr/commit/8c1e28850>`_
+- !!![TASK] Upgrade to Apache Solr 9.7.0 by Markus Friedrich `(323b1f0c2) <https://github.com/TYPO3-Solr/ext-solr/commit/323b1f0c2>`_
+- [RELEASE] 13.0.0-alpha-1 by Markus Friedrich `(3bd453d09) <https://github.com/TYPO3-Solr/ext-solr/commit/3bd453d09>`_
+- [FIX] allow tags/releases from main branch by Rafael Kähm `(26e38f8b7) <https://github.com/TYPO3-Solr/ext-solr/commit/26e38f8b7>`_
+- [TASK] migrate plugin subtype "list_type" by Rafael Kähm `(0c0f2b953) <https://github.com/TYPO3-Solr/ext-solr/commit/0c0f2b953>`_
+- [TASK] Upgrade typo3/testing-framework to dev-main 2024.10.15 by Rafael Kähm `(a4596d49e) <https://github.com/TYPO3-Solr/ext-solr/commit/a4596d49e>`_
+- [TASK] Use TYPO3 13.4+ and 13.4.x-dev after TYPO3 13 LTS release by Rafael Kähm `(0fd63e172) <https://github.com/TYPO3-Solr/ext-solr/commit/0fd63e172>`_
+- [TASK] Remove JSONP callback in suggest by Benni Mack `(094b4e5b2) <https://github.com/TYPO3-Solr/ext-solr/commit/094b4e5b2>`_
+- [FEATURE] Introduce method to unset the query string (#4136) by Ayke Halder `(b0ddab00e) <https://github.com/TYPO3-Solr/ext-solr/commit/b0ddab00e>`_
+- Update ExtensionSettings.rst by Jon Echeveste González `(d79c92c9d) <https://github.com/TYPO3-Solr/ext-solr/commit/d79c92c9d>`_
+- [FEATURE] Make Node->depth actually initialized and usable by snk-spo `(b530a2f03) <https://github.com/TYPO3-Solr/ext-solr/commit/b530a2f03>`_
+- [TASK] Update version matrix by Markus Friedrich `(b6bfad8f1) <https://github.com/TYPO3-Solr/ext-solr/commit/b6bfad8f1>`_
+- [TASK] 13.0.x-dev Update solarium/solarium requirement by dependabot[bot] `(64e978646) <https://github.com/TYPO3-Solr/ext-solr/commit/64e978646>`_
+- [TASK] improve exception handling by Rafael Kähm `(8f1597b4d) <https://github.com/TYPO3-Solr/ext-solr/commit/8f1597b4d>`_
+- [FIX] Garbage collector does not get configuration by Rafael Kähm `(f73de9da2) <https://github.com/TYPO3-Solr/ext-solr/commit/f73de9da2>`_
+- [FIX] CS in Configuration/Backend/Modules.php by Rafael Kähm `(08f717129) <https://github.com/TYPO3-Solr/ext-solr/commit/08f717129>`_
+- [FIX] deprecations in Dockerfile by Rafael Kähm `(af1e8cdcd) <https://github.com/TYPO3-Solr/ext-solr/commit/af1e8cdcd>`_
+- [BUGFIX] Ensure index document is deleted by Markus Friedrich `(10c0fde3c) <https://github.com/TYPO3-Solr/ext-solr/commit/10c0fde3c>`_
+- [DOCs] for release 12.0.4 by Rafael Kähm `(7b61833ad) <https://github.com/TYPO3-Solr/ext-solr/commit/7b61833ad>`_
+- [DOCs] Update EXT:solr 12.0.x line in version matrix by Rafael Kähm `(ac1ff3663) <https://github.com/TYPO3-Solr/ext-solr/commit/ac1ff3663>`_
+- [FIX] phpstan: Method UrlHelper::withQueryParameter() has parameter $value with no type specified by Rafael Kähm `(588564f27) <https://github.com/TYPO3-Solr/ext-solr/commit/588564f27>`_
+- [TASK] Remove Scrutinizer integrations on release-12.0.x by Rafael Kähm `(c2558c1d3) <https://github.com/TYPO3-Solr/ext-solr/commit/c2558c1d3>`_
+- [FIX] Re-added template variables for SearchFormViewHelper by thomashohn `(f7ad16ae4) <https://github.com/TYPO3-Solr/ext-solr/commit/f7ad16ae4>`_
+- [DOCs] for release 12.0.5 by Rafael Kähm `(ec97b6fd1) <https://github.com/TYPO3-Solr/ext-solr/commit/ec97b6fd1>`_
+- [TASK] Remove Implicitly nullable parameter declarations deprecated by Thomas Hohn `(207a0e5fa) <https://github.com/TYPO3-Solr/ext-solr/commit/207a0e5fa>`_
+- Update composer requirement by Thomas Hohn `(43f3baa94) <https://github.com/TYPO3-Solr/ext-solr/commit/43f3baa94>`_
+- [TASK] CS change to multiline parameters with comma on last by Rafael Kähm `(9aa403a65) <https://github.com/TYPO3-Solr/ext-solr/commit/9aa403a65>`_
+- [TASK] Clean and improve ConnectionManagerTest by Markus Friedrich `(edf482457) <https://github.com/TYPO3-Solr/ext-solr/commit/edf482457>`_
+- [TASK] Adjust mount point indexing by Markus Friedrich `(bf446c032) <https://github.com/TYPO3-Solr/ext-solr/commit/bf446c032>`_
+- [BUGFIX] Fix record monitoring if site is missing by Markus Friedrich `(0dfd4b454) <https://github.com/TYPO3-Solr/ext-solr/commit/0dfd4b454>`_
+- [TASK] Evaluate all entries in Services.yaml regarding to `shared` setting by Rafael Kähm `(f8083a616) <https://github.com/TYPO3-Solr/ext-solr/commit/f8083a616>`_
+- [TASK] Add int cast for sys_language_uid by Guido Schmechel `(de7d7efa7) <https://github.com/TYPO3-Solr/ext-solr/commit/de7d7efa7>`_
+- [TASK] Add int cast for sys_language_uid by Guido Schmechel `(5d659dd3a) <https://github.com/TYPO3-Solr/ext-solr/commit/5d659dd3a>`_
+- [DOCS] Switch documentation rendering to PHP-based rendering by Rafael Kähm `(4f7b9a73e) <https://github.com/TYPO3-Solr/ext-solr/commit/4f7b9a73e>`_
+- [DOCS] workaround for version matrix by Rafael Kähm `(bc5bf0b6f) <https://github.com/TYPO3-Solr/ext-solr/commit/bc5bf0b6f>`_
+- [FEATURE] Add timeframe filter to statistics module by Bastien Lutz `(0fc8d7cbd) <https://github.com/TYPO3-Solr/ext-solr/commit/0fc8d7cbd>`_
+- [BUGFIX] Respect foreignLabel in related items from mm table by Till Hörner `(f5271b049) <https://github.com/TYPO3-Solr/ext-solr/commit/f5271b049>`_
+- [BUGFIX] Make getHasChildNodeSelected recursive by Tobias Wojtylak `(a128c3018) <https://github.com/TYPO3-Solr/ext-solr/commit/a128c3018>`_
+- [BUGFIX] Add StartTimeRestriction to ConfigurationAwareRecordService by Amir Arends `(27f36af68) <https://github.com/TYPO3-Solr/ext-solr/commit/27f36af68>`_
+- [FEATURE] Use PHP generator to prevent processing of all available site by Stefan Frömken `(7fec14dc4) <https://github.com/TYPO3-Solr/ext-solr/commit/7fec14dc4>`_
+- [FIX] Indexing fails with SOLR_* cObj in TypoScript by Rafael Kähm `(bcb252197) <https://github.com/TYPO3-Solr/ext-solr/commit/bcb252197>`_
+- [FIX] missing TypoScript configuration on RecordMonitor stack by Rafael Kähm `(31199d2a1) <https://github.com/TYPO3-Solr/ext-solr/commit/31199d2a1>`_
 
 
 Contributors
@@ -89,16 +127,27 @@ awesome community. Here are the contributors to this release.
 
 (patches, comments, bug reports, reviews, ... in alphabetical order)
 
+*  Amir Arends
+*  Ayke Halder
+*  Bastien Lutz
 *  Benni Mack
-*  @derMatze82
+*  Christoph Lehmann
+*  Florian Seirer
+*  Guido Schmechel
 *  Hendrik vom Lehn
-*  @hnadler
+*  Jon Echeveste González
 *  Lars Tode
 *  Markus Friedrich
 *  Rafael Kähm
 *  Stefan Frömken
+*  Thomas Hohn
 *  Thomas Löffler
+*  Till Hörner
+*  Tobias Wojtylak
 *  Torben Hansen
+*  @snk-spo
+*  @derMatze82
+
 
 Also a big thank you to our partners who have already concluded one of our new development participation packages such
 as Apache Solr EB for TYPO3 13 LTS (Feature):

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,5 +1,0 @@
-=====
-Index
-=====
-
-.. Sphinx will insert here the general index automatically.

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -7,17 +7,19 @@
 >
   <extension
 	  class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
+	  interlink-shortcode="apache-solr-for-typo3/solr"
 	  project-home="https://www.typo3-solr.com"
-	  project-contact="https://typo3.slack.com/archives/C02FF05Q4"
+	  project-contact="info@dkd.de"
 	  project-repository="https://github.com/TYPO3-Solr/ext-solr"
 	  project-issues="https://github.com/TYPO3-Solr/ext-solr/issues"
+	  project-discussions="https://typo3.slack.com/archives/C02FF05Q4"
 	  edit-on-github-branch="main"
 	  edit-on-github="TYPO3-Solr/ext-solr"
-	  typo3-core-preferred="stable"
+	  typo3-core-preferred="13.4"
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="13.0.0"
+	  release="13.0"
 	  version="13.0"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,8 +3,8 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '13.0.0-alpha-1',
-    'state' => 'alpha',
+    'version' => '13.0.0',
+    'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',
     'author_email' => 'info@dkd.de',


### PR DESCRIPTION
We are happy to release EXT:solr 13.0.0 for TYPO3 13 LTS. The focus of this release has been on TYPO3 13 LTS compatibility. NOTE: At least TYPO3 v13.4.2 is required.

Huge improvements:

* TYPO3 13 LTS compatibility
* etc. and many more from epic task #3995

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/13.0/en-us/Releases/solr-release-13-0.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/13.0.0

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Fixes: #4271