### PR TITLE
[BUGFIX] Fix monitoring of mounted pages

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
@@ -15,9 +15,11 @@
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class PageStrategy
@@ -39,6 +41,23 @@ class PageStrategy extends AbstractStrategy
 
         if ($table === 'pages') {
             $this->collectPageGarbageByPageChange($uid);
+        }
+    }
+
+    /**
+     * Deletes a page from Solr and updates the item in the index queue
+     * The MountPagesUpdater takes care of mounted pages
+     *
+     * @throws DBALException
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    protected function deleteInSolrAndUpdateIndexQueue(string $table, int $uid): void
+    {
+        parent::deleteInSolrAndUpdateIndexQueue($table, $uid);
+
+        if ($table === 'pages') {
+            $mountPagesUpdater = GeneralUtility::makeInstance(MountPagesUpdater::class);
+            $mountPagesUpdater->update($uid);
         }
     }
 

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Traits\SkipRecordByRootlineConfigurationTrait;
 use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use Throwable;
@@ -46,6 +47,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DataUpdateHandler extends AbstractUpdateHandler
 {
+    use SkipRecordByRootlineConfigurationTrait;
+
     /**
      * List of fields in the update field array that
      * are required for processing
@@ -388,7 +391,9 @@ class DataUpdateHandler extends AbstractUpdateHandler
         }
         $rootPageIds = [$configurationPageId];
 
-        $this->processRecord('pages', $uid, $rootPageIds);
+        if (!$this->skipRecordByRootlineConfiguration($uid)) {
+            $this->processRecord('pages', $uid, $rootPageIds);
+        }
 
         $this->updateCanonicalPages($uid);
         $this->mountPageUpdater->update($uid);

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use PDO;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -224,8 +225,22 @@ class Page extends AbstractInitializer
     {
         $mountPointIdentifier = $this->getMountPointIdentifier($mountProperties);
         $mountPointPageIsWithExistingQueueEntry = $this->queueItemRepository->findPageIdsOfExistingMountPagesByMountIdentifier($mountPointIdentifier);
-        $mountedPagesThatNeedToBeAdded = array_diff($mountedPages, $mountPointPageIsWithExistingQueueEntry);
 
+        // update existing queue entries to trigger reindexing
+        array_walk(
+            $mountPointPageIsWithExistingQueueEntry,
+            function (int $pageUid): void {
+                $tstamp = GeneralUtility::makeInstance(Context::class)
+                    ->getPropertyFromAspect('date', 'timestamp') ?? time();
+                $items = $this->queueItemRepository->findItemsByItemTypeAndItemUid('pages', $pageUid);
+                foreach ($items as $item) {
+                    $this->queueItemRepository->updateChangedTimeByItem($item, $tstamp);
+                }
+            }
+        );
+
+        // add new items if necessary
+        $mountedPagesThatNeedToBeAdded = array_diff($mountedPages, $mountPointPageIsWithExistingQueueEntry);
         if (count($mountedPagesThatNeedToBeAdded) === 0) {
             //nothing to do
             return;

--- a/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
+++ b/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Traits;
+
+use TYPO3\CMS\Core\Exception\Page\PageNotFoundException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+trait SkipRecordByRootlineConfigurationTrait
+{
+    /**
+     * Check if at least one page in the record's rootline is configured to exclude sub-entries from indexing
+     */
+    protected function skipRecordByRootlineConfiguration(int $pid): bool
+    {
+        /** @var RootlineUtility $rootlineUtility */
+        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pid);
+        try {
+            $rootline = $rootlineUtility->get();
+        } catch (PageNotFoundException) {
+            return true;
+        }
+        foreach ($rootline as $page) {
+            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries']) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Tests/Integration/IndexQueue/Fixtures/mount_page_updates.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/mount_page_updates.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search_sub_entries"
+,2,1,1736145036,0,254,0,0,"/sysfolder","Sys folder (no_search_sub_entries)",1
+,20,2,1736145036,0,1,0,0,"/mounted-page-in-sysfolder","Mounted page in sysfolder",0
+,21,1,1736145036,0,1,0,0,"/mounted-page-on-root","Mounted page on root page",0
+,22,2,1736145036,0,1,0,0,"/another-mounted-page-in-sysfolder","Another mounted page in sysfolder",0
+,30,1,1736145036,0,7,20,1,"/mount-point-1","Mount point for page in sysfolder",0
+,31,1,1736145036,0,7,21,1,"/mount-point-2","Mount point for page on root page",0
+,32,1,1736145036,0,7,22,1,"/mount-point-3","Mount point for another page in sysfolder",0
+"tt_content",
+,"uid","pid","header","hidden"
+,20,20,"ce on mounted page",0
+,21,20,"hidden ce on mounted page",1
+,22,21,"ce on mounted page",0
+,23,21,"hidden ce on mounted page",1
+,24,22,"ce on another mounted page",0
+,25,22,"hidden ce on another mounted page",1
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","errors"
+,1,1,"pages",22,"pages",1,"22-32-1",""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,1,"mountPageSource",22
+,2,1,1,"mountPageDestination",32
+,3,1,1,"isMountedPage",1

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -24,9 +24,12 @@ use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * Testcase for the DataUpdateHandler class.
@@ -105,6 +108,9 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
             'sys_language_uid' => 0,
         ];
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
+
+        $rootineUtilityMock = $this->createMock(RootlineUtility::class);
+        GeneralUtility::addInstance(RootlineUtility::class, $rootineUtilityMock);
 
         $this->mountPagesUpdaterMock
             ->expects(self::once())
@@ -186,6 +192,9 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         ];
         $this->initSiteForDummyConfiguration($dummyPageRecord['uid']);
 
+        $rootineUtilityMock = $this->createMock(RootlineUtility::class);
+        GeneralUtility::addInstance(RootlineUtility::class, $rootineUtilityMock);
+
         $this->mountPagesUpdaterMock
             ->expects(self::once())
             ->method('update')
@@ -247,6 +256,9 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         ];
 
         $this->initBasicPageUpdateExpectations($dummyPageRecord);
+
+        $rootineUtilityMock = $this->createMock(RootlineUtility::class);
+        GeneralUtility::addInstance(RootlineUtility::class, $rootineUtilityMock);
 
         $this->mountPagesUpdaterMock
             ->expects(self::once())
@@ -338,6 +350,13 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         ];
 
         $GLOBALS['TCA']['pages'] = ['columns' => []];
+
+        $frontendCacheMock = $this->createMock(VariableFrontend::class);
+        $frontendCacheMock->method('has')->willReturn(true);
+        $frontendCacheMock->method('get')->willReturn(['uid' => 1, 'no_search_sub_entries' => false]);
+        $cacheManagerMock = $this->createMock(CacheManager::class);
+        $cacheManagerMock->method('getCache')->willReturn($frontendCacheMock);
+        GeneralUtility::setSingletonInstance(CacheManager::class, $cacheManagerMock);
 
         $this->pagesRepositoryMock
             ->expects(self::any())

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -33,7 +33,7 @@ class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
         $viewHelper->setRenderingContext($renderContextMock);
 
         $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
-        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
+        $requestUriBuilderStub = self::createStub(RequestBuilder::class);
 
         // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -37,7 +37,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $searchResultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($mockedPreviousFakedRequest);
 
-        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
+        $requestUriBuilderStub = self::createStub(RequestBuilder::class);
         $requestUriBuilderStub->method('build')->willReturn($mockedControllerRequest);
 
         $variableProvideMock = $this->createMock(StandardVariableProvider::class);


### PR DESCRIPTION
# What this pr does

EXT:solr fails to detect changes on mounted pages correctly in some special occasions:

* mounted pages not considered during garbage removal / ce updates
* no_search_sub_entries flag not respected by GarbageRemover
  strategies
* existing queue items of mounted pages not updated

By adjusting the monitoring related components the issues are fixed,
affected components:

* GarbageRemover strategies
* page initializer
* RecordMonitor
* DataUpdateHandler

# How to test

- Mount a page located in a sys_folder with enabled option no_search_sub_entries
- Test updates of page and content elements and check the index queue updates


Fixes: #4275
