### PR TITLE
 [BUGFIX:P:13.0] Fix monitoring of mounted pages

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
@@ -15,9 +15,11 @@
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
 
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class PageStrategy
@@ -39,6 +41,23 @@ class PageStrategy extends AbstractStrategy
 
         if ($table === 'pages') {
             $this->collectPageGarbageByPageChange($uid);
+        }
+    }
+
+    /**
+     * Deletes a page from Solr and updates the item in the index queue
+     * The MountPagesUpdater takes care of mounted pages
+     *
+     * @throws DBALException
+     * @throws UnexpectedTYPO3SiteInitializationException
+     */
+    protected function deleteInSolrAndUpdateIndexQueue(string $table, int $uid): void
+    {
+        parent::deleteInSolrAndUpdateIndexQueue($table, $uid);
+
+        if ($table === 'pages') {
+            $mountPagesUpdater = GeneralUtility::makeInstance(MountPagesUpdater::class);
+            $mountPagesUpdater->update($uid);
         }
     }
 

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
+use ApacheSolrForTypo3\Solr\Traits\SkipRecordByRootlineConfigurationTrait;
 use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
 use Throwable;
@@ -45,6 +46,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DataUpdateHandler extends AbstractUpdateHandler
 {
+    use SkipRecordByRootlineConfigurationTrait;
+
     /**
      * List of fields in the update field array that
      * are required for processing
@@ -381,7 +384,9 @@ class DataUpdateHandler extends AbstractUpdateHandler
         }
         $rootPageIds = [$configurationPageId];
 
-        $this->processRecord('pages', $uid, $rootPageIds);
+        if (!$this->skipRecordByRootlineConfiguration($uid)) {
+            $this->processRecord('pages', $uid, $rootPageIds);
+        }
 
         $this->updateCanonicalPages($uid);
         $this->mountPageUpdater->update($uid);

--- a/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
+++ b/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Traits;
+
+use TYPO3\CMS\Core\Exception\Page\PageNotFoundException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+trait SkipRecordByRootlineConfigurationTrait
+{
+    /**
+     * Check if at least one page in the record's rootline is configured to exclude sub-entries from indexing
+     */
+    protected function skipRecordByRootlineConfiguration(int $pid): bool
+    {
+        /** @var RootlineUtility $rootlineUtility */
+        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pid);
+        try {
+            $rootline = $rootlineUtility->get();
+        } catch (PageNotFoundException) {
+            return true;
+        }
+        foreach ($rootline as $page) {
+            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries']) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Tests/Integration/IndexQueue/Fixtures/mount_page_updates.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/mount_page_updates.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search_sub_entries"
+,2,1,1736145036,0,254,0,0,"/sysfolder","Sys folder (no_search_sub_entries)",1
+,20,2,1736145036,0,1,0,0,"/mounted-page-in-sysfolder","Mounted page in sysfolder",0
+,21,1,1736145036,0,1,0,0,"/mounted-page-on-root","Mounted page on root page",0
+,22,2,1736145036,0,1,0,0,"/another-mounted-page-in-sysfolder","Another mounted page in sysfolder",0
+,30,1,1736145036,0,7,20,1,"/mount-point-1","Mount point for page in sysfolder",0
+,31,1,1736145036,0,7,21,1,"/mount-point-2","Mount point for page on root page",0
+,32,1,1736145036,0,7,22,1,"/mount-point-3","Mount point for another page in sysfolder",0
+"tt_content",
+,"uid","pid","header","hidden"
+,20,20,"ce on mounted page",0
+,21,20,"hidden ce on mounted page",1
+,22,21,"ce on mounted page",0
+,23,21,"hidden ce on mounted page",1
+,24,22,"ce on another mounted page",0
+,25,22,"hidden ce on another mounted page",1
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","errors"
+,1,1,"pages",22,"pages",1,"22-32-1",""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,1,"mountPageSource",22
+,2,1,1,"mountPageDestination",32
+,3,1,1,"isMountedPage",1

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -882,6 +882,324 @@ class RecordMonitorTest extends IntegrationTestBase
     }
 
     #[Test]
+    #[DataProvider('mountedPageIsUpdatedInQueueOnUpdateDataProvider')]
+    public function mountedPageIsUpdatedInQueueOnUpdate(
+        int $monitoringType,
+        int $itemUid,
+        int $itemsInEventQueue,
+        array $dataMap,
+        array $expectedResult,
+    ): void {
+        $this->extensionConfiguration->set('solr', ['monitoringType' => $monitoringType]);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/mount_page_updates.csv');
+
+        $this->dataHandler->start($dataMap, [], $this->backendUser);
+        $this->dataHandler->process_datamap();
+
+        $this->assertEventQueueContainsItemAmount($itemsInEventQueue);
+        if ($monitoringType === 1) {
+            $this->processEventQueue();
+        }
+
+        $items = $this->indexQueue->getItems('pages', $itemUid);
+        self::assertCount(count($expectedResult), $items, 'Index queue items not added/updated as expected.');
+
+        foreach ($expectedResult as $itemCount => $itemData) {
+            self::assertEquals($itemData['mountPointIdentifier'], $items[$itemCount]->getMountPointIdentifier());
+            self::assertGreaterThan(0, $items[$itemCount]->getChanged());
+
+            if (($itemData['mountPageSource'] ?? null) !== null) {
+                self::assertEquals(
+                    [
+                        'mountPageSource' => $itemData['mountPageSource'],
+                        'mountPageDestination' => $itemData['mountPageDestination'],
+                        'isMountedPage' => 1,
+                    ],
+                    $items[$itemCount]->getIndexingProperties()
+                );
+            }
+        }
+    }
+
+    public static function mountedPageIsUpdatedInQueueOnUpdateDataProvider(): Traversable
+    {
+        $hideContentElementOnMountedPageInSysFolder = [
+            'monitoringType' => 0,
+            'itemUid' => 20,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'tt_content' => [
+                    20 => ['hidden' => 1],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '20-30-1',
+                    'mountPageSource' => '20',
+                    'mountPageDestination' => '30',
+                ],
+            ],
+        ];
+        yield 'hide content element on mounted page in sys_folder (default monitoring)'
+            => $hideContentElementOnMountedPageInSysFolder;
+
+        yield 'hide content element on mounted page in sys_folder (delayed monitoring)' => array_merge(
+            $hideContentElementOnMountedPageInSysFolder,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $enableContentElementOnMountedPageInSysFolder = [
+            'monitoringType' => 0,
+            'itemUid' => 20,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'tt_content' => [
+                    21 => ['hidden' => 0],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '20-30-1',
+                    'mountPageSource' => '20',
+                    'mountPageDestination' => '30',
+                ],
+            ],
+        ];
+        yield 'enable content element on mounted page in sys_folder (default monitoring)'
+            => $enableContentElementOnMountedPageInSysFolder;
+
+        yield 'enable content element on mounted page in sys_folder (delayed monitoring)' => array_merge(
+            $enableContentElementOnMountedPageInSysFolder,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ],
+        );
+
+        $hideContentElementOnMountedPageOnRoot = [
+            'monitoringType' => 0,
+            'itemUid' => 21,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'tt_content' => [
+                    22 => ['hidden' => 1],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '',
+                ],
+                1 => [
+                    'mountPointIdentifier' => '21-31-1',
+                    'mountPageSource' => '21',
+                    'mountPageDestination' => '31',
+                ],
+            ],
+        ];
+        yield 'hide content element on mounted page on root (default monitoring)'
+            => $hideContentElementOnMountedPageOnRoot;
+
+        yield 'hide content element on mounted page on root (delayed monitoring)' => array_merge(
+            $hideContentElementOnMountedPageOnRoot,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $updateMountedPageInSysFolder = [
+            'monitoringType' => 0,
+            'itemUid' => 20,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'pages' => [
+                    20 => ['subtitle' => 'new subtitle'],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '20-30-1',
+                    'mountPageSource' => '20',
+                    'mountPageDestination' => '30',
+                ],
+            ],
+        ];
+        yield 'update mounted page in sys_folder (default monitoring)' => $updateMountedPageInSysFolder;
+
+        yield 'update mounted page in sys_folder (delayed monitoring)' => array_merge(
+            $updateMountedPageInSysFolder,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $updateMountedPageInRoot = [
+            'monitoringType' => 0,
+            'itemUid' => 21,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'pages' => [
+                    21 => ['subtitle' => 'new subtitle'],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '',
+                ],
+                1 => [
+                    'mountPointIdentifier' => '21-31-1',
+                    'mountPageSource' => '21',
+                    'mountPageDestination' => '31',
+                ],
+            ],
+        ];
+        yield 'update mounted page in root (default monitoring)' => $updateMountedPageInRoot;
+
+        yield 'update mounted page in root (delayed monitoring)' => array_merge(
+            $updateMountedPageInRoot,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $hideMountedPageInSysFolder = [
+            'monitoringType' => 0,
+            'itemUid' => 20,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'pages' => [
+                    20 => ['hidden' => 1],
+                ],
+            ],
+            'expectedResult' => [],
+        ];
+        yield 'hide mounted page in sys_folder (default monitoring)' => $hideMountedPageInSysFolder;
+
+        yield 'hide mounted page in sys_folder (delayed monitoring)' => array_merge(
+            $hideMountedPageInSysFolder,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $hideMountedPageInRoot = [
+            'monitoringType' => 0,
+            'itemUid' => 21,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'pages' => [
+                    21 => ['hidden' => 1],
+                ],
+            ],
+            'expectedResult' => [],
+        ];
+        yield 'hide mounted page in root (default monitoring)' => $hideMountedPageInRoot;
+
+        yield 'hide mounted page in root (delayed monitoring)' => array_merge(
+            $hideMountedPageInRoot,
+            [
+                'monitoringType' => 1,
+                'itemsInEventQueue' => 2,
+            ]
+        );
+
+        $hideContentElementOnAnotherMountedPageInSysFolderWhichIsInQueue = [
+            'monitoringType' => 0,
+            'itemUid' => 22,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'tt_content' => [
+                    24 => ['hidden' => 1],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '22-32-1',
+                    'mountPageSource' => '22',
+                    'mountPageDestination' => '32',
+                ],
+            ],
+        ];
+        yield 'hide content element on another mounted page in sys_folder'
+                . ', which is already in queue (default monitoring)'
+            => $hideContentElementOnAnotherMountedPageInSysFolderWhichIsInQueue;
+
+        yield 'hide content element on another mounted page in sys_folder'
+                . ', which is already in queue (delayed monitoring)' => array_merge(
+                    $hideContentElementOnAnotherMountedPageInSysFolderWhichIsInQueue,
+                    [
+                        'monitoringType' => 1,
+                        'itemsInEventQueue' => 2,
+                    ]
+                );
+
+        $enableContentElementOnMountedPageInSysFolderWhichIsInQueue = [
+            'monitoringType' => 0,
+            'itemUid' => 22,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'tt_content' => [
+                    25 => ['hidden' => 0],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '22-32-1',
+                    'mountPageSource' => '22',
+                    'mountPageDestination' => '32',
+                ],
+            ],
+        ];
+        yield 'enable content element on another mounted page in sys_folder'
+            . ', which is already in queue (default monitoring)'
+            => $enableContentElementOnMountedPageInSysFolderWhichIsInQueue;
+
+        yield 'enable content element on another mounted page in sys_folder'
+            . ', which is already in queue (delayed monitoring)' => array_merge(
+                $enableContentElementOnMountedPageInSysFolderWhichIsInQueue,
+                [
+                    'monitoringType' => 1,
+                    'itemsInEventQueue' => 2,
+                ],
+            );
+
+        $updateMountedPageInSysFolderWhichIsInQueue = [
+            'monitoringType' => 0,
+            'itemUid' => 22,
+            'itemsInEventQueue' => 0,
+            'dataMap' => [
+                'pages' => [
+                    22 => ['subtitle' => 'new subtitle'],
+                ],
+            ],
+            'expectedResult' => [
+                0 => [
+                    'mountPointIdentifier' => '22-32-1',
+                    'mountPageSource' => '22',
+                    'mountPageDestination' => '32',
+                ],
+            ],
+        ];
+        yield 'update mounted page in sys_folder'
+            . ', which is already in queue (default monitoring)' => $updateMountedPageInSysFolderWhichIsInQueue;
+
+        yield 'update mounted page in sys_folder'
+            . ', which is already in queue (delayed monitoring)' => array_merge(
+                $updateMountedPageInSysFolderWhichIsInQueue,
+                [
+                    'monitoringType' => 1,
+                    'itemsInEventQueue' => 2,
+                ]
+            );
+    }
+
+    #[Test]
     public function localizedPageIsAddedToTheQueue(): void
     {
         $this->prepareLocalizedPageIsAddedToTheQueue();

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -33,7 +33,7 @@ class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
         $viewHelper->setRenderingContext($renderContextMock);
 
         $searchUriBuilderMock = $this->createMock(SearchUriBuilder::class);
-        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
+        $requestUriBuilderStub = self::createStub(RequestBuilder::class);
 
         // we expected that the getAddFacetOptionUri will be called on the searchUriBuilder in the end.
         $searchUriBuilderMock->expects(self::once())->method('getAddFacetValueUri')->with($facet->getResultSet()->getUsedSearchRequest(), 'Color', 'red');

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -39,7 +39,7 @@ class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
         $searchResultSetMock = $this->createMock(SearchResultSet::class);
         $searchResultSetMock->expects(self::once())->method('getUsedSearchRequest')->willReturn($mockedPreviousFakedRequest);
 
-        $requestUriBuilderStub = $this->createStub(RequestBuilder::class);
+        $requestUriBuilderStub = self::createStub(RequestBuilder::class);
         $requestUriBuilderStub->method('build')->willReturn($mockedControllerRequest);
 
         $variableProvideMock = $this->createMock(StandardVariableProvider::class);


### PR DESCRIPTION
# What this pr does

EXT:solr fails to detect changes on mounted pages correctly in some special occasions:

* mounted pages not considered during garbage removal / ce updates
* no_search_sub_entries flag not respected by GarbageRemover
  strategies
* existing queue items of mounted pages not updated

By adjusting the monitoring related components the issues are fixed,
affected components:

* GarbageRemover strategies
* page initializer
* RecordMonitor
* DataUpdateHandler

# How to test

- Mount a page located in a sys_folder with enabled option no_search_sub_entries
- Test updates of page and content elements and check the index queue updates


Fixes: #4275
