### PR TITLE
[BUGFIX:BP:12.0] Add check if generator is valid before traversing it

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -105,7 +105,9 @@ class SiteRepository
     {
         $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
         $siteGenerator->rewind();
-
+        if (!$siteGenerator->valid()) {
+            return null;
+        }
         $site = $siteGenerator->current();
 
         return $site instanceof Site ? $site : null;
@@ -131,6 +133,9 @@ class SiteRepository
         $siteGenerator->rewind();
 
         $sites = [];
+        if (!$siteGenerator->valid()) {
+            return $sites;
+        }
         foreach ($siteGenerator as $rootPageId => $site) {
             if (isset($sites[$rootPageId])) {
                 //get each site only once
@@ -152,6 +157,9 @@ class SiteRepository
     {
         $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
         $siteGenerator->rewind();
+        if (!$siteGenerator->valid()) {
+            return false;
+        }
 
         return ($site = $siteGenerator->current()) && $site instanceof Site;
     }
@@ -170,6 +178,9 @@ class SiteRepository
 
         $siteGenerator = $this->getAvailableTYPO3ManagedSites($stopOnInvalidSite);
         $siteGenerator->rewind();
+        if (!$siteGenerator->valid()) {
+            return false;
+        }
 
         // We start with 1 here as we know from hasAvailableSites() above we have at least one site
         $counter = 1;


### PR DESCRIPTION
If there's no solr configuration for any site, saving pages or content results in a PHP exception:

Uncaught TYPO3 Exception: Cannot traverse an already closed generator | Exception thrown in file .../Classes/Domain/Site/SiteRepository.php in line 135

The added check prevents this error.

Fixes: #4284
Ports: #4283