### PR TITLE
[FIX] docker image tests do not fail if core can not start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,19 @@ jobs:
           docker image ls -a
           ./Build/Test/cibuild_docker.sh
       -
-        name: Upload artifact
+        name: Upload Docker Image
         uses: actions/upload-artifact@v4
         with:
           name: solrci-image
           path: /tmp/solrci-image.tar
           retention-days: 1
+      -
+        name: Upload Solr-Server containers logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: solrci-logs
+          path: /tmp/docker_image_logs_**/
 
   test_documentation:
     name: test Documentation


### PR DESCRIPTION
Currently on Apache Solr 9.8.0 the cores can not boot up, because of
```
Plugin init failure for [schema.xml] fieldType "string_collated": Error loading class 'solr.ICUCollationField'
```
but the tests suite does not fail at all.

This change fixes the issue, which was caused by `prettyPrintOrExitOnError 0`

Ports: f52a50ec from #4290

---

### Maintainers notes:

Following actions jobs must succeed:

- [x] https://github.com/TYPO3-Solr/ext-solr/actions/runs/13030504859/job/36348490699#step:6:187with Apache Solr 9.7.0
- [x] https://github.com/TYPO3-Solr/ext-solr/actions/runs/13030514200/job/36348520414#step:6:187with Apache Solr 9.8.0