### PR TITLE
[RELEASE] 12.0.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Used versions (please complete the following information):**
  - TYPO3 Version: [e.g. 12.4.11]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 12.0.2]
+ - EXT:solr Version: [e.g. 12.0.6]
  - Used Apache Solr Version: [e.g. 9.8.0]
  - PHP Version: [e.g. 8.2.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Releases/solr-release-12-0.rst
+++ b/Documentation/Releases/solr-release-12-0.rst
@@ -9,7 +9,38 @@ Releases 12.0
 Release 12.0.6
 ==============
 
-This is a security release for TYPO3 12.4 LTS, containing:
+List of all changes
+
+- [BUGFIX] GroupViewHelperTest `9e2b6bf9f <https://github.com/TYPO3-Solr/ext-solr/commit/9e2b6bf9f>`_
+- [TASK] Remove Scrutinizer integrations on release-12.0.x `ac09602b4 <https://github.com/TYPO3-Solr/ext-solr/commit/ac09602b4>`_
+- [FIX] CS issue in Tests\\Unit\\System\\ContentObject\\ContentObjectServiceTest `b5be2e1c5 <https://github.com/TYPO3-Solr/ext-solr/commit/b5be2e1c5>`_
+- [BUGFIX] Convert getPageOverlay hook into PSR-14 Event `fe7c9eb08 <https://github.com/TYPO3-Solr/ext-solr/commit/fe7c9eb08>`_
+- [BUGFIX] PhpStan Variable $parameters in empty() always exists and is not falsy `1b3218b7c <https://github.com/TYPO3-Solr/ext-solr/commit/1b3218b7c>`_
+- [TASK] Apache Solr 9.7 compatibility `27ab5cd7f <https://github.com/TYPO3-Solr/ext-solr/commit/27ab5cd7f>`_
+- [TASK] 12.0.x-dev Update solarium/solarium requirement `01440e68d <https://github.com/TYPO3-Solr/ext-solr/commit/01440e68d>`_
+- [TASK] Remove Implicitly nullable parameter declarations deprecated `825bb9bdb <https://github.com/TYPO3-Solr/ext-solr/commit/825bb9bdb>`_
+- Fix file `a185cb863 <https://github.com/TYPO3-Solr/ext-solr/commit/a185cb863>`_
+- [TASK] CS change to multiline parameters with comma on last `b5b22eb3b <https://github.com/TYPO3-Solr/ext-solr/commit/b5b22eb3b>`_
+- [TASK] Evaluate all entries in Services.yaml regarding to `shared` setting `a3da67ac2 <https://github.com/TYPO3-Solr/ext-solr/commit/a3da67ac2>`_
+- [FEATURE] Add timeframe filter to statistics module `9e8d69772 <https://github.com/TYPO3-Solr/ext-solr/commit/9e8d69772>`_
+- [BUGFIX] Respect foreignLabel in related items from mm table `fc67246a5 <https://github.com/TYPO3-Solr/ext-solr/commit/fc67246a5>`_
+- [BUGFIX] Make getHasChildNodeSelected recursive `5d3ab6b0b <https://github.com/TYPO3-Solr/ext-solr/commit/5d3ab6b0b>`_
+- [BUGFIX] Add StartTimeRestriction to ConfigurationAwareRecordService `7369adf95 <https://github.com/TYPO3-Solr/ext-solr/commit/7369adf95>`_
+- [FEATURE] Use PHP generator to prevent processing of all available site `fe71a4f48 <https://github.com/TYPO3-Solr/ext-solr/commit/fe71a4f48>`_
+- [BUGFIX] Fix monitoring of mounted pages `f4924d144 <https://github.com/TYPO3-Solr/ext-solr/commit/f4924d144>`_
+- [DOCS] Switch documentation rendering to PHP-based rendering `82773617f <https://github.com/TYPO3-Solr/ext-solr/commit/82773617f>`_
+- [BUGFIX] Add check if generator is valid before traversing it `1c45b5318 <https://github.com/TYPO3-Solr/ext-solr/commit/1c45b5318>`_
+- [FIX] docker image tests do not fail if core can not start `f52a50ec2 <https://github.com/TYPO3-Solr/ext-solr/commit/f52a50ec2>`_
+- !!![SECURITY] Update to Apache solr 9.8.0 : CVE-2025-24814 `71ac3ee1a <https://github.com/TYPO3-Solr/ext-solr/commit/71ac3ee1a>`_
+- [DOCS] Actually mention the values of monitoringType `7f72a9fab <https://github.com/TYPO3-Solr/ext-solr/commit/7f72a9fab>`_
+- !!![TASK] Remove JSONP callback in suggest `fca9069ed <https://github.com/TYPO3-Solr/ext-solr/commit/fca9069ed>`_
+- [BUGFIX] Fix notice exception in ScoreCalculationService `52800162b <https://github.com/TYPO3-Solr/ext-solr/commit/52800162b>`_
+- [FIX] Docker tests suite does not contain all logs `9ce209824 <https://github.com/TYPO3-Solr/ext-solr/commit/9ce209824>`_
+- !!![FIX] Docker execution order issue for as-sudo tweaks `6ac30c124 <https://github.com/TYPO3-Solr/ext-solr/commit/6ac30c124>`_
+- [BUGFIX] Docker tweaks as-sudo do not preserve the Docker image ENV `c88254506 <https://github.com/TYPO3-Solr/ext-solr/commit/c88254506>`_
+- [TASK] Use relative path to typo3lib in Apache Solr config `ad32c9905 <https://github.com/TYPO3-Solr/ext-solr/commit/ad32c9905>`_
+- [DOCS] Improve Solr core creation via API and other deployment parts `387826fca <https://github.com/TYPO3-Solr/ext-solr/commit/387826fca>`_
+
 
 !!![SECURITY] Update to Apache solr 9.8.0 : CVE-2025-24814
 ----------------------------------------------------------

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '12.0.5',
+    'version' => '12.0.6',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
This is a security release for TYPO3 12.4 LTS, containing:

* !!![SECURITY] Update to Apache solr 9.8.0 : CVE-2025-24814
* !!![TASK] Remove JSONP callback in suggest
* and other fixes


Please read the release notes:
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/12.0.6
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/12.0/en-us/Releases/solr-release-12-0.html#release-12-0-6

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

---

Fixes: #4305