### PR TITLE
[BUGFIX] Fix mount point garbage collection

### DIFF
--- a/Classes/Domain/Index/Queue/QueueItemRepository.php
+++ b/Classes/Domain/Index/Queue/QueueItemRepository.php
@@ -783,12 +783,42 @@ class QueueItemRepository extends AbstractRepository
      */
     public function updateChangedTimeByItem(ItemInterface $item, int $changedTime = 0): int
     {
+        return $this->updateItemsChangedTime($changedTime, uids: [$item->getIndexQueueUid()]);
+    }
+
+    /**
+     * Updates items in the index queue filtered by the passed arguments.
+     *
+     * @throws DBALException
+     */
+    public function updateItemsChangedTime(
+        int $changedTime = 0,
+        array $sites = [],
+        array $indexQueueConfigurationNames = [],
+        array $itemTypes = [],
+        array $itemUids = [],
+        array $uids = [],
+    ): int {
+        $rootPageIds = SiteUtility::getRootPageIdsFromSites($sites);
+        $indexQueueConfigurationList = implode(',', $indexQueueConfigurationNames);
+        $itemTypeList = implode(',', $itemTypes);
+        $itemUids = array_map('intval', $itemUids);
+        $uids = array_map('intval', $uids);
+
         $queryBuilder = $this->getQueryBuilder();
-        return $queryBuilder
+        $queryBuilder
             ->update($this->table)
-            ->set('changed', $changedTime)
-            ->where($queryBuilder->expr()->eq('uid', $item->getIndexQueueUid()))
-            ->executeStatement();
+            ->set('changed', $changedTime);
+        $queryBuilder = $this->addItemWhereClauses(
+            $queryBuilder,
+            $rootPageIds,
+            $indexQueueConfigurationList,
+            $itemTypeList,
+            $itemUids,
+            $uids
+        );
+
+        return $queryBuilder->executeStatement();
     }
 
     /**
@@ -809,6 +839,7 @@ class QueueItemRepository extends AbstractRepository
      * Retrieves an array of pageIds from mountPoints that already have a queue entry.
      *
      * @throws DBALException
+     * @return int[]
      */
     public function findPageIdsOfExistingMountPagesByMountIdentifier(string $mountPointIdentifier): array
     {
@@ -827,7 +858,7 @@ class QueueItemRepository extends AbstractRepository
         $mountedPagesIdsWithQueueItems = [];
         while ($record = $resultSet->fetchAssociative()) {
             if ($record['queueItemCount'] > 0) {
-                $mountedPagesIdsWithQueueItems[] = $record['item_uid'];
+                $mountedPagesIdsWithQueueItems[] = (int)$record['item_uid'];
             }
         }
 
@@ -844,17 +875,42 @@ class QueueItemRepository extends AbstractRepository
         string $mountPointIdentifier,
         array $mountedPids,
     ): array {
+        return $this->findAllIndexQueueByMountIdentifier($rootPid, $mountPointIdentifier, $mountedPids);
+    }
+
+    /**
+     * Retrieves an array of items for mount destinations matched by root page ID and Mount Identifier
+     *
+     * @throws DBALException
+     */
+    public function findAllIndexQueueItemsByRootPidAndMountIdentifier(
+        int $rootPid,
+        string $mountPointIdentifier,
+    ): array {
+        return $this->findAllIndexQueueByMountIdentifier($rootPid, $mountPointIdentifier);
+    }
+
+    protected function findAllIndexQueueByMountIdentifier(
+        int $rootPid,
+        string $mountPointIdentifier,
+        ?array $mountedPids = null,
+    ): array {
         $queryBuilder = $this->getQueryBuilder();
-        return $queryBuilder
+        $queryBuilder = $queryBuilder
             ->select('*')
             ->from($this->table)
             ->where(
                 $queryBuilder->expr()->eq('root', $queryBuilder->createNamedParameter($rootPid, PDO::PARAM_INT)),
                 $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter('pages')),
-                $queryBuilder->expr()->in('item_uid', $mountedPids),
                 $queryBuilder->expr()->eq('has_indexing_properties', $queryBuilder->createNamedParameter(1, PDO::PARAM_INT)),
                 $queryBuilder->expr()->eq('pages_mountidentifier', $queryBuilder->createNamedParameter($mountPointIdentifier))
-            )
+            );
+
+        if ($mountedPids !== null) {
+            $queryBuilder->andWhere($queryBuilder->expr()->in('item_uid', $mountedPids));
+        }
+
+        return $queryBuilder
             ->executeQuery()
             ->fetchAllAssociative();
     }

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
@@ -73,6 +73,15 @@ class MountPagesUpdater
         }
     }
 
+    public function updateMountPoint(int $mountPointId): void
+    {
+        $mountingSite = $this->getSiteRepository()->getSiteByPageId($mountPointId);
+        $pageInitializer = $this->getPageInitializer();
+        $pageInitializer->setSite($mountingSite);
+        $pageInitializer->setIndexingConfigurationName('pages');
+        $pageInitializer->initializeMountPoint($mountPointId);
+    }
+
     /**
      * Adds a page to the Index Queue of a site mounting the page.
      *
@@ -83,14 +92,23 @@ class MountPagesUpdater
      */
     protected function addPageToMountingSiteIndexQueue(int $mountedPageId, array $mountProperties): void
     {
-        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $siteRepository = $this->getSiteRepository();
         $mountingSite = $siteRepository->getSiteByPageId($mountProperties['mountPageDestination']);
 
-        /** @var Page $pageInitializer */
-        $pageInitializer = GeneralUtility::makeInstance(Page::class);
+        $pageInitializer = $this->getPageInitializer();
         $pageInitializer->setSite($mountingSite);
         $pageInitializer->setIndexingConfigurationName('pages');
 
         $pageInitializer->initializeMountedPage($mountProperties, $mountedPageId);
+    }
+
+    protected function getPageInitializer(): Page
+    {
+        return GeneralUtility::makeInstance(Page::class);
+    }
+
+    protected function getSiteRepository(): SiteRepository
+    {
+        return GeneralUtility::makeInstance(SiteRepository::class);
     }
 }

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -204,12 +204,14 @@ class Site
      *
      * @param int|null $pageId Page ID from where to start collection sub-pages. Uses and includes the root page if none given.
      * @param string|null $indexQueueConfigurationName The name of index queue.
+     * @param string|null $additionalWhereClause
      *
      * @return array Array of pages (IDs) in this site
      */
     public function getPages(
         ?int $pageId = null,
         ?string $indexQueueConfigurationName = null,
+        ?string $additionalWhereClause = null
     ): array {
         $pageId = $pageId ?? (int)$this->rootPageRecord['uid'];
 
@@ -219,6 +221,13 @@ class Site
             $solrConfiguration = $this->getSolrConfiguration();
             $initialPagesAdditionalWhereClause = $solrConfiguration->getInitialPagesAdditionalWhereClause($indexQueueConfigurationName);
         }
+
+        if ($additionalWhereClause !== null) {
+            $initialPagesAdditionalWhereClause .=
+                ($initialPagesAdditionalWhereClause !== '' ? ' AND ' : '')
+                . '(' . $additionalWhereClause . ')';
+        }
+
         return $this->pagesRepository->findAllSubPageIdsByRootPage($pageId, $initialPagesAdditionalWhereClause);
     }
 

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -20,12 +20,14 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue;
 use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Access\RootlineElement;
 use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\PageUriBuilder;
+use ApacheSolrForTypo3\Solr\IndexQueue\Exception\IndexingException;
 use ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use Doctrine\DBAL\Exception as DBALException;
 use Exception;
 use Psr\Log\LogLevel;
 use RuntimeException;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Type\Bitmask\PageTranslationVisibility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -53,11 +55,18 @@ class PageIndexer extends Indexer
         $this->setLogging($item);
 
         // check whether we should move on at all
-        if (!$this->isPageIndexable($item)) {
+        if (!$this->isPageEnabled($item->getRecord())) {
             return false;
         }
 
         $systemLanguageUids = array_keys($this->getSolrConnectionsByItem($item));
+        if ($systemLanguageUids === []) {
+            throw new IndexingException(
+                'No Solr connections found for item',
+                1740383223
+            );
+        }
+
         foreach ($systemLanguageUids as $systemLanguageUid) {
             $contentAccessGroups = $this->getAccessGroupsFromContent($item, $systemLanguageUid);
             foreach ($contentAccessGroups as $userGroup) {
@@ -74,15 +83,22 @@ class PageIndexer extends Indexer
      * @param Item $item The page we want to index encapsulated in an index queue item
      *
      * @return bool True if we can index this page, FALSE otherwise
+     * @deprecated PageIndexer->isPageIndexable is deprecated and will be removed in v14.
+     *             Use PageIndexer->isPageEnabled() instead.
      */
     protected function isPageIndexable(Item $item): bool
     {
-        // TODO do we still need this?
-        // shouldn't those be sorted out by the record monitor / garbage collector already?
+        trigger_error(
+            'PageIndexer->isPageIndexable is deprecated and will be removed in v14.'
+            . ' Use PageIndexer->isPageEnabled instead.',
+            E_USER_DEPRECATED
+        );
+        return $this->isPageEnabled($item->getRecord());
+    }
 
+    protected function isPageEnabled(array $record): bool
+    {
         $isIndexable = true;
-        $record = $item->getRecord();
-
         if (isset($GLOBALS['TCA']['pages']['ctrl']['enablecolumns']['disabled'])
             && $record[$GLOBALS['TCA']['pages']['ctrl']['enablecolumns']['disabled']]
         ) {
@@ -103,25 +119,53 @@ class PageIndexer extends Indexer
      *
      * @throws NoSolrConnectionFoundException
      * @throws DBALException
+     * @throws IndexingException
      */
     protected function getSolrConnectionsByItem(Item $item): array
     {
-        $solrConnections = parent::getSolrConnectionsByItem($item);
+        $solrConnections = $this->filterSolrConectionByPage(
+            parent::getSolrConnectionsByItem($item),
+            $item->getRecord()
+        );
 
-        $page = $item->getRecord();
-        if ((new PageTranslationVisibility((int)($page['l18n_cfg'] ?? 0)))->shouldBeHiddenInDefaultLanguage()) {
+        if ($item->hasIndexingProperty('isMountedPage')) {
+            $mountPageId = $item->getIndexingProperty('mountPageDestination');
+            $mountPage = BackendUtility::getRecord(
+                'pages',
+                $mountPageId,
+            );
+            if ($mountPage === null) {
+                throw new IndexingException(
+                    'Mounted page couldn\'t be indexed, mount point ' . $mountPageId . ' not found',
+                    1740383224
+                );
+            }
+            $solrConnections = $this->filterSolrConectionByPage($solrConnections, $mountPage, true);
+        }
+
+        return $solrConnections;
+    }
+
+    protected function filterSolrConectionByPage(
+        array $solrConnections,
+        array $page,
+        bool $forceHideTranslationIfNoTranslatedRecordExists = false
+    ): array {
+        $pageTranslationVisibility = new PageTranslationVisibility((int)($page['l18n_cfg'] ?? 0));
+        if ($pageTranslationVisibility->shouldBeHiddenInDefaultLanguage()) {
             // page is configured to hide the default translation -> remove Solr connection for default language
             unset($solrConnections[0]);
         }
 
-        if ((new PageTranslationVisibility((int)($page['l18n_cfg'] ?? 0)))->shouldHideTranslationIfNoTranslatedRecordExists()) {
+        if ($forceHideTranslationIfNoTranslatedRecordExists
+            || $pageTranslationVisibility->shouldHideTranslationIfNoTranslatedRecordExists()
+        ) {
             $accessibleSolrConnections = [];
             if (isset($solrConnections[0])) {
                 $accessibleSolrConnections[0] = $solrConnections[0];
             }
 
             $translationOverlays = $this->pagesRepository->findTranslationOverlaysByPageId((int)$page['uid']);
-
             foreach ($translationOverlays as $overlay) {
                 $languageId = $overlay['sys_language_uid'];
                 if (array_key_exists($languageId, $solrConnections)) {
@@ -320,7 +364,8 @@ class PageIndexer extends Indexer
         }
 
         if (empty($indexActionResult['pageIndexed'])) {
-            $message = 'Failed indexing page Index Queue item: ' . $item->getIndexQueueUid() . ' url: ' . $indexRequestUrl;
+            $message = 'Failed indexing page Index Queue item: ' . $item->getIndexQueueUid()
+                . ', language: ' . $language . ', url: ' . $indexRequestUrl;
             throw new RuntimeException($message, 1331837081);
         }
 

--- a/Tests/Integration/Fixtures/mount_page_garbage.csv
+++ b/Tests/Integration/Fixtures/mount_page_garbage.csv
@@ -1,0 +1,14 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search"
+,10,1,1736145035,0,1,0,0,"/mounted-page","Mounted page on root page 1",1
+,11,10,1736145036,0,1,0,0,"/mounted-page/subpage-of-mounted-page","Subpage of mounted ",0
+,20,1,1736145037,0,7,10,1,"/mount-point","Mount point for page on root page",0
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","changed","errors"
+,1,1,"pages",11,"pages",0,"",1736145036,""
+,2,1,"pages",11,"pages",1,"10-20-1",1736145036,""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,2,"mountPageSource",10
+,2,1,2,"mountPageDestination",20
+,3,1,2,"isMountedPage",1

--- a/Tests/Integration/Fixtures/translated_mount_page_garbage.csv
+++ b/Tests/Integration/Fixtures/translated_mount_page_garbage.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search","sys_language_uid","l10n_parent"
+,10,1,1736145035,0,1,0,0,"/mounted-page","Mounted page on root page 1",1,0,0
+,11,1,1736145035,0,1,0,0,"/translated-mounted-page","Translated mounted page on root page 1",1,1,10
+,12,10,1736145036,0,1,0,0,"/mounted-page/subpage-of-mounted-page","Subpage of mounted ",0,0,0
+,13,10,1736145036,0,1,0,0,"/translated-mounted-page/translated-subpage-of-mounted-page","Translated subpage of mounted ",0,1,12
+,20,1,1736145037,0,7,10,1,"/mount-point","Mount point for page on root page",0,0,0
+,21,1,1736145037,0,7,10,1,"/translated-mount-point","Translated mount point for page on root page",0,1,20
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","changed","errors"
+,1,1,"pages",12,"pages",0,"",1736145036,""
+,2,1,"pages",12,"pages",1,"10-20-1",1736145036,""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,2,"mountPageSource",10
+,2,1,2,"mountPageDestination",20
+,3,1,2,"isMountedPage",1

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -18,11 +18,12 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\IndexQueue\Indexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\IndexQueue\ItemInterface;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\RecordMonitor;
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
-use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
@@ -33,7 +34,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * This testcase is used to check if the GarbageCollector can delete garbage from the
@@ -499,6 +499,204 @@ class GarbageCollectorTest extends IntegrationTestBase
     {
         yield 'Test soft delete' => [ false ];
         yield 'Test hard delete' => [ true ];
+    }
+
+    #[Test]
+    #[DataProvider('canCollectMountPageGarbageDataProvider')]
+    public function canCollectMountPageGarbage(
+        int $monitoringType,
+        array $dataMap,
+        array $cmdMap,
+        int $expectedQueueCount,
+        int $expectedDocumentCount,
+        int $expectedItemsToReindex = 0
+    ): void {
+        $this->extensionConfiguration->set('solr', ['monitoringType' => $monitoringType]);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/mount_page_garbage.csv');
+        $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
+        $this->cleanUpSolrServerAndAssertEmpty();
+        $this->assertEmptyEventQueue();
+
+        // index all queue items
+        foreach ($this->indexQueue->getAllItems() as $item) {
+            self::assertTrue($this->indexPageQueueItem($item), 'Queue item failed to be indexed.');
+        }
+        self::assertSolrContainsDocumentCount(2, 'Initial number of documents in index not as expected');
+
+        $this->dataHandler->start(
+            $dataMap,
+            $cmdMap,
+            $this->backendUser
+        );
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+
+        if ($monitoringType === 1) {
+            $this->processEventQueue();
+        }
+        $this->waitToBeVisibleInSolr();
+
+        $queueItems = $this->indexQueue->getAllItems();
+        self::assertCount($expectedQueueCount, $queueItems, 'Total number of index queue items differs');
+        $itemsToReindex = array_filter(
+            $queueItems,
+            static fn(Item $item): bool => $item->getState() === ItemInterface::STATE_PENDING
+        );
+        self::assertCount($expectedItemsToReindex, $itemsToReindex, 'Number of items that need reindexing differs');
+        self::assertSolrContainsDocumentCount($expectedDocumentCount, 'Final number of documents in index not as expected');
+    }
+
+    public static function canCollectMountPageGarbageDataProvider(): Traversable
+    {
+        yield 'collect garbage on mount point deletion (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [20 => ['delete' => 1]]],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCount' => 1,
+        ];
+        yield 'collect garbage on mount point deletion (delayed processing)' => [
+            'monitoringType' => 1,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [20 => ['delete' => 1]]],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCount' => 1,
+        ];
+        yield 'collect garbage on mount point deactivation (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => ['pages' => [20 => ['hidden' => 1]]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCount' => 1,
+        ];
+        yield 'collect garbage on mount point deactivation (delayed processing)' => [
+            'monitoringType' => 1,
+            'dataMap' => ['pages' => [20 => ['hidden' => 1]]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCount' => 1,
+        ];
+        yield 'collect garbage on mount point title update (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => ['pages' => [20 => ['title' => 'new title']]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCount' => 2,
+        ];
+        yield 'collect garbage on mount point title update (delayed processing)' => [
+            'monitoringType' => 1,
+            'dataMap' => ['pages' => [20 => ['title' => 'new title']]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCount' => 2,
+        ];
+        yield 'collect garbage on mount point slug update (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => ['pages' => [20 => ['slug' => '/new-mount-point-slug']]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCount' => 1,
+            'expectedItemsToReindex' => 1,
+        ];
+        yield 'collect garbage on mount point slug update (delayed) processing)' => [
+            'monitoringType' => 1,
+            'dataMap' => ['pages' => [20 => ['slug' => '/new-mount-point-slug']]],
+            'cmdMap' => [],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCount' => 1,
+            'expectedItemsToReindex' => 1,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('canCollectTranslatedMountPageGarbageDataProvider')]
+    public function canCollectTranslatedMountPageGarbage(
+        int $monitoringType,
+        array $dataMap,
+        array $cmdMap,
+        int $expectedQueueCount,
+        int $expectedDocumentCountEn,
+        int $expectedDocumentCountDe,
+        int $expectedItemsToReindex = 0,
+    ): void {
+        $this->extensionConfiguration->set('solr', ['monitoringType' => $monitoringType]);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/translated_mount_page_garbage.csv');
+        $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
+        $this->cleanUpSolrServerAndAssertEmpty('core_en');
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
+        $this->assertEmptyEventQueue();
+
+        // index all queue items
+        foreach ($this->indexQueue->getAllItems() as $item) {
+            self::assertTrue($this->indexPageQueueItem($item), 'Queue item failed to be indexed in default language.');
+            self::assertTrue(
+                $this->indexPageQueueItem($item, 1, 'core_de'),
+                'Queue item failed to be indexed in german translation.'
+            );
+        }
+        self::assertSolrContainsDocumentCount(2, 'Initial number of documents in english index not as expected', 'core_en');
+        self::assertSolrContainsDocumentCount(2, 'Initial number of documents in german index not as expected', 'core_de');
+
+        $this->dataHandler->start(
+            $dataMap,
+            $cmdMap,
+            $this->backendUser
+        );
+        $this->dataHandler->process_datamap();
+        $this->dataHandler->process_cmdmap();
+
+        if ($monitoringType === 1) {
+            $this->processEventQueue();
+        }
+        $this->waitToBeVisibleInSolr();
+
+        $queueItems = $this->indexQueue->getAllItems();
+        self::assertCount($expectedQueueCount, $queueItems, 'Total number of index queue items differs');
+        $itemsToReindex = array_filter(
+            $queueItems,
+            static fn(Item $item): bool => $item->getState() === ItemInterface::STATE_PENDING
+        );
+        self::assertCount($expectedItemsToReindex, $itemsToReindex, 'Number of items that need reindexing differs');
+        self::assertSolrContainsDocumentCount($expectedDocumentCountDe, 'Final number of documents in english index not as expected');
+        self::assertSolrContainsDocumentCount($expectedDocumentCountDe, 'Final number of documents in german index not as expected');
+    }
+
+    public static function canCollectTranslatedMountPageGarbageDataProvider(): Traversable
+    {
+        yield 'collect garbage on mount point deletion (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [20 => ['delete' => 1]]],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCountEn' => 1,
+            'expectedDocumentCountDe' => 1,
+        ];
+        yield 'collect garbage on mount point deletion (delayed processing)' => [
+            'monitoringType' => 1,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [20 => ['delete' => 1]]],
+            'expectedQueueCount' => 1,
+            'expectedDocumentCountEn' => 1,
+            'expectedDocumentCountDe' => 1,
+        ];
+        yield 'collect garbage on mount point translation deletion (immediate processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [21 => ['delete' => 1]]],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCountEn' => 1,
+            'expectedDocumentCountDe' => 1,
+            'expectedItemsToReindex' => 1,
+        ];
+        yield 'collect garbage on mount point translation deletion (delayed processing)' => [
+            'monitoringType' => 0,
+            'dataMap' => [],
+            'cmdMap' => ['pages' => [21 => ['delete' => 1]]],
+            'expectedQueueCount' => 2,
+            'expectedDocumentCountEn' => 1,
+            'expectedDocumentCountDe' => 1,
+            'expectedItemsToReindex' => 1,
+        ];
     }
 
     #[Test]
@@ -1009,15 +1207,5 @@ class GarbageCollectorTest extends IntegrationTestBase
         }
 
         return $result;
-    }
-
-    /**
-     * Triggers event queue processing
-     */
-    protected function processEventQueue(): void
-    {
-        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
-        $scheduler->executeTask($task);
     }
 }

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -27,7 +27,6 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -40,7 +39,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Scheduler\Scheduler;
 
 /**
  * Testcase for the record monitor
@@ -2166,19 +2164,6 @@ class RecordMonitorTest extends IntegrationTestBase
         );
 
         $this->assertIndexQueueContainsItemAmount(1);
-    }
-
-    /**
-     * Triggers event queue processing
-     */
-    protected function processEventQueue(): void
-    {
-        /** @var EventQueueWorkerTask $task */
-        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-
-        /** @var Scheduler $scheduler */
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
-        $scheduler->executeTask($task);
     }
 
     /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
@@ -357,6 +359,11 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $cacheManagerMock = $this->createMock(CacheManager::class);
         $cacheManagerMock->method('getCache')->willReturn($frontendCacheMock);
         GeneralUtility::setSingletonInstance(CacheManager::class, $cacheManagerMock);
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
 
         $this->pagesRepositoryMock
             ->expects(self::any())

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -95,6 +95,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         $item = $this->createMock(Item::class);
         $item->expects(self::any())->method('getRootPageUid')->willReturn(88);
         $item->expects(self::any())->method('getRecordUid')->willReturn(4711);
+        $item->expects(self::any())->method('getRecord')->willReturn(['uid' => 4711]);
         $item->expects(self::any())->method('getSite')->willReturn($siteMock);
         $item->expects(self::any())->method('getIndexingConfigurationName')->willReturn('pages');
 


### PR DESCRIPTION
EXT:solr failed to delete indexed mounted pages if a mount point is deleted or deactivated, this issue is fixed by extending the PageStrategy.

Additionally it's ensured, that changes to the slug of a mount page triggers a reindexing of the mounted pages as the indexed slug has become invalid.

Resolves: #4314