### PR TITLE
[BUGFIX] 404 on auto-suggest with enabled TYPO3 enforceValidation setting

### DIFF
--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -126,6 +126,7 @@ class ExtensionConfiguration
 
         if ($this->getIncludeGlobalQParameterInCacheHash() === false) {
             $exclusions[] = 'q';
+            $exclusions[] = '_';
         }
         return array_combine($exclusions, $exclusions);
     }


### PR DESCRIPTION
Excluding the `_` parameter from cHash to solve the issue for auto-suggest component by TYPO3 instances with enabled [enforceValidation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/CachingFramework/Index.html#confval-enforcevalidation) setting.

Fixes: #3919

