### PR TITLE
[BUGFIX:P:13] Fix mount point garbage collection

### DIFF
--- a/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/AbstractStrategy.php
@@ -16,13 +16,16 @@
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueItemRepository;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
+use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\GarbageCollectorPostProcessor;
 use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
 use ApacheSolrForTypo3\Solr\IndexQueue\QueueInterface;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Solr\Traits\SkipRecordByRootlineConfigurationTrait;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -40,15 +43,18 @@ abstract class AbstractStrategy
     protected QueueInterface $queue;
     protected ConnectionManager $connectionManager;
     protected SiteRepository $siteRepository;
+    protected QueueItemRepository $queueItemRepository;
 
     public function __construct(
         ?QueueInterface $queue = null,
         ?ConnectionManager $connectionManager = null,
         ?SiteRepository $siteRepository = null,
+        ?QueueItemRepository $queueItemRepository = null,
     ) {
         $this->queue = $queue ?? GeneralUtility::makeInstance(Queue::class);
         $this->connectionManager = $connectionManager ?? GeneralUtility::makeInstance(ConnectionManager::class);
         $this->siteRepository = $siteRepository ?? GeneralUtility::makeInstance(SiteRepository::class);
+        $this->queueItemRepository = $queueItemRepository ?? GeneralUtility::makeInstance(QueueItemRepository::class);
     }
 
     /**
@@ -162,28 +168,56 @@ abstract class AbstractStrategy
     ): void {
         foreach ($solrConnections as $solr) {
             $query = 'type:' . $table . ' AND uid:' . $uid . ' AND siteHash:' . $siteHash;
-            $response = $solr->getWriteService()->deleteByQuery($query);
-
-            if ($response->getHttpStatus() !== 200) {
-                $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
-                $logger->error(
-                    'Couldn\'t delete index document',
-                    [
-                        'status' => $response->getHttpStatus(),
-                        'msg' => $response->getHttpStatusMessage(),
-                        'core' => $solr->getWriteService()->getCorePath(),
-                        'query' => $query,
-                    ],
-                );
-
-                // @todo: Ensure index is updated later on, e.g. via a new index queue status
+            if (!$this->sendDeleteQuery($solr, $query, $enableCommitsSetting)) {
                 continue;
             }
+        }
+    }
 
-            if ($enableCommitsSetting) {
-                $solr->getWriteService()->commit(false, false);
+    /**
+     * Deletes indexed mounted pages in all solr connections from that site.
+     */
+    protected function deleteMountedPagesInAllSolrConnections(
+        Site $site,
+        string $mountPointIdentifier,
+    ): void {
+        $solrConnections = $this->connectionManager->getConnectionsBySite($site);
+        foreach ($solrConnections as $solr) {
+            $query = 'type:pages'
+                . ' AND id:*/pages/*/' . $mountPointIdentifier . '/*'
+                . ' AND siteHash:' . $site->getSiteHash();
+            if (!$this->sendDeleteQuery($solr, $query, $site->getSolrConfiguration()->getEnableCommits())) {
+                continue;
             }
         }
+    }
+
+    protected function sendDeleteQuery(
+        SolrConnection $connection,
+        string $query,
+        bool $enableCommitsSetting = true,
+    ): bool {
+        $response = $connection->getWriteService()->deleteByQuery($query);
+        $success = ($response->getHttpStatus() === 200);
+        if (!$success) {
+            $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+            $logger->error(
+                'Couldn\'t delete index document',
+                [
+                    'status' => $response->getHttpStatus(),
+                    'msg' => $response->getHttpStatusMessage(),
+                    'core' => $connection->getWriteService()->getCorePath(),
+                    'query' => $query,
+                ],
+            );
+            return false;
+        }
+
+        if ($enableCommitsSetting) {
+            $connection->getWriteService()->commit(false, false);
+        }
+
+        return $success;
     }
 
     /**

--- a/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
+++ b/Classes/Domain/Index/Queue/GarbageRemover/PageStrategy.php
@@ -17,8 +17,10 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover;
 
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
+use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
 use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -81,11 +83,44 @@ class PageStrategy extends AbstractStrategy
      */
     protected function collectPageGarbageByPageChange(int $uid): void
     {
-        $pageOverlay = BackendUtility::getRecord('pages', $uid, 'l10n_parent, sys_language_uid', '', false);
-        if (!empty($pageOverlay['l10n_parent']) && (int)($pageOverlay['l10n_parent']) !== 0) {
-            $this->deleteIndexDocuments('pages', (int)$pageOverlay['l10n_parent'], (int)$pageOverlay['sys_language_uid']);
+        $page = BackendUtility::getRecord('pages', $uid, '*', '', false);
+        if (!empty($page['l10n_parent']) && (int)($page['l10n_parent']) !== 0) {
+            $this->deleteIndexDocuments('pages', (int)$page['l10n_parent'], (int)$page['sys_language_uid']);
         } else {
             $this->deleteInSolrAndRemoveFromIndexQueue('pages', $uid);
         }
+
+        $this->collectMountPointGarbage($page);
+    }
+
+    protected function collectMountPointGarbage(?array $page): void
+    {
+        if ($page === null || (int)$page['doktype'] !== PageRepository::DOKTYPE_MOUNTPOINT) {
+            return;
+        }
+
+        $mountPointUid = (GeneralUtility::makeInstance(TCAService::class))
+            ->getTranslationOriginalUidIfTranslated('pages', $page, $page['uid']);
+
+        $site = $this->siteRepository->getSiteByPageId($page['pid']);
+        $itemUids = array_map(
+            static function (array $item): int {
+                return (int)$item['uid'];
+            },
+            $this->queueItemRepository->findAllIndexQueueItemsByRootPidAndMountIdentifier(
+                $site->getRootPageId(),
+                $page['mount_pid'] . '-' . $mountPointUid . '-' . $site->getRootPageId(),
+            ),
+        );
+
+        if ($itemUids !== []) {
+            if ($page['uid'] !== $mountPointUid) {
+                $this->queueItemRepository->updateItemsChangedTime(time(), uids: $itemUids);
+            } else {
+                $this->queueItemRepository->deleteItems(uids: $itemUids);
+            }
+        }
+
+        $this->deleteMountedPagesInAllSolrConnections($site, $page['mount_pid'] . '-' . $mountPointUid);
     }
 }

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/MountPagesUpdater.php
@@ -73,6 +73,15 @@ class MountPagesUpdater
         }
     }
 
+    public function updateMountPoint(int $mountPointId): void
+    {
+        $mountingSite = $this->getSiteRepository()->getSiteByPageId($mountPointId);
+        $pageInitializer = $this->getPageInitializer();
+        $pageInitializer->setSite($mountingSite);
+        $pageInitializer->setIndexingConfigurationName('pages');
+        $pageInitializer->initializeMountPoint($mountPointId);
+    }
+
     /**
      * Adds a page to the Index Queue of a site mounting the page.
      *
@@ -83,14 +92,23 @@ class MountPagesUpdater
      */
     protected function addPageToMountingSiteIndexQueue(int $mountedPageId, array $mountProperties): void
     {
-        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $siteRepository = $this->getSiteRepository();
         $mountingSite = $siteRepository->getSiteByPageId($mountProperties['mountPageDestination']);
 
-        /** @var Page $pageInitializer */
-        $pageInitializer = GeneralUtility::makeInstance(Page::class);
+        $pageInitializer = $this->getPageInitializer();
         $pageInitializer->setSite($mountingSite);
         $pageInitializer->setIndexingConfigurationName('pages');
 
         $pageInitializer->initializeMountedPage($mountProperties, $mountedPageId);
+    }
+
+    protected function getPageInitializer(): Page
+    {
+        return GeneralUtility::makeInstance(Page::class);
+    }
+
+    protected function getSiteRepository(): SiteRepository
+    {
+        return GeneralUtility::makeInstance(SiteRepository::class);
     }
 }

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -255,6 +255,7 @@ class Site
      *
      * @param int|null $pageId Page ID from where to start collection sub-pages. Uses and includes the root page if none given.
      * @param string|null $indexQueueConfigurationName The name of index queue.
+     * @param string|null $additionalWhereClause
      *
      * @return int[] Array of pages (IDs) in this site
      *
@@ -263,6 +264,7 @@ class Site
     public function getPages(
         ?int $pageId = null,
         ?string $indexQueueConfigurationName = null,
+        ?string $additionalWhereClause = null,
     ): array {
         $pageId = $pageId ?? (int)$this->rootPageRecord['uid'];
 
@@ -272,6 +274,13 @@ class Site
             $solrConfiguration = $this->getSolrConfiguration();
             $initialPagesAdditionalWhereClause = $solrConfiguration->getInitialPagesAdditionalWhereClause($indexQueueConfigurationName);
         }
+
+        if ($additionalWhereClause !== null) {
+            $initialPagesAdditionalWhereClause .=
+                ($initialPagesAdditionalWhereClause !== '' ? ' AND ' : '')
+                . '(' . $additionalWhereClause . ')';
+        }
+
         return $this->pagesRepository->findAllSubPageIdsByRootPage($pageId, $initialPagesAdditionalWhereClause);
     }
 

--- a/Classes/IndexQueue/Initializer/Page.php
+++ b/Classes/IndexQueue/Initializer/Page.php
@@ -80,6 +80,16 @@ class Page extends AbstractInitializer
     }
 
     /**
+     * Initializes the pages of a single mount point
+     *
+     * @param int $mountPointId Uid of mount point (doktype = 7) to initialize
+     */
+    public function initializeMountPoint(int $mountPointId)
+    {
+        return $this->initializeMountPointPages($mountPointId);
+    }
+
+    /**
      * Initializes Mount Point(pages) to be indexed through the Index Queue. The Mount
      * Points are searched and their mounted virtual sub-trees are then resolved
      * and added to the Index Queue as if they were actually present below the
@@ -91,13 +101,14 @@ class Page extends AbstractInitializer
      * @throws DBALException
      * @throws UnexpectedTYPO3SiteInitializationException
      */
-    protected function initializeMountPointPages(): bool
+    protected function initializeMountPointPages(?int $restrictToMountPoint = null): bool
     {
         $mountPointsInitialized = false;
         $mountPoints = $this->pagesRepository->findAllMountPagesByWhereClause(
             $this->buildPagesClause()
             . $this->buildTcaWhereClause()
-            . ' AND doktype = 7 AND no_search = 0',
+            . ' AND doktype = 7 AND no_search = 0'
+            . ($restrictToMountPoint !== null ? ' AND uid=' . $restrictToMountPoint : ''),
         );
 
         if (empty($mountPoints)) {
@@ -318,7 +329,14 @@ class Page extends AbstractInitializer
     {
         $mountPageSourceId = (int)$mountPage['mountPageSource'];
 
-        $mountPageTree = $this->site->getPages($mountPageSourceId, 'pages');
+        $mountPageTree = $this->site->getPages(
+            $mountPageSourceId,
+            'pages',
+            $this->site->getSolrConfiguration()->getValueByPathOrDefaultValue(
+                'plugin.tx_solr.index.queue.pages.additionalWhereClause',
+                '',
+            ),
+        );
 
         // Do not include $mountPageSourceId in tree, if the mount point is not set to overlay.
         if (!empty($mountPageTree) && !$mountPage['mountPageOverlayed']) {

--- a/Tests/Integration/Fixtures/mount_page_garbage.csv
+++ b/Tests/Integration/Fixtures/mount_page_garbage.csv
@@ -1,0 +1,14 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search"
+,10,1,1736145035,0,1,0,0,"/mounted-page","Mounted page on root page 1",1
+,11,10,1736145036,0,1,0,0,"/mounted-page/subpage-of-mounted-page","Subpage of mounted ",0
+,20,1,1736145037,0,7,10,1,"/mount-point","Mount point for page on root page",0
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","changed","errors"
+,1,1,"pages",11,"pages",0,"",1736145036,""
+,2,1,"pages",11,"pages",1,"10-20-1",1736145036,""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,2,"mountPageSource",10
+,2,1,2,"mountPageDestination",20
+,3,1,2,"isMountedPage",1

--- a/Tests/Integration/Fixtures/translated_mount_page_garbage.csv
+++ b/Tests/Integration/Fixtures/translated_mount_page_garbage.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","tstamp","hidden","doktype","mount_pid","mount_pid_ol","slug","title","no_search","sys_language_uid","l10n_parent"
+,10,1,1736145035,0,1,0,0,"/mounted-page","Mounted page on root page 1",1,0,0
+,11,1,1736145035,0,1,0,0,"/translated-mounted-page","Translated mounted page on root page 1",1,1,10
+,12,10,1736145036,0,1,0,0,"/mounted-page/subpage-of-mounted-page","Subpage of mounted ",0,0,0
+,13,10,1736145036,0,1,0,0,"/translated-mounted-page/translated-subpage-of-mounted-page","Translated subpage of mounted ",0,1,12
+,20,1,1736145037,0,7,10,1,"/mount-point","Mount point for page on root page",0,0,0
+,21,1,1736145037,0,7,10,1,"/translated-mount-point","Translated mount point for page on root page",0,1,20
+"tx_solr_indexqueue_item"
+,"uid","root","item_type","item_uid","indexing_configuration","has_indexing_properties","pages_mountidentifier","changed","errors"
+,1,1,"pages",12,"pages",0,"",1736145036,""
+,2,1,"pages",12,"pages",1,"10-20-1",1736145036,""
+"tx_solr_indexqueue_indexing_property"
+,"uid","root","item_id","property_key","property_value"
+,1,1,2,"mountPageSource",10
+,2,1,2,"mountPageDestination",20
+,3,1,2,"isMountedPage",1

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -27,13 +27,11 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\System\TCA\TCAService;
-use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\SkippedWithMessageException;
 use Psr\Log\LogLevel;
-use Psr\Log\NullLogger;
 use Traversable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -41,9 +39,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Scheduler\Domain\Repository\SchedulerTaskRepository;
-use TYPO3\CMS\Scheduler\Scheduler;
-use TYPO3\CMS\Scheduler\Task\TaskSerializer;
 
 /**
  * Testcase for the record monitor
@@ -2149,24 +2144,6 @@ class RecordMonitorTest extends IntegrationTestBase
         );
 
         $this->assertIndexQueueContainsItemAmount(1);
-    }
-
-    /**
-     * Triggers event queue processing
-     */
-    protected function processEventQueue(): void
-    {
-        /** @var EventQueueWorkerTask $task */
-        $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-
-        /** @var Scheduler $scheduler */
-        $scheduler = GeneralUtility::makeInstance(
-            Scheduler::class,
-            $this->createMock(NullLogger::class),
-            $this->createMock(TaskSerializer::class),
-            $this->createMock(SchedulerTaskRepository::class),
-        );
-        $scheduler->executeTask($task);
     }
 
     /**

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -26,6 +26,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -77,6 +79,7 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
                 'uid' => self::DUMMY_PAGE_ID,
                 'title' => 'dummy page on which dummy ce is placed',
                 'sys_language_uid' => 0,
+                'doktype' => 1,
             ]);
 
         $this->dataHandlerMock
@@ -372,6 +375,11 @@ class DataUpdateHandlerTest extends SetUpUpdateHandler
         $cacheManagerMock->method('getCache')->willReturn($frontendCacheMock);
         GeneralUtility::setSingletonInstance(CacheManager::class, $cacheManagerMock);
         GeneralUtility::addInstance(PageRepository::class, $this->createMock(PageRepository::class));
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $connectionPoolMock = $this->createMock(ConnectionPool::class);
+        $connectionPoolMock->method('getQueryBuilderForTable')->willReturn($queryBuilderMock);
+        GeneralUtility::addInstance(ConnectionPool::class, $connectionPoolMock);
 
         $this->pagesRepositoryMock
             ->expects(self::any())

--- a/Tests/Unit/IndexQueue/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerTest.php
@@ -95,6 +95,7 @@ class PageIndexerTest extends SetUpUnitTestCase
         $item = $this->createMock(Item::class);
         $item->expects(self::any())->method('getRootPageUid')->willReturn(88);
         $item->expects(self::any())->method('getRecordUid')->willReturn(4711);
+        $item->expects(self::any())->method('getRecord')->willReturn(['uid' => 4711]);
         $item->expects(self::any())->method('getSite')->willReturn($siteMock);
         $item->expects(self::any())->method('getIndexingConfigurationName')->willReturn('pages');
 


### PR DESCRIPTION
# What this pr does

EXT:solr failed to delete indexed mounted pages if a mount point is deleted or deactivated, this issue is fixed by extending the PageStrategy.

Additionally it's ensured, that changes to the slug of a mount page triggers a reindexing of the mounted pages as the indexed slug has become invalid.

Ports: #4315
Resolves: #4314