### PR TITLE
#4341 Form.html: maxlength for search text input field

### DIFF
--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -13,7 +13,7 @@
 				</f:for>
 
 				<div class="input-group">
-					<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" />
+					<input type="text" class="tx-solr-q js-solr-q tx-solr-suggest tx-solr-suggest-focus form-control" name="{pluginNamespace}[q]" value="{q}" maxlength="50" />
 					<button class="btn btn-primary tx-solr-submit" type="submit">
 							<span class="bi bi-search"></span>
 							<f:translate key="submit" extensionName="solr">Search</f:translate>


### PR DESCRIPTION
# What this pr does

inserting `maxlength="50"` to input field of search form 

# How to test

focus a search field with active auto suggest function. hold down the space key and fill the input field with spaces.
before:
watch the server log as requests with longer and longer search string appear until the server is locked up
after: 
just a few request appear as after 50 characters no further changes to the input text appear and trigger further AJAX requests

Fixes: #4341
