### PR TITLE
[BUGFIX] Pass correct TypoScript configuration to QueryBuilder in RelevanceComponent

### DIFF
--- a/Classes/Search/RelevanceComponent.php
+++ b/Classes/Search/RelevanceComponent.php
@@ -19,22 +19,21 @@ namespace ApacheSolrForTypo3\Solr\Search;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Boosting search component
  */
 class RelevanceComponent
 {
-    public function __construct(
-        protected readonly QueryBuilder $queryBuilder,
-    ) {}
-
     /**
      * Sets minimum match, boost function, boost query and tie-breaker.
      */
     public function __invoke(AfterSearchQueryHasBeenPreparedEvent $event): void
     {
-        $query = $this->queryBuilder
+        $typoScriptConfiguration = $event->getTypoScriptConfiguration();
+        $queryBuilder = GeneralUtility::makeInstance(QueryBuilder::class, $typoScriptConfiguration);
+        $query = $queryBuilder
             ->startFrom($event->getQuery())
             ->useMinimumMatchFromTypoScript()
             ->useBoostFunctionFromTypoScript()


### PR DESCRIPTION
# What this pr does

The RelevanceCopmonent used a QueryBuilder with a differing TypoScript configuration from the original search request. 

This PR tries to resolve this by using the given TypoScript within the ([AfterSearchQueryHasBeenPreparedEvent](https://github.com/TYPO3-Solr/ext-solr/blob/ca41f0fbc3dea1126928cb917f8168968ff8ce1f/Classes/Event/Search/AfterSearchQueryHasBeenPreparedEvent.php#L39)).

# How to test
Set a boostFonction or boostQuery within a page condition:

```
[page["uid"] == 22]
    plugin.tx_solr {
        search {
            query {
                boostFunction = myboostField_intS^2
...
```
Set an xdebug breakpoint in [QueryBuilder->useBoostFunctionFromTypoScript()](https://github.com/TYPO3-Solr/ext-solr/blob/ca41f0fbc3dea1126928cb917f8168968ff8ce1f/Classes/Domain/Search/Query/QueryBuilder.php#L205) and analyze the boostFunction content of $searchConfiguration.

It now should be `myboostField_intS^2`

Fixes: #4351
