### PR TITLE
Bugfix/4012 Correct closest page with template in rootline logic and refactor repository

### DIFF
--- a/Classes/System/Records/SystemTemplate/SystemTemplateRepository.php
+++ b/Classes/System/Records/SystemTemplate/SystemTemplateRepository.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\System\Records\SystemTemplate;
 
 use ApacheSolrForTypo3\Solr\System\Records\AbstractRepository;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception as DBALException;
 
 /**
@@ -39,20 +40,48 @@ class SystemTemplateRepository extends AbstractRepository
             return null;
         }
 
+        [$rootLinePageIds, $rootLinePositions] = $this->extractPageIdsAndPositions($rootLine);
+        $templateRecords = $this->getTemplateRecordsFromRootlinePages($rootLinePageIds);
+
+        if (empty($templateRecords)) {
+            return null;
+        }
+
+        $this->sortTemplateRecordsByPageRootlinePosition($templateRecords, $rootLinePositions);
+
+        return isset($templateRecords[0]['pid']) ? (int)$templateRecords[0]['pid'] : null;
+    }
+
+    /**
+     * @param array<int, array{uid: int}> $rootLine
+     * @return array{0: list<int>, 1: array<int, int>}
+     */
+    protected function extractPageIdsAndPositions(array $rootLine): array
+    {
         $rootLinePageIds = [0];
         $rootLinePositions = [];
 
-        // Create position mapping for sorting later
         foreach ($rootLine as $position => $rootLineItem) {
             $pageId = (int)$rootLineItem['uid'];
             $rootLinePageIds[] = $pageId;
             $rootLinePositions[$pageId] = $position;
         }
 
+        return [$rootLinePageIds, $rootLinePositions];
+    }
+
+    /**
+     * Retrieves template records associated with the given page IDs from the rootline.
+     *
+     * @param list<int> $rootLinePageIds The page IDs from the rootline to search for templates on.
+     * @return list<array{uid: int, pid: int}> A list of template records (uid, pid) found, or an empty list if none are found.
+     * @throws DBALException
+     */
+    protected function getTemplateRecordsFromRootlinePages(array $rootLinePageIds): array
+    {
         $queryBuilder = $this->getQueryBuilder();
 
-        // Get all pages with templates in the rootline
-        $templatesInRootline = $queryBuilder
+        $result = $queryBuilder
             ->select('uid', 'pid')
             ->from($this->table)
             ->where(
@@ -60,21 +89,24 @@ class SystemTemplateRepository extends AbstractRepository
                     'pid',
                     $queryBuilder->createNamedParameter(
                         $rootLinePageIds,
-                        \Doctrine\DBAL\ArrayParameterType::INTEGER
+                        ArrayParameterType::INTEGER
                     )
                 )
             )
             ->executeQuery()
             ->fetchAllAssociative();
 
-        if (empty($templatesInRootline)) {
-            return null;
-        }
+        return $result ?: [];
+    }
 
-        usort($templatesInRootline, function ($a, $b) use ($rootLinePositions) {
-            return $rootLinePositions[$b['pid']] <=> $rootLinePositions[$a['pid']];
-        });
-
-        return isset($templatesInRootline[0]['pid']) ? (int)$templatesInRootline[0]['pid'] : null;
+    /**
+     * Sorts template records based on the rootline position of the page they belong to.
+     *
+     * @param list<array{uid: int, pid: int}> $templateRecords The template records to sort.
+     * @param array<int, int> $pageRootlinePositions A map of page IDs to their rootline positions.
+     */
+    protected function sortTemplateRecordsByPageRootlinePosition(array &$templateRecords, array $pageRootlinePositions): void
+    {
+        usort($templateRecords, static fn(array $a, array $b): int => $pageRootlinePositions[$b['pid']] <=> $pageRootlinePositions[$a['pid']]);
     }
 }

--- a/Tests/Integration/System/Records/SystemTemplate/Fixtures/sys_template.csv
+++ b/Tests/Integration/System/Records/SystemTemplate/Fixtures/sys_template.csv
@@ -1,3 +1,4 @@
 "sys_template",
 ,"uid","pid","root","sorting","config"
 ,777,33,1,100,"page = PAGE"
+,778,44,1,200,"page = PAGE"

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -17,6 +17,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration\System\Records\SystemTemplat
 
 use ApacheSolrForTypo3\Solr\System\Records\SystemTemplate\SystemTemplateRepository;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -25,20 +26,61 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SystemTemplateRepositoryTest extends IntegrationTestBase
 {
+    public static function rootLineDataProvider(): array
+    {
+        return [
+            'Rootline with template on page 33 (2nd)' => [
+                [
+                    ['uid' => 4],  // No template
+                    ['uid' => 3],  // No template
+                    ['uid' => 2],  // No template
+                    ['uid' => 33], // Template here
+                    ['uid' => 1], // Current page
+                ],
+                33,
+            ],
+            'Rootline with template on page 44 (2nd)' => [
+                [
+                    ['uid' => 5],  // No template
+                    ['uid' => 33], // Template here, but 44 is closer
+                    ['uid' => 2],  // No template
+                    ['uid' => 44], // Template here
+                    ['uid' => 1], // Current page
+                ],
+                44,
+            ],
+            'Rootline with template on page 33 (3rd), page 44 (5th)' => [
+                [
+                    ['uid' => 44], // Template here, but 33 is closer
+                    ['uid' => 30], // No template
+                    ['uid' => 33], // Template here
+                    ['uid' => 20], // No template
+                    ['uid' => 10], // Current page
+                ],
+                33,
+            ],
+            'Rootline with template on page 44 (3rd), page 33 (5th)' => [
+                [
+                    ['uid' => 33], // Template here, but 44 is closer
+                    ['uid' => 30], // No template
+                    ['uid' => 44], // Template here
+                    ['uid' => 20], // No template
+                    ['uid' => 10], // Current page
+                ],
+                44,
+            ],
+        ];
+    }
+
+    #[DataProvider('rootLineDataProvider')]
     #[Test]
-    public function canFindOneClosestPageIdWithActiveTemplateByRootLine(): void
+    public function canFindOneClosestPageIdWithActiveTemplateByRootLine(array $fakeRootLine, int $expectedPageId): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_template.csv');
-
-        $fakeRootLine = [
-            ['uid' => 100],
-            ['uid' => 33],
-            ['uid' => 8657],
-        ];
 
         /** @var SystemTemplateRepository $repository */
         $repository = GeneralUtility::makeInstance(SystemTemplateRepository::class);
         $closestPageIdWithActiveTemplate = $repository->findOneClosestPageIdWithActiveTemplateByRootLine($fakeRootLine);
-        self::assertEquals(33, $closestPageIdWithActiveTemplate, 'Can not find closest page id with active template.');
+        self::assertEquals($expectedPageId, $closestPageIdWithActiveTemplate, 'Can not find closest page id with active template.');
     }
 }


### PR DESCRIPTION
# What this PR does

This PR addresses issue #4012 by:

**Correcting the logic for finding the closest page with an active system template within a given rootline.**
    *   Ensured that the rootline data provided to the `SystemTemplateRepository` is interpreted correctly (root page first, current page last).
    *   Verified that the sorting logic correctly identifies the template on the current page or its nearest ancestor as the "closest".
    *   Updated unit tests to reflect the correct rootline structure and expected outcomes.

# How to test

1.  Verify that the integration tests in `SystemTemplateRepositoryTest.php` pass.
2.  Manually test scenarios where a TYPO3 page tree has system templates on various levels of the rootline. Ensure that the system correctly identifies the template from the closest parent page in the rootline that has a template.
    *   Example:
        *   Root Page (no template)
            *   Level 1 Page (no template)
                *   Level 2 Page (has template A)
                    *   Current Page (has template B) -> Template B should be found.
        *   Root Page (no template)
            *   Level 1 Page (has template C)
                *   Level 2 Page (no template)
                    *   Current Page (no template) -> Template C should be found.

Fixes: #4012