### PR TITLE
[TASK] fix integration tests for TYPO3 13.4.10+

### DIFF
--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -25,6 +25,7 @@ use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use Traversable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -33,7 +34,9 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Domain\Repository\SchedulerTaskRepository;
 use TYPO3\CMS\Scheduler\Scheduler;
+use TYPO3\CMS\Scheduler\Task\TaskSerializer;
 
 /**
  * This testcase is used to check if the GarbageCollector can delete garbage from the
@@ -983,7 +986,12 @@ class GarbageCollectorTest extends IntegrationTestBase
     protected function processEventQueue(): void
     {
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler = GeneralUtility::makeInstance(
+            Scheduler::class,
+            $this->createMock(NullLogger::class),
+            $this->createMock(TaskSerializer::class),
+            $this->createMock(SchedulerTaskRepository::class),
+        );
         $scheduler->executeTask($task);
     }
 }

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\SkippedWithMessageException;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Traversable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -40,7 +41,9 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Domain\Repository\SchedulerTaskRepository;
 use TYPO3\CMS\Scheduler\Scheduler;
+use TYPO3\CMS\Scheduler\Task\TaskSerializer;
 
 /**
  * Testcase for the record monitor
@@ -2157,7 +2160,12 @@ class RecordMonitorTest extends IntegrationTestBase
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
 
         /** @var Scheduler $scheduler */
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler = GeneralUtility::makeInstance(
+            Scheduler::class,
+            $this->createMock(NullLogger::class),
+            $this->createMock(TaskSerializer::class),
+            $this->createMock(SchedulerTaskRepository::class),
+        );
         $scheduler->executeTask($task);
     }
 

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -21,9 +21,12 @@ use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Domain\Repository\SchedulerTaskRepository;
 use TYPO3\CMS\Scheduler\Scheduler;
+use TYPO3\CMS\Scheduler\Task\TaskSerializer;
 
 /**
  * Test case to check if the scheduler task EventQueueWorkerTask can process
@@ -59,7 +62,12 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
 
         /** @var Scheduler $scheduler */
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler = GeneralUtility::makeInstance(
+            Scheduler::class,
+            $this->createMock(NullLogger::class),
+            $this->createMock(TaskSerializer::class),
+            $this->createMock(SchedulerTaskRepository::class),
+        );
         $scheduler->executeTask($task);
 
         self::assertEquals(1, $this->indexQueue->getAllItemsCount());
@@ -72,7 +80,12 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_handle_erroneous_event_queue_items.csv');
 
         $task = GeneralUtility::makeInstance(EventQueueWorkerTask::class);
-        $scheduler = GeneralUtility::makeInstance(Scheduler::class);
+        $scheduler = GeneralUtility::makeInstance(
+            Scheduler::class,
+            $this->createMock(NullLogger::class),
+            $this->createMock(TaskSerializer::class),
+            $this->createMock(SchedulerTaskRepository::class),
+        );
         $scheduler->executeTask($task);
 
         self::assertEquals(0, $this->indexQueue->getAllItemsCount());


### PR DESCRIPTION
TYPO3 13.4.x-dev requires mocking of Scheduler components since: https://github.com/TYPO3/typo3/commit/9b9861bc7dc3ab2c323278190c91cf51813e1ce4