### PR TITLE
Update hardcoded legacy css resource filepath

### DIFF
--- a/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
+++ b/Classes/Task/ReIndexTaskAdditionalFieldProvider.php
@@ -138,7 +138,7 @@ class ReIndexTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
     protected function getIndexingConfigurationSelector(): string
     {
         $selectorMarkup = 'Please select a site first.';
-        $this->getPageRenderer()->addCssFile('../typo3conf/ext/solr/Resources/Css/Backend/indexingconfigurationselectorfield.css');
+        $this->getPageRenderer()->addCssFile('EXT:solr/Resources/Public/Css/Backend/indexingconfigurationselectorfield.css');
 
         if (is_null($this->site)) {
             return $selectorMarkup;


### PR DESCRIPTION
The existing file path wouldn't work with composer installation and the directory is not correct either.
This pull request updates the path to use an extension-relative EXT: path instead.