### PR TITLE
[FEATURE] Add arm64 and ppc64le platforms to docker-images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ main, release-13.0.x, release-12.0.x, release-11.6.x, release-11.5.x, task/*_compatibility ]
+    branches: [ main, release-13.0.x, release-12.0.x, task/*_compatibility ]
     tags:
       - "**"
   pull_request:
-    branches: [ main, release-13.0.x, release-12.0.x, release-11.6.x, release-11.5.x, task/*_compatibility ]
+    branches: [ main, release-13.0.x, release-12.0.x, task/*_compatibility ]
 
   # Run tests daily at 19:23 to get TYPO3 changes and fix them immediately.
   # @todo:
@@ -17,6 +17,7 @@ on:
 
 env:
   IS_ON_GITHUB_ACTIONS: 'true'
+  IS_LATEST_VERSION: 'true'
   CI_BUILD_DIRECTORY: '/home/runner/work/ext-solr/ext-solr/.Build'
   LOCAL_IMAGE_NAME: 'solrci-image:latest'
   LOCAL_CONTAINER_NAME: 'solrci-container'
@@ -201,6 +202,83 @@ jobs:
           sudo rm -Rf ${{ env.CI_BUILD_DIRECTORY }}/Web/typo3temp/* \
             ${{ env.CI_BUILD_DIRECTORY }}/data-mysql \
             ${{ env.CI_BUILD_DIRECTORY }}/data-solr
+
+  publish-docker-hub:
+    name: Publish docker-image to docker-hub
+    needs: tests
+    if: |
+      (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        startsWith(github.ref, 'refs/tags/')
+      )
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PLATFORMS:  "linux/amd64,linux/arm64,linux/ppc64le"
+      DOCKER_HUB_IMAGE_NAME: "${{ secrets.DOCKERHUB_USERNAME }}/ext-solr"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: enrich Environment Variables
+        id: env
+        run: |
+          echo "NOW=$(date +'%F %Z %T')" >> $GITHUB_ENV
+          echo "BRANCH_TAG=$(jq -r '.extra."branch-alias" | to_entries | .[0].key' composer.json)" >> $GITHUB_ENV
+          echo "BRANCH_ALIAS_TAG=$(jq -r '.extra."branch-alias" | to_entries | .[0].value' composer.json)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKER_HUB_IMAGE_NAME }}
+
+          tags: |
+            type=raw,value=${{ env.BRANCH_TAG }}
+            type=raw,value=${{ env.BRANCH_ALIAS_TAG }}
+            # Only the newest major EXT:solr branch can become the latest tag.
+            # So if main branch becomes dev state for next TYPO3 LTS, the latest tag must be commented there.
+            type=raw,value=latest,enable=${{ (startsWith(github.ref, 'refs/tags/')) && (env.IS_LATEST_VERSION == true) }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=${{github.event.repository.name}}
+            org.opencontainers.image.description=Docker image for Apache Solr for TYPO3 CMS EXT:solr extension
+            org.opencontainers.image.vendor=${{github.repository_owner}}
+            org.opencontainers.image.licenses=GPL-3.0,APACHE
+            org.opencontainers.image.version=${{github.ref_name}}
+            org.opencontainers.image.created=${{ env.NOW }}
+            org.opencontainers.image.source=${{github.server_url}}/${{github.repository}}
+            org.opencontainers.image.revision=${{github.sha}}
+            org.opencontainers.image.url=https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Appendix/DockerTweaks.html
+            org.opencontainers.image.documentation=https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Index.html
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Docker/SolrServer/Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   publish:
     name: Publish new version to TER


### PR DESCRIPTION
This PR also updates all required actions in .github/workflow/ci.yml and adds a new publish-docker-hub job to the pipeline.

Fixes: #2891
Replaces: #3501