### PR TITLE
[TASK] disable dependabot on release-11.6.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,13 +38,3 @@ updates:
     target-branch: "release-12.0.x"
     commit-message:
       prefix: "[TASK] 12.0.x-dev "
-
-  # For release-11.6.x
-  -
-    package-ecosystem: "docker"
-    directory: "/Docker/SolrServer"
-    schedule:
-      interval: "daily"
-    target-branch: "release-11.6.x"
-    commit-message:
-      prefix: "[TASK] 11.6.x-dev "


### PR DESCRIPTION
The release-11.6.x branch was locked and moved to non public ELTS repository. No merges are possible against release-11.6.x, therefore the dependabot PRs against that branch are useless.

Relates: #4333