### PR TITLE
Avoid PHP warning if related record was not found

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -330,7 +330,7 @@ class Relation extends AbstractContentObject
 
         $contentObject = clone $parentContentObject;
         $contentObject->start($relatedRecord, $foreignTableName);
-        $values = [$contentObject->stdWrapValue('foreignLabel', $this->configuration, $relatedRecord[$foreignTableLabelField])];
+        $values = [$contentObject->stdWrapValue('foreignLabel', $this->configuration, $relatedRecord[$foreignTableLabelField] ?? '')];
 
         if (
             !empty($foreignTableName)


### PR DESCRIPTION
# What this pr does

Set `''` as third parameter `$defaultValue` for `$contentObject->stdWrapValue()` as fallback

Fixes: #4381
