### PR TITLE
[BUGFIX] Find correct site for mountpoints

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -58,7 +58,7 @@ class Builder
         $pageRecord = $pageInformation->getPageRecord();
 
         $document = GeneralUtility::makeInstance(Document::class);
-        $site = $this->getSiteByPageId($pageId);
+        $site = $this->getSiteByPageId($tsfe->rootLine[0]['uid'] ?? $pageId);
 
         $accessGroups = $this->getDocumentIdGroups($pageAccessRootline);
         $documentId = $this->getPageDocumentId($pageInformation, $pageArguments, $siteLanguage, $accessGroups, $mountPointParameter);


### PR DESCRIPTION
# What this pr does

Find correct root page and Site for mountpages.

Before that fix, only the current page id is used to find the correct site. For mountpoints across page trees, this always results in the original site and the page was indexed twice for the original site but not for the correct page tree.

| before | after |
| --- | --- |
| ![](https://github.com/user-attachments/assets/53bc5288-92a7-41eb-afaa-1e80d09dbd53) | ![](https://github.com/user-attachments/assets/2d025141-457d-44c8-8813-39223d4c2437) |

# How to test

You need to have multiple page trees. Create a mountpoint of a page inside another page tree and run indexer.

Fixes: #4364

