### PR TITLE
[TASK:BP:12] Allow Apache Solr 9.9.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ If applicable, add screenshots to help explain your problem.
  - TYPO3 Version: [e.g. 12.4.34]
  - Browser: [e.g. chrome, safari]
  - EXT:solr Version: [e.g. 12.0.7]
- - Used Apache Solr Version: [e.g. 9.8.1]
+ - Used Apache Solr Version: [e.g. 9.9.0]
  - PHP Version: [e.g. 8.2.0]
  - MySQL Version: [e.g. 8.0.0]
 

--- a/Docker/SolrServer/Dockerfile
+++ b/Docker/SolrServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:9.8.1
+FROM solr:9.9.0
 LABEL org.opencontainers.image.authors="dkd Internet Service GmbH info@dkd.de"
 ENV TERM=linux
 

--- a/Documentation/Appendix/VersionMatrix.rst
+++ b/Documentation/Appendix/VersionMatrix.rst
@@ -15,7 +15,7 @@ List of EXT:solr versions and the matching versions of Apache Solr and TYPO3 tha
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
 TYPO3      EXT:solr (↻)   EXT:solrmlt (↻)   EXT:tika (↻)   EXT:solrfal ($)    EXT:solrconsole ($)   EXT:solrdebugtools ($)   EXT:solrfluidgrouping ($↺)        Apache Solr      Configset
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
-12.4       12.0           12.0 (Ø)          12.0           12.0               12.0                  12.0                     N/A (integrated in EXT:solr)      9.8.1¹           ext_solr_12_0_0
+12.4       12.0           12.0 (Ø)          12.0           12.0               12.0                  12.0                     N/A (integrated in EXT:solr)      9.9.0¹           ext_solr_12_0_0
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
 
 | $ - Funding contribution extensions. See: https://www.typo3-solr.com/solr-for-typo3/open-source-version/

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
         "ext-solrdebugtools": "^12.0",
         "ext-solrmlt": "^12.0",
         "Apache-Solr": [
+          "9.9.0",
           "9.8.1",
           "9.8.0",
           "9.7.0",


### PR DESCRIPTION
# What this pr does

After testing EXT:solr 13.0 with the newly released Apache Solr version 9.9.0, this version is added to the list of supported versions.

9.9.0 can be used without any update steps to consider.

Ports: #4389