### PR TITLE
[BUGFIX] Ensure rootline order is respected detecting closest template

### DIFF
--- a/Classes/System/Records/SystemTemplate/SystemTemplateRepository.php
+++ b/Classes/System/Records/SystemTemplate/SystemTemplateRepository.php
@@ -35,18 +35,29 @@ class SystemTemplateRepository extends AbstractRepository
      */
     public function findOneClosestPageIdWithActiveTemplateByRootLine(array $rootLine): ?int
     {
-        $rootLinePageIds = [0];
+        // rootline always is given in reverse order, so iterate over, as it will go to top of rootline
+        // from the current called pid
         foreach ($rootLine as $rootLineItem) {
-            $rootLinePageIds[] = (int)$rootLineItem['uid'];
+            $foundPage = $this->getTemplateIdForGivenPageId($rootLineItem['uid']);
+            if ($foundPage !== null) {
+                return $foundPage;
+            }
         }
+        return null;
+    }
 
+    /**
+     * @throws DBALException
+     */
+    private function getTemplateIdForGivenPageId(int $pageId): ?int
+    {
         $queryBuilder = $this->getQueryBuilder();
 
         $result = $queryBuilder
             ->select('uid', 'pid')
             ->from($this->table)
             ->where(
-                $queryBuilder->expr()->in('pid', $rootLinePageIds),
+                $queryBuilder->expr()->eq('pid', $pageId)
             )
             ->executeQuery()
             ->fetchAssociative();

--- a/Tests/Integration/System/Records/SystemTemplate/Fixtures/pages.csv
+++ b/Tests/Integration/System/Records/SystemTemplate/Fixtures/pages.csv
@@ -1,0 +1,6 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,1,"EXT:solr Test"
+,100,1,1,""
+,33,100,1,"Page with sys_template",
+,8657,33,1,"Entry Point for rootline"

--- a/Tests/Integration/System/Records/SystemTemplate/Fixtures/sys_template.csv
+++ b/Tests/Integration/System/Records/SystemTemplate/Fixtures/sys_template.csv
@@ -1,3 +1,4 @@
 "sys_template",
 ,"uid","pid","root","sorting","config"
+,2,100,1,128,"page = PAGE"
 ,777,33,1,100,"page = PAGE"

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -25,15 +25,21 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SystemTemplateRepositoryTest extends IntegrationTestBase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_template.csv');
+    }
+
     #[Test]
     public function canFindOneClosestPageIdWithActiveTemplateByRootLine(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_template.csv');
-
         $fakeRootLine = [
-            ['uid' => 100],
-            ['uid' => 33],
-            ['uid' => 8657],
+            4 => ['uid' => 1],
+            3 => ['uid' => 100],
+            2 => ['uid' => 33],
+            1 => ['uid' => 8657],
         ];
 
         /** @var SystemTemplateRepository $repository */


### PR DESCRIPTION
# What this pr does

When detecting the closest template inside a rootline, it is necessary, respecting the order of the rootline itself.

The current database call has a random sorting, which does not respect the ordering, therefore, could return a wrong dataset if multiple templates are given in the root line.

To ensure the order is respected, every page inside rootline is called single against the database and returns the pid if a template record exists.

# How to test

Given a rootline with multiple siteroots, the database query does not respect the order of the elements and only returns the first hit form the database, which could be the right looked up, but not has to be.

Example build:

```
0
|- 165 (doktype 254)
 |- 271 (doktype 1, is siteroot, has root template)
  |- 348 (doktype 254)
   |- 396 (doktype 254)
    |- 491 (doktype 1, is siteroot, has root template)
     |- 29455 (doktype 254)
      |- 29456 (doktype 254, Records located here)
```

The system calls with the rootline:
```
7 => 29456
6 => 29455
5 => 491
4 => 396
3 => 348
2 => 271
1 => 165
```

And the database always returns `271` as the found pid, which is wrong.

Fixes: #4012 
