### PR TITLE
[BUGFIX] Close #3868 Exclude current page from check for subEntries in rootline

### DIFF
--- a/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
+++ b/Classes/Traits/SkipRecordByRootlineConfigurationTrait.php
@@ -36,7 +36,7 @@ trait SkipRecordByRootlineConfigurationTrait
             return true;
         }
         foreach ($rootline as $page) {
-            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries']) {
+            if (isset($page['no_search_sub_entries']) && $page['no_search_sub_entries'] && $pid !== $page['uid']) {
                 return true;
             }
         }


### PR DESCRIPTION
# What this pr does

Skips the current page when traversing the rootline.

# How to test

Testscenario is described in #3868 .

Fixes: #3868 
