### PR TITLE
[BUGFIX] #4395: Avoid "Undefined array key" in PageFieldMappingIndexer

### DIFF
--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -120,7 +120,7 @@ class PageFieldMappingIndexer
                 $fieldValue = unserialize($fieldValue);
             }
         } else {
-            $fieldValue = $pageRecord[$pageIndexingConfiguration[$solrFieldName]];
+            $fieldValue = $pageRecord[$pageIndexingConfiguration[$solrFieldName]] ?? null;
         }
 
         return $fieldValue;


### PR DESCRIPTION
# What this pr does

Prevents PHP notices/warnings (“Undefined array key …”) in PageFieldMappingIndexer  when a configured source key is missing from the record. Uses null-coalescing  to safely assign `null` instead of directly accessing the array key.  
Behavior is unchanged when the key exists; no configuration changes required.

# How to test

1. Configure page field mapping so that Solr field `title` reads from a non-existing source key, e.g. `preview`.
2. Queue any page and run indexing (Scheduler or CLI).
3. Before this PR: PHP notice/warning `Undefined array key "preview"` appears in logs.
4. With this PR: No notice/warning; the field is set to `null` when the source key is missing.

Fixes: #4395 