### PR TITLE
[BUGFIX] Allow initializer interface in event

### DIFF
--- a/Classes/Event/IndexQueue/AfterIndexQueueHasBeenInitializedEvent.php
+++ b/Classes/Event/IndexQueue/AfterIndexQueueHasBeenInitializedEvent.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Event\IndexQueue;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
-use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\AbstractInitializer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\IndexQueueInitializer;
 
 /**
  * PSR-14 Event which is fired after a index queue has been (re-) initialized.
@@ -29,7 +29,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\Initializer\AbstractInitializer;
 final class AfterIndexQueueHasBeenInitializedEvent
 {
     public function __construct(
-        private readonly AbstractInitializer $initializer,
+        private readonly IndexQueueInitializer $initializer,
         private readonly Site $site,
         private readonly string $indexingConfigurationName,
         private readonly string $type,
@@ -37,7 +37,7 @@ final class AfterIndexQueueHasBeenInitializedEvent
         private bool $isInitialized,
     ) {}
 
-    public function getInitializer(): AbstractInitializer
+    public function getInitializer(): IndexQueueInitializer
     {
         return $this->initializer;
     }


### PR DESCRIPTION
# What this pr does

AfterIndexQueueHasBeenInitializedEvent requires AbstractInitializer instead of the interface IndexQueueInitializer, this prevents the usage of own implementations not based on the abstract initializer, e.g. an initializer for external data.

By requiring the interface instead of the AbstractInitializer this issue is fixed.

Resolves: #4402