### PR TITLE
[FEATURE:BP:12.0] add typo3Context[_stringS] and domain[_stringS] fields to documents

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -124,8 +124,10 @@ class Builder
         $document->setField('type', $type);
         $document->setField('appKey', 'EXT:solr');
 
-        // site, siteHash
-        $document->setField('site', $site->getDomain());
+        $document->setField('site', $site->getSiteIdentifier());
+        if ($this->extensionConfiguration->getSiteHashStrategy() === 0) {
+            $document->setField('site', $site->getDomain());
+        }
         $document->setField('siteHash', $site->getSiteHash());
 
         // uid, pid

--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -26,6 +26,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use ApacheSolrForTypo3\Solr\Util;
 use Doctrine\DBAL\Exception as DBALException;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -61,10 +62,12 @@ class Builder
 
         $document->setField('id', $documentId);
         $document->setField('site', $site->getSiteIdentifier());
+        $document->setField('typo3Context_stringS', (string)Environment::getContext());
         if ($this->extensionConfiguration->getSiteHashStrategy() === 0) {
             $document->setField('site', $site->getDomain());
         }
         $document->setField('siteHash', $site->getSiteHash());
+        $document->setField('domain_stringS', $site->getDomain());
         $document->setField('appKey', 'EXT:solr');
         $document->setField('type', 'pages');
 
@@ -125,10 +128,12 @@ class Builder
         $document->setField('appKey', 'EXT:solr');
 
         $document->setField('site', $site->getSiteIdentifier());
+        $document->setField('typo3Context_stringS', (string)Environment::getContext());
         if ($this->extensionConfiguration->getSiteHashStrategy() === 0) {
             $document->setField('site', $site->getDomain());
         }
         $document->setField('siteHash', $site->getSiteHash());
+        $document->setField('domain_stringS', $site->getDomain());
 
         // uid, pid
         $document->setField('uid', $itemRecord['uid']);

--- a/Classes/Eid/ApiEid.php
+++ b/Classes/Eid/ApiEid.php
@@ -19,6 +19,7 @@ use ApacheSolrForTypo3\Solr\Api;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteHashService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -78,6 +79,7 @@ class ApiEid
         $siteHash = $siteHashService->getSiteHashForSiteIdentifier($siteIdentifier);
         $jsonResponseContents = [
             'sitehash' => $siteHash,
+            'typo3Context' => (string)Environment::getContext(),
         ];
         // @todo, remove this backwards-compatibility-adjustment together with siteHashStrategy setting.
         if (isset($queryParams['domain'])) {

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -152,7 +152,7 @@ class BuilderTest extends SetUpUnitTestCase
         $this->fakeDocumentId('testSiteHash/news/4711');
 
         $this->siteMock->expects(self::any())->method('getRootPageId')->willReturn(99);
-        $this->siteMock->expects(self::once())->method('getDomain')->willReturn('test.typo3.org');
+        $this->siteMock->expects(self::any())->method('getDomain')->willReturn('test.typo3.org');
         $this->siteMock->expects(self::any())->method('getSiteHash')->willReturn('testSiteHash');
         $this->variantIdBuilderMock->expects(self::once())->method('buildFromTypeAndUid')->with($type, 4711, $fakeRecord, $this->siteMock)->willReturn('testVariantId');
 


### PR DESCRIPTION
This change
* adds the fields to the documents, which will be renamed to native fields without `_stringS` in EXT:solr 13.1.x+:
   * `typo3Context_stringS`
   * `domain_stringS`
* adds `typo3Context` as response data of ApiEid, to be able to set that field by external index writers

Relates: #4411
Ports: #4413

---

### [BUGFIX] set site field on record documents in same way as on pages

Fixes: #3459
Ports: #4413