### PR TITLE
Remove OpenSearch profile link

### DIFF
--- a/Configuration/TypoScript/OpenSearch/setup.typoscript
+++ b/Configuration/TypoScript/OpenSearch/setup.typoscript
@@ -11,7 +11,6 @@ page {
 		typolink.returnLast = url
 
 		wrap (
-			<link rel="profile" href="http://a9.com/-/spec/opensearch/1.1/" />
 			<link rel="search"
 				  type="application/opensearchdescription+xml"
 				  href="|"


### PR DESCRIPTION
Does not comply with the opensearch draft. "The rel attribute must contain the value "search". The profile attribute should be placed on the head-tag instead. see https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#autodiscovery-in-htmlxhtml

# What this pr does

Removes an undocumented link-tag.

# How to test

only link rel=search should be rendered.

Fixes: #4417
