### PR TITLE
[BUGFIX] Site check fails in Tsfe fails

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -292,7 +292,7 @@ class Tsfe implements SingletonInterface
         $incomingRootPageId = $rootPageId;
 
         // handle plugin.tx_solr.index.queue.[indexConfig].additionalPageIds
-        if (isset($rootPageId) && !$this->isRequestedPageAPartOfRequestedSite($pidToUse)) {
+        if (isset($rootPageId) && !$this->isRequestedPageAPartOfRequestedSite($pidToUse, $rootPageId)) {
             return $rootPageId;
         }
         $pageRecord = BackendUtility::getRecord('pages', $pidToUse);


### PR DESCRIPTION
# What this pr does

Tsfe tries to dermine if a page is within a site in method getPidToUseForTsfeInitialization(), but as the current root page is not passed to isRequestedPageAPartOfRequestedSite() the check always fails.

Passing the root page solves this issue.

Resolves: #4425

---

### Notices:

- [x] port to release-12.0.x, 
    **do not merge before**