### PR TITLE
[BUGFIX:BP:12.0] Site check fails in Tsfe fails

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -323,7 +323,7 @@ class Tsfe implements SingletonInterface
         $incomingRootPageId = $rootPageId;
 
         // handle plugin.tx_solr.index.queue.[indexConfig].additionalPageIds
-        if (isset($rootPageId) && !$this->isRequestedPageAPartOfRequestedSite($pidToUse)) {
+        if (isset($rootPageId) && !$this->isRequestedPageAPartOfRequestedSite($pidToUse, $rootPageId)) {
             return $rootPageId;
         }
         $pageRecord = BackendUtility::getRecord('pages', $pidToUse);


### PR DESCRIPTION
Tsfe tries to dermine if a page is within a site in method getPidToUseForTsfeInitialization(), but as the current root page is not passed to isRequestedPageAPartOfRequestedSite() the check always fails.

Passing the root page solves this issue.

Resolves: #4425
Ports: #4426