### PR TITLE
[TASK] Replace md5/sha1 calls with hash method

### DIFF
--- a/Classes/Api.php
+++ b/Classes/Api.php
@@ -38,7 +38,8 @@ class Api
      */
     public static function getApiKey(): string
     {
-        return sha1(
+        return hash(
+            'sha1',
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] .
             'tx_solr_api',
         );

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -95,7 +95,7 @@ class ConnectionManager implements SingletonInterface
         array $writeEndpointConfiguration,
         TypoScriptConfiguration $typoScriptConfiguration,
     ): SolrConnection {
-        $connectionHash = md5(json_encode($readEndpointConfiguration) . json_encode($writeEndpointConfiguration));
+        $connectionHash = hash('md5', json_encode($readEndpointConfiguration) . json_encode($writeEndpointConfiguration));
         if (!isset(self::$connections[$connectionHash])) {
             $readEndpoint = new Endpoint($readEndpointConfiguration);
             if (!$this->isValidEndpoint($readEndpoint)) {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -127,7 +127,7 @@ class ConfigurationAwareRecordService
         string $recordWhereClause = '',
     ): array {
         $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
-        $cacheId = md5('ConfigurationAwareRecordService' . ':' . 'getRecordIfIndexConfigurationIsValid' . ':' . $recordTable . ':' . $recordUid . ':' . $recordWhereClause);
+        $cacheId = hash('md5', 'ConfigurationAwareRecordService' . ':' . 'getRecordIfIndexConfigurationIsValid' . ':' . $recordTable . ':' . $recordUid . ':' . $recordWhereClause);
 
         $row = $cache->get($cacheId);
         if (!empty($row)) {

--- a/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
+++ b/Classes/Domain/Search/FrequentSearches/FrequentSearchesService.php
@@ -136,7 +136,7 @@ class FrequentSearchesService
             $identifier .= '_L' . $serverRequest->getAttribute('language')?->getLanguageId();
         }
 
-        $identifier .= '_' . md5(serialize($frequentSearchConfiguration));
+        $identifier .= '_' . hash('md5', serialize($frequentSearchConfiguration));
         return $identifier;
     }
 

--- a/Classes/Domain/Search/Query/AbstractQueryBuilder.php
+++ b/Classes/Domain/Search/Query/AbstractQueryBuilder.php
@@ -176,10 +176,10 @@ abstract class AbstractQueryBuilder
         $boostQueryArray = [];
         if (is_array($boostQueries)) {
             foreach ($boostQueries as $boostQuery) {
-                $boostQueryArray[] = ['key' => md5($boostQuery), 'query' => $boostQuery];
+                $boostQueryArray[] = ['key' => hash('md5', $boostQuery), 'query' => $boostQuery];
             }
         } else {
-            $boostQueryArray[] = ['key' => md5($boostQueries), 'query' => $boostQueries];
+            $boostQueryArray[] = ['key' => hash('md5', $boostQueries), 'query' => $boostQueries];
         }
 
         $this->queryToBuild->getEDisMax()->setBoostQueries($boostQueryArray);

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -268,7 +268,7 @@ class SearchUriBuilder
         $values = [];
         $structure = $arguments;
         $this->getSubstitution($structure, $values);
-        $hash = md5($pageUid . json_encode($structure));
+        $hash = hash('md5', $pageUid . json_encode($structure));
         if (isset(self::$preCompiledLinks[$hash])) {
             self::$hitCount++;
             $uriCacheTemplate = self::$preCompiledLinks[$hash];
@@ -284,7 +284,7 @@ class SearchUriBuilder
             } catch (InvalidParameterException $exception) {
                 // the placeholders may result in an exception when route enhancers with requirements are active
                 // In this case, try to build the URL with original arguments
-                $hash = md5($pageUid . json_encode($arguments));
+                $hash = hash('md5', $pageUid . json_encode($arguments));
                 if (isset(self::$preCompiledLinks[$hash])) {
                     self::$hitCount++;
                     $uriCacheTemplate = self::$preCompiledLinks[$hash];

--- a/Classes/Domain/Site/SiteHashService.php
+++ b/Classes/Domain/Site/SiteHashService.php
@@ -127,7 +127,7 @@ class SiteHashService
         if ($this->extensionConfiguration->getSiteHashStrategy() === 0) {
             $applicationContext = '';
         }
-        $siteHashes[$siteIdentifier] = sha1($applicationContext . $siteIdentifier . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] . 'tx_solr');
+        $siteHashes[$siteIdentifier] = hash('sha1', $applicationContext . $siteIdentifier . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] . 'tx_solr');
         return $siteHashes[$siteIdentifier];
     }
 

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -202,7 +202,8 @@ class PageIndexerRequest
             'item' => $itemId,
             'page' => $pageId,
             'actions' => implode(',', $this->actions),
-            'hash' => md5(
+            'hash' => hash(
+                'md5',
                 $itemId . '|' .
                 $pageId . '|' .
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],
@@ -240,7 +241,8 @@ class PageIndexerRequest
             return false;
         }
 
-        $calculatedHash = md5(
+        $calculatedHash = hash(
+            'md5',
             $this->parameters['item'] . '|' .
             $this->parameters['page'] . '|' .
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -295,7 +295,7 @@ class Queue implements QueueInterface, QueueInitializationServiceAwareInterface
         string $additionalRecordFields,
     ): ?array {
         $cache = GeneralUtility::makeInstance(TwoLevelCache::class, 'runtime');
-        $cacheId = md5('Queue' . ':' . 'getRecordCached' . ':' . $itemType . ':' . (string)$itemUid . ':' . 'pid' . $additionalRecordFields);
+        $cacheId = hash('md5', 'Queue' . ':' . 'getRecordCached' . ':' . $itemType . ':' . (string)$itemUid . ':' . 'pid' . $additionalRecordFields);
 
         $record = $cache->get($cacheId);
         if (empty($record)) {

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -156,7 +156,7 @@ class PagesRepository extends AbstractRepository
         int $rootPageId,
         string $initialPagesAdditionalWhereClause = '',
     ): array {
-        $cacheIdentifier = sha1('getPages' . $rootPageId . $initialPagesAdditionalWhereClause);
+        $cacheIdentifier = hash('sha1', 'getPages' . $rootPageId . $initialPagesAdditionalWhereClause);
         if ($this->transientVariableCache->get($cacheIdentifier) !== false) {
             return $this->transientVariableCache->get($cacheIdentifier);
         }

--- a/Classes/Utility/RoutingUtility.php
+++ b/Classes/Utility/RoutingUtility.php
@@ -36,7 +36,7 @@ class RoutingUtility
             return $value;
         }
         // removing one bit, e.g. for enforced route prefix `{!value}`
-        $hash = substr(md5($value), 0, -1);
+        $hash = substr(hash('md5', $value), 0, -1);
         // Symfony Route Compiler requires first literal to be non-integer
         if ($hash[0] === (string)(int)$hash[0]) {
             $hash[0] = str_replace(

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -236,7 +236,7 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         ?int $port = 8983,
         ?bool $disableDefaultLanguage = false,
     ): void {
-        $siteCreatedHash = md5($scheme . $host . $port . $disableDefaultLanguage);
+        $siteCreatedHash = hash('md5', $scheme . $host . $port . $disableDefaultLanguage);
         if (self::$lastSiteCreated === $siteCreatedHash) {
             return;
         }

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -55,7 +55,7 @@ class FrequentSearchesServiceTest extends SetUpUnitTestCase
     public function cachedResultIsUsedWhenIdentifierIsPresent(): void
     {
         $fakeConfiguration = [];
-        $expectedCacheIdentifier = 'frequentSearchesTags_' . md5(serialize($fakeConfiguration));
+        $expectedCacheIdentifier = 'frequentSearchesTags_' . hash('md5', serialize($fakeConfiguration));
         $this->configurationMock->expects(self::once())->method('getSearchFrequentSearchesConfiguration')->willReturn($fakeConfiguration);
 
         $this->fakeCacheResult($expectedCacheIdentifier, ['term a']);

--- a/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
+++ b/Tests/Unit/IndexQueue/PageIndexerRequestTest.php
@@ -38,7 +38,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $jsonEncodedParameters = json_encode([
             'item' => 1,
             'page' => 1,
-            'hash' => md5('1|1|' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']),
+            'hash' => hash('md5', '1|1|' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']),
         ]);
 
         $request = $this->getPageIndexerRequest($jsonEncodedParameters);
@@ -51,7 +51,7 @@ class PageIndexerRequestTest extends SetUpUnitTestCase
         $jsonEncodedParameters = json_encode([
             'item' => 1,
             'page' => 1,
-            'hash' => md5('invalid|invalid|invalid'),
+            'hash' => hash('md5', 'invalid|invalid|invalid'),
         ]);
 
         $request = $this->getPageIndexerRequest($jsonEncodedParameters);


### PR DESCRIPTION
# What this pr does

Fixes deprecated PHP 8.4 calls to md5/sha1 with using hash instead

# How to test

Automatic tests should cover these changes

Fixes: #4436
