### PR TITLE
[FEATURE:BP:12.0] Add DenseVectorField in schemas

### DIFF
--- a/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/general_schema_fields.xml
@@ -272,6 +272,9 @@
 
 	<dynamicField name="*_currency"  type="currency"  indexed="true" stored="true" multiValued="false" />
 
+	<field name="vectorContent" type="string" indexed="false" stored="false"/>
+	<field name="vector" type="knn_vector" indexed="true" stored="false"/>
+
 	<!--
 		The following causes solr to ignore any fields that don't already
 		match an existing field name or dynamic field, rather than

--- a/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/general_schema_types.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/general_schema_types.xml
@@ -218,6 +218,7 @@
 
 	<fieldType name="currency" class="solr.CurrencyFieldType" amountLongSuffix="_longS" codeStrSuffix="_stringS" defaultCurrency="USD" currencyConfig="currency.xml" />
 
+	<fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="${solr.vector.dimension:768}" similarityFunction="cosine"/>
 
 	<!-- since fields of this type are by default not stored or indexed, any data added to
 		them will be ignored outright

--- a/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_12_0_0/conf/solrconfig.xml
@@ -470,6 +470,16 @@
 		<processor class="solr.RunUpdateProcessorFactory"/>
 	</updateRequestProcessorChain>
 
+	<queryParser name="knn_text_to_vector" class="org.apache.solr.llm.textvectorisation.search.TextToVectorQParserPlugin"/>
+	<updateRequestProcessorChain name="textToVector">
+		<processor class="solr.llm.textvectorisation.update.processor.TextToVectorUpdateProcessorFactory">
+			<str name="inputField">vectorContent</str>
+			<str name="outputField">vector</str>
+			<str name="model">llm</str>
+		</processor>
+		<processor class="solr.LogUpdateProcessorFactory"/>
+		<processor class="solr.RunUpdateProcessorFactory"/>
+	</updateRequestProcessorChain>
 
 	<queryResponseWriter name="json" class="solr.JSONResponseWriter" default="true"/>
 	<queryResponseWriter name="php" class="org.apache.solr.response.PHPResponseWriter"/>

--- a/Resources/Private/Solr/solr.xml
+++ b/Resources/Private/Solr/solr.xml
@@ -13,7 +13,7 @@
 		<int name="connTimeout">${connTimeout:0}</int>
 	</shardHandlerFactory>
 
-	<str name="modules">scripting,analytics,analysis-extras,langid,clustering,extraction,${solr.modules:}</str>
+	<str name="modules">scripting,analytics,analysis-extras,langid,clustering,extraction,llm,${solr.modules:}</str>
 	<str name="allowPaths">${solr.allowPaths:}</str>
 	<str name="allowUrls">${solr.allowUrls:}</str>
 


### PR DESCRIPTION
This commit contains minimal adjustemnts for Dense-Vector-Search field. EXT:solr requires adjustemnts to work with. This will be provided on EXT:solr 13.1.x and 12.1.x versions soon. This change is required for DEMOs and POCs.

Refs: #225112
Ports: #4439