### PR TITLE
Add checks for flexParentDatabaseRow key in methods

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -42,6 +42,11 @@ class FlexFormUserFunctions
      */
     public function getFacetFieldsFromSchema(array &$parentInformation): void
     {
+        if (!array_key_exists('flexParentDatabaseRow', $parentInformation)) {
+            $parentInformation['items'] = [];
+            return;
+        }
+
         $pageRecord = $parentInformation['flexParentDatabaseRow'];
         // @todo: Fix type hinting issue properly on whole call chain.
         $configuredFacets = $this->getConfiguredFacetsForPage($pageRecord['pid'] ?? null);
@@ -139,6 +144,11 @@ class FlexFormUserFunctions
      */
     public function getAvailableTemplates(array &$parentInformation): void
     {
+        if (!array_key_exists('flexParentDatabaseRow', $parentInformation)) {
+            $parentInformation['items'] = [];
+            return;
+        }
+
         $pageRecord = $parentInformation['flexParentDatabaseRow'];
         if (!is_array($pageRecord) || !isset($pageRecord['pid'])) {
             $parentInformation['items'] = [];


### PR DESCRIPTION
In a customers project I get critical errors opening the page record history due to those checks missing.

# What this pr does

This pull request adds two checks for keys to exist in the `FlexFormUserFunctions` class. The functionality is not being changed at all.


Fixes: https://github.com/TYPO3-Solr/ext-solr/issues/4441
