### PR TITLE
[FEATURE:BP:12.1] Initial vector search

### DIFF
--- a/Classes/Domain/Search/Query/SearchQuery.php
+++ b/Classes/Domain/Search/Query/SearchQuery.php
@@ -17,4 +17,18 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
-class SearchQuery extends Query {}
+class SearchQuery extends Query
+{
+    protected string $rawSearchTerm = '';
+
+    public function setRawSearchTerm(string $rawSearchTerm): self
+    {
+        $this->rawSearchTerm = $rawSearchTerm;
+        return $this;
+    }
+
+    public function getRawSearchTerm(): string
+    {
+        return $this->rawSearchTerm;
+    }
+}

--- a/Classes/Domain/Search/ResultSet/Result/SearchResult.php
+++ b/Classes/Domain/Search/ResultSet/Result/SearchResult.php
@@ -160,6 +160,11 @@ class SearchResult extends Document
         return (float)($this->fields['score'] ?? 0.0);
     }
 
+    public function getVectorSimilarityScore(): float
+    {
+        return (float)($this->fields['$q_vector'] ?? 0.0);
+    }
+
     public function getUrl(): string
     {
         return $this->fields['url'] ?? '';

--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -86,7 +86,7 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             $field = $sortingOptions['field'];
             $label = $sortingOptions['label'] ?? '';
 
-            $isResetOption = $field === 'relevance';
+            $isResetOption = $field === 'relevance' || $field === '$q_vector';
 
             // Allow stdWrap on label:
             $labelHasSubConfiguration = is_array($sortingOptions['label.'] ?? null);

--- a/Classes/IndexQueue/FrontendHelper/PageIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageIndexer.php
@@ -198,6 +198,11 @@ class PageIndexer implements FrontendHelper, SingletonInterface
         $this->solrConnection = $this->getSolrConnection($indexQueueItem, $tsfe->getLanguage(), $this->configuration->getLoggingExceptions());
 
         $document = $this->getPageDocument($tsfe, $this->generatePageUrl($tsfe), $this->getAccessRootline(), $tsfe->MP);
+
+        if ($this->configuration?->isVectorSearchEnabled()) {
+            $document->setField('vectorContent', $document['content']);
+        }
+
         $document = $this->substitutePageDocument($document, $tsfe->page, $indexQueueItem, $tsfe);
 
         $this->responseData['pageIndexed'] = (int)$this->indexPage($document, $indexQueueItem, $tsfe);

--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -380,7 +380,13 @@ class Indexer extends AbstractIndexer
             $itemIndexingConfiguration = $this->getItemTypeConfiguration($item, $language);
             $document = $this->getBaseDocument($item, $itemRecord);
             $tsfe = $this->getTsfeByItemAndLanguageId($item, $language);
-            $document = $this->addDocumentFieldsFromTyposcript($document, $itemIndexingConfiguration, $itemRecord, $tsfe);
+            $document = $this->addDocumentFieldsFromTyposcript(
+                $document,
+                $itemIndexingConfiguration,
+                $itemRecord,
+                $tsfe,
+                $language
+            );
         }
 
         return $document;

--- a/Classes/Report/TextToVectorModelStoreStatus.php
+++ b/Classes/Report/TextToVectorModelStoreStatus.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Report;
+
+use ApacheSolrForTypo3\Solr\ConnectionManager;
+use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
+use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrAdminService;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Reports\Status;
+
+/**
+ * Provides a status report about the TextToVectorModelStore
+ */
+class TextToVectorModelStoreStatus extends AbstractSolrStatus
+{
+    /**
+     * Checks the status of the vector plugin and store
+     *
+     * @throws UnexpectedTYPO3SiteInitializationException
+     * @return array <int, Status>
+     */
+    public function getStatus(): array
+    {
+        $reports = [];
+        /** @var ConnectionManager $connectionManager */
+        $connectionManager = GeneralUtility::makeInstance(ConnectionManager::class);
+
+        $endpoints = [];
+        foreach ($connectionManager->getAllConnections() as $connection) {
+            $endpoints = $this->addEndpoint($endpoints, $connection, 'read');
+            $endpoints = $this->addEndpoint($endpoints, $connection, 'write');
+        }
+
+        $configuredEndpoints = [];
+        $unsupportedEndpoints = 0;
+        $configuredModels = [];
+        $missingModelConfigurations = 0;
+        foreach ($endpoints as $endpoint => $adminService) {
+            if (!property_exists(
+                $adminService->getPluginsInformation()->plugins->QUERYPARSER,
+                'org.apache.solr.llm.textvectorisation.search.TextToVectorQParserPlugin',
+            )) {
+                $configuredEndpoints[] = [
+                    'baseUrl' => $endpoint,
+                    'status' => ContextualFeedbackSeverity::WARNING,
+                ];
+                $unsupportedEndpoints++;
+                continue;
+            }
+
+            $configuredEndpoints[] = [
+                'baseUrl' => $endpoint,
+                'status' => ContextualFeedbackSeverity::OK,
+            ];
+
+            $models = $adminService->getVectorModelStore();
+            if (!isset($models['llm'])) {
+                $configuredModels[] = [
+                    'baseUrl' => $endpoint,
+                    'status' => ContextualFeedbackSeverity::WARNING,
+                ];
+                $missingModelConfigurations++;
+            } else {
+                $modelParams = (array)$models['llm']['params'];
+                $configuredModels[] = [
+                    'baseUrl' => $endpoint,
+                    'status' => ContextualFeedbackSeverity::OK,
+                    'class' => $models['llm']['class'] ?? '',
+                    'modelBaseUrl' => $modelParams['baseUrl'] ?? '',
+                    'modelName' => $modelParams['modelName'] ?? '',
+                ];
+            }
+        }
+
+        $reports[] = GeneralUtility::makeInstance(
+            Status::class,
+            'Apache Solr Text to Vector',
+            '',
+            $this->getRenderedReport(
+                'TextToVectorModelStorePluginStatus.html',
+                [
+                    'endpoints' => $configuredEndpoints,
+                    'unsupportedEndpoints' => $unsupportedEndpoints,
+                ],
+            ),
+            ($unsupportedEndpoints ? ContextualFeedbackSeverity::WARNING : ContextualFeedbackSeverity::OK),
+        );
+
+        if ($configuredModels !== []) {
+            $reports[] = GeneralUtility::makeInstance(
+                Status::class,
+                'Apache Solr Text to Vector: Configured Models',
+                '',
+                $this->getRenderedReport(
+                    'TextToVectorModelStoreModelStatus.html',
+                    [
+                        'endpoints' => $configuredModels,
+                        'missingModelConfigurations' => $missingModelConfigurations,
+                    ],
+                ),
+                ($missingModelConfigurations ? ContextualFeedbackSeverity::WARNING : ContextualFeedbackSeverity::OK),
+            );
+        }
+
+        return $reports;
+    }
+
+    /**
+     * @param array<string, SolrAdminService> $endpoints
+     * @return array<string, SolrAdminService>
+     */
+    protected function addEndpoint(array $endpoints, SolrConnection $connection, string $endpointType): array
+    {
+        $endpoint = $connection->getEndpoint($endpointType);
+        $baseUri = $endpoint->getV1BaseUri();
+        if (!isset($endpoints[$baseUri])) {
+            $endpoints[$baseUri] = $connection->buildAdminService($endpointType);
+        }
+
+        return $endpoints;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLabel(): string
+    {
+        return 'LLL:EXT:solr/Resources/Private/Language/locallang_reports.xlf:status_solr_vector_support';
+    }
+}

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1088,6 +1088,46 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns the configured query type
+     *
+     * 0 = default
+     * 1 = vector (requires additional configuration)
+     */
+    public function getSearchQueryType(): int
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.type', 0);
+    }
+
+    /**
+     * Indicates if a vector based search is enabled
+     *
+     * If enabled e.g. the indexing of vectors using processor chain
+     * "textToVector" is enabled
+     */
+    public function isVectorSearchEnabled(): bool
+    {
+        return $this->getSearchQueryType() > 0;
+    }
+
+    /**
+     * Indicates if a pure vector based search is enabled
+     */
+    public function isPureVectorSearchEnabled(): bool
+    {
+        return $this->getSearchQueryType() === 1;
+    }
+
+    public function getMinimumVectorSimilarity(): float
+    {
+        return (float)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.vectorSearch.minimumSimilarity', 0.75);
+    }
+
+    public function getTopKClosestVectorLimit(): int
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.vectorSearch.topK', 1000);
+    }
+
+    /**
      * Returns if an empty query is allowed on the query level.
      *
      * plugin.tx_solr.search.query.allowEmptyQuery

--- a/Classes/System/Solr/Parser/VectorStoreParser.php
+++ b/Classes/System/Solr/Parser/VectorStoreParser.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\System\Solr\Parser;
+
+/**
+ * Class to parse the vector store data from a solr response.
+ */
+class VectorStoreParser
+{
+    public function parseJson(string $jsonString): array
+    {
+        $decodedResponse = json_decode($jsonString);
+        $models = [];
+
+        if (isset($decodedResponse->models)) {
+            foreach ((array)$decodedResponse->models as $model) {
+                $models[$model->name] = (array)$model;
+            }
+        }
+
+        return $models;
+    }
+}

--- a/Classes/System/Solr/Service/AbstractSolrService.php
+++ b/Classes/System/Solr/Service/AbstractSolrService.php
@@ -318,12 +318,17 @@ abstract class AbstractSolrService
         return round(microtime(true) * 1000);
     }
 
+    protected function createRequest(QueryInterface $query): Request
+    {
+        return $this->client->createRequest($query);
+    }
+
     /**
      * Creates and executes the request and returns the response
      */
     protected function createAndExecuteRequest(QueryInterface $query): ResponseAdapter
     {
-        $request = $this->client->createRequest($query);
+        $request = $this->createRequest($query);
         return $this->executeRequest($request);
     }
 

--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\StopWordParser;
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SynonymParser;
+use ApacheSolrForTypo3\Solr\System\Solr\Parser\VectorStoreParser;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\Schema\Schema;
 use Solarium\Client;
@@ -44,6 +45,7 @@ class SolrAdminService extends AbstractSolrService
     public const SCHEMA_SERVLET = 'schema';
     public const SYNONYMS_SERVLET = 'schema/analysis/synonyms/';
     public const STOPWORDS_SERVLET = 'schema/analysis/stopwords/';
+    public const VECTOR_STORAGE_SERVLET = 'schema/text-to-vector-model-store/';
 
     protected array $lukeData = [];
 
@@ -61,9 +63,13 @@ class SolrAdminService extends AbstractSolrService
 
     protected string $_stopWordsUrl = '';
 
+    protected string $_vectorStoreUrl = '';
+
     protected SynonymParser $synonymParser;
 
     protected StopWordParser $stopWordParser;
+
+    protected VectorStoreParser $vectorStoreParser;
 
     public function __construct(
         Client $client,
@@ -72,12 +78,14 @@ class SolrAdminService extends AbstractSolrService
         ?SynonymParser $synonymParser = null,
         ?StopWordParser $stopWordParser = null,
         ?SchemaParser $schemaParser = null,
+        ?VectorStoreParser $vectorStoreParser = null,
     ) {
         parent::__construct($client, $typoScriptConfiguration, $logManager);
 
         $this->synonymParser = $synonymParser ?? GeneralUtility::makeInstance(SynonymParser::class);
         $this->stopWordParser = $stopWordParser ?? GeneralUtility::makeInstance(StopWordParser::class);
         $this->schemaParser = $schemaParser ?? GeneralUtility::makeInstance(SchemaParser::class);
+        $this->vectorStoreParser = $vectorStoreParser ?? GeneralUtility::makeInstance(VectorStoreParser::class);
     }
 
     /**
@@ -312,5 +320,21 @@ class SolrAdminService extends AbstractSolrService
         }
 
         $this->_stopWordsUrl = $this->_constructUrl(self::STOPWORDS_SERVLET) . $this->getSchema()->getManagedResourceId();
+    }
+
+    public function getVectorModelStore(): array
+    {
+        $this->initializeVectorStorageUrl();
+        $response = $this->_sendRawGet($this->_vectorStoreUrl);
+        return $this->vectorStoreParser->parseJson($response->getRawResponse());
+    }
+
+    protected function initializeVectorStorageUrl(): void
+    {
+        if (trim($this->_vectorStoreUrl ?? '') !== '') {
+            return;
+        }
+
+        $this->_vectorStoreUrl = $this->_constructUrl(self::VECTOR_STORAGE_SERVLET) . $this->getSchema()->getManagedResourceId();
     }
 }

--- a/Classes/System/Solr/Service/SolrWriteService.php
+++ b/Classes/System/Solr/Service/SolrWriteService.php
@@ -105,7 +105,13 @@ class SolrWriteService extends AbstractSolrService
     {
         $update = $this->client->createUpdate();
         $update->addDocuments($documents);
-        return $this->createAndExecuteRequest($update);
+
+        $request = $this->createRequest($update);
+        if ($this->configuration->isVectorSearchEnabled()) {
+            $request->addParam('update.chain', 'textToVector');
+        }
+
+        return $this->executeRequest($request);
     }
 
     /**

--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -131,9 +131,8 @@ class SolrConnection
     /**
      * Builds and returns Solr admin service
      */
-    protected function buildAdminService(): SolrAdminService
+    public function buildAdminService(string $endpointKey = 'admin'): SolrAdminService
     {
-        $endpointKey = 'admin';
         $client = $this->getClient($endpointKey);
         $this->initializeClient($client, $endpointKey);
         return GeneralUtility::makeInstance(

--- a/Classes/ViewHelpers/Document/RelevanceViewHelper.php
+++ b/Classes/ViewHelpers/Document/RelevanceViewHelper.php
@@ -59,16 +59,21 @@ class RelevanceViewHelper extends AbstractSolrFrontendViewHelper
         /** @var SearchResultSet $resultSet */
         $resultSet = $arguments['resultSet'];
 
-        $maximumScore = $arguments['maximumScore'] ?? $resultSet->getMaximumScore();
-        $content = 0;
+        $configuration = $resultSet->getUsedSearchRequest()?->getContextTypoScriptConfiguration();
+        if ($configuration?->isPureVectorSearchEnabled()) {
+            $maximumScore = 1;
+            $documentScore = $document->getVectorSimilarityScore();
+        } else {
+            $maximumScore = $arguments['maximumScore'] ?? $resultSet->getMaximumScore();
+            $documentScore = $document->getScore();
+        }
 
+        $content = 0;
         if ($maximumScore <= 0) {
             return $content;
         }
 
-        $documentScore = $document->getScore();
-        $score = $documentScore;
         $multiplier = 100 / $maximumScore;
-        return (string)round($score * $multiplier);
+        return (string)round($documentScore * $multiplier);
     }
 }

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -72,6 +72,7 @@ plugin.tx_solr {
     ignoreGlobalQParameter = 0
 
     query {
+      type = 0
       allowEmptyQuery = 0
 
       allowedSites = __solr_current_site
@@ -160,6 +161,11 @@ plugin.tx_solr {
         fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subtitle^10.0, navtitle^10.0
         slop = 0
       }
+    }
+
+    vectorSearch {
+      minimumSimilarity = 0.75
+      topK = 1000
     }
 
     grouping = 0

--- a/Documentation/Appendix/KnownIssues.rst
+++ b/Documentation/Appendix/KnownIssues.rst
@@ -1,0 +1,25 @@
+.. _appendix-known-issues:
+
+Appendix - Known issues
+=======================
+
+Text embedding failure
+----------------------
+
+EXT:solr 12.1 and 13.1 introduced an initial vector search option, but further improvements and features are planned and in progress.
+
+A weak point of the vector search feature is the error handling, if the required llm is not defined or the embedding fails, indexing and/or search will be impaired.
+
+Indexing
+~~~~~~~~
+
+If the vectors couldn't be calculated during indexing, the index process won't fail, but the documents will miss the vectors and cannot be found.
+
+Solr status is fine, but the `TextToVectorUpdateProcessor` reports "Could not vectorise".
+
+Search
+~~~~~~
+
+The search term has also to be vectorized to perform a search in the frontend, missing or unavailable large language models will currently lead to a `SolrInternalServerErrorException`.
+
+Apache Solr returns HTTP status 500 and details about the exception are available, but differ depending on the model used.

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -95,6 +95,26 @@ query
 
 The query sub-section defines a few query parameters for the query that will be sent to the Solr server later on. Some query parameters are also generated and set by the extension itself, f.e. when using facets.
 
+query.type
+~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.query.type
+:Default: 0
+:Options: 0,1
+:Since: 12.1.0, 13.1.0
+
+Allows to configure the query type that should be configured
+
+*   0: default score based Solr search (= well-known behaviour since EXT:solr started)
+*   1: pure vector based search (requires additional configuration and an LLM)
+
+..  note::
+    A full reindex is required if vector search is enabled, as vectors are only created if vector search is active
+
+..  note::
+    As no classic search term is used/available for the pure vector search, the highlighting component will not work. Using the siteHighlighting and an adjusted JavaScript could be an alternative approach.
+
 query.allowEmptyQuery
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -456,6 +476,36 @@ This parameter defines the "trigram phrase slop" value, which represents the num
 
 Note: The value of this setting has NO influence on explicit phrase search.
 
+query.vectorSearch.minimumSimilarity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Float
+:TS Path: plugin.tx_solr.search.query.vectorSearch.minimumSimilarity
+:Default: 0.75
+:Since: 12.1.0, 13.1.0
+
+By default only documents with at least 0.75 of vector similarity score are returned, highest similarity score is 1.
+
+The calculated vector similarity score is returned in field `$q_vector`
+
+..  note::
+    This setting is only relevant if pure vector queries are used (query.type = 1).
+
+
+query.vectorSearch.topK
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Integer
+:TS Path: plugin.tx_solr.search.query.vectorSearch.topK
+:Default: 1000
+:Since: 12.1.0, 13.1.0
+
+Number of documents to return in vector search.
+
+..  note::
+    This setting is only relevant if pure vector queries are used (query.type = 1).
+
+
 results
 -------
 
@@ -470,7 +520,11 @@ results.resultsHighlighting
 
 En-/disables search term highlighting on the results page.
 
-Note:  The FastVectorHighlighter is used by default (Since 4.0) if fragmentSize is set to at least 18 (this is required by the FastVectorHighlighter to work).
+..  note::
+    The FastVectorHighlighter is used by default (Since 4.0) if fragmentSize is set to at least 18 (this is required by the FastVectorHighlighter to work).
+
+..  note::
+    The highlighting component will not work for vector search (`query.type=1`), as no classic search term is used/available to be highlighted. Using the siteHighlighting and an adjusted JavaScript could be an alternative approach.
 
 results.resultsHighlighting.highlightFields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -720,3 +720,42 @@ The container log did not contain any output relevant to the container quitting.
 Changing to Docker Desktop as provider keep the container alive.
 
 Relevant DDEV link: https://ddev.readthedocs.io/en/latest/users/providers/
+
+I want to use the vector search, how can I define a large language model
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To use the vector search introduced in 13.1 a large language model has to be connected and and is used to encode text to vectors.
+
+Details about the configuration can be found in the `Apache Solr Reference Guide 9.9: Text to Vector <https://solr.apache.org/guide/solr/latest/query-guide/text-to-vector.html>`_
+
+Uploading a model
+~~~~~~~~~~~~~~~~~
+
+Store the model details in a local JSON file, e.g. `llm.json`, and upload the definition using cURL:
+
+..  code-block:: shell
+
+    curl -XPUT 'http://solr-ddev-site.ddev.site:8983/solr/core_en/schema/text-to-vector-model-store' --data-binary "@llm.json" -H 'Content-type:application/json'
+
+
+The JSON file could look like this:
+
+..  code-block:: json
+
+    {
+      "class": "dev.langchain4j.model.openai.OpenAiEmbeddingModel",
+      "name": "llm",
+      "params": {
+        "baseUrl": "https://api.openai.com/v1",
+        "apiKey": "apiKey-openAI",
+        "modelName": "text-embedding-3-small",
+        "timeout": 5,
+        "logRequests": true,
+        "logResponses": true,
+        "maxRetries": 2
+      }
+    }
+
+..  note::
+    The number of dimensions depends on the selected model. The default in EXT:solr is 768, but you can adjust
+    the correct number of dimensions by setting environment variable SOLR_VECTOR_DIMENSION

--- a/Resources/Private/Language/locallang_reports.xlf
+++ b/Resources/Private/Language/locallang_reports.xlf
@@ -27,6 +27,9 @@
 			<trans-unit id="status_solr_solrversion" resname="status_solr_solrversion">
 				<source>Solr Version</source>
 			</trans-unit>
+			<trans-unit id="status_solr_vector_support" resname="status_solr_vector_support">
+				<source>Solr Vector Support</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Backend/Reports/TextToVectorModelStoreModelStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/TextToVectorModelStoreModelStatus.html
@@ -1,0 +1,30 @@
+<html data-namespace-typo3-fluid="true"
+	xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	xmlns:acoBase="http://typo3.org/ns/Aco/AcoBase/ViewHelpers"
+>
+
+<f:if condition="{missingModelConfigurations}">
+	<p>To use vector search all endpoints need an uploaded "llm" model, please push your model configuration</p>
+	<p>You can ignore this warning, if you do not want to use Vector search</p>
+</f:if>
+
+<table class="table table-condensed table-hover table-striped">
+	<thead>
+	<tr>
+		<th>Endpoint</th>
+		<th>Class</th>
+		<th>Base url</th>
+		<th>Model</th>
+	</tr>
+	</thead>
+	<f:for each="{endpoints}" as="endpoint">
+		<tr class="{endpoint.status.cssClass}">
+			<td>{endpoint.baseUrl}</td>
+			<td>{endpoint.class}</td>
+			<td>{endpoint.modelBaseUrl}</td>
+			<td>{endpoint.modelName}</td>
+		</tr>
+	</f:for>
+</table>
+
+</html>

--- a/Resources/Private/Templates/Backend/Reports/TextToVectorModelStorePluginStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/TextToVectorModelStorePluginStatus.html
@@ -1,0 +1,18 @@
+<html data-namespace-typo3-fluid="true"
+	xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	xmlns:acoBase="http://typo3.org/ns/Aco/AcoBase/ViewHelpers"
+>
+<f:if condition="{unsupportedEndpoints}">
+	<p>Vector plugin is not configured for all endpoints, please check configsets of marked endpoints.</p>
+	<p>You can ignore this warning, if you do not want to use Vector search</p>
+</f:if>
+
+<table class="table table-condensed table-hover table-striped">
+	<f:for each="{endpoints}" as="endpoint">
+		<tr class="{endpoint.status.cssClass}">
+			<td>{endpoint.baseUrl}</td>
+		</tr>
+	</f:for>
+</table>
+
+</html>

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -53,9 +53,9 @@
 					</f:then>
 
 					<f:else>
-						<f:if condition="{resultSet.usedQuery.query}">
+						<f:if condition="{resultSet.usedQuery.rawSearchTerm}">
 						<span class="searched-for">
-							<f:translate key="results_searched_for" arguments="{0: resultSet.usedQuery.query}" extensionName="solr">Searched for "%s"</f:translate>
+							<f:translate key="results_searched_for" arguments="{0: resultSet.usedQuery.rawSearchTerm}" extensionName="solr">Searched for "%s"</f:translate>
 						</span>
 						</f:if>
 					</f:else>

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -121,4 +121,18 @@ class SearchResultTest extends SetUpUnitTestCase
             'Calling getter for unexisting field does not return null'
         );
     }
+
+    #[Test]
+    public function canGetVectorSimilarityScore(): void
+    {
+        self::assertSame(
+            0.0,
+            $this->searchResult->getVectorSimilarityScore(),
+        );
+
+        self::assertSame(
+            85.0,
+            (new SearchResult(['$q_vector' => 85]))->getVectorSimilarityScore(),
+        );
+    }
 }

--- a/Tests/Unit/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\IndexQueue\FrontendHelper;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
+use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
+use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Traversable;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+class PageIndexerTest extends SetUpUnitTestCase
+{
+    #[Test]
+    #[DataProvider('canCreatePageDocumentDataProvider')]
+    public function canCreatePageDocument(bool $vectorSearchEnabled): void
+    {
+        $subject = $this->getAccessibleMock(
+            PageIndexer::class,
+            ['getSolrConnection', 'generatePageUrl', 'substitutePageDocument', 'indexPage'],
+        );
+
+        $tsfeMock = $this->createMock(TypoScriptFrontendController::class);
+        $tsfeMock->id = 123;
+        $tsfeMock->page = [
+            'uid' => 123,
+            'pid' => 1,
+            'crdate' => 1759928546,
+            'SYS_LASTCHANGED' => 1759928546,
+            'subtitle' => '',
+            'nav_title' => '',
+            'author' => '',
+            'description' => '',
+            'abstract' => '',
+        ];
+        $tsfeMock->cObj = $this->createMock(ContentObjectRenderer::class);
+
+        $contentExtractorMock = $this->createMock(Typo3PageContentExtractor::class);
+        $contentExtractorMock->method('getIndexableContent')->willReturn('indexible page content');
+        $builderMock = $this->getAccessibleMock(
+            Builder::class,
+            ['getSiteByPageId', 'getPageDocumentId', 'getExtractorForPageContent'],
+            [$this->createMock(IdBuilder::class), $this->createMock(ExtensionConfiguration::class)]
+        );
+        $builderMock->method('getExtractorForPageContent')->willReturn($contentExtractorMock);
+        GeneralUtility::addInstance(Builder::class, $builderMock);
+
+        $document = new Document();
+        GeneralUtility::addInstance(Document::class, $document);
+
+        $subject->expects(self::once())->method('substitutePageDocument')->willReturnArgument(0);
+        $connectionMock = $this->createMock(SolrConnection::class);
+        $subject->expects(self::once())->method('getSolrConnection')->willReturn($connectionMock);
+
+        $configurationMock = $this->createMock(TypoScriptConfiguration::class);
+        $configurationMock->expects(self::once())->method('isVectorSearchEnabled')->willReturn($vectorSearchEnabled);
+        $subject->_set('configuration', $configurationMock);
+
+        $subject->_call('index', $this->createMock(Item::class), $tsfeMock);
+        if ($vectorSearchEnabled) {
+            self::assertNotEmpty($document['vectorContent']);
+            self::assertEquals($document['vectorContent'], $document['content']);
+        } else {
+            self::assertArrayNotHasKey('vectorContent', $document->getFields());
+        }
+    }
+
+    public static function canCreatePageDocumentDataProvider(): Traversable
+    {
+        yield 'vector search disabled' => [ false ];
+        yield 'vector search enabled' => [ true ];
+    }
+}


### PR DESCRIPTION
# What this pr does
Introduces a pure vector search as new search variant, by activating the vector search type vectors are automatically generated during indexing and frontend search:

Note: A connected LLM is required and not directly related with EXT:solr.

Ports: #4446