### PR TITLE
[BUGFIX] don't use pages uid 0 via l10n_parent

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -400,7 +400,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
 
         // We need to get the full record to find out if this is a page translation
         $fullRecord = $this->getRecord('pages', $uid);
-        if (($fullRecord['sys_language_uid'] ?? null) > 0) {
+        if (($fullRecord['sys_language_uid'] ?? null) > 0 && (int)($fullRecord['l10n_parent']) > 0) {
             $uid = (int)$fullRecord['l10n_parent'];
         }
 

--- a/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
@@ -131,7 +131,7 @@ class GarbageHandler extends AbstractUpdateHandler
             // We need to get the full record to find out if this is a page translation
             $fullRecord = $this->getRecord('pages', $uid);
             $uidForRecursiveTriggers = $uid;
-            if (($fullRecord['sys_language_uid'] ?? null) > 0) {
+            if (($fullRecord['sys_language_uid'] ?? null) > 0 && (int)($fullRecord['l10n_parent']) > 0) {
                 $uidForRecursiveTriggers = (int)$fullRecord['l10n_parent'];
             }
             $this->deleteSubEntriesWhenRecursiveTriggerIsRecognized($table, $uidForRecursiveTriggers, $updatedFields);


### PR DESCRIPTION
Fixes following error, if a translation page is inserted via TCE without l10n_parent:

```
ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\AbstractUpdateHandler::getAllCurrentStateFieldsMatch()
         : Argument #2 ($pageRecord) must be of type array, null given, called in
         /var/www/html/packages/ext-solr/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php on line 230
         [0] (File: /var/www/html/packages/ext-solr/Classes/Domain/Index/Queue/UpdateHandler/AbstractUpdateHandler.php,
         line: 245)
```