### PR TITLE
[BUGFIX] pass a request with page id to Configuration manager

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use Doctrine\DBAL\Exception as DBALException;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -189,6 +190,9 @@ class FlexFormUserFunctions
         }
 
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
+
+        $request = (new ServerRequest())->withQueryParams(['id' => $pid]);
+        $configurationManager->setRequest($request);
         $typoScript = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 
         return GeneralUtility::makeInstance(TypoScriptConfiguration::class, $typoScript);


### PR DESCRIPTION
# What this pr does

This fixes an issue where, in a multi page TYPO3 installation, if both pages have different setups for available templates the previous code would always use the first pages config

# How to test

1.  Create a TYPO3 installation with 2 sites configured
2.  Create a template for each site with different Configurations for available templates
3.  Create a page on each site with a the search plugin
4. The available templates for each site are different

Fixes: #4451
