### PR TITLE
[BUGFIX] Replace TSFE call for page type

### DIFF
--- a/Configuration/TypoScript/OpenSearch/setup.typoscript
+++ b/Configuration/TypoScript/OpenSearch/setup.typoscript
@@ -59,7 +59,7 @@ OpenSearch {
 	20.value (
 	<Url type="application/opensearchdescription+xml"
 		 rel="self"
-		 template="{getIndpEnv:TYPO3_SITE_URL}index.php?type={TSFE:type}&amp;L={siteLanguage:languageId}" />
+		 template="{getIndpEnv:TYPO3_SITE_URL}index.php?type={request:routing|pageType}&amp;L={siteLanguage:languageId}" />
 	)
 
 


### PR DESCRIPTION
# What this pr does

This change replaces the outdated `{TSFE:type}` call for Open Search.
It prevents "Undefined property" PHP warnings for these calls, which are logged in the TYPO3 log.

# How to test

1. Import the TypoScript template for Open Search from EXT:solr in the installation

2. Open the URL found in the `href` attribute of the following HTML tag

```
	<link rel="search"
		  type="application/opensearchdescription+xml"
		  href="https://www.example.org/?type=7567"
		  title="Website Search"
	/>
```

3. It downloads an unnamed XML file containing the OpenSearchDescription. The page type in the `template` attribute should be properly replaced:

```
	<Url type="application/opensearchdescription+xml"
		 rel="self"
		 template="https://www.example.org/index.php?type=7567&amp;L=0" />
```

Fixes: #4407
