### PR TITLE
[BUGFIX] Do not use records with pid = 0 in version swap handling

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -224,7 +224,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
             $this->applyPageChangesToQueue($uid);
         } else {
             $recordPageId = $this->getValidatedPid($table, $uid);
-            if ($recordPageId === null) {
+            if (empty($recordPageId)) {
                 return;
             }
             $this->applyRecordChangesToQueue($table, $uid, $recordPageId);


### PR DESCRIPTION
# What this pr does

When swapping a content element that contains linked file references, TYPO3 also includes related records from sys_file_metadata.
These metadata records are stored with pid = 0.

The ext-solr extension attempts to resolve the Site for these records, which causes an exception because typically no Site exists for pid = 0.

This PR changes the condition from $pid === null to empty($pid) to also handle the case where pid = 0.

# How to test

1. Create a workspace entry.
2. Add a sys_file_reference to an inline field.
3. Attempt to swap this record to live.
4. Verify that no exception is thrown.