### PR TITLE
[BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS

### DIFF
--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -102,7 +102,7 @@ class ConfigurationManager implements SingletonInterface
      */
     public function getTypoScriptConfiguration(?int $contextPageId = null, int $contextLanguageId = 0): TypoScriptConfiguration
     {
-        if ($contextPageId !== null) {
+        if ($contextPageId !== null && BackendUtility::getRecord('pages', $contextPageId) !== null) {
             $site = GeneralUtility::makeInstance(SiteFinder::class)
                 ->getSiteByPageId($contextPageId);
             $language = $site->getLanguageById($contextLanguageId);


### PR DESCRIPTION
# What this pr does

When publishing content from a workspace (WS) to live that includes deleted records, the ConfigurationManager attempts to retrieve the $contextPageId of a deleted page. Since this page no longer exists, the SiteFinder cannot determine a corresponding Site and throws an exception. As a result, the publishing process is interrupted, and TYPO3 fails to publish all workspace data.

# How to test

1. Delete a live page in the workspace.
2. Attempt to publish the entire workspace.
3. TYPO3 throws an exception and stops the publishing process before all data is published.
