### PR TITLE
[BUGFIX] Add setting to disabled facets

### DIFF
--- a/Classes/Controller/AbstractBaseController.php
+++ b/Classes/Controller/AbstractBaseController.php
@@ -179,7 +179,7 @@ abstract class AbstractBaseController extends ActionController
             $this->typoScriptConfiguration->mergeSolrConfiguration(
                 $typoScriptService->convertPlainArrayToTypoScriptArray($pluginSettings),
                 true,
-                false
+                true
             );
         }
 

--- a/Classes/Query/Modifier/Faceting.php
+++ b/Classes/Query/Modifier/Faceting.php
@@ -119,6 +119,10 @@ class Faceting implements Modifier, SearchRequestAware
         foreach ($allFacets as $facetName => $facetConfiguration) {
             $facetName = substr($facetName, 0, -1);
             $type = $facetConfiguration['type'] ?? 'options';
+            $enabled = isset($facetConfiguration['enabled']) ? boolval($facetConfiguration['enabled']) : true;
+            if ($enabled === false) {
+                continue;
+            }
             $facetParameterBuilder = $this->facetRegistry->getPackage($type)->getQueryBuilder();
 
             if (is_null($facetParameterBuilder)) {


### PR DESCRIPTION
There is an issue resolving the typoscript configuration properly. Currently there is no way to override the default tx_solr configuration in the context of another content element/plugin. The problem occurs in the AbstractBaseController initializeAction. If e.g. __UNSET is used to unset a facet this is properly done in line 169. As intended, the facet is removed, but also the __UNSET rule. In line 179 mergeSolrConfiguration() the facet is added again from the "default" plugin configuration as the __UNSET rule is now removed. This might affect other settings than facets too (e.g. sorting.options).

Resolves: #4419 #2333

# What this pr does

Please add a description here

# How to test

Please add a testing instruction here

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
