### PR TITLE
[BUGFIX] Pass TypoScript configuration to SolrWriteService

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -166,7 +166,7 @@ class SolrConnection
         $endpointKey = 'read';
         $client = $this->getClient($endpointKey);
         $this->initializeClient($client, $endpointKey);
-        return GeneralUtility::makeInstance(SolrReadService::class, $client);
+        return GeneralUtility::makeInstance(SolrReadService::class, $client, $this->configuration);
     }
 
     /**
@@ -189,7 +189,7 @@ class SolrConnection
         $endpointKey = 'write';
         $client = $this->getClient($endpointKey);
         $this->initializeClient($client, $endpointKey);
-        return GeneralUtility::makeInstance(SolrWriteService::class, $client);
+        return GeneralUtility::makeInstance(SolrWriteService::class, $client, $this->configuration);
     }
 
     /**


### PR DESCRIPTION
# What this pr does

During indexing the TypoScript configuration of the current item is not passed to the SolrWriteService, thus wrong settings might be used, e.g. the Solr query type.

By passing the TypoScript configuration to the write and read services, it's ensured the right TypoScript configuration is used.

Fixes: #4474