### PR TITLE
[BUGFIX] Describe array shape of findTranslationOverlaysByPageId correctly

### DIFF
--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -232,11 +232,11 @@ class PagesRepository extends AbstractRepository
     /**
      * Finds translation overlays by given page Id.
      *
-     * @return array{array{
+     * @return array<int, array{
      *    'pid': int,
      *    'l10n_parent': int,
      *    'sys_language_uid': int,
-     * }}
+     * }>
      *
      * @throws DBALException
      */


### PR DESCRIPTION
The previously existing shape means: "an array with exactly one item". However it should be "an array with an arbitrary number of records".

We have extended this method in our code base and try to return `[]` for some cases however phpstan thinks that does not comply with the parent method's array shape.