### PR TITLE
[BUGFIX] Use the return value of the UPDATE statement correctly in the `LastSearchesRepository::update` method

### DIFF
--- a/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
@@ -139,7 +139,7 @@ class LastSearchesRepository extends AbstractRepository
             ->set('keywords', $lastSearchesRow['keywords'])
             ->executeStatement();
 
-        if ($affectedRows < 1) {
+        if ($affectedRows === false) {
             throw new InvalidArgumentException(vsprintf('By trying to update last searches row with values "%s" nothing was updated, make sure the given "sequence_id" exists in database.', [json_encode($lastSearchesRow)]), 1502717923);
         }
     }

--- a/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
+++ b/Classes/Domain/Search/LastSearches/LastSearchesRepository.php
@@ -139,8 +139,6 @@ class LastSearchesRepository extends AbstractRepository
             ->set('keywords', $lastSearchesRow['keywords'])
             ->executeStatement();
 
-        if ($affectedRows === false) {
-            throw new InvalidArgumentException(vsprintf('By trying to update last searches row with values "%s" nothing was updated, make sure the given "sequence_id" exists in database.', [json_encode($lastSearchesRow)]), 1502717923);
-        }
+
     }
 }


### PR DESCRIPTION
To Reproduce

This confirms that the exception is triggered in valid and expected situations, for example when:

multiple users perform the same search query at nearly the same time, or

the same search term is executed repeatedly within the same second.

In these cases:

the UPDATE statement does find the row (correct sequence_id)

but writes identical values (keywords and second-based tstamp)

MySQL / MariaDB correctly returns affectedRows = 0

the current logic incorrectly interprets this as “row not found”
