### PR TITLE
[DOCS] Update version matrix in main for current versions

### DIFF
--- a/Documentation/Appendix/VersionMatrix.rst
+++ b/Documentation/Appendix/VersionMatrix.rst
@@ -15,7 +15,7 @@ List of EXT:solr versions and the matching versions of Apache Solr and TYPO3 tha
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
 TYPO3      EXT:solr (↻)   EXT:solrmlt (↻)   EXT:tika (↻)   EXT:solrfal ($)    EXT:solrconsole ($)   EXT:solrdebugtools ($)   EXT:solrfluidgrouping ($↺)        Apache Solr      Configset
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
-12.4       12.1           12.0 (Ø)          12.0           12.0               12.0                  12.0                     N/A (integrated in EXT:solr)      9.10.0¹           ext_solr_12_1_0
+12.4       12.1           12.0 (Ø)          12.1           12.0               12.0                  12.0                     N/A (integrated in EXT:solr)      9.10.0¹           ext_solr_12_1_0
 =========  =============  ================  =============  =================  ====================  =======================  ================================  ===============  =================
 
 | $ - Funding contribution extensions. See: https://www.typo3-solr.com/solr-for-typo3/open-source-version/


### PR DESCRIPTION
Update the Version matrix in main after releases of EXT:solr 12.1 and EXT:tika 13.1 + 12.1