### PR TITLE
[BUGFIX] Handle inaccessible solr server in reporst module better

### DIFF
--- a/Classes/Report/TextToVectorModelStoreStatus.php
+++ b/Classes/Report/TextToVectorModelStoreStatus.php
@@ -54,7 +54,7 @@ class TextToVectorModelStoreStatus extends AbstractSolrStatus
         $missingModelConfigurations = 0;
         foreach ($endpoints as $endpoint => $adminService) {
             if (!property_exists(
-                $adminService->getPluginsInformation()->plugins->QUERYPARSER,
+                $adminService->getPluginsInformation()->plugins?->QUERYPARSER ?? '',
                 'org.apache.solr.llm.textvectorisation.search.TextToVectorQParserPlugin',
             )) {
                 $configuredEndpoints[] = [


### PR DESCRIPTION
Refs: #4507

# What this pr does

When the solr server is not accessible, the reports module can crash due to an unexpected response.

# How to test

Please add a testing instruction here

Fixes: #4507 
