### PR TITLE
[BUGFIX] Filter Solr connections based on language fallback settings

### DIFF
--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -161,10 +161,10 @@ class PageIndexer extends Indexer
 
             $site = $siteFinder->getSiteByPageId($page['uid']);
 
-            foreach($solrConnections as $languageId => $solrConnection){
+            foreach ($solrConnections as $languageId => $solrConnection) {
                 $language = $site->getLanguageById($languageId);
 
-                if($language->getFallbackLanguageIds() === [0]){
+                if ($language->getFallbackLanguageIds() === [0]) {
                     // this language falls back to default language only -> remove Solr connection
                     unset($solrConnections[$languageId]);
                 }


### PR DESCRIPTION
# What this pr does

Added a check if then solrConnections language has only 0 as fallback language - if so and the default language is hidden also hide this language.

# How to test

See description of issue.

Fixes: #4513
