### PR TITLE
[TASK] Allow other views than FluidViewAdapter in search controller

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -117,7 +117,9 @@ class SearchController extends AbstractBaseController
 
             // we pass the search result set to the controller context, to have the possibility
             // to access it without passing it from partial to partial
-            $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
+            if ($this->view instanceof FluidViewAdapter) {
+                $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
+            }
 
             $currentPage = $this->request->hasArgument('page') ? (int)$this->request->getArgument('page') : 1;
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -209,7 +209,9 @@ class SearchController extends AbstractBaseController
         $searchRequest = $this->getSearchRequestBuilder()->buildForFrequentSearches($pageId, $languageId);
         $searchResultSet->setUsedSearchRequest($searchRequest);
 
-        $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
+        if ($this->view instanceof FluidViewAdapter) {
+            $this->view->getRenderingContext()->getVariableProvider()->add('searchResultSet', $searchResultSet);
+        }
 
         /** @var AfterFrequentlySearchHasBeenExecutedEvent $afterFrequentlySearchedEvent*/
         $afterFrequentlySearchedEvent = $this->eventDispatcher->dispatch(

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -26,9 +26,11 @@ use ApacheSolrForTypo3\Solr\Pagination\ResultsPaginator;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\View\ViewInterface;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Fluid\View\FluidViewAdapter;
 use TYPO3Fluid\Fluid\View\AbstractTemplateView;
+use TYPO3Fluid\Fluid\View\ViewInterface as FluidStandaloneViewInterface;
 
 /**
  * Class SearchController
@@ -56,8 +58,12 @@ class SearchController extends AbstractBaseController
         }
     }
 
-    public function initializeView(FluidViewAdapter $view): void
+    public function initializeView(FluidStandaloneViewInterface|ViewInterface $view): void
     {
+        if (!$view instanceof FluidViewAdapter) {
+            return;
+        }
+
         $variableProvider = GeneralUtility::makeInstance(SolrVariableProvider::class);
         $variableProvider->setSource($view->getRenderingContext()->getVariableProvider()->getSource());
         $view->getRenderingContext()->setVariableProvider($variableProvider);


### PR DESCRIPTION
# What this pr does

This PR modifies `\ApacheSolrForTypo3\Solr\Controller\SearchController::initializeView` to allow other template views than `FluidViewAdapter` for template rendering. This effectively opens EXT:solr plugin rendering for other templating engines or custom view implementations. Since the provided view initializations are exclusively written for `FluidViewAdapter` instances, the method returns early if other instances are passed.

# How to test

Testing is hard, because it requires a lot of custom components, e.g. a custom `ViewFactory` and a custom `View` implementation.

Fixes: #4521