### PR TITLE
[BUGFIX] Add no-cache headers for indexing requests to prevent caching

### DIFF
--- a/Classes/Middleware/PageIndexerInitialization.php
+++ b/Classes/Middleware/PageIndexerInitialization.php
@@ -72,7 +72,11 @@ class PageIndexerInitialization implements MiddlewareInterface
             return (new Response())
                 ->withBody($body)
                 ->withHeader('Content-Length', (string)strlen($content))
-                ->withHeader('Content-Type', 'application/json');
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('Expires', '0')
+                ->withHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT')
+                ->withHeader('Pragma', 'no-cache')
+                ->withHeader('Cache-Control', 'private, no-store');
         }
         return $response;
     }


### PR DESCRIPTION
# What this pr does

Add the correct cache control header (private) to the page indexer response.
This prevents caching in reverse proxies.