### PR TITLE
[BUGFIX] Respect plugin TS in RelevanceComponent

### DIFF
--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -68,6 +68,12 @@ class QueryBuilder extends AbstractQueryBuilder
         $this->siteHashService = $siteHashService ?? GeneralUtility::makeInstance(SiteHashService::class);
     }
 
+    public function useTypoScriptConfiguration(TypoScriptConfiguration $typoScriptConfiguration): self
+    {
+        $this->typoScriptConfiguration = $typoScriptConfiguration;
+        return $this;
+    }
+
     public function newSearchQuery(string $queryString): QueryBuilder
     {
         $this->queryToBuild = $this->getSearchQueryInstance($queryString);

--- a/Classes/Search/RelevanceComponent.php
+++ b/Classes/Search/RelevanceComponent.php
@@ -35,6 +35,7 @@ class RelevanceComponent
     public function __invoke(AfterSearchQueryHasBeenPreparedEvent $event): void
     {
         $query = $this->queryBuilder
+            ->useTypoScriptConfiguration($event->getTypoScriptConfiguration())
             ->startFrom($event->getQuery())
             ->useMinimumMatchFromTypoScript()
             ->useBoostFunctionFromTypoScript()


### PR DESCRIPTION
The RelevanceComponent gets a QueryBuilder injected via DI,
which in turn only receives global TypoScriptConfiguration, as the plugin
context is lost during DI.

Allow setting TypoScriptConfiguration in QueryBuilder to be
able to set the The TypoScriptConfiguration from the event,
similar to the startFrom() method to set the query.