### PR TITLE
[BUGFIX] Catch InvalidArgumentException for missing site languages in…

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\StrategyFactory;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use Doctrine\DBAL\Exception as DBALException;
+use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
@@ -198,7 +199,7 @@ class GarbageHandler extends AbstractUpdateHandler
     {
         try {
             $isAllowedPageType = $this->frontendEnvironment->isAllowedPageType($record);
-        } catch (SiteNotFoundException $e) {
+        } catch (SiteNotFoundException | InvalidArgumentException $e) {
             $this->logger->log(
                 LogLevel::WARNING,
                 'Couldn\t determine site for page ' . $record['uid'],


### PR DESCRIPTION
# What this PR does

Adds `\InvalidArgumentException` to the catch block in `GarbageHandler::isIndexablePageType()`.

When a page record references a `sys_language_uid` that does not exist in the site configuration (e.g. a language was removed or disabled), `Site::getLanguageById()` throws an `InvalidArgumentException`. The existing catch only handles `SiteNotFoundException`, causing the backend to crash when saving page properties.

With this fix, pages referencing unconfigured languages are treated as non-indexable (same behavior as when a site is not found).

# How to test

1. Set up a TYPO3 site with multiple languages configured
2. Create page translations in one of those languages
3. Remove that language from the site configuration (so page records with that `sys_language_uid` still exist in the database)
4. Open page properties of any page and click "Save"
5. **Before fix:** `InvalidArgumentException: Language X does not exist on site Y`
6. **After fix:** Page saves successfully, a warning is logged

Fixes: #4533