### PR TITLE
[BUGFIX] Add headers palette to solr plugin CType TCA definitions

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -16,12 +16,15 @@ $pluginSearchSignature = ExtensionUtility::registerPlugin(
     'extensions-solr-plugin-contentelement',
     'search',
 );
-$GLOBALS['TCA']['tt_content']['types'][$pluginSearchSignature]['showitem'] = 'pi_flexform';
 ExtensionManagementUtility::addPiFlexFormValue(
     '*',
     'FILE:EXT:solr/Configuration/FlexForms/Form.xml',
     $pluginSearchSignature,
 );
+$GLOBALS['TCA']['tt_content']['types'][$pluginSearchSignature]['showitem'] = '
+    --palette--;;headers,
+    pi_flexform,
+';
 
 $pluginFrequentlySearchedSignature = ExtensionUtility::registerPlugin(
     'solr',
@@ -30,7 +33,9 @@ $pluginFrequentlySearchedSignature = ExtensionUtility::registerPlugin(
     'extensions-solr-plugin-contentelement',
     'search',
 );
-$GLOBALS['TCA']['tt_content']['types'][$pluginFrequentlySearchedSignature]['showitem'] = '';
+$GLOBALS['TCA']['tt_content']['types'][$pluginFrequentlySearchedSignature]['showitem'] = '
+    --palette--;;headers,
+';
 
 $pluginResultsSignature = ExtensionUtility::registerPlugin(
     'solr',
@@ -39,9 +44,12 @@ $pluginResultsSignature = ExtensionUtility::registerPlugin(
     'extensions-solr-plugin-contentelement',
     'search',
 );
-$GLOBALS['TCA']['tt_content']['types'][$pluginResultsSignature]['showitem'] = 'pi_flexform';
 ExtensionManagementUtility::addPiFlexFormValue(
     '*',
     'FILE:EXT:solr/Configuration/FlexForms/Results.xml',
     $pluginResultsSignature,
 );
+$GLOBALS['TCA']['tt_content']['types'][$pluginResultsSignature]['showitem'] = '
+    --palette--;;headers,
+    pi_flexform,
+';


### PR DESCRIPTION
Since the migration from list_type to CType the headers palette is missing in solr plugins showitem config.

In the [commit](https://github.com/TYPO3-Solr/ext-solr/commit/0c0f2b9532a29688c431883b913ff1b0c19bd50d#diff-7821b1083fe6eaa596eb4e69cdc60c01edc85992b54f3428d8f177c138db169eR42) the addition of 'pi_flexform' is replaced by the full definition. Since the headers palette is no part of the [automatically added palettes](https://docs.typo3.org/m/typo3/reference-tca/13.4/en-us/Types/TtContent.html#types-content) it is left out.

---

**Note: Required by TYPO3 14**

TYPO3 14's `fluid_styled_content` templates use the new `TextViewHelper`
(`f:render.text`) which accesses record fields via the strict `Record`
domain object. `Record::get('header')` only works if the field is
defined in the CType's TCA sub-schema via `showitem`.

The EXT:solr plugin CTypes (`solr_pi_search`, `solr_pi_frequentlySearched`,
`solr_pi_results`) had minimal `showitem` definitions without the standard
`--palette--;;headers`. This caused `RecordPropertyNotFoundException` when
rendering content elements on pages containing solr plugins.

---

Fixes: #4420
Ports: #4535
