### PR TITLE
[BUGFIX:13.1] Catch InvalidArgumentException for missing site languages in GarbageHandler

### DIFF
--- a/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/GarbageHandler.php
@@ -20,6 +20,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\StrategyFactory;
 use ApacheSolrForTypo3\Solr\Domain\Site\Exception\UnexpectedTYPO3SiteInitializationException;
 use Doctrine\DBAL\Exception as DBALException;
+use InvalidArgumentException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
@@ -198,7 +199,7 @@ class GarbageHandler extends AbstractUpdateHandler
     {
         try {
             $isAllowedPageType = $this->frontendEnvironment->isAllowedPageType($record);
-        } catch (SiteNotFoundException $e) {
+        } catch (SiteNotFoundException | InvalidArgumentException $e) {
             $this->logger->log(
                 LogLevel::WARNING,
                 'Couldn\t determine site for page ' . $record['uid'],


### PR DESCRIPTION
When page records reference a sys_language_uid that is not configured in the site, Site::getLanguageById() throws an InvalidArgumentException. The existing catch only handles SiteNotFoundException. This adds InvalidArgumentException to the catch block so pages with unconfigured languages are treated as non-indexable instead of crashing.

Fixes: #4533
Ports: #4534