### PR TITLE
[BUGFIX] Allow GroupItemPaginateViewHelper template to be overriden

### DIFF
--- a/Classes/ViewHelpers/GroupItemPaginateViewHelper.php
+++ b/Classes/ViewHelpers/GroupItemPaginateViewHelper.php
@@ -75,7 +75,7 @@ class GroupItemPaginateViewHelper extends AbstractSolrViewHelper
             ],
         );
 
-        $paginationRendered = $paginationView->render();
+        $paginationRendered = $paginationView->render('GroupItemPaginate/Index');
 
         $variableProvider = $this->renderingContext->getVariableProvider();
         $variableProvider->add('paginator', $paginator);
@@ -129,7 +129,6 @@ class GroupItemPaginateViewHelper extends AbstractSolrViewHelper
             layoutRootPaths: $layoutRootPaths,
             request: $request,
             format: 'html',
-            templatePathAndFilename: GeneralUtility::getFileAbsFileName('EXT:solr/Resources/Private/Templates/ViewHelpers/GroupItemPaginate/Index.html'),
         ));
     }
 


### PR DESCRIPTION
Relates: #4541

By not passing a fixed `templatePathAndFilename` all templatePaths are checked again. This makes it possible to provide custom templates for the GroupItemPaginateViewHelper.