### PR TITLE
[BUGFIX] Polish infobox to align with current ContextualFeedbackSeverity

### DIFF
--- a/Resources/Private/Partials/Backend/NoSiteAvailable.html
+++ b/Resources/Private/Partials/Backend/NoSiteAvailable.html
@@ -1,6 +1,6 @@
 <f:if condition="{showSelectOtherPage}">
 	<f:then>
-		<f:be.infobox title="No site could be found." state="3">
+		<f:be.infobox title="No site could be found." state="2">
 			<p>Please choose other page in the page tree, which has solr configured.</p>
 		</f:be.infobox>
 	</f:then>
@@ -8,7 +8,7 @@
 	<f:else>
 		<p>When all of these steps are done check this module again.</p>
 
-		<f:be.infobox title="There is no site configured for your solr extension!" state="3">
+		<f:be.infobox title="There is no site configured for your solr extension!" state="2">
 			<p>Please check the following:</p>
 			<p>If you want to use solr with the TYPO3 site configuration:</p>
 


### PR DESCRIPTION
# What this PR does

Fixes the usage of an invalid state="3" value in the f:be.infobox ViewHelper within NoSiteAvailable.html.

state="3" does not map to any valid enum case, which causes the infobox to render incorrectly (or throw an error) in TYPO3 v14. This PR updates both occurrences in Resources/Private/Partials/Backend/NoSiteAvailable.html to use state="2" (ERROR), which is the appropriate severity for a missing/misconfigured site.

# How to test

1. Open the TYPO3 backend with EXT:solr installed
2. Navigate to a page in the Solr module that has no site configuration
3. Verify the infobox renders correctly with an error-level styling (red/danger) instead of breaking or falling back to a default style

  Fixes: #4550