### PR TITLE
[BUGFIX] Update backend form rendering result processing

### DIFF
--- a/Classes/Backend/IndexingConfigurationSelectorField.php
+++ b/Classes/Backend/IndexingConfigurationSelectorField.php
@@ -17,7 +17,6 @@ namespace ApacheSolrForTypo3\Solr\Backend;
 
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use TYPO3\CMS\Backend\Form\Exception as BackendFormException;
-use TYPO3\CMS\Backend\Form\FormResultFactory;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
@@ -203,17 +202,16 @@ class IndexingConfigurationSelectorField
         $options['parameterArray']['fieldConf']['config']['items'] = $items;
         $options['parameterArray']['fieldTSConfig']['noMatchingValue_label'] = '';
 
-        $selectCheckboxResult = $nodeFactory->create($options)->render();
-        $formResult = GeneralUtility::makeInstance(FormResultFactory::class)->create($selectCheckboxResult);
+        $formResult = $nodeFactory->create($options)->render();
 
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-        foreach ($formResult->stylesheetFiles as $stylesheetFile) {
+        foreach ($formResult['stylesheetFiles'] as $stylesheetFile) {
             $pageRenderer->addCssFile($stylesheetFile);
         }
-        foreach ($formResult->javaScriptModules as $module) {
+        foreach ($formResult['javaScriptModules'] as $module) {
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction($module);
         }
 
-        return $formResult->html;
+        return $formResult['html'];
     }
 }


### PR DESCRIPTION
# What this pr does

Adapts to changes in how form rendering results are returned by `NodeFactory->render()`. The `render()` method now directly returns an array structure, removing the need for `FormResultFactory` and updating asset extraction to use array keys.

# How to test

  1. Install EXT:solr on TYPO3 v14
  2. Go to the Solr backend module > Index Queue
  3. Select a site with indexing configurations
  4. Click "Initialize Indexing" to trigger the indexing configuration selector
  5. Verify the checkbox selector renders correctly without errors

Fixes: #4552
