### PR TITLE
[TASK] Speed up tests by sending autoCommit for updates

### DIFF
--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -58,7 +58,7 @@ class SearchControllerTest extends IntegrationTestBase
      */
     protected function tearDown(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
     }
 

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -50,7 +50,7 @@ class SuggestControllerTest extends IntegrationTestBase
      */
     protected function tearDown(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
     }
 

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -70,7 +70,7 @@ class IndexServiceTest extends IntegrationTestBase
     #[Test]
     public function canResolveBaseAsPrefix(string $absRefPrefix, string $expectedUrl): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_custom_record_withBasePrefix_' . $absRefPrefix . '.csv');
 
@@ -96,6 +96,6 @@ class IndexServiceTest extends IntegrationTestBase
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         self::assertStringContainsString('"numFound":1', $solrContent, 'Could not index document into solr');
         self::assertStringContainsString('"url":"' . $expectedUrl, $solrContent, 'Generated unexpected url with absRefPrefix = auto');
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
     }
 }

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -45,7 +45,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
      */
     protected function tearDown(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         unset($this->apacheSolrDocumentRepository);
         parent::tearDown();
     }

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -43,7 +43,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
      */
     protected function tearDown(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
     }
 

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -506,6 +506,7 @@ class GarbageCollectorTest extends IntegrationTestBase
         foreach ($this->indexQueue->getAllItems() as $item) {
             self::assertTrue($this->indexPageQueueItem($item), 'Queue item failed to be indexed.');
         }
+        $this->waitToBeVisibleInSolr();
         self::assertSolrContainsDocumentCount(2, 'Initial number of documents in index not as expected');
 
         $this->dataHandler->start(
@@ -619,6 +620,8 @@ class GarbageCollectorTest extends IntegrationTestBase
                 'Queue item failed to be indexed in german translation.',
             );
         }
+        $this->waitToBeVisibleInSolr();
+        $this->waitToBeVisibleInSolr('core_de');
         self::assertSolrContainsDocumentCount(2, 'Initial number of documents in english index not as expected', 'core_en');
         self::assertSolrContainsDocumentCount(2, 'Initial number of documents in german index not as expected', 'core_de');
 
@@ -726,7 +729,7 @@ class GarbageCollectorTest extends IntegrationTestBase
      */
     protected function prepareCanRemoveDeletedContentElement(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexed_content.csv');
 
@@ -761,7 +764,6 @@ class GarbageCollectorTest extends IntegrationTestBase
 
         // we index this item
         $this->indexPages([1]);
-        $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
@@ -919,13 +921,12 @@ class GarbageCollectorTest extends IntegrationTestBase
      */
     protected function prepareCanRemoveContentElementTests(array $dataMap, string $fixture = 'indexed_content.csv', array $indexPageIds = [1]): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/' . $fixture);
 
         // we index a page with two content elements and expect solr contains the content of both
         $this->indexPages($indexPageIds);
-        $this->waitToBeVisibleInSolr();
 
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         if ($fixture === 'indexed_content.csv') {
@@ -958,7 +959,6 @@ class GarbageCollectorTest extends IntegrationTestBase
             $pages[] = $item->getRecordUid();
         }
         $this->indexPages($pages);
-        $this->waitToBeVisibleInSolr();
 
         // now only one document should be left with the content of the first content element
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
@@ -999,7 +999,6 @@ class GarbageCollectorTest extends IntegrationTestBase
             $pages[] = $item->getRecordUid();
         }
         $this->indexPages($pages);
-        $this->waitToBeVisibleInSolr();
 
         // now only one document should be left with the content of the first content element
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
@@ -1088,7 +1087,7 @@ class GarbageCollectorTest extends IntegrationTestBase
      */
     protected function prepareCanRemovePagesTests(array $dataMap, array $cmdMap = []): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         $this->addSimpleFrontendRenderingToTypoScriptRendering(1);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_remove_page.csv');
 
@@ -1160,7 +1159,7 @@ class GarbageCollectorTest extends IntegrationTestBase
             }',
         );
 
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
 
         $this->addToQueueAndIndexRecord('tx_fakeextension_domain_model_foo', 111);
         $this->waitToBeVisibleInSolr();

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -46,15 +46,13 @@ class PageIndexerTest extends IntegrationTestBase
      */
     protected function tearDown(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
         parent::tearDown();
     }
 
     #[Test]
     public function canIndexPageIntoSolr(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_into_solr.csv');
         $this->addSimpleFrontendRenderingToTypoScriptRendering(
             1,
@@ -83,8 +81,6 @@ class PageIndexerTest extends IntegrationTestBase
     #[Test]
     public function canIndexPageWithCustomPageTypeIntoSolr(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_custom_pagetype_into_solr.csv');
 
         // @TODO: Check page type in fixture, currently not set to 130
@@ -119,8 +115,6 @@ class PageIndexerTest extends IntegrationTestBase
     #[Test]
     public function canIndexTranslatedPageToPageRelation(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_page_with_relation_to_page.csv');
         $this->addSimpleFrontendRenderingToTypoScriptRendering(
             1,
@@ -149,8 +143,7 @@ class PageIndexerTest extends IntegrationTestBase
         $solrContentDe = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
         self::assertStringContainsString('"title":"Seite"', $solrContentDe, 'Solr did not contain the translated page');
         self::assertStringContainsString('"relatedPageTitles_stringM":["Verwandte Seite"]', $solrContentDe, 'Did not get content of related field');
-
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty('core_de');
     }
 
     /**
@@ -159,8 +152,6 @@ class PageIndexerTest extends IntegrationTestBase
     #[Test]
     public function canIndexPageToCategoryRelation(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_page_with_relation_to_category.csv');
         $this->addSimpleFrontendRenderingToTypoScriptRendering(
             1,
@@ -182,8 +173,6 @@ class PageIndexerTest extends IntegrationTestBase
         $solrContentEn = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*');
         self::assertStringContainsString('"title":"Sub page"', $solrContentEn, 'Solr did not contain the english page');
         self::assertStringContainsString('"categories_stringM":["Test"]', $solrContentEn, 'There is no relation for the original, so ther should not be a related field');
-
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
     }
 
     #[Test]
@@ -247,8 +236,6 @@ class PageIndexerTest extends IntegrationTestBase
     #[Test]
     public function canExecutePostProcessor(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
-
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_into_solr.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexQueuedPage();
@@ -303,7 +290,6 @@ class PageIndexerTest extends IntegrationTestBase
     {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids'] = 1;
 
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_mounted_page.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexQueuedPage();
@@ -335,7 +321,6 @@ class PageIndexerTest extends IntegrationTestBase
     {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids'] = 1;
 
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_mounted_page_from_another_site.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexQueuedPage();
@@ -365,7 +350,6 @@ class PageIndexerTest extends IntegrationTestBase
     #[Test]
     public function canIndexMultipleMountedPage(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_multiple_mounted_page.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
 

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -120,7 +120,7 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         // cleanup the solr server
         $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
         $response = $requestFactory->request(
-            $this->getSolrConnectionUriAuthority() . '/solr/' . $coreName . '/update',
+            $this->getSolrConnectionUriAuthority() . '/solr/' . $coreName . '/update?commit=true',
             'POST',
             [
                 'headers' => ['Content-Type' => 'application/xml'],
@@ -132,9 +132,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         if (!str_contains($result, '<int name="QTime">')) {
             self::fail('Could not empty solr test index');
         }
-
-        // we wait to make sure the document will be deleted in solr
-        $this->waitToBeVisibleInSolr($coreName);
 
         $this->assertSolrIsEmpty($coreName);
     }
@@ -153,11 +150,18 @@ abstract class IntegrationTestBase extends FunctionalTestCase
     /**
      * @throws InvalidArgumentException
      */
-    protected function waitToBeVisibleInSolr(string $coreName = 'core_en'): array|false
+    protected function waitToBeVisibleInSolr(string $coreName = 'core_en'): void
     {
         $this->validateTestCoreName($coreName);
-        $url = $this->getSolrConnectionUriAuthority() . '/solr/' . $coreName . '/update?softCommit=true';
-        return get_headers($url);
+        $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+        $requestFactory->request(
+            $this->getSolrConnectionUriAuthority() . '/solr/' . $coreName . '/update?commit=true',
+            'POST',
+            [
+                'headers' => ['Content-Type' => 'application/xml'],
+                'body' => '<commit/>',
+            ],
+        );
     }
 
     /**
@@ -284,7 +288,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         $this->importRootPagesAndTemplatesForConfiguredSites();
 
         clearstatcache();
-        usleep(500);
         self::$lastSiteCreated = $siteCreatedHash;
     }
 
@@ -450,7 +453,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         );
 
         $response = $this->executePageIndexer($frontendUrl, $item);
-        $this->waitToBeVisibleInSolr($coreName);
 
         $connection = $this->getConnectionPool()->getConnectionForTable('sys_template');
         $connection->update(

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -54,7 +54,7 @@ class SearchTest extends IntegrationTestBase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
     }
 
     /**
@@ -65,7 +65,6 @@ class SearchTest extends IntegrationTestBase
     #[Test]
     public function canSearchForADocument(): void
     {
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Search/can_search.csv');
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
 

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -146,6 +146,6 @@ class ReIndexTaskTest extends IntegrationTestBase
         $this->assertSolrIsEmpty();
 
         // if not we cleanup now
-        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        $this->cleanUpSolrServerAndAssertEmpty();
     }
 }


### PR DESCRIPTION
cleanUpSolrServerAndAssertEmpty() gets a "?commit=true" call, so many waitToBeVisibleInSolr() calls were removed, and waitToBeVisibleInSolr() itself uses RequestFactory and commit=true instead of softCommit so no wait time is needed anymore.

A usleep() call was removed as it is not needed, as we use clearstatcache() and PHP 8 does not need this anymore.

