### PR TITLE
[TASK] Update test extension path in IntegrationTestBase

### DIFF
--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -80,7 +80,7 @@ abstract class IntegrationTestBase extends FunctionalTestCase
     ];
 
     protected array $testExtensionsToLoad = [
-        'typo3conf/ext/solr',
+        'apache-solr-for-typo3/solr',
     ];
 
     protected array $testSolrCores = [


### PR DESCRIPTION
* Adjust path from `typo3conf/ext/solr` to `apache-solr-for-typo3/solr` in `$testExtensionsToLoad`