### PR TITLE
[TASK] Remove deprecated Solr error handler and adjust PHPUnit configs

### DIFF
--- a/Build/Test/IntegrationTestsWithProcessIsolation.xml
+++ b/Build/Test/IntegrationTestsWithProcessIsolation.xml
@@ -16,6 +16,7 @@
 		 failOnRisky="true"
 		 failOnWarning="false"
 		 failOnPhpunitDeprecation="true"
+		 processIsolation="true"
 >
 	<source>
 		<include>
@@ -24,10 +25,11 @@
 	</source>
 	<testsuites>
 		<testsuite name="ext-solr-integration-tests">
-			<directory>../../Tests/Integration/Access/</directory>
-			<directory>../../Tests/Integration/ContentObject/</directory>
-			<directory>../../Tests/Integration/FrontendEnvironment/</directory>
-			<directory>../../Tests/Integration/System/Records/</directory>
+			<directory>../../Tests/Integration/</directory>
+			<exclude>../../Tests/Integration/Access/</exclude>
+			<exclude>../../Tests/Integration/ContentObject/</exclude>
+			<exclude>../../Tests/Integration/FrontendEnvironment/</exclude>
+			<exclude>../../Tests/Integration/System/Records/</exclude>
 		</testsuite>
 	</testsuites>
 	<php>

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -51,7 +51,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 abstract class IntegrationTestBase extends FunctionalTestCase
 {
     use SiteBasedTestTrait;
-    private $previousErrorHandler;
 
     protected array $coreExtensionsToLoad = [
         'typo3/cms-install',
@@ -98,14 +97,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         //this is needed by the TYPO3 core.
         chdir(Environment::getPublicPath() . '/');
         $this->instancePath = $this->getInstancePath();
-        $this->previousErrorHandler = $this->failWhenSolrDeprecationIsCreated();
-    }
-
-    protected function tearDown(): void
-    {
-        set_error_handler($this->previousErrorHandler);
-
-        parent::tearDown();
     }
 
     /**
@@ -307,23 +298,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sites_setup_and_data_set/01_integration_tree_one.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sites_setup_and_data_set/02_integration_tree_two.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/sites_setup_and_data_set/03_integration_tree_three.csv');
-    }
-
-    /**
-     * This method registers an error handler that fails the testcase when an E_USER_DEPRECATED error
-     * is thrown with the prefix solr:deprecation
-     */
-    protected function failWhenSolrDeprecationIsCreated(): ?callable
-    {
-        error_reporting(error_reporting() & ~E_USER_DEPRECATED);
-        return set_error_handler(
-            function (int $id, string $msg, string $file, int $line): bool {
-                if ($id === E_USER_DEPRECATED && str_starts_with($msg, 'solr:deprecation: ')) {
-                    $this->fail("Executed deprecated EXT:solr code: in $file:$line" . PHP_EOL . $msg);
-                }
-                return true;
-            },
-        );
     }
 
     protected function getSolrConnectionInfo(): array

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,8 @@
     ],
     "tests:integration": [
       "Composer\\Config::disableProcessTimeout",
-      "phpunit --config=Build/Test/IntegrationTests.xml"
+      "phpunit --config=Build/Test/IntegrationTests.xml",
+      "phpunit --config=Build/Test/IntegrationTestsWithProcessIsolation.xml"
     ],
     "tests:phpstan": [
       "phpstan analyze -c Build/Test/phpstan.neon"


### PR DESCRIPTION
* Removed the custom Solr deprecation error handler from IntegrationTestBase.
* Added a new PHPUnit configuration for tests with process isolation.
* Updated existing PHPUnit configuration to refine error and warning handling.