### PR TITLE
[TASK] Refactor UnitTests for Rootline and RootlineElement

### DIFF
--- a/Tests/Unit/Access/RootlineElementTest.php
+++ b/Tests/Unit/Access/RootlineElementTest.php
@@ -16,6 +16,7 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\Access;
 
 use ApacheSolrForTypo3\Solr\Access\RootlineElement;
+use ApacheSolrForTypo3\Solr\Access\RootlineElementFormatException;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -26,6 +27,15 @@ use Traversable;
  */
 class RootlineElementTest extends SetUpUnitTestCase
 {
+    /**
+     * @return Traversable<string, array{
+     *     stringRepresentation: string,
+     *     expectedType: int,
+     *     expectedGroups: list<int>,
+     *     expectedPageId: ?int,
+     *     expectedToString: string
+     * }>
+     */
     public static function validRootLineRePresentations(): Traversable
     {
         yield 'empty' => [
@@ -101,23 +111,27 @@ class RootlineElementTest extends SetUpUnitTestCase
     }
 
     /**
-     * @param string $stringRepresentation
-     * @param int $expectedType
-     * @param array $expectedGroups
-     * @param int|null $expectedPageId
-     * @param string $expectedToString
+     * @param list<int> $expectedGroups
+     * @throws RootlineElementFormatException
      */
-    #[DataProvider('validRootLineRePresentations')]
     #[Test]
-    public function canParse($stringRepresentation, $expectedType, $expectedGroups, $expectedPageId, $expectedToString): void
-    {
+    #[DataProvider(
+        methodName: 'validRootLineRePresentations',
+    )]
+    public function canParse(
+        string $stringRepresentation,
+        int $expectedType,
+        array $expectedGroups,
+        ?int $expectedPageId,
+        string $expectedToString,
+    ): void {
         $rootLine = new RootlineElement($stringRepresentation);
 
         self::assertSame($expectedType, $rootLine->getType(), 'Unexpected type after parsing the RootlineElement');
         self::assertSame($expectedGroups, $rootLine->getGroups(), 'Unexpected groups after parsing the RootlineElement');
         self::assertSame($expectedPageId, $rootLine->getPageId(), 'Unexpected pageId after parsing the RootlineElement field');
 
-        // most of the times the to string value is the same
+        // most of the time the string value is the same
         self::assertSame($expectedToString, (string)$rootLine, 'Conversion to string is not returning expected result');
     }
 }

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -26,19 +26,43 @@ use Traversable;
  */
 class RootlineTest extends SetUpUnitTestCase
 {
+    /**
+     * @return Traversable<string, array{
+     *     rootLineString: string,
+     *     expectedGroups: list<int>
+     * }>
+     */
     public static function rootLineDataProvider(): Traversable
     {
-        yield 'simple' => ['rootLineString' => 'c:0', 'expectedGroups' => [0]];
-        yield 'simpleOneGroup' => ['rootLineString' => 'c:1', 'expectedGroups' => [1]];
-        yield 'mixed' => ['rootLineString' => '35:1/c:0', 'expectedGroups' => [0, 1]];
+        yield 'simple' => [
+            'rootLineString' => 'c:0',
+            'expectedGroups' => [0],
+        ];
+        yield 'simpleOneGroup' => [
+            'rootLineString' => 'c:1',
+            'expectedGroups' => [1],
+        ];
+        yield 'mixed' => [
+            'rootLineString' => '35:1/c:0',
+            'expectedGroups' => [0, 1],
+        ];
     }
 
-    #[DataProvider('rootLineDataProvider')]
+    /**
+     * @param list<int> $expectedGroups
+     */
     #[Test]
-    public function canParse(string $rootLineString, $expectedGroups): void
+    #[DataProvider(
+        methodName: 'rootLineDataProvider',
+    )]
+    public function canParse(string $rootLineString, array $expectedGroups): void
     {
-        $rootline = new Rootline($rootLineString);
-        $groups = $rootline->getGroups();
-        self::assertSame($expectedGroups, $groups);
+        $rootLine = new Rootline($rootLineString);
+        $groups = $rootLine->getGroups();
+
+        self::assertSame(
+            $expectedGroups,
+            $groups,
+        );
     }
 }


### PR DESCRIPTION
- Add type annotations and improve readability by reformatting arrays.
- Replace inline `DataProvider` references with `methodName` annotation.
- Add thrown exception annotation to RootlineElementTest.