### PR TITLE
[TASK] Refactor facet ViewHelpers to use shared trait

### DIFF
--- a/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/AddFacetItemViewHelper.php
@@ -15,20 +15,43 @@
 
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
 
-/**
- * Class AddFacetItemViewHelper
- */
-class AddFacetItemViewHelper extends AbstractValueViewHelper
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\AbstractUriViewHelper;
+
+class AddFacetItemViewHelper extends AbstractUriViewHelper
 {
+    use ValueViewHelperArgumentTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('facet', AbstractFacet::class, 'The facet');
+        $this->registerArgument('facetName', 'string', 'The facet name');
+        $this->registerArgument('facetItem', AbstractFacetItem::class, 'The facet item');
+        $this->registerArgument('facetItemValue', 'string', 'The facet item');
+        $this->registerArgument('resultSet', SearchResultSet::class, 'The result set');
+    }
+
     /**
      * Renders URI for adding the facet item.
      */
-    public function render()
+    public function render(): string
     {
-        $name = self::getNameFromArguments($this->arguments);
-        $itemValue = self::getValueFromArguments($this->arguments);
-        $resultSet = self::getResultSetFromArguments($this->arguments);
+        $name = $this->getNameFromArguments($this->arguments);
+        $itemValue = $this->getValueFromArguments($this->arguments);
+        $resultSet = $this->getResultSetFromArguments($this->arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
-        return self::getSearchUriBuilder($this->renderingContext)->getAddFacetValueUri($previousRequest, $name, $itemValue);
+
+        return self::getSearchUriBuilder($this->renderingContext)->getAddFacetValueUri(
+            $previousRequest,
+            $name,
+            $itemValue,
+        );
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelper.php
@@ -15,21 +15,43 @@
 
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
 
-/**
- * Class RemoveFacetItemViewHelper
- */
-class RemoveFacetItemViewHelper extends AbstractValueViewHelper
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\AbstractUriViewHelper;
+
+class RemoveFacetItemViewHelper extends AbstractUriViewHelper
 {
+    use ValueViewHelperArgumentTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('facet', AbstractFacet::class, 'The facet');
+        $this->registerArgument('facetName', 'string', 'The facet name');
+        $this->registerArgument('facetItem', AbstractFacetItem::class, 'The facet item');
+        $this->registerArgument('facetItemValue', 'string', 'The facet item');
+        $this->registerArgument('resultSet', SearchResultSet::class, 'The result set');
+    }
+
     /**
      * Renders URI for removing the facet item.
      */
-    public function render()
+    public function render(): string
     {
-        $name = self::getNameFromArguments($this->arguments);
-        $itemValue = self::getValueFromArguments($this->arguments);
-        $resultSet = self::getResultSetFromArguments($this->arguments);
+        $name = $this->getNameFromArguments($this->arguments);
+        $itemValue = $this->getValueFromArguments($this->arguments);
+        $resultSet = $this->getResultSetFromArguments($this->arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
 
-        return self::getSearchUriBuilder($this->renderingContext)->getRemoveFacetValueUri($previousRequest, $name, $itemValue);
+        return $this->getSearchUriBuilder($this->renderingContext)->getRemoveFacetValueUri(
+            $previousRequest,
+            $name,
+            $itemValue,
+        );
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
+++ b/Classes/ViewHelpers/Uri/Facet/SetFacetItemViewHelper.php
@@ -15,21 +15,43 @@
 
 namespace ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet;
 
-/**
- * Class SetFacetItemViewHelper
- */
-class SetFacetItemViewHelper extends AbstractValueViewHelper
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
+use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\AbstractUriViewHelper;
+
+class SetFacetItemViewHelper extends AbstractUriViewHelper
 {
+    use ValueViewHelperArgumentTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('facet', AbstractFacet::class, 'The facet');
+        $this->registerArgument('facetName', 'string', 'The facet name');
+        $this->registerArgument('facetItem', AbstractFacetItem::class, 'The facet item');
+        $this->registerArgument('facetItemValue', 'string', 'The facet item');
+        $this->registerArgument('resultSet', SearchResultSet::class, 'The result set');
+    }
+
     /**
      * Renders URI for setting the facet item.
      */
-    public function render()
+    public function render(): string
     {
-        $name = self::getNameFromArguments($this->arguments);
-        $itemValue = self::getValueFromArguments($this->arguments);
-        $resultSet = self::getResultSetFromArguments($this->arguments);
+        $name = $this->getNameFromArguments($this->arguments);
+        $itemValue = $this->getValueFromArguments($this->arguments);
+        $resultSet = $this->getResultSetFromArguments($this->arguments);
         $previousRequest = $resultSet->getUsedSearchRequest();
 
-        return self::getSearchUriBuilder($this->renderingContext)->getSetFacetValueUri($previousRequest, $name, $itemValue);
+        return $this->getSearchUriBuilder($this->renderingContext)->getSetFacetValueUri(
+            $previousRequest,
+            $name,
+            $itemValue,
+        );
     }
 }

--- a/Classes/ViewHelpers/Uri/Facet/ValueViewHelperArgumentTrait.php
+++ b/Classes/ViewHelpers/Uri/Facet/ValueViewHelperArgumentTrait.php
@@ -19,30 +19,13 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItem;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
-use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\AbstractUriViewHelper;
 
-/**
- * Class AbstractValueViewHelper
- */
-abstract class AbstractValueViewHelper extends AbstractUriViewHelper
+trait ValueViewHelperArgumentTrait
 {
-    /**
-     * @inheritdoc
-     */
-    public function initializeArguments(): void
-    {
-        parent::initializeArguments();
-        $this->registerArgument('facet', AbstractFacet::class, 'The facet');
-        $this->registerArgument('facetName', 'string', 'The facet name');
-        $this->registerArgument('facetItem', AbstractFacetItem::class, 'The facet item');
-        $this->registerArgument('facetItemValue', 'string', 'The facet item');
-        $this->registerArgument('resultSet', SearchResultSet::class, 'The result set');
-    }
-
     /**
      * Extracts and Returns value from given arguments.
      */
-    protected static function getValueFromArguments(array $arguments = []): string
+    private function getValueFromArguments(array $arguments = []): string
     {
         if (isset($arguments['facetItem'])) {
             /** @var AbstractFacetItem $facetItem */
@@ -63,7 +46,7 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     /**
      * Extracts and returns name from arguments.
      */
-    protected static function getNameFromArguments(array $arguments = []): string
+    private function getNameFromArguments(array $arguments = []): string
     {
         if (isset($arguments['facet'])) {
             /** @var AbstractFacet $facet */
@@ -84,7 +67,7 @@ abstract class AbstractValueViewHelper extends AbstractUriViewHelper
     /**
      * Extracts and returns result-set from arguments.
      */
-    protected static function getResultSetFromArguments(array $arguments = []): SearchResultSet
+    private function getResultSetFromArguments(array $arguments = []): SearchResultSet
     {
         if (isset($arguments['facet'])) {
             /** @var AbstractFacet $facet */


### PR DESCRIPTION
- Extract shared methods into new `ValueViewHelperArgumentTrait` for reuse.
- Replace `AbstractValueViewHelper` inheritance with trait in 
    - `AddFacetItemViewHelper`
    - `SetFacetItemViewHelper`
    - `RemoveFacetItemViewHelper`
- Remove obsolete `AbstractValueViewHelper` class.
- Migrate static calls
- Move initializeArguments method back into each ViewHelper.