### PR TITLE
[TASK] Fix namespace typo in SearchFormViewHelperTest

### DIFF
--- a/Tests/Integration/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Integration/ViewHelpers/SearchFormViewHelperTest.php
@@ -13,7 +13,7 @@
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace ApacheSolrForTypo3\Solr\Tests\Integration\ViewHelper;
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\ViewHelpers;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;


### PR DESCRIPTION
Correct namespace from `ViewHelper` to `ViewHelpers` in test file.