### PR TITLE
[TASK] Refactor and optimize Classification handling

### DIFF
--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -41,6 +41,10 @@ class Classification extends AbstractContentObject
 {
     public const CONTENT_OBJECT_NAME = 'SOLR_CLASSIFICATION';
 
+    public function __construct(
+        protected ClassificationService $classificationService,
+    ) {}
+
     /**
      * Executes the SOLR_CLASSIFICATION content object.
      *
@@ -70,10 +74,8 @@ class Classification extends AbstractContentObject
             $data = $this->cObj->stdWrap($data, $conf);
         }
         $classifications = $this->buildClassificationsFromConfiguration($configuredMappedClasses);
-        /** @var ClassificationService $classificationService */
-        $classificationService = GeneralUtility::makeInstance(ClassificationService::class);
 
-        return serialize($classificationService->getMatchingClassNames((string)$data, $classifications));
+        return serialize($this->classificationService->getMatchingClassNames((string)$data, $classifications));
     }
 
     /**
@@ -84,6 +86,7 @@ class Classification extends AbstractContentObject
     protected function buildClassificationsFromConfiguration(array $configuredMappedClasses): array
     {
         $classifications = [];
+
         foreach ($configuredMappedClasses as $class) {
             if ((empty($class['patterns']) && empty($class['matchPatterns'])) || empty($class['class'])) {
                 throw new InvalidArgumentException(
@@ -99,12 +102,7 @@ class Classification extends AbstractContentObject
             $unMatchPatters = empty($class['unmatchPatterns']) ? [] : GeneralUtility::trimExplode(',', $class['unmatchPatterns']);
 
             $className = $class['class'];
-            $classifications[] = GeneralUtility::makeInstance(
-                ClassificationItem::class,
-                $matchPatterns,
-                $unMatchPatters,
-                $className,
-            );
+            $classifications[] = new ClassificationItem($matchPatterns, $unMatchPatters, $className);
         }
 
         return $classifications;

--- a/Classes/Domain/Index/Classification/Classification.php
+++ b/Classes/Domain/Index/Classification/Classification.php
@@ -17,44 +17,17 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
 
-/**
- * Class Classification
- */
 class Classification
 {
-    /**
-     * Array of regular expressions
-     */
-    protected array $matchPatterns = [];
-
-    /**
-     * Array of regular expressions
-     */
-    protected array $unMatchPatterns = [];
-
-    protected string $mappedClass;
-
-    /**
-     * Classification constructor.
-     */
     public function __construct(
-        array $matchPatterns = [],
-        array $unMatchPatterns = [],
-        string $mappedClass = '',
-    ) {
-        $this->matchPatterns = $matchPatterns;
-        $this->unMatchPatterns = $unMatchPatterns;
-        $this->mappedClass = $mappedClass;
-    }
+        protected array $matchPatterns = [],
+        protected array $unMatchPatterns = [],
+        protected string $mappedClass = '',
+    ) {}
 
     public function getUnMatchPatterns(): array
     {
         return $this->unMatchPatterns;
-    }
-
-    public function setUnMatchPatterns(array $unMatchPatterns): void
-    {
-        $this->unMatchPatterns = $unMatchPatterns;
     }
 
     public function getMatchPatterns(): array
@@ -62,18 +35,8 @@ class Classification
         return $this->matchPatterns;
     }
 
-    public function setMatchPatterns(array $matchPatterns): void
-    {
-        $this->matchPatterns = $matchPatterns;
-    }
-
     public function getMappedClass(): string
     {
         return $this->mappedClass;
-    }
-
-    public function setMappedClass(string $mappedClass): void
-    {
-        $this->mappedClass = $mappedClass;
     }
 }

--- a/Classes/Domain/Index/Classification/ClassificationService.php
+++ b/Classes/Domain/Index/Classification/ClassificationService.php
@@ -17,9 +17,6 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Index\Classification;
 
-/**
- * Class ClassificationService
- */
 class ClassificationService
 {
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -377,7 +377,8 @@ services:
 
   ###  EXT:solr content objects
   ApacheSolrForTypo3\Solr\ContentObject\Classification:
-    shared: false
+    public: true
+    autowire: true
     tags:
       - name: frontend.contentobject
         identifier: 'SOLR_CLASSIFICATION'

--- a/Tests/Integration/ContentObject/ClassificationTest.php
+++ b/Tests/Integration/ContentObject/ClassificationTest.php
@@ -15,21 +15,34 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\ContentObject;
 
 use ApacheSolrForTypo3\Solr\ContentObject\Classification;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Tests for the SOLR_CLASSIFICATION cObj.
  */
-class ClassificationTest extends SetUpContentObject
+class ClassificationTest extends IntegrationTestBase
 {
-    protected function getTestableContentObjectClassName(): string
+    protected ContentObjectRenderer $contentObjectRenderer;
+
+    protected function setUp(): void
     {
-        return Classification::class;
+        parent::setUp();
+
+        $request = (new ServerRequest('https://example.com'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
+
+        $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $this->contentObjectRenderer->setRequest($request);
     }
 
     #[Test]
@@ -52,9 +65,15 @@ class ClassificationTest extends SetUpContentObject
             ],
         ];
 
-        $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize(['cms']);
-        self::assertEquals($expected, $actual);
+        $actual = $this->contentObjectRenderer->cObjGetSingle(
+            Classification::CONTENT_OBJECT_NAME,
+            $configuration,
+        );
+
+        self::assertEquals(
+            serialize(['cms']),
+            $actual,
+        );
     }
 
     public static function excludePatternDataProvider(): Traversable
@@ -69,8 +88,10 @@ class ClassificationTest extends SetUpContentObject
         ];
     }
 
-    #[DataProvider('excludePatternDataProvider')]
     #[Test]
+    #[DataProvider(
+        methodName: 'excludePatternDataProvider',
+    )]
     public function canExcludePatterns($input, $expectedOutput): void
     {
         $this->contentObjectRenderer->start(['content' => $input]);
@@ -86,8 +107,14 @@ class ClassificationTest extends SetUpContentObject
             ],
         ];
 
-        $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize($expectedOutput);
-        self::assertEquals($expected, $actual);
+        $actual = $this->contentObjectRenderer->cObjGetSingle(
+            Classification::CONTENT_OBJECT_NAME,
+            $configuration,
+        );
+
+        self::assertEquals(
+            serialize($expectedOutput),
+            $actual,
+        );
     }
 }

--- a/Tests/Unit/ContentObject/SetUpContentObject.php
+++ b/Tests/Unit/ContentObject/SetUpContentObject.php
@@ -43,8 +43,13 @@ abstract class SetUpContentObject extends SetUpUnitTestCase
         parent::setUp();
 
         $request = new ServerRequest();
+
         $this->contentObjectRenderer = $this->createMock(ContentObjectRenderer::class);
-        $this->contentObjectRenderer->method('getRequest')->willReturn($request);
+        $this->contentObjectRenderer
+            ->expects(self::any())
+            ->method('getRequest')
+            ->willReturn($request);
+
         $cObjectFactoryMock = $this->getMockBuilder(ContentObjectFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -53,9 +58,12 @@ abstract class SetUpContentObject extends SetUpUnitTestCase
         $this->testableContentObject->setRequest($request);
         $this->testableContentObject->setContentObjectRenderer($this->contentObjectRenderer);
 
-        $cObjectFactoryMock->method('getContentObject')->willReturnMap([
-            [($this->getTestableContentObjectClassName())::CONTENT_OBJECT_NAME, $request, $this->contentObjectRenderer, $this->testableContentObject],
-        ]);
+        $cObjectFactoryMock
+            ->expects(self::any())
+            ->method('getContentObject')
+            ->willReturnMap([
+                [($this->getTestableContentObjectClassName())::CONTENT_OBJECT_NAME, $request, $this->contentObjectRenderer, $this->testableContentObject],
+            ]);
 
         $container = new Container();
         $container->set(ContentObjectFactory::class, $cObjectFactoryMock);
@@ -64,33 +72,43 @@ abstract class SetUpContentObject extends SetUpUnitTestCase
 
         // Track data set via start() for use in stdWrap
         $data = [];
-        $this->contentObjectRenderer->method('start')->willReturnCallback(
-            function (array $inputData) use (&$data) {
-                $data = $inputData;
-            },
-        );
+        $this->contentObjectRenderer
+            ->expects(self::any())
+            ->method('start')
+            ->willReturnCallback(
+                function (array $inputData) use (&$data) {
+                    $data = $inputData;
+                },
+            );
 
         // Configure stdWrap to return field values from data
-        $this->contentObjectRenderer->method('stdWrap')->willReturnCallback(
-            function (string $content, array $conf) use (&$data) {
-                if (isset($conf['field']) && isset($data[$conf['field']])) {
-                    return $data[$conf['field']];
-                }
-                return $content;
-            },
-        );
+        $this->contentObjectRenderer
+            ->expects(self::any())
+            ->method('stdWrap')
+            ->willReturnCallback(
+                function (string $content, array $conf) use (&$data) {
+                    if (isset($conf['field']) && isset($data[$conf['field']])) {
+                        return $data[$conf['field']];
+                    }
+                    return $content;
+                },
+            );
 
         // Configure the mock to call the actual content object's render method
         $testableContentObject = $this->testableContentObject;
-        $this->contentObjectRenderer->method('cObjGetSingle')->willReturnCallback(
-            function (string $name, array $conf) use ($testableContentObject) {
-                $contentObjectName = ($testableContentObject::class)::CONTENT_OBJECT_NAME;
-                if ($name === $contentObjectName) {
-                    return $testableContentObject->render($conf);
-                }
-                return '';
-            },
-        );
+
+        $this->contentObjectRenderer
+            ->expects(self::any())
+            ->method('cObjGetSingle')
+            ->willReturnCallback(
+                function (string $name, array $conf) use ($testableContentObject) {
+                    $contentObjectName = ($testableContentObject::class)::CONTENT_OBJECT_NAME;
+                    if ($name === $contentObjectName) {
+                        return $testableContentObject->render($conf);
+                    }
+                    return '';
+                },
+            );
     }
 
     abstract protected function getTestableContentObjectClassName(): string;


### PR DESCRIPTION
- Set `public: true` and add `autowire: true` for Classification service.
- Refactor tests to use `IntegrationTestBase` and improve readability:
  - Add type annotations, reformat arrays, and streamline mock setup.
  - Replace inline `DataProvider` references with `methodName` annotation.
- Simplify `Classification` and `ClassificationService` classes:
  - Implement constructor property promotion.
  - Remove unused setter methods.
  - Optimize instance creation by replacing `GeneralUtility::makeInstance` with direct instantiation.