### PR TITLE
[BUGFIX] GeneralUtility::trimExplode(): Argument #2 ($string) must be of type string, int given

### DIFF
--- a/Classes/FieldProcessor/PageUidToHierarchy.php
+++ b/Classes/FieldProcessor/PageUidToHierarchy.php
@@ -60,7 +60,7 @@ class PageUidToHierarchy extends AbstractHierarchyProcessor implements FieldProc
         $results = [];
 
         foreach ($values as $value) {
-            $rootPageUidAndMountPoint = GeneralUtility::trimExplode(',', $value, true, 2);
+            $rootPageUidAndMountPoint = GeneralUtility::trimExplode(',', (string)$value, true, 2);
             $results[] = $this->getSolrRootlineForPageId(
                 (int)$rootPageUidAndMountPoint[0],
                 $rootPageUidAndMountPoint[1] ?? '',


### PR DESCRIPTION
Resolves: #4370
Ports: #4511