### PR TITLE
[TASK] Refactor event listeners with `AsEventListener` attribute

### DIFF
--- a/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedPathVariableModifier.php
@@ -20,27 +20,29 @@ namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 use ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
 use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Event listener to handle path elements containing placeholder
  *
- *
  * @noinspection PhpUnused Listener for {@link BeforeCachedVariablesAreProcessedEvent}
  */
-class CachedPathVariableModifier
+final readonly class CachedPathVariableModifier
 {
-    protected RoutingService $routingService;
-
+    #[AsEventListener(
+        identifier: 'solr.routing.cachedurl-modifier',
+    )]
     public function __invoke(BeforeCachedVariablesAreProcessedEvent $event): void
     {
         if (!$event->hasRouting()) {
             return;
         }
+
         $pathVariables = $this->getPathVariablesFromUri($event->getUri());
 
-        // No path variables exists .. skip processing
-        if (empty($pathVariables)) {
+        // No path variables exist. Skip processing
+        if ($pathVariables === []) {
             return;
         }
 
@@ -48,13 +50,12 @@ class CachedPathVariableModifier
         $variableValues = $event->getVariableValues();
         $enhancerConfiguration = $event->getRouterConfiguration();
 
-        $this->routingService = GeneralUtility::makeInstance(
-            RoutingService::class,
+        $routingService = $this->getRoutingService(
             $enhancerConfiguration['solr'] ?? [],
             (string)$enhancerConfiguration['extensionKey'],
         );
 
-        if (!$this->routingService->isRouteEnhancerForSolr((string)$enhancerConfiguration['type'])) {
+        if (!$routingService->isRouteEnhancerForSolr((string)$enhancerConfiguration['type'])) {
             return;
         }
 
@@ -63,13 +64,15 @@ class CachedPathVariableModifier
         $variableKeysCount = count($variableKeys);
         for ($i = 0; $i < $variableKeysCount; $i++) {
             $standardizedKey = $this->standardizeKey($variableKeys[$i]);
-            if (!$this->containsPathVariable($standardizedKey, $pathVariables) || empty($variableValues[$standardizedKey])) {
+            if (!$this->containsPathVariable($standardizedKey, $pathVariables, $routingService)
+                || empty($variableValues[$standardizedKey])
+            ) {
                 continue;
             }
             // Note: Some values contain the multi value separator
             if ($this->containsMultiValue()) {
-                // Note: if the customer configured a + as separator an additional check on the facet value is required!
-                $facets = $this->routingService->pathFacetStringToArray(
+                // Note: if the customer configured a + as a separator, an additional check on the facet value is required!
+                $facets = $routingService->pathFacetStringToArray(
                     $this->standardizeKey((string)$variableValues[$standardizedKey]),
                 );
 
@@ -84,7 +87,7 @@ class CachedPathVariableModifier
                         $singleValues[$index - 1] .= ' ' . $facet;
                     }
                 }
-                $value = $this->routingService->pathFacetsToString($singleValues);
+                $value = $routingService->pathFacetsToString($singleValues);
             } else {
                 $value = explode(
                     ':',
@@ -103,7 +106,7 @@ class CachedPathVariableModifier
     /**
      * Extract path variables from URI
      */
-    protected function getPathVariablesFromUri(UriInterface $uri): array
+    private function getPathVariablesFromUri(UriInterface $uri): array
     {
         $elements = explode('/', $uri->getPath());
         $variables = [];
@@ -124,9 +127,9 @@ class CachedPathVariableModifier
     }
 
     /**
-     * Standardize a given string in order to reduce the amount of if blocks
+     * Standardize a given string to reduce the number of if blocks
      */
-    protected function standardizeKey(string $key): string
+    private function standardizeKey(string $key): string
     {
         $map = [
             '%23' => '#',
@@ -136,15 +139,19 @@ class CachedPathVariableModifier
     }
 
     /**
-     * Check if the variable is includes within the path variables
+     * Check if the variable is included within the path variables
      */
-    protected function containsPathVariable(string $variableName, array $pathVariables): bool
-    {
+    private function containsPathVariable(
+        string $variableName,
+        array $pathVariables,
+        RoutingService $routingService,
+    ): bool {
         if (in_array($variableName, $pathVariables)) {
             return true;
         }
+
         foreach ($pathVariables as $value) {
-            $segments = explode($this->routingService->getUrlFacetPathService()->getMultiValueSeparator(), $value);
+            $segments = explode($routingService->getUrlFacetPathService()->getMultiValueSeparator(), $value);
             if (in_array($variableName, $segments)) {
                 return true;
             }
@@ -153,9 +160,18 @@ class CachedPathVariableModifier
         return false;
     }
 
-    protected function containsMultiValue(): bool
+    private function containsMultiValue(): bool
     {
         // @todo: implement the check, or remove contents of if statement.
         return false;
+    }
+
+    private function getRoutingService(array $solrEnhancerConfiguration, string $extensionKey): RoutingService
+    {
+        return GeneralUtility::makeInstance(
+            RoutingService::class,
+            $solrEnhancerConfiguration,
+            $extensionKey,
+        );
     }
 }

--- a/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
+++ b/Classes/EventListener/EnhancedRouting/CachedUrlModifier.php
@@ -18,20 +18,25 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 
 use ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 
 /**
  * This modifier is in use if the URL processed by a route enhancer
  *
  * In this case some characters need to be replaced in order to do a placeholder replacement later
  */
-class CachedUrlModifier
+final readonly class CachedUrlModifier
 {
+    #[AsEventListener(
+        identifier: 'solr.routing.cachedurl-modifier',
+    )]
     public function __invoke(BeforeVariableInCachedUrlAreReplacedEvent $event): void
     {
-        // Do not react on routing events
+        // Do not react to routing events
         if (!$event->hasRouting()) {
             return;
         }
+
         $uri = $event->getUri();
         $path = $uri->getPath();
         $path = str_replace(':', '%3A', $path);

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -19,23 +19,26 @@ namespace ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting;
 
 use ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This event listener concat the filter if configured or masking is active.
  */
-class PostEnhancedUriProcessor
+final readonly class PostEnhancedUriProcessor
 {
+    #[AsEventListener(
+        identifier: 'solr.routing.postenhanceduriprocessor-modifier',
+    )]
     public function __invoke(AfterUriIsProcessedEvent $event): void
     {
         if (!$event->hasRouting()) {
             return;
         }
+
         $configuration = $event->getRouterConfiguration();
 
-        /** @var RoutingService $routingService */
-        $routingService = GeneralUtility::makeInstance(
-            RoutingService::class,
+        $routingService = $this->getRoutingService(
             $configuration['solr'] ?? [],
             (string)$configuration['extensionKey'],
         );
@@ -63,6 +66,16 @@ class PostEnhancedUriProcessor
         $query = http_build_query($queryParameters);
         $uri = $uri->withQuery($query);
         $uri = $uri->withPath($path);
+
         $event->replaceUri($uri);
+    }
+
+    private function getRoutingService(array $solrEnhancerConfiguration, string $extensionKey): RoutingService
+    {
+        return GeneralUtility::makeInstance(
+            RoutingService::class,
+            $solrEnhancerConfiguration,
+            $extensionKey,
+        );
     }
 }

--- a/Classes/EventListener/Extbase/PersistenceEventListener.php
+++ b/Classes/EventListener/Extbase/PersistenceEventListener.php
@@ -21,15 +21,16 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDelete
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordGarbageCheckEvent;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdatedEvent;
 use ApacheSolrForTypo3\Solr\Traits\SkipMonitoringTrait;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Extbase\Event\Persistence\EntityPersistedEvent;
 use TYPO3\CMS\Extbase\Event\Persistence\EntityRemovedFromPersistenceEvent;
 use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapFactory;
 
 /**
- * Event listener that handle record changes by \TYPO3\CMS\Extbase\Persistence\Generic\Backend
+ * Event listener that handles record changes by \TYPO3\CMS\Extbase\Persistence\Generic\Backend
  */
-class PersistenceEventListener
+final readonly class PersistenceEventListener
 {
     use SkipMonitoringTrait;
 
@@ -38,6 +39,9 @@ class PersistenceEventListener
         protected EventDispatcher $eventDispatcher,
     ) {}
 
+    #[AsEventListener(
+        identifier: 'solr.index.ExtbaseEntityPersisted',
+    )]
     public function entityPersisted(EntityPersistedEvent $event): void
     {
         $object = $event->getObject();
@@ -50,6 +54,9 @@ class PersistenceEventListener
         }
     }
 
+    #[AsEventListener(
+        identifier: 'solr.index.ExtbaseEntityRemoved',
+    )]
     public function entityRemoved(EntityRemovedFromPersistenceEvent $event): void
     {
         $object = $event->getObject();
@@ -59,7 +66,7 @@ class PersistenceEventListener
         }
     }
 
-    protected function getTableName(object $object): string
+    private function getTableName(object $object): string
     {
         $dataMap = $this->dataMapFactory->buildDataMap(get_class($object));
         return $dataMap->getTableName();

--- a/Classes/EventListener/PageIndexer/AdditionalFieldsForPageIndexing.php
+++ b/Classes/EventListener/PageIndexer/AdditionalFieldsForPageIndexing.php
@@ -19,7 +19,7 @@ namespace ApacheSolrForTypo3\Solr\EventListener\PageIndexer;
 
 use ApacheSolrForTypo3\Solr\Event\Indexing\AfterPageDocumentIsCreatedForIndexingEvent;
 use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 
 /**
  * Additional fields indexer.
@@ -29,30 +29,27 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Adds page document fields as configured in
  * plugin.tx_solr.index.additionalFields.
  */
-class AdditionalFieldsForPageIndexing
+final readonly class AdditionalFieldsForPageIndexing
 {
-    protected array $additionalIndexingFields = [];
-
-    protected array $additionalFieldNames = [];
-
-    protected ContentObjectService $contentObjectService;
-
-    public function __construct(?ContentObjectService $contentObjectService = null)
-    {
-        $this->contentObjectService = $contentObjectService ?? GeneralUtility::makeInstance(ContentObjectService::class);
-    }
+    public function __construct(
+        private ContentObjectService $contentObjectService,
+    ) {}
 
     /**
      * Returns a substituted document for the currently being indexed page.
      */
+    #[AsEventListener(
+        identifier: 'solr.index.AdditionalFieldsForPageIndexing',
+    )]
     public function __invoke(AfterPageDocumentIsCreatedForIndexingEvent $event): void
     {
-        $this->additionalIndexingFields = $event->getConfiguration()->getIndexAdditionalFieldsConfiguration();
-        $this->additionalFieldNames = $event->getConfiguration()->getIndexMappedAdditionalFieldNames();
-
         $originalPageDocument = $event->getDocument();
         $substitutePageDocument = clone $originalPageDocument;
-        $additionalFields = $this->getAdditionalFields();
+
+        $additionalFields = $this->getAdditionalFields(
+            $event->getConfiguration()->getIndexAdditionalFieldsConfiguration(),
+            $event->getConfiguration()->getIndexMappedAdditionalFieldNames(),
+        );
 
         foreach ($additionalFields as $fieldName => $fieldValue) {
             if (!isset($originalPageDocument->{$fieldName})) {
@@ -60,18 +57,22 @@ class AdditionalFieldsForPageIndexing
                 $substitutePageDocument->setField($fieldName, $fieldValue);
             }
         }
+
         $event->overrideDocument($substitutePageDocument);
     }
 
     /**
      * Gets the additional fields as an array mapping field names to values.
      */
-    protected function getAdditionalFields(): array
+    private function getAdditionalFields(array $additionalIndexingFields, array $additionalFieldNames): array
     {
         $additionalFields = [];
 
-        foreach ($this->additionalFieldNames as $additionalFieldName) {
-            $additionalFields[$additionalFieldName] = $this->getFieldValue($additionalFieldName);
+        foreach ($additionalFieldNames as $additionalFieldName) {
+            $additionalFields[$additionalFieldName] = $this->getFieldValue(
+                $additionalIndexingFields,
+                $additionalFieldName,
+            );
         }
 
         return $additionalFields;
@@ -80,8 +81,11 @@ class AdditionalFieldsForPageIndexing
     /**
      * Uses the page's cObj instance to resolve the additional field's value.
      */
-    protected function getFieldValue(string $fieldName): string
+    private function getFieldValue(array $additionalIndexingFields, string $fieldName): string
     {
-        return $this->contentObjectService->renderSingleContentObjectByArrayAndKey($this->additionalIndexingFields, $fieldName);
+        return $this->contentObjectService->renderSingleContentObjectByArrayAndKey(
+            $additionalIndexingFields,
+            $fieldName,
+        );
     }
 }

--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\UserGroupDetector;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -34,13 +35,16 @@ use TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontendGroupsEvent;
  *
  * This class is involved only on {@link PageIndexer} processing.
  */
-class FrontendGroupsModifier
+final readonly class FrontendGroupsModifier
 {
     /**
      * Modifies the fe_groups of a user on X-Tx-Solr-Iq requests.
      *
      * @throws PropagateResponseException
      */
+    #[AsEventListener(
+        identifier: 'solr.index.PageIndexer.FrontendUserAuthenticator',
+    )]
     public function __invoke(ModifyResolvedFrontendGroupsEvent $event): void
     {
         $pageIndexerRequest = $event->getRequest()->getAttribute('solr.pageIndexingInstructions');
@@ -106,8 +110,7 @@ class FrontendGroupsModifier
         if ((int)$pageIndexerRequest->getParameter('userGroup') === 0
             && (
                 (int)$pageIndexerRequest->getParameter('pageUserGroup') !== -2
-                &&
-                (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1
+                && (int)$pageIndexerRequest->getParameter('pageUserGroup') < 1
             )
             && $noRelevantFrontendUserGroupResolved
         ) {
@@ -133,9 +136,9 @@ class FrontendGroupsModifier
     }
 
     /**
-     * Resolves a logged in fe_groups to retrieve access restricted content.
+     * Resolves a logged-in fe_groups to retrieve access restricted content.
      */
-    protected function resolveFrontendUserGroups(PageIndexerRequest $pageIndexerRequest): array
+    private function resolveFrontendUserGroups(PageIndexerRequest $pageIndexerRequest): array
     {
         $accessRootline = $this->getAccessRootline($pageIndexerRequest);
         $stringAccessRootline = (string)$accessRootline;
@@ -148,7 +151,7 @@ class FrontendGroupsModifier
     /**
      * Gets the access rootline as defined by the request.
      */
-    protected function getAccessRootline(PageIndexerRequest $pageIndexerRequest): Rootline
+    private function getAccessRootline(PageIndexerRequest $pageIndexerRequest): Rootline
     {
         $stringAccessRootline = '';
         if ($pageIndexerRequest->getParameter('accessRootline')) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -22,8 +22,8 @@ services:
     shared: false
 
   event_listener:
-    namespace: ApacheSolrForTypo3\Solr\EventListener\Backend\
-    resource: '../Classes/EventListener/Backend/*'
+    namespace: ApacheSolrForTypo3\Solr\EventListener\
+    resource: '../Classes/EventListener/*'
     autowire: true
     autoconfigure: true
 
@@ -109,24 +109,6 @@ services:
     autowire: true
     shared: true
 
-  ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\CachedUrlModifier:
-    shared: true
-    tags:
-      - name: event.listener
-        identifier: 'solr.routing.cachedurl-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent
-  ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\CachedPathVariableModifier:
-    shared: true
-    tags:
-      - name: event.listener
-        identifier: 'solr.routing.cachedurl-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent
-  ApacheSolrForTypo3\Solr\EventListener\EnhancedRouting\PostEnhancedUriProcessor:
-    shared: true
-    tags:
-      - name: event.listener
-        identifier: 'solr.routing.postenhanceduriprocessor-modifier'
-        event: ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent
   ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\NoProcessingEventListener:
     shared: true
     arguments:
@@ -334,13 +316,6 @@ services:
     arguments:
       $siteRepository: '@ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository'
 
-  ApacheSolrForTypo3\Solr\EventListener\PageIndexer\AdditionalFieldsForPageIndexing:
-    autowire: true
-    shared: false
-    tags:
-      - name: event.listener
-        identifier: 'solr.index.AdditionalFieldsForPageIndexing'
-
   ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer:
     autowire: true
     shared: false
@@ -358,17 +333,6 @@ services:
         identifier: 'solr.index.UserGroupDetector.removeFeGroupConstraint'
         event: TYPO3\CMS\Core\Domain\Event\ModifyDefaultConstraintsForDatabaseQueryEvent
         method: 'removeFeGroupConstraintFromDatabaseQuery'
-
-  ApacheSolrForTypo3\Solr\EventListener\Extbase\PersistenceEventListener:
-    autowire: true
-    shared: true
-    tags:
-      - name: event.listener
-        identifier: 'solr.index.ExtbaseEntityPersisted'
-        method: 'entityPersisted'
-      - name: event.listener
-        identifier: 'solr.index.ExtbaseEntityRemoved'
-        method: 'entityRemoved'
 
   ###  EXT:solr content objects
   ApacheSolrForTypo3\Solr\ContentObject\Classification:


### PR DESCRIPTION
- Add `#[AsEventListener]` attribute to all event listeners.
- Make event listener classes `final` and `readonly` for immutability.
- Adjust method visibility from `protected` to `private` where applicable.
- Improve constructor property promotion in listener classes.
- Simplify service tagging in `Services.yaml` by removing explicit definitions.