### PR TITLE
[TASK] Refactor FrontendAwareEnvironment and adjust tests

### DIFF
--- a/Classes/FrontendSimulation/FrontendAwareEnvironment.php
+++ b/Classes/FrontendSimulation/FrontendAwareEnvironment.php
@@ -32,7 +32,6 @@ use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Routing\PageArguments;
-use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -48,19 +47,17 @@ use TYPO3\CMS\Frontend\Page\PageInformation;
  * for use in contexts where frontend capabilities are needed but no actual
  * frontend request exists (e.g., indexing, backend modules, CLI commands).
  */
-class FrontendAwareEnvironment implements SingletonInterface
+class FrontendAwareEnvironment
 {
     /**
      * @var ServerRequest[]
      */
     protected array $serverRequestCache = [];
 
-    protected SiteFinder $siteFinder;
-
-    public function __construct(?SiteFinder $siteFinder = null)
-    {
-        $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
-    }
+    public function __construct(
+        protected SiteFinder $siteFinder,
+        protected ConfigurationManager $configurationManager,
+    ) {}
 
     /**
      * Initializes the simulated frontend environment for a given page ID and language.
@@ -105,7 +102,6 @@ class FrontendAwareEnvironment implements SingletonInterface
         $pageInformation->setLocalRootLine($rootLine);
 
         $pageArguments = GeneralUtility::makeInstance(PageArguments::class, $pageId, '0', []);
-        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
 
         $serverRequest = GeneralUtility::makeInstance(ServerRequest::class)
             ->withAttribute('site', $site)
@@ -117,17 +113,13 @@ class FrontendAwareEnvironment implements SingletonInterface
 
         $serverRequest = $serverRequest->withAttribute(
             'frontend.typoscript',
-            $configurationManager->getCoreTypoScriptFrontendByRequest($serverRequest),
+            $this->configurationManager->getCoreTypoScriptFrontendByRequest($serverRequest),
         );
 
         // Configure visibility aspect for indexing (hide hidden elements)
         $context->setAspect(
             'visibility',
-            GeneralUtility::makeInstance(
-                VisibilityAspect::class,
-                false,
-                false,
-            ),
+            new VisibilityAspect(false, false),
         );
 
         // Set up frontend user with appropriate access rights
@@ -185,8 +177,10 @@ class FrontendAwareEnvironment implements SingletonInterface
      *
      * @param int ...$languageFallbackChain
      */
-    public function getServerRequestByPageIdAndLanguageFallbackChain(int $pageId, int ...$languageFallbackChain): ?ServerRequest
-    {
+    public function getServerRequestByPageIdAndLanguageFallbackChain(
+        int $pageId,
+        int ...$languageFallbackChain,
+    ): ?ServerRequest {
         foreach ($languageFallbackChain as $languageId) {
             try {
                 $request = $this->getServerRequestByPageIdAndLanguageId($pageId, $languageId);
@@ -213,26 +207,16 @@ class FrontendAwareEnvironment implements SingletonInterface
         } catch (Throwable) {
             return null;
         }
+
         $availableLanguageIds = array_map(static function ($siteLanguage) {
             return $siteLanguage->getLanguageId();
         }, $typo3Site->getLanguages());
 
-        if (empty($availableLanguageIds)) {
+        if ($availableLanguageIds === []) {
             return null;
         }
-        return $this->getServerRequestByPageIdAndLanguageFallbackChain($pageId, ...$availableLanguageIds);
-    }
 
-    /**
-     * Returns the page ID from a ServerRequest.
-     *
-     * Convenience method to extract the page ID from the PageInformation attribute.
-     */
-    public function getPageIdFromRequest(ServerRequest $request): int
-    {
-        /** @var PageInformation|null $pageInformation */
-        $pageInformation = $request->getAttribute('frontend.page.information');
-        return $pageInformation?->getId() ?? 0;
+        return $this->getServerRequestByPageIdAndLanguageFallbackChain($pageId, ...$availableLanguageIds);
     }
 
     /**
@@ -282,6 +266,7 @@ class FrontendAwareEnvironment implements SingletonInterface
         $pageRecord = BackendUtility::getRecord('pages', $pidToUse);
         $isSpacerOrSysfolder = ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SPACER
             || ($pageRecord['doktype'] ?? null) == PageRepository::DOKTYPE_SYSFOLDER;
+
         if ($isSpacerOrSysfolder === false && $this->isPageAvailable($pageRecord)) {
             return $pidToUse;
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -27,6 +27,12 @@ services:
     autowire: true
     autoconfigure: true
 
+  frontend_simulation:
+    namespace: ApacheSolrForTypo3\Solr\FrontendSimulation\
+    resource: '../Classes/FrontendSimulation/*'
+    autowire: true
+    autoconfigure: true
+
   facets:
     namespace: ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\
     resource: '../Classes/Domain/Search/ResultSet/Facets/*'

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,6 +32,7 @@ services:
     resource: '../Classes/FrontendSimulation/*'
     autowire: true
     autoconfigure: true
+    public: true
 
   facets:
     namespace: ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\

--- a/Tests/Integration/FrontendEnvironment/TsfeTest.php
+++ b/Tests/Integration/FrontendEnvironment/TsfeTest.php
@@ -3,9 +3,11 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\FrontendEnvironment;
 
 use ApacheSolrForTypo3\Solr\FrontendSimulation\FrontendAwareEnvironment;
+use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TsfeTest extends IntegrationTestBase
@@ -16,7 +18,12 @@ class TsfeTest extends IntegrationTestBase
         $this->writeDefaultSolrTestSiteConfiguration();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/can_initialize_tsfe_for_page_with_different_fe_groups_settings.csv');
 
-        $requestNotRestricted = GeneralUtility::makeInstance(FrontendAwareEnvironment::class)->getServerRequestByPageIdIgnoringLanguage(1);
+        $frontendAwareEnvironment = new FrontendAwareEnvironment(
+            GeneralUtility::makeInstance(SiteFinder::class),
+            GeneralUtility::makeInstance(ConfigurationManager::class),
+        );
+
+        $requestNotRestricted = $frontendAwareEnvironment->getServerRequestByPageIdIgnoringLanguage(1);
         self::assertInstanceOf(
             ServerRequest::class,
             $requestNotRestricted,
@@ -24,7 +31,7 @@ class TsfeTest extends IntegrationTestBase
                 'Most probably nothing will work.',
         );
 
-        $requestRestrictedForExistingFeGroup = GeneralUtility::makeInstance(FrontendAwareEnvironment::class)->getServerRequestByPageIdIgnoringLanguage(2);
+        $requestRestrictedForExistingFeGroup = $frontendAwareEnvironment->getServerRequestByPageIdIgnoringLanguage(2);
         self::assertInstanceOf(
             ServerRequest::class,
             $requestRestrictedForExistingFeGroup,
@@ -32,7 +39,7 @@ class TsfeTest extends IntegrationTestBase
                 'This will lead to failures on editing the access restricted [sub]pages in BE.',
         );
 
-        $requestForLoggedInUserOnly = GeneralUtility::makeInstance(FrontendAwareEnvironment::class)->getServerRequestByPageIdIgnoringLanguage(3);
+        $requestForLoggedInUserOnly = $frontendAwareEnvironment->getServerRequestByPageIdIgnoringLanguage(3);
         self::assertInstanceOf(
             ServerRequest::class,
             $requestForLoggedInUserOnly,


### PR DESCRIPTION
- Refactor `FrontendAwareEnvironment` to use constructor property promotion.
- Remove unused `SingletonInterface` implementation and related usages.
- Replace `GeneralUtility::makeInstance` calls with dependency injection.
- Add `frontend_simulation` service configuration in `Services.yaml`.
- Simplify `TsfeTest` by using an explicitly instantiated `FrontendAwareEnvironment`.