### PR TITLE
[TASK] Run integration tests without processIsolation

### DIFF
--- a/Build/Test/IntegrationTests.xml
+++ b/Build/Test/IntegrationTests.xml
@@ -16,7 +16,6 @@
 	failOnRisky="true"
 	failOnWarning="true"
 	failOnPhpunitDeprecation="true"
-	processIsolation="true"
 >
   <source>
     <include>

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -46,6 +46,16 @@ class ConnectionManager implements SingletonInterface
      */
     protected static array $connections = [];
 
+    /**
+     * Resets the static connection cache.
+     *
+     * @internal Only for use in test tearDown methods.
+     */
+    public static function resetConnections(): void
+    {
+        self::$connections = [];
+    }
+
     protected PagesRepositoryAtExtSolr $pagesRepositoryAtExtSolr;
 
     protected SiteRepository $siteRepository;

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -50,6 +50,8 @@ class IndexService
 
     protected SolrLogManager $logger;
 
+    protected array $httpHosts = [];
+
     public function __construct(
         Site $site,
         ?QueueInterface $queue = null,
@@ -235,15 +237,14 @@ class IndexService
      */
     protected function initializeHttpServerEnvironment(Item $item): void
     {
-        static $hosts = [];
         $rootPageId = $item->getRootPageUid();
-        $hostFound = !empty($hosts[$rootPageId]);
+        $hostFound = !empty($this->httpHosts[$rootPageId]);
 
         if (!$hostFound) {
-            $hosts[$rootPageId] = $item->getSite()->getDomain();
+            $this->httpHosts[$rootPageId] = $item->getSite()->getDomain();
         }
 
-        $_SERVER['HTTP_HOST'] = $hosts[$rootPageId];
+        $_SERVER['HTTP_HOST'] = $this->httpHosts[$rootPageId];
 
         // needed since TYPO3 7.5
         GeneralUtility::flushInternalRuntimeCaches();

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -40,6 +40,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PageIndexer extends Indexer
 {
+    protected array $accessGroupsCache = [];
+    protected array $accessRootlineCache = [];
     /**
      * Indexes an item from the indexing queue.
      *
@@ -172,10 +174,8 @@ class PageIndexer extends Indexer
      */
     protected function getAccessGroupsFromContent(Item $item, int $language = 0): array
     {
-        static $accessGroupsCache;
-
         $accessGroupsCacheEntryId = $item->getRecordUid() . '|' . $language;
-        if (!isset($accessGroupsCache[$accessGroupsCacheEntryId])) {
+        if (!isset($this->accessGroupsCache[$accessGroupsCacheEntryId])) {
             $request = $this->buildBasePageIndexerRequest();
             $request->setIndexQueueItem($item);
             $request->addAction('findUserGroups');
@@ -192,7 +192,7 @@ class PageIndexer extends Indexer
 
             $groups = $response->getActionResult('findUserGroups');
             if (is_array($groups)) {
-                $accessGroupsCache[$accessGroupsCacheEntryId] = $groups;
+                $this->accessGroupsCache[$accessGroupsCacheEntryId] = $groups;
             }
 
             if ($this->loggingEnabled) {
@@ -210,7 +210,7 @@ class PageIndexer extends Indexer
             }
         }
 
-        return $accessGroupsCache[$accessGroupsCacheEntryId];
+        return $this->accessGroupsCache[$accessGroupsCacheEntryId];
     }
 
     // Utility methods
@@ -389,8 +389,6 @@ class PageIndexer extends Indexer
      */
     protected function getAccessRootline(Item $item, int $language = 0, ?int $contentAccessGroup = null): string
     {
-        static $accessRootlineCache;
-
         $mountPointParameter = $this->getMountPageDataUrlParameter($item);
 
         $accessRootlineCacheEntryId = $item->getType() . '|' . $item->getRecordUid() . '|' . $language;
@@ -401,7 +399,7 @@ class PageIndexer extends Indexer
             $accessRootlineCacheEntryId .= '|' . $contentAccessGroup;
         }
 
-        if (!isset($accessRootlineCache[$accessRootlineCacheEntryId])) {
+        if (!isset($this->accessRootlineCache[$accessRootlineCacheEntryId])) {
             $accessRootline = $this->getAccessRootlineByPageId($item->getRecordUid(), $mountPointParameter);
 
             // current page's content access groups
@@ -412,10 +410,10 @@ class PageIndexer extends Indexer
             $element = GeneralUtility::makeInstance(RootlineElement::class, 'c:' . implode(',', $contentAccessGroups));
             $accessRootline->push($element);
 
-            $accessRootlineCache[$accessRootlineCacheEntryId] = $accessRootline;
+            $this->accessRootlineCache[$accessRootlineCacheEntryId] = $accessRootline;
         }
 
-        return (string)$accessRootlineCache[$accessRootlineCacheEntryId];
+        return (string)$this->accessRootlineCache[$accessRootlineCacheEntryId];
     }
 
     /**

--- a/Classes/System/Cache/TwoLevelCache.php
+++ b/Classes/System/Cache/TwoLevelCache.php
@@ -32,6 +32,16 @@ class TwoLevelCache
 
     protected static array $firstLevelCache = [];
 
+    /**
+     * Flushes all first-level caches across all cache instances.
+     *
+     * @internal Only for use in test tearDown methods.
+     */
+    public static function flushAllCaches(): void
+    {
+        self::$firstLevelCache = [];
+    }
+
     protected FrontendInterface $secondLevelCache;
 
     /**

--- a/Classes/System/Environment/CliEnvironment.php
+++ b/Classes/System/Environment/CliEnvironment.php
@@ -26,6 +26,8 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 class CliEnvironment implements SingletonInterface
 {
+    protected static ?string $webRoot = null;
+
     protected array $backupServerVariables = [];
 
     protected bool $isInitialized = false;
@@ -51,7 +53,7 @@ class CliEnvironment implements SingletonInterface
             return false;
         }
 
-        if (defined('TYPO3_PATH_WEB')) {
+        if (self::$webRoot !== null) {
             throw new WebRootAllReadyDefinedException(
                 'TYPO3_PATH_WEB is already defined',
                 7904456080,
@@ -62,13 +64,18 @@ class CliEnvironment implements SingletonInterface
             $scriptFileName = Environment::getPublicPath() . '/';
         }
 
-        define('TYPO3_PATH_WEB', $webRoot);
+        self::$webRoot = $webRoot;
         $_SERVER['SCRIPT_FILENAME'] = $scriptFileName;
         $_SERVER['PHP_SELF'] = $phpSelf;
         $_SERVER['SCRIPT_NAME'] = $scriptName;
 
         $this->isInitialized = true;
         return true;
+    }
+
+    public function getWebRoot(): ?string
+    {
+        return self::$webRoot;
     }
 
     public function getIsInitialized(): bool
@@ -79,5 +86,7 @@ class CliEnvironment implements SingletonInterface
     public function restore(): void
     {
         $_SERVER = $this->backupServerVariables;
+        self::$webRoot = null;
+        $this->isInitialized = false;
     }
 }

--- a/Classes/Traits/SkipMonitoringTrait.php
+++ b/Classes/Traits/SkipMonitoringTrait.php
@@ -27,9 +27,8 @@ trait SkipMonitoringTrait
      */
     protected function skipMonitoringOfTable(string $table): bool
     {
-        static $configurationMonitorTables;
-
-        if (empty($configurationMonitorTables)) {
+        static $configurationMonitorTables = null;
+        if ($configurationMonitorTables === null) {
             $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
             $configurationMonitorTables = $configuration->getIsUseConfigurationMonitorTables();
         }

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use ApacheSolrForTypo3\Solr\Tests\Integration\TSFETestBootstrapper;
 use ApacheSolrForTypo3\Solr\Util;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
@@ -36,6 +37,7 @@ class SearchResultSetServiceTest extends IntegrationTestBase
     {
         parent::setUp();
         $this->writeDefaultSolrTestSiteConfiguration();
+        GeneralUtility::makeInstance(TSFETestBootstrapper::class)->bootstrap(1);
     }
 
     /**

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -16,9 +16,12 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\IndexQueue\Item;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use Doctrine\DBAL\Exception as DBALException;
 use Psr\Http\Message\ResponseInterface;
@@ -52,6 +55,7 @@ abstract class IntegrationTestBase extends FunctionalTestCase
 {
     use SiteBasedTestTrait;
     private $previousErrorHandler;
+    private int $previousErrorReporting;
 
     protected array $coreExtensionsToLoad = [
         'typo3/cms-install',
@@ -98,12 +102,19 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         //this is needed by the TYPO3 core.
         chdir(Environment::getPublicPath() . '/');
         $this->instancePath = $this->getInstancePath();
+        $this->previousErrorReporting = error_reporting();
         $this->previousErrorHandler = $this->failWhenSolrDeprecationIsCreated();
     }
 
     protected function tearDown(): void
     {
-        set_error_handler($this->previousErrorHandler);
+        restore_error_handler();
+        error_reporting($this->previousErrorReporting);
+
+        // Reset static caches that survive GeneralUtility::purgeInstances()
+        ConnectionManager::resetConnections();
+        SiteUtility::reset();
+        TwoLevelCache::flushAllCaches();
 
         parent::tearDown();
     }
@@ -219,8 +230,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         $this->writeDefaultSolrTestSiteConfigurationForHostAndPort($solrConnectionInfo['scheme'], $solrConnectionInfo['host'], $solrConnectionInfo['port']);
     }
 
-    protected static string $lastSiteCreated = '';
-
     /**
      * @internal Don't use that method in tests, except you want to simulate the misconfiguration.
      */
@@ -230,11 +239,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         ?int $port = 8983,
         ?bool $disableDefaultLanguage = false,
     ): void {
-        $siteCreatedHash = hash('md5', $scheme . $host . $port . $disableDefaultLanguage);
-        if (self::$lastSiteCreated === $siteCreatedHash) {
-            return;
-        }
-
         $defaultLanguage = $this->buildDefaultLanguageConfiguration('EN', '/en/');
         $defaultLanguage['solr_core_read'] = 'core_en';
 
@@ -288,7 +292,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         $this->importRootPagesAndTemplatesForConfiguredSites();
 
         clearstatcache();
-        self::$lastSiteCreated = $siteCreatedHash;
     }
 
     /**

--- a/Tests/Integration/System/Environment/CliEnvironmentTest.php
+++ b/Tests/Integration/System/Environment/CliEnvironmentTest.php
@@ -32,28 +32,30 @@ class CliEnvironmentTest extends IntegrationTestBase
     #[Test]
     public function canInitialize(): void
     {
-        self::assertFalse(defined('TYPO3_PATH_WEB'));
-
         $cliEnvironment = new CliEnvironment();
+        self::assertNull($cliEnvironment->getWebRoot());
+
         $cliEnvironment->initialize('/var/www');
 
-        self::assertTrue(defined('TYPO3_PATH_WEB'));
-        self::assertEquals('/var/www', TYPO3_PATH_WEB);
+        self::assertEquals('/var/www', $cliEnvironment->getWebRoot());
 
         $cliEnvironment->restore();
+        self::assertNull($cliEnvironment->getWebRoot());
     }
 
     #[Test]
     public function canNotInitializeTwiceWithTwoInstances(): void
     {
-        $this->expectException(WebRootAllReadyDefinedException::class);
-        self::assertFalse(defined('TYPO3_PATH_WEB'));
-
         $cliEnvironment = new CliEnvironment();
         $cliEnvironment->initialize('/var/www');
 
-        $cliEnvironment2 = new CliEnvironment();
-        $cliEnvironment2->initialize('/var/otherwww');
+        try {
+            $cliEnvironment2 = new CliEnvironment();
+            $this->expectException(WebRootAllReadyDefinedException::class);
+            $cliEnvironment2->initialize('/var/otherwww');
+        } finally {
+            $cliEnvironment->restore();
+        }
     }
 
     #[Test]
@@ -61,13 +63,15 @@ class CliEnvironmentTest extends IntegrationTestBase
     {
         $cliEnvironment = GeneralUtility::makeInstance(CliEnvironment::class);
 
-        // the result should be true because the constant should have been set
+        // the result should be true because the web root should have been set
         $firstInit = $cliEnvironment->initialize('/var/www');
 
-        // the second init should return false because an initialization was allready done before
+        // the second init should return false because an initialization was already done before
         $secondInit = $cliEnvironment->initialize('/var/www2');
 
         self::assertTrue($firstInit);
         self::assertFalse($secondInit);
+
+        $cliEnvironment->restore();
     }
 }

--- a/Tests/Integration/TSFETestBootstrapper.php
+++ b/Tests/Integration/TSFETestBootstrapper.php
@@ -2,6 +2,7 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -26,6 +27,7 @@ class TSFETestBootstrapper
         $pageInformation->setPageRecord(['uid' => $pageId]);
 
         $request = new ServerRequest($site->getRouter()->generateUri($site->getRootPageId()));
+        $request = $request->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
         $request = $request->withAttribute('site', $site);
         $request = $request->withAttribute('language', $siteLanguage);
         $request = $request->withAttribute('routing', $pageArguments);


### PR DESCRIPTION
# What this pr does

This change adds some base functionality in our
code base to make all integration tests run without PHPUnits' process isolation.

# How to test

This means: The integration test suite now runs roughly 9 minutes, instead of 36-40 minutes, making it 75% faster.

If all tests run through, this makes our Earth happier.