### PR TITLE
[TASK] Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
       -
         name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # End: Workaround for issue with actions/checkout...
       -
         name: Collect build matrix
@@ -60,10 +60,10 @@ jobs:
           echo "matrix=$(echo $matrix)" >> $GITHUB_OUTPUT
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Docker/SolrServer/Dockerfile
@@ -79,14 +79,14 @@ jobs:
           ./Build/Test/cibuild_docker.sh
       -
         name: Upload Docker Image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: solrci-image
           path: /tmp/solrci-image.tar
           retention-days: 1
       -
         name: Upload Solr-Server containers logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: solrci-logs
@@ -99,13 +99,13 @@ jobs:
       # Workaround for issue with actions/checkout "wrong PR commit checkout". See: ci_bootstrapping job
       - name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout current state of Branch
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       # End: Workaround for issue with actions/checkout...
@@ -135,14 +135,14 @@ jobs:
       -
         name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       # End: Workaround for issue with actions/checkout...
@@ -156,10 +156,10 @@ jobs:
             && sudo chown 8983:8983 ${{ env.CI_BUILD_DIRECTORY }}/data-solr
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Download solrci-image from "ci_bootstrapping" job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: solrci-image
           path: /tmp
@@ -223,7 +223,7 @@ jobs:
       DOCKER_HUB_IMAGE_NAME: "${{ secrets.DOCKERHUB_USERNAME }}/ext-solr"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: enrich Environment Variables
         id: env
@@ -234,7 +234,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.DOCKER_HUB_IMAGE_NAME }}
@@ -261,22 +261,22 @@ jobs:
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Docker/SolrServer/Dockerfile
@@ -295,7 +295,7 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -


### PR DESCRIPTION
- .github/workflows/ci.yml:
  - actions/checkout v4 → v6
  - docker/setup-buildx-action v3 → v4
  - docker/build-push-action v5/v6 → v7
  - actions/upload-artifact v4 → v7
  - actions/download-artifact v4 → v8
  - docker/setup-qemu-action v2 → v4
  - docker/metadata-action v5 → v6
  - docker/login-action v2 → v4

Fixes: #4597
Ports: #4599
