### PR TITLE
[BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS

### DIFF
--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -102,7 +102,8 @@ class ConfigurationManager implements SingletonInterface
      */
     public function getTypoScriptConfiguration(?int $contextPageId = null, int $contextLanguageId = 0): TypoScriptConfiguration
     {
-        if ($contextPageId !== null) {
+        $contextPageRecord = $contextPageId !== null ? $this->fetchPageRecord($contextPageId) : null;
+        if ($contextPageRecord !== null) {
             $site = GeneralUtility::makeInstance(SiteFinder::class)
                 ->getSiteByPageId($contextPageId);
             $language = $site->getLanguageById($contextLanguageId);
@@ -110,7 +111,7 @@ class ConfigurationManager implements SingletonInterface
             $uri = $site->getRouter()->generateUri($contextPageId, ['_language' => $language]);
             $pageInformation = new PageInformation();
             $pageInformation->setId($contextPageId);
-            $pageInformation->setPageRecord(BackendUtility::getRecord('pages', $contextPageId));
+            $pageInformation->setPageRecord($contextPageRecord);
             $pageInformation->setContentFromPid($contextPageId);
             $request = (new ServerRequest($uri, 'GET'))
                 ->withAttribute('site', $site)
@@ -202,6 +203,11 @@ class ConfigurationManager implements SingletonInterface
             null,
             null,
         );
+    }
+
+    protected function fetchPageRecord(int $pageId): ?array
+    {
+        return BackendUtility::getRecord('pages', $pageId);
     }
 
     /**

--- a/Tests/Unit/System/Configuration/ConfigurationManagerTest.php
+++ b/Tests/Unit/System/Configuration/ConfigurationManagerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Configuration;
+
+use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ConfigurationManagerTest extends SetUpUnitTestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getTypoScriptConfigurationFallsBackToTypo3RequestWhenPageIsDeleted(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = $this->createMock(ServerRequestInterface::class);
+        $expectedConfiguration = new TypoScriptConfiguration([]);
+
+        $manager = $this->createPartialMock(
+            ConfigurationManager::class,
+            ['fetchPageRecord', 'getTypoScriptFromRequest'],
+        );
+
+        // Simulate a page that was deleted in a workspace swap
+        $manager->method('fetchPageRecord')
+            ->with(999)
+            ->willReturn(null);
+
+        // The fallback must be called with TYPO3_REQUEST, not a page-derived request
+        $manager->expects(self::once())
+            ->method('getTypoScriptFromRequest')
+            ->with($GLOBALS['TYPO3_REQUEST'])
+            ->willReturn($expectedConfiguration);
+
+        $result = $manager->getTypoScriptConfiguration(999);
+
+        self::assertSame($expectedConfiguration, $result);
+    }
+}


### PR DESCRIPTION
# What this pr does

When publishing a workspace that contains a deleted page, `ConfigurationManager::getTypoScriptConfiguration()` was called with the $contextPageId of the deleted page. Without checking whether the page still exists, the code immediately called `SiteFinder::getSiteByPageId()`, which throws an exception because the live record is gone. This interrupted theentire workspace publish process.

A unit test covering the deleted-page scenario is included.

# How to test

1. Switch to a workspace in the TYPO3 backend.
2. Delete a live page from within the workspace.
3. Publish the entire workspace.
4. Verify the publish completes without exception and all remaining workspace records are published.

Fixes: #4602 