### PR TITLE
[FEATURE] Support solrcloud mode

### DIFF
--- a/Classes/Report/SolrStatus.php
+++ b/Classes/Report/SolrStatus.php
@@ -119,6 +119,7 @@ class SolrStatus extends AbstractSolrStatus
             ->getAdminService();
 
         $solrVersion = $this->checkSolrVersion($solrAdmin);
+        $solrMode = $this->checkSolrMode($solrAdmin);
         $accessFilter = $this->checkAccessFilter($solrAdmin);
         $pingTime = $this->checkPingTime($solrAdmin);
         $configName = $this->checkSolrConfigName($solrAdmin);
@@ -135,6 +136,7 @@ class SolrStatus extends AbstractSolrStatus
             'connection' => $solrConnection,
             'solr' => $solrAdmin,
             'solrVersion' => $solrVersion,
+            'solrMode' => $solrMode,
             'pingTime' => $pingTime,
             'configName' => $configName,
             'schemaName' => $schemaName,
@@ -166,6 +168,23 @@ class SolrStatus extends AbstractSolrStatus
         }
 
         return $solrVersion;
+    }
+
+    /**
+     * Checks the solr mode and adds it to the report.
+     *
+     * @return string solr mode
+     */
+    protected function checkSolrMode(SolrAdminService $solr): string
+    {
+        try {
+            $solrMode = $solr->getSolrServerMode();
+        } catch (Throwable $e) {
+            $this->responseStatus = ContextualFeedbackSeverity::ERROR;
+            $solrMode = 'Error getting solr version: ' . $e->getMessage();
+        }
+
+        return $solrMode;
     }
 
     /**

--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -41,6 +41,7 @@ class SolrAdminService extends AbstractSolrService
     public const LUKE_SERVLET = 'admin/luke';
     public const SYSTEM_SERVLET = 'admin/system';
     public const CORES_SERVLET = '../admin/cores';
+    public const COLLECTIONS_SERVLET = '../admin/collections';
     public const FILE_SERVLET = 'admin/file';
     public const SCHEMA_SERVLET = 'schema';
     public const SYNONYMS_SERVLET = 'schema/analysis/synonyms/';
@@ -203,6 +204,23 @@ class SolrAdminService extends AbstractSolrService
     }
 
     /**
+     * Gets the Solr server's mode.
+     */
+    public function getSolrServerMode(): string
+    {
+        $systemInformation = $this->getSystemInformation();
+        return $systemInformation->mode ?? '';
+    }
+
+    /**
+     * Check if solr server is running in cloud mode.
+     */
+    public function isSolrCloudMode(): bool
+    {
+        return $this->getSolrServerMode() === 'solrcloud';
+    }
+
+    /**
      * Reloads the current core
      */
     public function reloadCore(): ResponseAdapter
@@ -215,7 +233,11 @@ class SolrAdminService extends AbstractSolrService
      */
     public function reloadCoreByName(string $coreName): ResponseAdapter
     {
-        $coreAdminReloadUrl = $this->_constructUrl(self::CORES_SERVLET) . '?action=reload&core=' . $coreName;
+        if ($this->isSolrCloudMode()) {
+            $coreAdminReloadUrl = $this->_constructUrl(self::COLLECTIONS_SERVLET) . '?action=reload&name=' . $coreName;
+        } else {
+            $coreAdminReloadUrl = $this->_constructUrl(self::CORES_SERVLET) . '?action=reload&core=' . $coreName;
+        }
         return $this->_sendRawGet($coreAdminReloadUrl);
     }
 

--- a/Resources/Private/Templates/Backend/Reports/SolrStatus.html
+++ b/Resources/Private/Templates/Backend/Reports/SolrStatus.html
@@ -28,13 +28,17 @@
 		<th>Port</th>
 		<td>{solr.primaryEndpoint.port}</td>
 	</tr>
-<tr>
-	<th>Username</th>
-	<td>{connection.solrUsername}</td>
-</tr>
+	<tr>
+		<th>Username</th>
+		<td>{connection.solrUsername}</td>
+	</tr>
 	<tr>
 		<th>Apache Solr</th>
 		<td>{solrVersion}</td>
+	</tr>
+	<tr>
+		<th>Solr Mode</th>
+		<td>{solrMode}</td>
 	</tr>
 	<tr>
 		<th>solrconfig.xml</th>


### PR DESCRIPTION
# What this pr does

Add support for solrcloud.

When solr is running in `solrcloud` mode, it uses collections as the main entrypoint instead of cores. A collection exists of multiple cores, that can be spread across different machines. `solrcloud` is typically used in cloud hostes environments for scalability.

From the extension perspective, I only had to change the `reloadCoreByName()` method to select the correct API endpoint depending of the mode.

In addition the status page now shows the solr mode.

Functions that work without changes:

- Fetching informations about solr server
- Indexing
- Searching (including Autosuggest)
- Clearing the index
- Index fields info
- Adding/Removing Synonyms
- Adding/Removing Stop Words

# How to test

Will update here as soon as the ddev add-on ddev-typo3-solr is updated. I'm currently working on supporting both modes  (standalone / solrcloud) in this add-on for easy testing.

Fixes: #4031
