### PR TITLE
[FEATURE] Add site sets for all registered TypoScript templates

### DIFF
--- a/Configuration/Sets/BootstrapCss/config.yaml
+++ b/Configuration/Sets/BootstrapCss/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-bootstrap-css
+label: "Solr search - Bootstrap CSS Framework"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/BootstrapCss/setup.typoscript
+++ b/Configuration/Sets/BootstrapCss/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/BootstrapCss/setup.typoscript'

--- a/Configuration/Sets/ExampleAjaxify/config.yaml
+++ b/Configuration/Sets/ExampleAjaxify/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-ajaxify
+label: "Solr search - (Example) Ajaxify the search results"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleAjaxify/setup.typoscript
+++ b/Configuration/Sets/ExampleAjaxify/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Ajaxify/setup.typoscript'

--- a/Configuration/Sets/ExampleBoostQueries/config.yaml
+++ b/Configuration/Sets/ExampleBoostQueries/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-boost-queries
+label: "Solr search - (Example) Boost more recent results"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleBoostQueries/setup.typoscript
+++ b/Configuration/Sets/ExampleBoostQueries/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/BoostQueries/setup.typoscript'

--- a/Configuration/Sets/ExampleEverythingOn/config.yaml
+++ b/Configuration/Sets/ExampleEverythingOn/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-everything-on
+label: "Solr search - (Example) Everything On"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleEverythingOn/setup.typoscript
+++ b/Configuration/Sets/ExampleEverythingOn/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/EverythingOn/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsDateRange/config.yaml
+++ b/Configuration/Sets/ExampleFacetsDateRange/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-date-range
+label: "Solr search - (Example) DateRange facet with datepicker on created field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsDateRange/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsDateRange/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/DateRange/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsHierarchy/config.yaml
+++ b/Configuration/Sets/ExampleFacetsHierarchy/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-hierarchy
+label: "Solr search - (Example) Hierarchy facet on the rootline field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsHierarchy/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsHierarchy/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/Hierarchy/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsNumericRange/config.yaml
+++ b/Configuration/Sets/ExampleFacetsNumericRange/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-numeric-range
+label: "Solr search - (Example) NumericRange facet with slider on pid field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsNumericRange/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsNumericRange/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/NumericRange/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsOptions/config.yaml
+++ b/Configuration/Sets/ExampleFacetsOptions/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-options
+label: "Solr search - (Example) Options facet on author field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsOptions/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsOptions/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/Options/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsOptionsFiltered/config.yaml
+++ b/Configuration/Sets/ExampleFacetsOptionsFiltered/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-options-filtered
+label: "Solr search - (Example) Options filterable by option value"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsOptionsFiltered/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsOptionsFiltered/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsFiltered/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsOptionsPrefixGrouped/config.yaml
+++ b/Configuration/Sets/ExampleFacetsOptionsPrefixGrouped/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-options-prefix-grouped
+label: "Solr search - (Example) Options grouped by prefix"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsOptionsPrefixGrouped/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsOptionsPrefixGrouped/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsPrefixGrouped/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsOptionsSinglemode/config.yaml
+++ b/Configuration/Sets/ExampleFacetsOptionsSinglemode/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-options-single-mode
+label: "Solr search - (Example) Options with singlemode (only one option at a time)"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsOptionsSinglemode/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsOptionsSinglemode/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsSinglemode/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsOptionsToggle/config.yaml
+++ b/Configuration/Sets/ExampleFacetsOptionsToggle/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-options-toggle
+label: "Solr search - (Example) Options with on/off toggle"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsOptionsToggle/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsOptionsToggle/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/OptionsToggle/setup.typoscript'

--- a/Configuration/Sets/ExampleFacetsQueryGroup/config.yaml
+++ b/Configuration/Sets/ExampleFacetsQueryGroup/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-facets-query-group
+label: "Solr search - (Example) QueryGroup facet on the created field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFacetsQueryGroup/setup.typoscript
+++ b/Configuration/Sets/ExampleFacetsQueryGroup/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Facets/QueryGroup/setup.typoscript'

--- a/Configuration/Sets/ExampleFilterPages/config.yaml
+++ b/Configuration/Sets/ExampleFilterPages/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-filter-pages
+label: "Solr search - (Example) Filter to only show page results"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleFilterPages/setup.typoscript
+++ b/Configuration/Sets/ExampleFilterPages/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/FilterPages/setup.typoscript'

--- a/Configuration/Sets/ExampleIndexQueueNews/config.yaml
+++ b/Configuration/Sets/ExampleIndexQueueNews/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-index-queue-news
+label: "Solr search - (Example) Index Queue Configuration for news"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleIndexQueueNews/setup.typoscript
+++ b/Configuration/Sets/ExampleIndexQueueNews/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueNews/setup.typoscript'

--- a/Configuration/Sets/ExampleIndexQueueNewsContentElements/config.yaml
+++ b/Configuration/Sets/ExampleIndexQueueNewsContentElements/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-index-queue-news-content-elements
+label: "Solr search - (Example) Index Queue Configuration for news with content elements"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleIndexQueueNewsContentElements/setup.typoscript
+++ b/Configuration/Sets/ExampleIndexQueueNewsContentElements/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/IndexQueueNewsContentElements/setup.typoscript'

--- a/Configuration/Sets/ExamplePidQueryGroup/config.yaml
+++ b/Configuration/Sets/ExamplePidQueryGroup/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-pid-query-group
+label: "Solr search - (Example) Querygroup on pid field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExamplePidQueryGroup/setup.typoscript
+++ b/Configuration/Sets/ExamplePidQueryGroup/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/PidQueryGroup/setup.typoscript'

--- a/Configuration/Sets/ExampleSuggest/config.yaml
+++ b/Configuration/Sets/ExampleSuggest/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-suggest
+label: "Solr search - (Example) Suggest/autocomplete"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleSuggest/setup.typoscript
+++ b/Configuration/Sets/ExampleSuggest/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript'

--- a/Configuration/Sets/ExampleTypeFieldGroup/config.yaml
+++ b/Configuration/Sets/ExampleTypeFieldGroup/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-example-type-field-group
+label: "Solr search - (Example) Fieldgroup on type field"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/ExampleTypeFieldGroup/setup.typoscript
+++ b/Configuration/Sets/ExampleTypeFieldGroup/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Examples/TypeFieldGroup/setup.typoscript'

--- a/Configuration/Sets/OpenSearch/config.yaml
+++ b/Configuration/Sets/OpenSearch/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-open-search
+label: "Solr search - OpenSearch"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/OpenSearch/constants.typoscript
+++ b/Configuration/Sets/OpenSearch/constants.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/OpenSearch/constants.typoscript'

--- a/Configuration/Sets/OpenSearch/setup.typoscript
+++ b/Configuration/Sets/OpenSearch/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/OpenSearch/setup.typoscript'

--- a/Configuration/Sets/Solr/config.yaml
+++ b/Configuration/Sets/Solr/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr
+label: "Solr search - Base Configuration"
+dependencies:
+  - typo3/fluid-styled-content

--- a/Configuration/Sets/Solr/constants.typoscript
+++ b/Configuration/Sets/Solr/constants.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Solr/constants.typoscript'

--- a/Configuration/Sets/Solr/page.tsconfig
+++ b/Configuration/Sets/Solr/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/page.tsconfig'

--- a/Configuration/Sets/Solr/setup.typoscript
+++ b/Configuration/Sets/Solr/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/Solr/setup.typoscript'

--- a/Configuration/Sets/StyleSheets/config.yaml
+++ b/Configuration/Sets/StyleSheets/config.yaml
@@ -1,0 +1,4 @@
+name: apache-solr-for-typo3/solr-stylesheets
+label: "Solr search - Default Stylesheets"
+dependencies:
+  - apache-solr-for-typo3/solr

--- a/Configuration/Sets/StyleSheets/setup.typoscript
+++ b/Configuration/Sets/StyleSheets/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:solr/Configuration/TypoScript/StyleSheets/setup.typoscript'

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -29,5 +29,6 @@ Configuration Reference
 	./Reference/TxSolrSuggest
 	./Reference/TxSolrStatistics
 	./Reference/TxSolrLogging
+	./SiteSets
 	./Reference/ExtensionSettings
 	./Reference/SolrConnection

--- a/Documentation/Configuration/SiteSets.rst
+++ b/Documentation/Configuration/SiteSets.rst
@@ -1,0 +1,88 @@
+.. _configuration-site-sets:
+
+Site Sets
+=========
+
+.. versionadded:: 14.0
+
+   EXT:solr provides TYPO3 site sets in :file:`Configuration/Sets/`.
+
+TYPO3 site sets are the recommended way to provide reusable site-scoped
+configuration in TYPO3 14 projects. EXT:solr ships site sets for the base
+configuration, optional frontend assets, OpenSearch and the example
+configurations that were previously available as static TypoScript includes.
+
+If your project does not use TypoScript template records
+(``sys_template``), add EXT:solr configuration through site set
+dependencies. TYPO3 resolves, orders and deduplicates site set dependencies,
+which makes this approach more robust than managing dependencies manually in
+TypoScript records.
+
+Example site configuration:
+
+.. code-block:: yaml
+   :caption: config/sites/my-site/config.yaml
+
+   dependencies:
+     - apache-solr-for-typo3/solr
+     - apache-solr-for-typo3/solr-stylesheets
+
+TypoScript template records are still supported for existing installations and
+mixed setups. When using site sets, prefer dependencies between sets instead
+of cross-extension TypoScript imports or duplicated static includes.
+
+Available Site Sets
+-------------------
+
+The following site sets are provided by EXT:solr:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Site set
+     - Description
+   * - ``apache-solr-for-typo3/solr``
+     - Base Configuration
+   * - ``apache-solr-for-typo3/solr-bootstrap-css``
+     - Bootstrap CSS Framework
+   * - ``apache-solr-for-typo3/solr-stylesheets``
+     - Default Stylesheets
+   * - ``apache-solr-for-typo3/solr-open-search``
+     - OpenSearch
+   * - ``apache-solr-for-typo3/solr-example-ajaxify``
+     - Ajaxify the search results
+   * - ``apache-solr-for-typo3/solr-example-boost-queries``
+     - Boost more recent results
+   * - ``apache-solr-for-typo3/solr-example-everything-on``
+     - Everything On
+   * - ``apache-solr-for-typo3/solr-example-filter-pages``
+     - Filter to only show page results
+   * - ``apache-solr-for-typo3/solr-example-suggest``
+     - Suggest/autocomplete
+   * - ``apache-solr-for-typo3/solr-example-facets-options``
+     - Options facet on author field
+   * - ``apache-solr-for-typo3/solr-example-facets-options-toggle``
+     - Options with on/off toggle
+   * - ``apache-solr-for-typo3/solr-example-facets-options-prefix-grouped``
+     - Options grouped by prefix
+   * - ``apache-solr-for-typo3/solr-example-facets-options-single-mode``
+     - Options with singlemode (only one option at a time)
+   * - ``apache-solr-for-typo3/solr-example-facets-options-filtered``
+     - Options filterable by option value
+   * - ``apache-solr-for-typo3/solr-example-facets-query-group``
+     - QueryGroup facet on the created field
+   * - ``apache-solr-for-typo3/solr-example-facets-hierarchy``
+     - Hierarchy facet on the rootline field
+   * - ``apache-solr-for-typo3/solr-example-facets-date-range``
+     - DateRange facet with datepicker on created field
+   * - ``apache-solr-for-typo3/solr-example-numeric-range``
+     - NumericRange facet with slider on pid field
+   * - ``apache-solr-for-typo3/solr-example-type-field-group``
+     - Fieldgroup on type field
+   * - ``apache-solr-for-typo3/solr-example-pid-query-group``
+     - Querygroup on pid field
+   * - ``apache-solr-for-typo3/solr-example-index-queue-news``
+     - Index Queue Configuration for news
+   * - ``apache-solr-for-typo3/solr-example-index-queue-news-content-elements``
+     - Index Queue Configuration for news with content elements

--- a/Documentation/GettingStarted/ConfigureExtension.rst
+++ b/Documentation/GettingStarted/ConfigureExtension.rst
@@ -23,11 +23,19 @@ Underlying settings can be found in the extension configuration, though the defa
 
 
 
-Static TypoScript
------------------
+Site Sets or Static TypoScript
+------------------------------
 
-The extension already comes with basic TypoScript configuration that will work for small pages out of the box. For now create or
-edit an existing TypoScript Template record in your page tree and add the provided static TypoScript:
+The extension already comes with basic TypoScript configuration that will work
+for small pages out of the box.
+
+For TYPO3 14 projects, the recommended setup is to include EXT:solr through
+site set dependencies. See :ref:`configuration-site-sets` for the available
+site sets and an example site configuration.
+
+If your project still uses TypoScript Template records, create or edit an
+existing TypoScript Template record in your page tree and add the provided
+static TypoScript:
 
 .. image:: /Images/GettingStarted/typo3-include-static-typoscript.png
 

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -21,6 +21,16 @@ TYPO3 14 LTS Compatibility
 EXT:solr has been fully adapted for TYPO3 14 LTS, including Fluid v5 ViewHelper
 compatibility, TCA changes, deprecation removals, and testing framework updates.
 
+TYPO3 Site Sets
+~~~~~~~~~~~~~~~
+
+EXT:solr now provides TYPO3 site sets for the base configuration, optional
+frontend assets, OpenSearch and the shipped example configurations. For TYPO3
+14 projects that do not use TypoScript template records, site set dependencies
+are the recommended way to include EXT:solr configuration.
+
+See :ref:`configuration-site-sets` for the full list of available site sets.
+
 XLIFF 2.0 Migration
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# What this pr does

This PR provides add sitesets to use Solr in environments where TypoScript records are no longer used. It adds compatibility changes and migration guidance so sites can continue using Solr search without TypoScript-based records. Existing TypoScript remains in place and site sets only refer to this TypoScript. Integrators still can use TypoScript the old way however, they can also use site sets because those provide much better dependency management.

There is one base site set and all other size sets refer to this site set as a dependency. Examples are also converted, and since there were many examples this also creates many site sets.

This PR does not add any site settings because people have a lot of TypoScript constants configured and it is expected for now that they will still use those constants. We can do a second PR if we decide that we want to move to site settings, but we'll need to think about what names we give to those site seedings to make sure that cost Custom TypoScript setup is still compatible. For example, we could name those site settings like this later:

```yaml
categories:
  apache-solr-for-typo3:
    label: Solr search

settings:
  plugin.tx_solr.enabled:
    default: true
    type: bool
    category: apache-solr-for-typo3
    label: Enable Solr search
```

The definition above would make the following TypoScript setup working for both constants and site settings:

```
plugin.tx_solr {
  enabled = {$plugin.tx_solr.enabled}
}
```

# How to test

You can add dependencies on solr site sets as follows in your own site set or site configuration:

```yaml
dependencies:
  - typo3/fluid-styled-content
  - typo3/form
  - typo3/seo-sitemap
  - apache-solr-for-typo3/solr
  - apache-solr-for-typo3/solr-bootstrap-css
  - apache-solr-for-typo3/solr-example-facets-options-toggle
  - apache-solr-for-typo3/solr-example-suggest
```

Fixes: #4527
