### PR TITLE
[BUGFIX:12.1] Correct field name casing for subTitle and navTitle in TypoScript queryFields

### DIFF
--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -78,7 +78,7 @@ plugin.tx_solr {
       allowedSites = __solr_current_site
 
       // qf parameter http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29
-      queryFields = content^40.0, title^5.0, keywords^2.0, tagsH1^5.0, tagsH2H3^3.0, tagsH4H5H6^2.0, tagsInline^1.0, description^4.0, abstract^1.0, subtitle^1.0, navtitle^1.0, author^1.0
+      queryFields = content^40.0, title^5.0, keywords^2.0, tagsH1^5.0, tagsH2H3^3.0, tagsH4H5H6^2.0, tagsInline^1.0, description^4.0, abstract^1.0, subTitle^1.0, navTitle^1.0, author^1.0
 
       // fl parameter http://wiki.apache.org/solr/CommonQueryParameters#fl
       returnFields = *, score
@@ -112,7 +112,7 @@ plugin.tx_solr {
       phrase = 0
       phrase {
         // Note: Those are field for implicit phrase searching. On explicit "phrase searching" Apache Solr uses queryFields("qf" parameter)
-        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subtitle^10.0, navtitle^10.0
+        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subTitle^10.0, navTitle^10.0
         // The number of words between words in query phrase is the slop-value.
         // e.g. on query phrase "Hello World"
         // @ slop = 0 will math "Hello World" but not "Hello wonderful World"
@@ -143,7 +143,7 @@ plugin.tx_solr {
       // Note: The triplets phrases will be stripped down to two two-word phrases
       bigramPhrase = 0
       bigramPhrase {
-        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subtitle^10.0, navtitle^10.0
+        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subTitle^10.0, navTitle^10.0
         slop = 0
       }
 
@@ -158,7 +158,7 @@ plugin.tx_solr {
       //                      "to triplets phrases"
       trigramPhrase = 0
       trigramPhrase {
-        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subtitle^10.0, navtitle^10.0
+        fields = content^10.0, title^10.0, tagsH1^10.0, tagsH2H3^10.0, tagsH4H5H6^10.0, tagsInline^10.0, description^10.0, abstract^10.0, subTitle^10.0, navTitle^10.0
         slop = 0
       }
     }


### PR DESCRIPTION
The Solr schema defines subTitle and navTitle as camelCase field names, but the TypoScript configuration referenced them as subtitle and navtitle (all lowercase). 
Since Solr field names are case-sensitive, both fields were indexed correctly but silently excluded from all search queries.

Fixes: #4617
Ports: #4618