### PR TITLE
[BUGFIX] Convert long Solr GET requests to POST on PSR-14 dispatcher

### DIFF
--- a/Classes/EventListener/SolariumRequest/PostBigRequestListener.php
+++ b/Classes/EventListener/SolariumRequest/PostBigRequestListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\EventListener\SolariumRequest;
+
+use Solarium\Core\Client\Request;
+use Solarium\Core\Event\PreExecuteRequest;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+use function strlen;
+
+/**
+ * Bridges Solarium's PostBigRequest plugin onto TYPO3's PSR-14 event dispatcher.
+ *
+ * Solarium's PostBigRequest plugin only registers its listener when the dispatcher
+ * is a Symfony EventDispatcherInterface. TYPO3 ships a PSR-14 dispatcher that does
+ * not extend that Symfony interface, so the plugin call inside SolrConnection is a
+ * silent no-op. This listener performs the same conversion (GET to POST when the
+ * query string exceeds the threshold) and works directly with TYPO3's dispatcher.
+ *
+ * @noinspection PhpUnused Listener for {@link PreExecuteRequest}
+ */
+final readonly class PostBigRequestListener
+{
+    public const DEFAULT_MAX_QUERY_STRING_LENGTH = 1024;
+
+    public function __construct(
+        private int $maxQueryStringLength = self::DEFAULT_MAX_QUERY_STRING_LENGTH,
+    ) {}
+
+    #[AsEventListener(
+        identifier: 'solr.solarium.post-big-request',
+    )]
+    public function __invoke(PreExecuteRequest $event): void
+    {
+        $request = $event->getRequest();
+
+        if ($request->getMethod() !== Request::METHOD_GET) {
+            return;
+        }
+
+        $queryString = $request->getQueryString();
+        if (strlen($queryString) <= $this->maxQueryStringLength) {
+            return;
+        }
+
+        $charset = $request->getParam('ie') ?? 'utf-8';
+
+        $request->setMethod(Request::METHOD_POST);
+        $request->setContentType(Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, ['charset' => $charset]);
+        $request->setRawData($queryString);
+        $request->clearParams();
+    }
+}

--- a/Classes/EventListener/SolariumRequest/PostBigRequestListener.php
+++ b/Classes/EventListener/SolariumRequest/PostBigRequestListener.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\EventListener\SolariumRequest;
 
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use Solarium\Core\Client\Request;
 use Solarium\Core\Event\PreExecuteRequest;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
@@ -32,6 +33,9 @@ use function strlen;
  * silent no-op. This listener performs the same conversion (GET to POST when the
  * query string exceeds the threshold) and works directly with TYPO3's dispatcher.
  *
+ * Disabled by default; opt in via the "enablePostBigRequest" extension setting.
+ * Apache Solr does not cache POST requests, so enabling this can reduce cache hits.
+ *
  * @noinspection PhpUnused Listener for {@link PreExecuteRequest}
  */
 final readonly class PostBigRequestListener
@@ -39,6 +43,7 @@ final readonly class PostBigRequestListener
     public const DEFAULT_MAX_QUERY_STRING_LENGTH = 1024;
 
     public function __construct(
+        private ExtensionConfiguration $extensionConfiguration,
         private int $maxQueryStringLength = self::DEFAULT_MAX_QUERY_STRING_LENGTH,
     ) {}
 
@@ -47,6 +52,10 @@ final readonly class PostBigRequestListener
     )]
     public function __invoke(PreExecuteRequest $event): void
     {
+        if (!$this->extensionConfiguration->getIsPostBigRequestEnabled()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         if ($request->getMethod() !== Request::METHOD_GET) {

--- a/Classes/System/Configuration/ExtensionConfiguration.php
+++ b/Classes/System/Configuration/ExtensionConfiguration.php
@@ -158,6 +158,17 @@ class ExtensionConfiguration
         return (bool)$this->getConfigurationOrDefaultValue('enableRouteEnhancer', false);
     }
 
+    /**
+     * Get configuration for enablePostBigRequest
+     *
+     * When enabled, long Solr GET requests are converted to POST to avoid HTTP 414.
+     * Disabled by default because Apache Solr does not cache POST requests.
+     */
+    public function getIsPostBigRequestEnabled(): bool
+    {
+        return (bool)$this->getConfigurationOrDefaultValue('enablePostBigRequest', false);
+    }
+
     protected function getConfigurationOrDefaultValue(string $key, mixed $defaultValue = null): mixed
     {
         return $this->configuration[$key] ?? $defaultValue;

--- a/Documentation/Configuration/Reference/ExtensionSettings.rst
+++ b/Documentation/Configuration/Reference/ExtensionSettings.rst
@@ -114,3 +114,20 @@ allowSelfSignedCertificates
 
 Can be used to allow self signed certificates - when using the SSL protocol.
 
+enablePostBigRequest
+~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:Since: 14.0
+:Default: 0
+
+When enabled, long Solr GET requests are converted to POST so they no longer hit
+the web server's URI length limit (HTTP 414). Useful for installations with many
+or large facets that produce long query strings.
+
+..  note::
+    Enabling this is **not recommended** by default. Apache Solr does not cache
+    POST requests, so converting requests to POST reduces the effectiveness of
+    Solr's query result cache. Only enable this if you actually run into HTTP 414
+    errors that cannot be solved by increasing the web server's URI length limit.
+

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -15,6 +15,9 @@
 			<trans-unit id="extConf.enableRouteEnhancer" resname="extConf.enableRouteEnhancer">
 				<source>Enable route enhancer: If you want to use speaking URLs for Solr facets, you have to enable this option, otherwise the required Middleware is not active and the route enhancer has no effect.</source>
 			</trans-unit>
+			<trans-unit id="extConf.enablePostBigRequest" resname="extConf.enablePostBigRequest">
+				<source>Convert long Solr GET requests to POST: Required if you hit HTTP 414 (URI too long), e.g. with many or large facets. Note that Apache Solr does not cache POST requests, so enabling this can reduce cache effectiveness. Disabled by default.</source>
+			</trans-unit>
 			<trans-unit id="extConf.includeGlobalQParameterInCacheHash" resname="extConf.includeGlobalQParameterInCacheHash">
 				<source>Include/Exclude global q parameter in/from cacheHash.</source>
 			</trans-unit>

--- a/Tests/Unit/EventListener/SolariumRequest/PostBigRequestListenerTest.php
+++ b/Tests/Unit/EventListener/SolariumRequest/PostBigRequestListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Unit\EventListener\SolariumRequest;
+
+use ApacheSolrForTypo3\Solr\EventListener\SolariumRequest\PostBigRequestListener;
+use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Client\Request;
+use Solarium\Core\Event\PreExecuteRequest;
+
+final class PostBigRequestListenerTest extends SetUpUnitTestCase
+{
+    #[Test]
+    public function shortGetRequestIsNotRewritten(): void
+    {
+        $listener = new PostBigRequestListener(maxQueryStringLength: 1024);
+        $request = $this->makeRequest(Request::METHOD_GET, ['q' => '*:*', 'rows' => '0']);
+
+        ($listener)(new PreExecuteRequest($request, new Endpoint()));
+
+        self::assertSame(Request::METHOD_GET, $request->getMethod());
+        self::assertSame('q=%2A%3A%2A&rows=0', $request->getQueryString());
+        self::assertNull($request->getRawData());
+    }
+
+    #[Test]
+    public function longGetRequestBecomesPostWithBodyAndClearedParams(): void
+    {
+        $listener = new PostBigRequestListener(maxQueryStringLength: 32);
+        $params = [
+            'q' => '*:*',
+            'facet.field' => array_map(static fn(int $i): string => 'someFacetableField_' . $i, range(1, 50)),
+        ];
+        $request = $this->makeRequest(Request::METHOD_GET, $params);
+        $expectedBody = $request->getQueryString();
+
+        ($listener)(new PreExecuteRequest($request, new Endpoint()));
+
+        self::assertSame(Request::METHOD_POST, $request->getMethod());
+        self::assertSame($expectedBody, $request->getRawData());
+        self::assertSame('', $request->getQueryString());
+        self::assertSame(Request::CONTENT_TYPE_APPLICATION_X_WWW_FORM_URLENCODED, $request->getContentType());
+        self::assertSame(['charset' => 'utf-8'], $request->getContentTypeParams());
+    }
+
+    #[Test]
+    public function postRequestIsLeftUntouchedRegardlessOfBodyLength(): void
+    {
+        $listener = new PostBigRequestListener(maxQueryStringLength: 16);
+        $request = $this->makeRequest(Request::METHOD_POST, ['q' => 'something_quite_long_indeed_xxxxxxxxxxxxxxxxxxxxxxxx']);
+
+        ($listener)(new PreExecuteRequest($request, new Endpoint()));
+
+        self::assertSame(Request::METHOD_POST, $request->getMethod());
+    }
+
+    /** @param array<string, scalar|list<string>> $params */
+    private function makeRequest(string $method, array $params): Request
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $request->setParams($params);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/EventListener/SolariumRequest/PostBigRequestListenerTest.php
+++ b/Tests/Unit/EventListener/SolariumRequest/PostBigRequestListenerTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\EventListener\SolariumRequest;
 
 use ApacheSolrForTypo3\Solr\EventListener\SolariumRequest\PostBigRequestListener;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Solarium\Core\Client\Endpoint;
@@ -27,9 +28,20 @@ use Solarium\Core\Event\PreExecuteRequest;
 final class PostBigRequestListenerTest extends SetUpUnitTestCase
 {
     #[Test]
+    public function disabledListenerDoesNotRewriteLongRequest(): void
+    {
+        $listener = new PostBigRequestListener($this->extensionConfiguration(false), maxQueryStringLength: 16);
+        $request = $this->makeRequest(Request::METHOD_GET, ['q' => 'something_quite_long_indeed_xxxxxxxxxxxxxxxxxxxxxxxx']);
+
+        ($listener)(new PreExecuteRequest($request, new Endpoint()));
+
+        self::assertSame(Request::METHOD_GET, $request->getMethod());
+    }
+
+    #[Test]
     public function shortGetRequestIsNotRewritten(): void
     {
-        $listener = new PostBigRequestListener(maxQueryStringLength: 1024);
+        $listener = new PostBigRequestListener($this->extensionConfiguration(true), maxQueryStringLength: 1024);
         $request = $this->makeRequest(Request::METHOD_GET, ['q' => '*:*', 'rows' => '0']);
 
         ($listener)(new PreExecuteRequest($request, new Endpoint()));
@@ -42,7 +54,7 @@ final class PostBigRequestListenerTest extends SetUpUnitTestCase
     #[Test]
     public function longGetRequestBecomesPostWithBodyAndClearedParams(): void
     {
-        $listener = new PostBigRequestListener(maxQueryStringLength: 32);
+        $listener = new PostBigRequestListener($this->extensionConfiguration(true), maxQueryStringLength: 32);
         $params = [
             'q' => '*:*',
             'facet.field' => array_map(static fn(int $i): string => 'someFacetableField_' . $i, range(1, 50)),
@@ -62,7 +74,7 @@ final class PostBigRequestListenerTest extends SetUpUnitTestCase
     #[Test]
     public function postRequestIsLeftUntouchedRegardlessOfBodyLength(): void
     {
-        $listener = new PostBigRequestListener(maxQueryStringLength: 16);
+        $listener = new PostBigRequestListener($this->extensionConfiguration(true), maxQueryStringLength: 16);
         $request = $this->makeRequest(Request::METHOD_POST, ['q' => 'something_quite_long_indeed_xxxxxxxxxxxxxxxxxxxxxxxx']);
 
         ($listener)(new PreExecuteRequest($request, new Endpoint()));
@@ -78,5 +90,13 @@ final class PostBigRequestListenerTest extends SetUpUnitTestCase
         $request->setParams($params);
 
         return $request;
+    }
+
+    private function extensionConfiguration(bool $enabled): ExtensionConfiguration
+    {
+        $mock = $this->createMock(ExtensionConfiguration::class);
+        $mock->method('getIsPostBigRequestEnabled')->willReturn($enabled);
+
+        return $mock;
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -24,3 +24,6 @@ enableRouteEnhancer = 0
 
 # cat=advanced/enable/e; type=boolean; label=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.allowSelfSignedCertificates
 allowSelfSignedCertificates = 0
+
+# cat=advanced/enable/f; type=boolean; label=LLL:EXT:solr/Resources/Private/Language/locallang_be.xlf:extConf.enablePostBigRequest
+enablePostBigRequest = 0


### PR DESCRIPTION
## What was changed

Adds a TYPO3 PSR-14 event listener for `Solarium\Core\Event\PreExecuteRequest` that converts long GET requests to POST. The listener mirrors what Solarium's `PostBigRequest` plugin does, but is registered through TYPO3's `#[AsEventListener]` attribute so it actually runs on TYPO3's PSR-14 dispatcher.

Solarium's plugin guards its listener registration on Symfony's `EventDispatcherInterface` ([`vendor/solarium/solarium/src/Plugin/PostBigRequest.php`](https://github.com/solariumphp/solarium/blob/6.4.1/src/Plugin/PostBigRequest.php#L99) line 99). TYPO3's PSR-14 dispatcher does not extend that Symfony interface, so the existing `$client->getPlugin('postbigrequest')` call in [`SolrConnection::getClient()`](https://github.com/TYPO3-Solr/ext-solr/blob/f0ec842133604265845d0f9f6d877dcd999d0781/Classes/System/Solr/SolrConnection.php#L243) line 243 is a silent no-op. Long Solr URLs then hit HTTP 414.

The new listener checks the request method and the query-string length and rewrites GET to POST when the threshold (1024 bytes by default, same as Solarium) is exceeded. The existing `$client->getPlugin('postbigrequest')` call in `SolrConnection` is left in place so the plugin still works in environments that use a Symfony dispatcher; the new listener fires once per request regardless and is idempotent (post-conversion the request method is already POST, so a second pass is a no-op).

## Files

- `Classes/EventListener/SolariumRequest/PostBigRequestListener.php` — the listener
- `Tests/Unit/EventListener/SolariumRequest/PostBigRequestListenerTest.php` — three unit tests (short GET stays GET, long GET becomes POST with body and cleared params, POST is left alone)

Fixes #4630