### PR TITLE
[BUGFIX] Improve assertion message in AccessProtectedContentTest

### DIFF
--- a/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
+++ b/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
@@ -94,7 +94,7 @@ class AccessProtectedContentTest extends IntegrationTestBase
             true,
         );
 
-        self::assertEquals($expectedNumFound, $solrContent['response']['numFound'] ?? 0, 'Could not index documents into Solr');
+        self::assertEquals($expectedNumFound, $solrContent['response']['numFound'] ?? 0, 'Unexpected count of documents in Solr index.');
         foreach ($expectedAccessFieldValues as $index => $expectedAccessFieldValue) {
             self::assertEquals(
                 $expectedAccessFieldValue,


### PR DESCRIPTION
The previous message "Could not index documents into Solr" implies "too few documents indexed", but this assertion can fail for any unexpected count — including too many. The new wording is direction- neutral and accurately describes what is being checked.

Files:
- Tests/Integration/IndexQueue/AccessProtectedContentTest.php
  - Replaced 'Could not index documents into Solr' with 'Unexpected count of documents in Solr index.' on the numFound assertion.