### PR TITLE
[BUGFIX] Restore globals after frontend subrequest

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -270,12 +270,29 @@ readonly class IndexingService
             // Ensure CWD matches the document root so that third-party code
             // relying on relative paths (e.g. cache file checks) works the
             // same way as in a real web request served by the web server.
+            $hadBackendUser = array_key_exists('BE_USER', $GLOBALS);
+            $previousBackendUser = $GLOBALS['BE_USER'] ?? null;
+            $hadTypo3Request = array_key_exists('TYPO3_REQUEST', $GLOBALS);
+            $previousTypo3Request = $GLOBALS['TYPO3_REQUEST'] ?? null;
             $previousWorkingDirectory = getcwd();
+
             chdir(Environment::getPublicPath());
             try {
                 $response = $this->frontendApplication->handle($request);
             } finally {
                 chdir($previousWorkingDirectory);
+
+                if ($hadBackendUser) {
+                    $GLOBALS['BE_USER'] = $previousBackendUser;
+                } else {
+                    unset($GLOBALS['BE_USER']);
+                }
+
+                if ($hadTypo3Request) {
+                    $GLOBALS['TYPO3_REQUEST'] = $previousTypo3Request;
+                } else {
+                    unset($GLOBALS['TYPO3_REQUEST']);
+                }
             }
 
             $statusCode = $response->getStatusCode();


### PR DESCRIPTION
Fixes: #4628

# What this pr does

This PR solves the following exception when running schedued jobs:

> Fri, 08 May 2026 12:40:34 +0200 [CRITICAL] request="7a184e7069ba8" component="TYPO3.CMS.Core.Error.DebugExceptionHandler": Core: Exception handler (CLI: FE): TypeError, code #0, file /var/www/html/vendor/typo3/cms-core/Classes/DataHandling/DataHandler.php, line 458: Cannot assign null to property TYPO3\CMS\Core\DataHandling\DataHandler::$BE_USER of type TYPO3\CMS\Core\Authentication\BackendUserAuthentication- TypeError: Cannot assign null to property TYPO3\CMS\Core\DataHandling\DataHandler::$BE_USER of type TYPO3\CMS\Core\Authentication\BackendUserAuthentication, in file /var/www/html/vendor/typo3/cms-core/Classes/DataHandling/DataHandler.php:458 - {"mode":"CLI","application_mode":"FE","exception_class":"TypeError","exception_code":0,"file":"/var/www/html/vendor/typo3/cms-core/Classes/DataHandling/DataHandler.php","line":458,"message":"Cannot assign null to property TYPO3\\CMS\\Core\\DataHandling\\DataHandler::$BE_USER of type TYPO3\\CMS\\Core\\Authentication\\BackendUserAuthentication","request_url":"http:///vendor/bin/typo3","exception":"TypeError: Cannot assign null to property TYPO3\\CMS\\Core\\DataHandling\\DataHandler::$BE_USER of type TYPO3\\CMS\\Core\\Authentication\\BackendUserAuthentication in /var/www/html/vendor/typo3/cms-core/Classes/DataHandling/DataHandler.php:458\nStack trace:\n#0 /var/www/html/vendor/typo3/cms-scheduler/Classes/Domain/Repository/SchedulerTaskRepository.php(116): TYPO3\\CMS\\Core\\DataHandling\\DataHandler->start()\n#1 /var/www/html/vendor/typo3/cms-scheduler/Classes/Scheduler.php(142): TYPO3\\CMS\\Scheduler\\Domain\\Repository\\SchedulerTaskRepository->updateExecution()\n#2 /var/www/html/vendor/typo3/cms-scheduler/Classes/Command/SchedulerCommand.php(254): TYPO3\\CMS\\Scheduler\\Scheduler->executeTask()\n#3 /var/www/html/vendor/typo3/cms-scheduler/Classes/Command/SchedulerCommand.php(189): TYPO3\\CMS\\Scheduler\\Command\\SchedulerCommand->executeOrStopTask()\n#4 /var/www/html/vendor/typo3/cms-scheduler/Classes/Command/SchedulerCommand.php(123): TYPO3\\CMS\\Scheduler\\Command\\SchedulerCommand->loopTasks()\n#5 /var/www/html/vendor/symfony/console/Command/Command.php(341): TYPO3\\CMS\\Scheduler\\Command\\SchedulerCommand->execute()\n#6 /var/www/html/vendor/symfony/console/Application.php(1117): Symfony\\Component\\Console\\Command\\Command->run()\n#7 /var/www/html/vendor/symfony/console/Application.php(356): Symfony\\Component\\Console\\Application->doRunCommand()\n#8 /var/www/html/vendor/symfony/console/Application.php(195): Symfony\\Component\\Console\\Application->doRun()\n#9 /var/www/html/vendor/typo3/cms-core/Classes/Console/CommandApplication.php(113): Symfony\\Component\\Console\\Application->run()\n#10 /var/www/html/vendor/typo3/cms-cli/typo3(23): TYPO3\\CMS\\Core\\Console\\CommandApplication->run()\n#11 /var/www/html/vendor/typo3/cms-cli/typo3(24): {closure}()\n#12 /var/www/html/vendor/bin/typo3(119): include('...')\n#13 {main}"}

If solr is complete, scheduler will try to execute another task and die because of corrupted BE user and request.

# How to test

ddev typo3 scheduler:run

Best to run with several jobs, when indexing is already over and the next job needs to run.

Fixes: #4628 
