### PR TITLE
[BUGFIX] Preserve BE web context across indexing sub-request

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -39,6 +39,8 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Page\AssetCollector;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -267,15 +269,63 @@ readonly class IndexingService
             $request = $this->buildServerRequest($item, $language);
             $request = $request->withAttribute('solr.indexingInstructions', $instructions);
 
-            // Ensure CWD matches the document root so that third-party code
-            // relying on relative paths (e.g. cache file checks) works the
-            // same way as in a real web request served by the web server.
+            // Snapshot global/singleton state that the frontend sub-request
+            // would otherwise clobber, so the BE web context (e.g. scheduler
+            // module dispatching this task) survives the call (#4628).
+            // Inspired by TYPO3 testing-framework's FrameworkState (which the
+            // testing-framework uses around executeFrontendSubRequest), but
+            // limited to the state we actually observe getting tainted in
+            // production indexing — the testing-framework's full reset relies
+            // on re-bootstrapping a fresh DI container, which is not feasible
+            // here. Concretely:
+            // - BackendUserAuthenticator (frontend middleware) overwrites
+            //   $GLOBALS['BE_USER'] and $GLOBALS['LANG']; without restore the
+            //   BE response rendering crashes (TypeError on getBackendUser())
+            //   or loses its localisation.
+            // - The frontend RequestHandler reassigns $GLOBALS['TYPO3_REQUEST'].
+            // - AssetCollector and PageRenderer are shared singletons whose
+            //   state is mutated by the frontend rendering chain; without
+            //   restore the BE module loses its registered CSS/JS.
+            // CWD is also pinned to the document root so third-party code
+            // using relative paths behaves like in a real web request.
             $previousWorkingDirectory = getcwd();
+            // For $GLOBALS keys, distinguish "key was unset" from "key was null"
+            // so the restore preserves the original semantics — assigning null
+            // when the key was previously absent would change array_key_exists()
+            // results and could mislead downstream code (e.g. CLI runs where
+            // $GLOBALS['BE_USER'] is genuinely not set at all).
+            $hadBackendUser = array_key_exists('BE_USER', $GLOBALS);
+            $previousBackendUser = $GLOBALS['BE_USER'] ?? null;
+            $hadLanguageService = array_key_exists('LANG', $GLOBALS);
+            $previousLanguageService = $GLOBALS['LANG'] ?? null;
+            $hadRequest = array_key_exists('TYPO3_REQUEST', $GLOBALS);
+            $previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+            $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
+            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            $previousAssetCollectorState = $assetCollector->getState();
+            $previousPageRendererState = $pageRenderer->getState();
             chdir(Environment::getPublicPath());
             try {
                 $response = $this->frontendApplication->handle($request);
             } finally {
                 chdir($previousWorkingDirectory);
+                if ($hadBackendUser) {
+                    $GLOBALS['BE_USER'] = $previousBackendUser;
+                } else {
+                    unset($GLOBALS['BE_USER']);
+                }
+                if ($hadLanguageService) {
+                    $GLOBALS['LANG'] = $previousLanguageService;
+                } else {
+                    unset($GLOBALS['LANG']);
+                }
+                if ($hadRequest) {
+                    $GLOBALS['TYPO3_REQUEST'] = $previousRequest;
+                } else {
+                    unset($GLOBALS['TYPO3_REQUEST']);
+                }
+                $assetCollector->updateState($previousAssetCollectorState);
+                $pageRenderer->updateState($previousPageRendererState);
             }
 
             $statusCode = $response->getStatusCode();

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -24,7 +24,12 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\AssetCollector;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -130,5 +135,181 @@ class IndexServiceTest extends IntegrationTestBase
         $this->waitToBeVisibleInSolr();
         $solrContent = file_get_contents($this->getSolrCoreUrl('core_en') . '/select?q=*:*');
         self::assertStringContainsString('"numFound":1', $solrContent, 'Indexing failed when CWD was not the public directory');
+    }
+
+    /**
+     * Reproduces #4628: when the IndexQueueWorker scheduler task runs in BE web
+     * context, the frontend sub-request must not clobber $GLOBALS['BE_USER'] or
+     * $GLOBALS['TYPO3_REQUEST'] — otherwise the scheduler module crashes when
+     * rendering its list view after the task (ModuleTemplate::getBackendUser()
+     * returns null -> TypeError).
+     */
+    #[Test]
+    public function subRequestsRestoreBackendUserAndRequestGlobals(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_custom_record_withBasePrefix_foo.csv');
+
+        $this->addToIndexQueue('tx_fakeextension_domain_model_bar', 111);
+
+        // Simulate BE web context: $GLOBALS['BE_USER'] and $GLOBALS['TYPO3_REQUEST']
+        // are set when the scheduler module dispatches the task.
+        $sentinelBackendUser = $this->createMock(BackendUserAuthentication::class);
+        $sentinelRequest = new ServerRequest('http://testone.site/typo3/module/system/scheduler');
+        $previousBackendUser = $GLOBALS['BE_USER'] ?? null;
+        $previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $GLOBALS['BE_USER'] = $sentinelBackendUser;
+        $GLOBALS['TYPO3_REQUEST'] = $sentinelRequest;
+
+        try {
+            $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+            $site = $siteRepository->getFirstAvailableSite();
+            $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
+
+            $indexService->indexItems(1);
+
+            self::assertSame(
+                $sentinelBackendUser,
+                $GLOBALS['BE_USER'] ?? null,
+                '$GLOBALS[\'BE_USER\'] was not restored after sub-request indexing — '
+                . 'breaks scheduler module list rendering in BE web context (#4628).',
+            );
+            self::assertSame(
+                $sentinelRequest,
+                $GLOBALS['TYPO3_REQUEST'] ?? null,
+                '$GLOBALS[\'TYPO3_REQUEST\'] was not restored after sub-request indexing.',
+            );
+        } finally {
+            $GLOBALS['BE_USER'] = $previousBackendUser;
+            $GLOBALS['TYPO3_REQUEST'] = $previousRequest;
+        }
+    }
+
+    /**
+     * Reproduces #4628 follow-up: even after BE_USER/TYPO3_REQUEST were
+     * preserved, the BE module's styles were broken because the frontend
+     * sub-request replaces the AssetCollector and PageRenderer singletons'
+     * state and overrides $GLOBALS['LANG'] (LanguageService). The BE module
+     * loses its registered CSS/JS/labels and renders without styles.
+     */
+    #[Test]
+    public function subRequestsRestoreAssetCollectorPageRendererAndLanguageService(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_custom_record_withBasePrefix_foo.csv');
+
+        $this->addToIndexQueue('tx_fakeextension_domain_model_bar', 111);
+
+        $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+
+        // Add a sentinel BE-style asset that should still be present after
+        // the sub-request returns. Without the save/restore, the frontend
+        // replaces the singleton state and the sentinel is gone.
+        $assetCollector->addInlineStyleSheet('solr-test-be-style', '/* be sentinel */');
+        $pageRenderer->addCssInlineBlock('solr-test-be-page-css', '/* page-renderer be sentinel */');
+        $assetCollectorStateBefore = $assetCollector->getState();
+        $pageRendererStateBefore = $pageRenderer->getState();
+
+        // Simulate BE web context: $GLOBALS['LANG'] is set to a sentinel
+        // LanguageService that the BE module would use for label translation.
+        $sentinelLanguageService = $this->createMock(LanguageService::class);
+        $previousLanguageService = $GLOBALS['LANG'] ?? null;
+        $GLOBALS['LANG'] = $sentinelLanguageService;
+
+        try {
+            $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+            $site = $siteRepository->getFirstAvailableSite();
+            $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
+
+            $indexService->indexItems(1);
+
+            self::assertSame(
+                $assetCollectorStateBefore,
+                $assetCollector->getState(),
+                'AssetCollector singleton state was not restored after sub-request — '
+                . 'breaks BE module CSS/JS rendering (#4628 follow-up).',
+            );
+            self::assertSame(
+                $pageRendererStateBefore,
+                $pageRenderer->getState(),
+                'PageRenderer singleton state was not restored after sub-request — '
+                . 'breaks BE module CSS/JS rendering (#4628 follow-up).',
+            );
+            self::assertSame(
+                $sentinelLanguageService,
+                $GLOBALS['LANG'] ?? null,
+                '$GLOBALS[\'LANG\'] was not restored after sub-request — '
+                . 'breaks BE module label localisation (#4628 follow-up).',
+            );
+        } finally {
+            $GLOBALS['LANG'] = $previousLanguageService;
+            // Drop the sentinel BE assets so subsequent tests get a clean
+            // singleton state. AssetCollector has no public remove API,
+            // so we updateState() with a snapshot taken without the sentinel.
+            $assetCollector->updateState(
+                array_diff_key($assetCollectorStateBefore, ['inlineStyleSheets' => true])
+                + ['inlineStyleSheets' => []],
+            );
+        }
+    }
+
+    /**
+     * Reproduces the CLI multi-task scenario from #4628 (and PR #4646): when
+     * $GLOBALS['BE_USER'], 'LANG' or 'TYPO3_REQUEST' were not set before the
+     * sub-request, the restore must leave the keys absent — not assign them
+     * to null. Otherwise downstream code that distinguishes "key missing"
+     * from "key set to null" (e.g. via array_key_exists()) sees a state that
+     * never existed before and may take wrong code paths (cf. CLI scheduler
+     * running multiple tasks where the second task crashes in DataHandler
+     * because it expects $GLOBALS['BE_USER'] to be a real BackendUserAuthentication
+     * or be absent — not null).
+     */
+    #[Test]
+    public function subRequestsLeaveUnsetGlobalsUnsetAfterSubRequest(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/can_index_custom_record_withBasePrefix_foo.csv');
+
+        $this->addToIndexQueue('tx_fakeextension_domain_model_bar', 111);
+
+        // Simulate CLI context: ensure the three globals are entirely absent.
+        $previousBackendUser = $GLOBALS['BE_USER'] ?? null;
+        $previousLanguageService = $GLOBALS['LANG'] ?? null;
+        $previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $hadBackendUser = array_key_exists('BE_USER', $GLOBALS);
+        $hadLanguageService = array_key_exists('LANG', $GLOBALS);
+        $hadRequest = array_key_exists('TYPO3_REQUEST', $GLOBALS);
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG'], $GLOBALS['TYPO3_REQUEST']);
+
+        try {
+            $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+            $site = $siteRepository->getFirstAvailableSite();
+            $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
+
+            $indexService->indexItems(1);
+
+            self::assertFalse(
+                array_key_exists('BE_USER', $GLOBALS),
+                '$GLOBALS[\'BE_USER\'] was unset before the sub-request and must remain absent afterwards '
+                . '(not be assigned null) — otherwise CLI multi-task scheduler runs see a fake null value '
+                . 'and crash in downstream code (#4628 / PR #4646).',
+            );
+            self::assertFalse(
+                array_key_exists('LANG', $GLOBALS),
+                '$GLOBALS[\'LANG\'] was unset before the sub-request and must remain absent afterwards.',
+            );
+            self::assertFalse(
+                array_key_exists('TYPO3_REQUEST', $GLOBALS),
+                '$GLOBALS[\'TYPO3_REQUEST\'] was unset before the sub-request and must remain absent afterwards.',
+            );
+        } finally {
+            if ($hadBackendUser) {
+                $GLOBALS['BE_USER'] = $previousBackendUser;
+            }
+            if ($hadLanguageService) {
+                $GLOBALS['LANG'] = $previousLanguageService;
+            }
+            if ($hadRequest) {
+                $GLOBALS['TYPO3_REQUEST'] = $previousRequest;
+            }
+        }
     }
 }


### PR DESCRIPTION
When the `IndexQueueWorker` scheduler task is dispatched from the BE
web context (Scheduler module) or chained on the CLI via
`scheduler:run`, the frontend sub-request executed via
`$frontendApplication->handle()` during indexing replaces global state
that callers of the sub-request rely on. Two failure modes have been
observed:

  TypeError: `ModuleTemplate::getBackendUser()`: Return value must be of
  type `BackendUserAuthentication`, null returned
    at `ModuleTemplate::makeDocHeaderModuleMenu()`
    at `SchedulerModuleController::renderListTasksView()` (line 346)
  - happens in the BE web context after the task runs.

  TypeError: Cannot assign null to property
  `DataHandler::$BE_USER` of type `BackendUserAuthentication`
    at `SchedulerTaskRepository::updateExecution()`
  - happens on the CLI when `scheduler:run` chains multiple tasks; the
    next task after indexing crashes because `DataHandler` expects
    `$GLOBALS['BE_USER']` to be a real `BackendUserAuthentication`
    instance. Reported by @dmitryd in PR #4646.

Indexing itself succeeds — only the post-task code (BE response
rendering or the next CLI task) crashes or renders without styles.

The fix snapshots the BE-context state before the sub-request and
restores it in the `finally` block — the same shape TYPO3's testing-
framework `FrameworkState` class uses around `executeFrontendSubRequest`,
limited to the state we observe getting tainted in production
indexing (testing-framework can fully reset by re-bootstrapping a
fresh DI container, which is not feasible here).

State snapshot/restore covers:
- `$GLOBALS['BE_USER']` / `$GLOBALS['LANG']`
  Frontend `BackendUserAuthenticator` middleware overrides both.
- `$GLOBALS['TYPO3_REQUEST']`
  Frontend `RequestHandler` reassigns it.
- `AssetCollector` / `PageRenderer` state (via `getState()` / `updateState()`)
  Shared singletons whose collected assets are mutated by the
  frontend rendering chain — restoring keeps the BE module's
  registered CSS/JS intact.
- Working directory (pre-existing): pinned to the document root so
  third-party code using relative paths behaves like in a real web
  request.

For the three `$GLOBALS` keys the restore distinguishes "key was
absent" from "key was null": when a key was not set before the
sub-request (typical CLI scenario), it is `unset()` again instead of
being assigned `null`. This preserves `array_key_exists()` semantics
for downstream code. Pattern adopted from @dmitryd's PR #4646.

Files:
- `Classes/IndexQueue/IndexingService.php`
  - In `executeSubRequest()`: snapshot `$GLOBALS['BE_USER']`,
    `$GLOBALS['LANG']`, `$GLOBALS['TYPO3_REQUEST']`, `AssetCollector`
    and `PageRenderer` singleton states alongside CWD; restore all in
    the `finally` block. For the three `$GLOBALS` keys: if the key
    was absent before, `unset()` it instead of assigning `null`.
- `Tests/Integration/Domain/Index/IndexServiceTest.php`
  - Added test `subRequestsRestoreBackendUserAndRequestGlobals`
    which sets sentinel `$GLOBALS['BE_USER']` and
    `$GLOBALS['TYPO3_REQUEST']`, runs `IndexService::indexItems(1)`,
    and asserts both still hold the sentinel values after the
    sub-request returns.
  - Added test
    `subRequestsRestoreAssetCollectorPageRendererAndLanguageService`
    which adds a sentinel inline style to `AssetCollector`, an inline
    block to `PageRenderer`, and sets a sentinel `LanguageService` in
    `$GLOBALS['LANG']`; asserts all three are still in place after
    indexing.
  - Added test `subRequestsLeaveUnsetGlobalsUnsetAfterSubRequest`
    which `unset()`s `$GLOBALS['BE_USER']`, `$GLOBALS['LANG']` and
    `$GLOBALS['TYPO3_REQUEST']` before the sub-request and asserts
    that all three remain absent afterwards (not assigned `null`).
  - All three tests fail without the source fix.

Fixes: #4628

Co-Authored-By: @dmitryd via #4646
