### PR TITLE
[BUGFIX] Use more robust way to calculate suggest dropdown position

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -258,19 +258,11 @@ class SuggestController {
     document.body.appendChild(list);
 
     const input = this.autoCompleteInstance.input;
-    let top = 0;
-    let left = 0;
-    let element = input;
+    const inputRect = input.getBoundingClientRect();
 
-    while (element) {
-      top += element.offsetTop;
-      left += element.offsetLeft;
-      element = element.offsetParent;
-    }
-
-    list.style.top = `${top + input.offsetHeight}px`;
-    list.style.left = `${left}px`;
-    list.style.width = `${input.offsetWidth}px`;
+    list.style.top = `${inputRect.bottom + window.scrollY}px`;
+    list.style.left = `${inputRect.left + window.scrollX}px`;
+    list.style.width = `${inputRect.width}px`;
   }
 
   /**
@@ -356,6 +348,7 @@ class SuggestController {
             },
             open: () => {
               this.lastSelectedIndex = null
+              this.setSuggestionBoxWidthAndPosition();
             },
             close: () => {
               this.lastSelectedIndex = null


### PR DESCRIPTION
# What this pr does

Fixes position calculation method so that it reliably works if suggest is located in the block, which is offxcanvas (like `left: -1000px`) and then moved into place.

# How to test

See the description, or by code review, or by testing that it still works in your usual environment.

Fixes: #4652
