### PR TITLE
[FEATURE] Add hybrid edismax + KNN reRank query mode (query.type=2)

### DIFF
--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -164,7 +164,7 @@ class QueryBuilder extends AbstractQueryBuilder
         $topK = $this->typoScriptConfiguration->getTopKClosestVectorLimit();
         // Use the smaller of topK (KNN candidate pool) and reRankDocs so
         // the KNN side never returns fewer docs than the re-ranker needs.
-        $knnTopK = min($topK, $reRankDocs);
+        $knnTopK = max(1, min($topK, $reRankDocs));
 
         $weightForSolr = rtrim(rtrim(sprintf('%F', $reRankWeight), '0'), '.');
         if ($weightForSolr === '' || $weightForSolr === '-') {

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -111,6 +111,10 @@ class QueryBuilder extends AbstractQueryBuilder
                 ->usePhraseFieldsFromTypoScript()
                 ->useBigramPhraseFieldsFromTypoScript()
                 ->useTrigramPhraseFieldsFromTypoScript();
+
+            if ($this->typoScriptConfiguration->isHybridVectorSearchEnabled()) {
+                $this->attachHybridVectorReRanking($rawQuery);
+            }
         }
 
         return $this
@@ -141,6 +145,47 @@ class QueryBuilder extends AbstractQueryBuilder
         $this->queryToBuild->addParam(
             'q_vector',
             '{!knn_text_to_vector model=llm f=vector topK=' . $topK . '}' . $rawQuery,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Attaches a KNN re-rank stage on top of the classical edismax query.
+     *
+     * The classical query produces the candidate set (recall); Solr's
+     * reRank query parser then orders the top-N candidates by combining
+     * bm25 with a weighted cosine similarity score.
+     */
+    protected function attachHybridVectorReRanking(string $rawQuery): self
+    {
+        $reRankDocs = $this->typoScriptConfiguration->getVectorReRankDocs();
+        $reRankWeight = $this->typoScriptConfiguration->getVectorReRankWeight();
+        $topK = $this->typoScriptConfiguration->getTopKClosestVectorLimit();
+        // Use the smaller of topK (KNN candidate pool) and reRankDocs so
+        // the KNN side never returns fewer docs than the re-ranker needs.
+        $knnTopK = min($topK, $reRankDocs);
+
+        $weightForSolr = rtrim(rtrim(sprintf('%F', $reRankWeight), '0'), '.');
+        if ($weightForSolr === '' || $weightForSolr === '-') {
+            $weightForSolr = '0';
+        }
+
+        $this->queryToBuild->addParam(
+            'rq',
+            sprintf(
+                '{!rerank reRankQuery=$rqq reRankDocs=%d reRankWeight=%s}',
+                $reRankDocs,
+                $weightForSolr,
+            ),
+        );
+        $this->queryToBuild->addParam(
+            'rqq',
+            sprintf(
+                '{!knn_text_to_vector model=llm f=vector topK=%d}%s',
+                $knnTopK,
+                $rawQuery,
+            ),
         );
 
         return $this;

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1078,8 +1078,9 @@ class TypoScriptConfiguration
     /**
      * Returns the configured query type
      *
-     * 0 = default
-     * 1 = vector (requires additional configuration)
+     * 0 = default (classical edismax)
+     * 1 = pure vector (requires additional configuration and an LLM)
+     * 2 = hybrid (classical edismax + KNN re-rank on top-N)
      */
     public function getSearchQueryType(): int
     {
@@ -1103,6 +1104,38 @@ class TypoScriptConfiguration
     public function isPureVectorSearchEnabled(): bool
     {
         return $this->getSearchQueryType() === 1;
+    }
+
+    /**
+     * Indicates if hybrid vector + classical re-ranking is enabled
+     * (query.type = 2). The classical edismax pipeline still produces
+     * the candidate set; KNN is attached via Solr's reRank query parser
+     * to refine the top-N ordering.
+     */
+    public function isHybridVectorSearchEnabled(): bool
+    {
+        return $this->getSearchQueryType() === 2;
+    }
+
+    /**
+     * Number of candidate documents the KNN re-ranker considers.
+     *
+     * plugin.tx_solr.search.vectorSearch.reRank.docs
+     */
+    public function getVectorReRankDocs(): int
+    {
+        return (int)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.vectorSearch.reRank.docs', 200);
+    }
+
+    /**
+     * Multiplier applied to the cosine similarity in the final
+     * reRanked score: bm25 + (weight * cosine).
+     *
+     * plugin.tx_solr.search.vectorSearch.reRank.weight
+     */
+    public function getVectorReRankWeight(): float
+    {
+        return (float)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.vectorSearch.reRank.weight', 2.0);
     }
 
     public function getMinimumVectorSimilarity(): float

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -101,13 +101,14 @@ query.type
 :Type: Boolean
 :TS Path: plugin.tx_solr.search.query.type
 :Default: 0
-:Options: 0,1
+:Options: 0,1,2
 :Since: 12.1.0, 13.1.0
 
 Allows to configure the query type that should be configured
 
 *   0: default score based Solr search (= well-known behaviour since EXT:solr started)
 *   1: pure vector based search (requires additional configuration and an LLM)
+*   2: hybrid search — classical edismax produces the candidate set, KNN re-ranks the top-N by ``bm25 + weight * cosine`` (requires the same vector configuration as type 1)
 
 ..  note::
     A full reindex is required if vector search is enabled, as vectors are only created if vector search is active
@@ -522,7 +523,7 @@ By default only documents with at least 0.75 of vector similarity score are retu
 The calculated vector similarity score is returned in field `$q_vector`
 
 ..  note::
-    This setting is only relevant if pure vector queries are used (query.type = 1).
+    This setting is only relevant if pure vector queries are used (query.type = 1). It has no effect on the hybrid path (query.type = 2), which uses Solr's reRank scoring instead of a similarity cutoff.
 
 
 query.vectorSearch.topK
@@ -536,7 +537,40 @@ query.vectorSearch.topK
 Number of documents to return in vector search.
 
 ..  note::
-    This setting is only relevant if pure vector queries are used (query.type = 1).
+    This setting is only relevant if pure vector queries are used (query.type = 1). For hybrid search (query.type = 2) the effective KNN topK is capped at ``vectorSearch.reRank.docs``.
+
+
+query.vectorSearch.reRank.docs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Integer
+:TS Path: plugin.tx_solr.search.vectorSearch.reRank.docs
+:Default: 200
+:Since: 14.0.0
+
+Number of top candidate documents the hybrid re-ranker considers. The
+classical edismax query produces up to this many results before the KNN
+re-ranking step combines bm25 with cosine similarity.
+
+..  note::
+    This setting is only relevant for hybrid search (query.type = 2).
+
+
+query.vectorSearch.reRank.weight
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Float
+:TS Path: plugin.tx_solr.search.vectorSearch.reRank.weight
+:Default: 2.0
+:Since: 14.0.0
+
+Multiplier applied to the cosine similarity in the re-ranked score:
+``final_score = bm25_score + weight * cosine``. Higher values give the
+embedding more influence; values close to zero collapse to plain
+classical relevance.
+
+..  note::
+    This setting is only relevant for hybrid search (query.type = 2).
 
 
 results

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -334,6 +334,25 @@ class QueryBuilderTest extends SetUpUnitTestCase
     }
 
     #[Test]
+    public function canBuildSearchQueryForHybridVectorSearchClampsKnnTopKToReRankDocs(): void
+    {
+        $this->configurationMock->method('isPureVectorSearchEnabled')->willReturn(false);
+        $this->configurationMock->method('isHybridVectorSearchEnabled')->willReturn(true);
+        $this->configurationMock->method('getVectorReRankDocs')->willReturn(50);
+        $this->configurationMock->method('getVectorReRankWeight')->willReturn(2.0);
+        $this->configurationMock->method('getTopKClosestVectorLimit')->willReturn(1000);
+
+        $query = $this->builder->buildSearchQuery('term', 10);
+        $params = $query->getParams();
+
+        self::assertSame(
+            '{!knn_text_to_vector model=llm f=vector topK=50}term',
+            $params['rqq'],
+            'KNN topK should be clamped to the smaller of getTopKClosestVectorLimit and getVectorReRankDocs',
+        );
+    }
+
+    #[Test]
     public function canEnableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -317,7 +317,8 @@ class QueryBuilderTest extends SetUpUnitTestCase
         $query = $this->builder->buildSearchQuery('hybrid term', 10);
         $params = $query->getParams();
 
-        self::assertSame('hybrid term', $query->getQuery(), 'Hybrid uses the search term as query string');
+        self::assertTrue($query instanceof SearchQuery);
+        self::assertSame('hybrid term', $query->getRawSearchTerm());
         self::assertNotSame('*:*', $query->getQuery(), 'Hybrid uses classical query, not match-all');
 
         self::assertArrayHasKey('rq', $params, 'reRank parameter missing');

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -317,7 +317,7 @@ class QueryBuilderTest extends SetUpUnitTestCase
         $query = $this->builder->buildSearchQuery('hybrid term', 10);
         $params = $query->getParams();
 
-        self::assertSame('hybrid term', $query->getRawSearchTerm());
+        self::assertSame('hybrid term', $query->getQuery(), 'Hybrid uses the search term as query string');
         self::assertNotSame('*:*', $query->getQuery(), 'Hybrid uses classical query, not match-all');
 
         self::assertArrayHasKey('rq', $params, 'reRank parameter missing');

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -306,6 +306,34 @@ class QueryBuilderTest extends SetUpUnitTestCase
     }
 
     #[Test]
+    public function canBuildSearchQueryForHybridVectorSearch(): void
+    {
+        $this->configurationMock->method('isPureVectorSearchEnabled')->willReturn(false);
+        $this->configurationMock->method('isHybridVectorSearchEnabled')->willReturn(true);
+        $this->configurationMock->method('getVectorReRankDocs')->willReturn(200);
+        $this->configurationMock->method('getVectorReRankWeight')->willReturn(2.0);
+        $this->configurationMock->method('getTopKClosestVectorLimit')->willReturn(200);
+
+        $query = $this->builder->buildSearchQuery('hybrid term', 10);
+        $params = $query->getParams();
+
+        self::assertSame('hybrid term', $query->getRawSearchTerm());
+        self::assertNotSame('*:*', $query->getQuery(), 'Hybrid uses classical query, not match-all');
+
+        self::assertArrayHasKey('rq', $params, 'reRank parameter missing');
+        self::assertSame(
+            '{!rerank reRankQuery=$rqq reRankDocs=200 reRankWeight=2}',
+            $params['rq'],
+        );
+
+        self::assertArrayHasKey('rqq', $params, 'reRank inner query missing');
+        self::assertSame(
+            '{!knn_text_to_vector model=llm f=vector topK=200}hybrid term',
+            $params['rqq'],
+        );
+    }
+
+    #[Test]
     public function canEnableHighlighting(): void
     {
         $query = $this->getInitializedTestSearchQuery();

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -922,4 +922,61 @@ class TypoScriptConfigurationTest extends SetUpUnitTestCase
         ]);
         self::assertEquals(9999, $configuration->getTopKClosestVectorLimit());
     }
+
+    #[Test]
+    public function isHybridVectorSearchEnabledReturnsTrueForQueryTypeTwo(): void
+    {
+        $config = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => ['query.' => ['type' => 2]]]],
+        ]);
+        self::assertTrue($config->isHybridVectorSearchEnabled());
+        self::assertFalse($config->isPureVectorSearchEnabled());
+        self::assertTrue($config->isVectorSearchEnabled());
+    }
+
+    #[Test]
+    public function isHybridVectorSearchEnabledReturnsFalseForOtherQueryTypes(): void
+    {
+        foreach ([0, 1, 3] as $type) {
+            $config = new TypoScriptConfiguration([
+                'plugin.' => ['tx_solr.' => ['search.' => ['query.' => ['type' => $type]]]],
+            ]);
+            self::assertFalse(
+                $config->isHybridVectorSearchEnabled(),
+                'Expected hybrid=false for query.type=' . $type,
+            );
+        }
+    }
+
+    #[Test]
+    public function getVectorReRankDocsReturnsConfiguredValue(): void
+    {
+        $config = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => ['vectorSearch.' => ['reRank.' => ['docs' => 500]]]]],
+        ]);
+        self::assertSame(500, $config->getVectorReRankDocs());
+    }
+
+    #[Test]
+    public function getVectorReRankDocsReturnsDefaultWhenUnset(): void
+    {
+        $config = new TypoScriptConfiguration([]);
+        self::assertSame(200, $config->getVectorReRankDocs());
+    }
+
+    #[Test]
+    public function getVectorReRankWeightReturnsConfiguredValue(): void
+    {
+        $config = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => ['vectorSearch.' => ['reRank.' => ['weight' => '3.5']]]]],
+        ]);
+        self::assertSame(3.5, $config->getVectorReRankWeight());
+    }
+
+    #[Test]
+    public function getVectorReRankWeightReturnsDefaultWhenUnset(): void
+    {
+        $config = new TypoScriptConfiguration([]);
+        self::assertSame(2.0, $config->getVectorReRankWeight());
+    }
 }


### PR DESCRIPTION
Builds on #4065. Adds a hybrid (classical + KNN) sibling to the existing
`query.type = 1` (pure vector) mode introduced as part of that feature.

## Motivation

The existing `plugin.tx_solr.search.query.type = 1` performs a pure KNN
vector search (`q=*:*` plus a vector frange filter), discarding classical
term-matching signals. For keyword-heavy queries this produces phantom
matches from the embedding cluster while exact-term hits get scored
identically to remote semantic neighbours.

In practice, on a TYPO3 demo site (`solr-ddev-site` with `nomic-embed-text`
embeddings), searching for `WordPress` in pure-vector mode returns 25 hits
(all unrelated TYPO3 pages sharing a "CMS" embedding cluster) while
searching for `TYPO3` — the dominant term on the site — returns only 1.
Raising the minimum-similarity threshold does not help; it only shifts the
phantom count linearly.

## What this PR adds

A third value `query.type = 2` — **hybrid re-rank mode**:

- Classical edismax produces the candidate set (recall driver),
  preserving qf/pf/mm/highlighting/facets/spellcheck.
- Solr's `{!rerank reRankQuery={!knn_text_to_vector ...}}` orders
  the top-N candidates by `bm25 + weight * cosine` (precision refinement).
- Score-mix is tunable via two new TypoScript keys.

The hybrid branch is **strictly additive**: a new
`isHybridVectorSearchEnabled()` predicate sits inside the existing
else-arm of `buildSearchQuery()`. `query.type = 0` (classical) and
`query.type = 1` (pure vector) code paths are byte-identical to base.

## Configuration

Two new TypoScript keys under `plugin.tx_solr.search.vectorSearch.reRank`:

| Key      | Type    | Default | Effect                                                        |
|----------|---------|---------|---------------------------------------------------------------|
| `docs`   | Integer | `200`   | Candidate pool size for re-ranking                            |
| `weight` | Float   | `2.0`   | Cosine multiplier: `final = bm25 + weight * cosine`           |

Existing keys (`vectorSearch.minimumSimilarity`, `vectorSearch.topK`)
stay relevant only for `query.type = 1`; the docs notes have been updated
to make this explicit.

## Manual verification (TYPO3 14 / Solr 10)

| Term        | `type=0` | `type=1` | `type=2` |
|-------------|----------|----------|----------|
| `TYPO3`     | 31       | 1        | 31       |
| `WordPress` | 0        | 25       | 0        |
| `language`  | 6        | varies   | 6        |

`type=2` matches `type=0` on recall (correct counts) while top-of-list
ordering is refined by the cosine signal. The phantom CMS-cluster matches
under `type=1` disappear because BM25 = 0 documents are not candidates.

## Test coverage

- 961 unit tests pass (8 new: getter defaults + configured values, hybrid
  build path including `rq`/`rqq` parameter shape, `min()` clamp branch
  with `reRankDocs < topK`, cross-relation with the existing vector flags)
- 84 integration tests (`QueryBuilder|Search` filter) pass, no regressions
- PHPStan level 6: 0 errors
- TYPO3 Coding Standards: clean

## Known gaps / follow-ups

- The hardcoded `model=llm f=vector` strings in
  `attachHybridVectorReRanking()` mirror `preparePureVectorSearch()` — same
  hardcoding, kept for symmetry. A future PR could hoist both to a config
  getter.
- No integration test exercises hybrid against a live Solr — would require
  seeded vector fixture data, scoped out of this PR.
- The `2.0` default weight is a heuristic chosen for the demo site; large
  production indices may need re-tuning.
- Pre-existing doc inconsistency in `TxSolrSearch.rst`: section headings
  use `query.vectorSearch.*` while `:TS Path:` values correctly use
  `plugin.tx_solr.search.vectorSearch.*` (no `.query.` segment in the
  TypoScript path). The two new sections follow the existing heading style
  for consistency; cleanup is a separate concern.

## Commits

1. `[FEATURE] Add config getters for hybrid vector re-rank search`
2. `[FEATURE] Hybrid edismax + KNN reRank query path (query.type=2)`
3. `[BUGFIX] Clamp hybrid KNN topK to 1 and cover min() branch with a test`
4. `[TASK] Apply TYPO3 coding standards and fix PHPStan to hybrid vector path`
5. `[BUGFIX] Restore getRawSearchTerm() assertion with instanceof guard`
6. `[DOCS] Document hybrid query.type=2 and reRank settings`
