### PR TITLE
 [DOCS] Fix case-sensitive X-Tx-Solr-Iq header in BestPractice.rst

### DIFF
--- a/Documentation/Development/BestPractice.rst
+++ b/Documentation/Development/BestPractice.rst
@@ -20,7 +20,7 @@ non-content elements. Like this for example:
 
 .. code-block:: typoscript
 
-    [request && traverse(request.getHeaders(), 'x-tx-solr-iq/0')]
+    [request && traverse(request.getHeaders(), 'X-Tx-Solr-Iq/0')]
     page.10.dataProcessing >
     page.10.variables >
     page.10.variables {


### PR DESCRIPTION
 # What this pr does

   This PR fixes the TypoScript example in `Documentation/Development/BestPractice.rst` by correcting the request header key case in the condition:

   - from: `traverse(request.getHeaders(), 'x-tx-solr-iq/0')`
   - to: `traverse(request.getHeaders(), 'X-Tx-Solr-Iq/0')`

   This ensures the example uses the correct case-sensitive header key (`X-Tx-Solr-Iq`).