### PR TITLE
[BUGFIX] Make suggest widget form submission preventable

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -182,7 +182,7 @@ class SuggestController {
     // If nothing is selected or suggestion box is closed then submit form
     if ((cursor === undefined || cursor === -1) || !this.autoCompleteInstance.isOpen) {
       if (this.autoCompleteInstance.input.value.length) {
-        this.form.submit()
+        this.form.requestSubmit()
       }
     } else {
       this.autoCompleteInstance.select(cursor)
@@ -333,7 +333,7 @@ class SuggestController {
                 // Get href from selected item and open it
                 window.location.href = resultItems[selectionIndex].children[0].href
               } else {
-                this.form.submit()
+                this.form.requestSubmit()
               }
             },
             navigate: (event) => {


### PR DESCRIPTION
# What this pr does

Replace `this.form.submit()` with `this.form.requestSubmit()` (modern, fires submit event and respects validation).

# How to test

1. Add a `submit` event listener to the search form that calls `event.preventDefault()`.
2. Type a search query into the Solr suggest input.
3. Press **Enter** while the suggestion box is closed (or select an autocomplete suggestion from the list).
4. `submit` event is fired and the page does not reload/submit.

Fixes: #4657
