### PR TITLE
[BUGFIX] Pin guzzlehttp/psr7 to <2.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "ext-libxml": "*",
     "ext-pdo": "*",
     "ext-simplexml": "*",
+    "guzzlehttp/psr7": "<2.10.0",
     "solarium/solarium": "6.4.1",
     "typo3/cms-backend": "*",
     "typo3/cms-core": "^v14.3.0",


### PR DESCRIPTION
`guzzlehttp/psr7` 2.10.0 ([PR #655](https://github.com/guzzle/psr7/pull/655))
changed `Utils::modifyRequest()` to mutate the original `RequestInterface`
via `withHeader()` instead of rebuilding a Guzzle `Request`. Combined with
Guzzle's `PrepareBodyMiddleware` setting `Content-Length` as an `int`, this
triggers `InvalidArgumentException` in spec-compliant PSR-7 implementations
like `TYPO3\CMS\Core\Http\Message`, breaking all Solr write requests through
the Solarium `Psr18Adapter`.

Until the underlying issue is fixed in Guzzle upstream, pin to `<2.10.0`.

## Verification
- Without pin: 69 integration test errors (`Invalid header value for header "Content-Length"`)
- With pin: integration tests pass

See #4660 for the full stack trace and root cause analysis.