### PR TITLE
[BUGFIX:12.1] Pin guzzlehttp/psr7 to <2.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "ext-libxml": "*",
     "ext-pdo": "*",
     "ext-simplexml": "*",
+    "guzzlehttp/psr7": "<2.10.0",
     "solarium/solarium": "6.4.1",
     "typo3/cms-backend": "*",
     "typo3/cms-core": "^v12.4.3",


### PR DESCRIPTION
guzzlehttp/psr7 2.10.0 changed Utils::modifyRequest() to mutate the original RequestInterface via withHeader() instead of rebuilding a Guzzle Request. Combined with Guzzle's PrepareBodyMiddleware setting Content-Length as an int, this triggers InvalidArgumentException in spec-compliant PSR-7 implementations like TYPO3\CMS\Core\Http\Message, breaking all Solr write requests through the Solarium Psr18Adapter.

Relates: #4660
Ports: #4661