### PR TITLE
[Release] 14.0.0-beta2

### DIFF
--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -401,6 +401,11 @@ Since EXT:solr 9 and Apache Solr 7 dynamic fields based on trie fields are marke
 All Changes
 -----------
 
+*   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4661 <https://github.com/TYPO3-Solr/ext-solr/pull/4661>`_
+*   [BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS by @amirarends in `#4603 <https://github.com/TYPO3-Solr/ext-solr/pull/4603>`_
+*   [BUGFIX] Make suggest widget form submission preventable by @danilovq in `#4657 <https://github.com/TYPO3-Solr/ext-solr/pull/4657>`_
+*   [BUGFIX] Use more robust way to calculate suggest dropdown position that works also with mobile/offcanvas layouts by @dmitryd in `#4652 <https://github.com/TYPO3-Solr/ext-solr/pull/4652>`_
+*   [DOCS] Fix case-sensitive X-Tx-Solr-Iq header in BestPractice.rst by @hnadler in `#4656 <https://github.com/TYPO3-Solr/ext-solr/pull/4656>`_
 *   [BUGFIX] Preserve BE web context across indexing sub-request by @dkd-kaehm in `#4647 <https://github.com/TYPO3-Solr/ext-solr/pull/4647>`_
 *   [BUGFIX] fix suggestion query if routeEnhancer is set by @dkd-lehnebach in `#4644 <https://github.com/TYPO3-Solr/ext-solr/pull/4644>`_
 *   [BUGFIX] Improve assertion message in AccessProtectedContentTest by @dkd-kaehm in `#4643 <https://github.com/TYPO3-Solr/ext-solr/pull/4643>`_

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0-or-later",
   "keywords": ["typo3", "TYPO3 CMS", "solr", "search"],
   "homepage": "https://www.typo3-solr.com",
-  "version": "14.0.0-beta1",
+  "version": "14.0.0-beta2",
   "authors": [
     {
       "name": "dkd Internet Service GmbH",


### PR DESCRIPTION
This is a maintenance release for EXT:solr 14 LTS (beta phase), primarily restoring Solr write functionality after a regression introduced by an upstream PSR-7 library update.

Highlights since 14.0.0-beta1:

* [BUGFIX] Pin `guzzlehttp/psr7` to `<2.10.0` — `guzzlehttp/psr7` 2.10.0 changed `Utils::modifyRequest()` to mutate the original `RequestInterface` via `withHeader()` instead of rebuilding a Guzzle `Request`. Combined with Guzzle's `PrepareBodyMiddleware` passing `Content-Length` as an `int`, this broke all Solr write requests through Solarium's `Psr18Adapter` in spec-compliant PSR-7 implementations like `TYPO3\CMS\Core\Http\Message` (#4660 / @dkd-kaehm)
* [BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in workspace (@amirarends)
* [BUGFIX] Make suggest widget form submission preventable — replaces `form.submit()` with `form.requestSubmit()` so external listeners can cancel via `event.preventDefault()` (#4657 / @danilovq)
* [BUGFIX] More robust suggest dropdown positioning that also works in mobile/offcanvas layouts (#4652 / @dmitryd)
* [DOCS] Fix case-sensitive `X-Tx-Solr-Iq` header in `BestPractice.rst` (#4656 / @hnadler)

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/14.0/en-us/Releases/solr-release-14-0.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/14.0.0-beta2

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4660
