### PR TITLE
[RELEASE] 13.1.2

### DIFF
--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -9,12 +9,25 @@ Releases 13.1
 Release 13.1.2
 ==============
 
-This is a bugfix release for TYPO3 13 LTS.
+This is a bugfix release for TYPO3 13 LTS, primarily restoring Solr
+write functionality after a regression introduced by an upstream PSR-7
+library update.
 
 All Changes
 -----------
 
+*   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4662 <https://github.com/TYPO3-Solr/ext-solr/pull/4662>`_
 *   [BUGFIX] Prevent c:0 variant and content leakage on fe_group-restricted pages by @dkd-kaehm in `#4641 <https://github.com/TYPO3-Solr/ext-solr/pull/4641>`_
+*   [BUGFIX] facet URL encoding mismatch (spaces) when using urlParameterStyle=assoc by @dkd-hauser in `#4626 <https://github.com/TYPO3-Solr/ext-solr/pull/4626>`_
+*   [BUGFIX] Correct field name casing for subTitle and navTitle in TypoScript queryFields by @amirarends in `#4624 <https://github.com/TYPO3-Solr/ext-solr/pull/4624>`_
+*   [TASK] Add PHP 8.5 to version matrix on TYPO3 13 by @dkd-kaehm in `#4599 <https://github.com/TYPO3-Solr/ext-solr/pull/4599>`_
+*   [TASK] Upgrade GitHub Actions to latest versions by @dkd-kaehm in `#4599 <https://github.com/TYPO3-Solr/ext-solr/pull/4599>`_
+*   [BUGFIX] GeneralUtility::trimExplode(): Argument #2 ($string) must be of type string, int given by @kitzberger in `#4586 <https://github.com/TYPO3-Solr/ext-solr/pull/4586>`_
+*   [BUGFIX] Cast result offset to integer by @SaschaNoLe in `#4585 <https://github.com/TYPO3-Solr/ext-solr/pull/4585>`_
+*   [BUGFIX] Respect plugin TS in RelevanceComponent by @helhum in `#4538 <https://github.com/TYPO3-Solr/ext-solr/pull/4538>`_
+*   [BUGFIX] Catch InvalidArgumentException for missing site languages in GarbageHandler by @mikelwohlschlegel in `#4537 <https://github.com/TYPO3-Solr/ext-solr/pull/4537>`_
+*   [BUGFIX] Add headers palette to solr plugin CType TCA definitions by @dkd-kaehm in `#4535 <https://github.com/TYPO3-Solr/ext-solr/pull/4535>`_
+*   [BUGFIX] CS issues 2026.02.05 by @dkd-kaehm in `#4535 <https://github.com/TYPO3-Solr/ext-solr/pull/4535>`_
 
 Release 13.1.1
 ==============

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,7 +19,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="13.1.1"
+	  release="13.1.2"
 	  version="13.1"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '13.1.1',
+    'version' => '13.1.2',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
This is a bugfix release for TYPO3 13 LTS, primarily restoring Solr write functionality after a regression introduced by an upstream PSR-7 library update.

Highlights since 13.1.1:

* [BUGFIX] Pin `guzzlehttp/psr7` to `<2.10.0` — `guzzlehttp/psr7` 2.10.0 changed `Utils::modifyRequest()` to mutate the original `RequestInterface` via `withHeader()` instead of rebuilding a Guzzle `Request`. Combined with Guzzle's `PrepareBodyMiddleware` passing `Content-Length` as an `int`, this broke all Solr write requests through Solarium's `Psr18Adapter` in spec-compliant PSR-7 implementations like `TYPO3\CMS\Core\Http\Message` (#4660 / @dkd-kaehm)
* [BUGFIX] Prevent c:0 variant and content leakage on fe_group-restricted pages (#4641 / @dkd-kaehm)
* Plus 10 additional bugfixes and maintenance updates — see release notes for details.

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/13.1/en-us/Releases/solr-release-13-1.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/13.1.2

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4660
