### PR TITLE
[RELEASE] 12.1.2

### DIFF
--- a/Documentation/Releases/solr-release-12-1.rst
+++ b/Documentation/Releases/solr-release-12-1.rst
@@ -6,6 +6,26 @@ Releases 12.1
 
 ..  include:: HintAboutOutdatedChangelog.rst.txt
 
+Release 12.1.2
+==============
+
+This is a bugfix release for TYPO3 12 LTS, primarily restoring Solr
+write functionality after a regression introduced by an upstream PSR-7
+library update.
+
+All Changes
+-----------
+
+*   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4663 <https://github.com/TYPO3-Solr/ext-solr/pull/4663>`_
+*   [BUGFIX] facet URL encoding mismatch (spaces) when using urlParameterStyle=assoc by @dkd-hauser in `#4625 <https://github.com/TYPO3-Solr/ext-solr/pull/4625>`_
+*   [BUGFIX] Correct field name casing for subTitle and navTitle in TypoScript queryFields by @amirarends in `#4623 <https://github.com/TYPO3-Solr/ext-solr/pull/4623>`_
+*   [TASK] Upgrade GitHub Actions to latest versions by @dkd-kaehm in `#4600 <https://github.com/TYPO3-Solr/ext-solr/pull/4600>`_
+*   [BUGFIX] Cast result offset to integer by @SaschaNoLe in `#4584 <https://github.com/TYPO3-Solr/ext-solr/pull/4584>`_
+*   [TASK] fix CS 2026.03.08 by @dkd-kaehm in `#4579 <https://github.com/TYPO3-Solr/ext-solr/pull/4579>`_
+*   [BUGFIX] pass a request with page id to Configuration manager by @WebsiteDeveloper in `#4579 <https://github.com/TYPO3-Solr/ext-solr/pull/4579>`_
+*   [BUGFIX] Add checks for flexParentDatabaseRow key in methods by @Myrmod in `#4579 <https://github.com/TYPO3-Solr/ext-solr/pull/4579>`_
+
+
 Release 12.1.1
 ==============
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -17,7 +17,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="12.1.1"
+	  release="12.1.2"
 	  version="12.1"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '12.1.1',
+    'version' => '12.1.2',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
This is a bugfix release for TYPO3 12 LTS, primarily restoring Solr write functionality after a regression introduced by an upstream PSR-7 library update.

Highlights since 12.1.1:

* [BUGFIX] Pin `guzzlehttp/psr7` to `<2.10.0` — `guzzlehttp/psr7` 2.10.0 changed `Utils::modifyRequest()` to mutate the original `RequestInterface` via `withHeader()` instead of rebuilding a Guzzle `Request`. Combined with Guzzle's `PrepareBodyMiddleware` passing `Content-Length` as an `int`, this broke all Solr write requests through Solarium's `Psr18Adapter` in spec-compliant PSR-7 implementations like `TYPO3\CMS\Core\Http\Message` (#4660 / @dkd-kaehm)
* Plus 7 additional bugfixes and maintenance updates ported from 12.0.x and other branches — see release notes for details.

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/12.1/en-us/Releases/solr-release-12-1.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/12.1.2

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4660
