### PR TITLE
[Release] 14.0.0-beta3

### DIFF
--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -401,6 +401,7 @@ Since EXT:solr 9 and Apache Solr 7 dynamic fields based on trie fields are marke
 All Changes
 -----------
 
+*   [TASK] Remove guzzlehttp/psr7 <2.10.0 pin (upstream fix in guzzlehttp/guzzle 7.10.2) by @dkd-kaehm in `#4660 <https://github.com/TYPO3-Solr/ext-solr/issues/4660>`_
 *   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4661 <https://github.com/TYPO3-Solr/ext-solr/pull/4661>`_
 *   [BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS by @amirarends in `#4603 <https://github.com/TYPO3-Solr/ext-solr/pull/4603>`_
 *   [BUGFIX] Make suggest widget form submission preventable by @danilovq in `#4657 <https://github.com/TYPO3-Solr/ext-solr/pull/4657>`_

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,7 +19,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="14.0.0-beta1"
+	  release="14.0.0-beta3"
 	  version="14.0"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0-or-later",
   "keywords": ["typo3", "TYPO3 CMS", "solr", "search"],
   "homepage": "https://www.typo3-solr.com",
-  "version": "14.0.0-beta2",
+  "version": "14.0.0-beta3",
   "authors": [
     {
       "name": "dkd Internet Service GmbH",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "ext-libxml": "*",
     "ext-pdo": "*",
     "ext-simplexml": "*",
-    "guzzlehttp/psr7": "<2.10.0",
     "solarium/solarium": "6.4.1",
     "typo3/cms-backend": "*",
     "typo3/cms-core": "^v14.3.0",


### PR DESCRIPTION
This is a maintenance release for EXT:solr 14 LTS (beta phase)
that removes the temporary `guzzlehttp/psr7 <2.10.0` pin
introduced in 14.0.0-beta2.

Highlights since 14.0.0-beta2:

* [TASK] Remove `guzzlehttp/psr7 <2.10.0` pin — replaced by the
  upstream fix in `guzzlehttp/guzzle` 7.10.2, which casts
  `Content-Length` to a string in `PrepareBodyMiddleware`. The
  workaround pin introduced in 14.0.0-beta2 is no longer needed;
  `guzzlehttp/psr7` is pulled in transitively via
  `guzzlehttp/guzzle` again. (#4660 / @dkd-kaehm)

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/14.0/en-us/Releases/solr-release-14-0.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/14.0.0-beta3

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
  existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing
  development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4660