### PR TITLE
[RELEASE] 12.1.3

### DIFF
--- a/Documentation/Releases/solr-release-12-1.rst
+++ b/Documentation/Releases/solr-release-12-1.rst
@@ -6,6 +6,27 @@ Releases 12.1
 
 ..  include:: HintAboutOutdatedChangelog.rst.txt
 
+Release 12.1.3
+==============
+
+This is a maintenance release for TYPO3 12 LTS that removes the
+temporary `guzzlehttp/psr7 <2.10.0` pin introduced in 12.1.2, now
+that the upstream fix is available.
+
+.. note::
+
+   This is the **final regular release on the 12.1.x line before
+   the transition to EXT:solr ELTS 12** (if sufficiently funded).
+   Subsequent maintenance for TYPO3 12 LTS will be delivered through
+   the EXT:solr ELTS program. See https://www.typo3-solr.com for
+   ELTS subscription details.
+
+All Changes
+-----------
+
+*   [TASK] Remove guzzlehttp/psr7 <2.10.0 pin (upstream fix in guzzlehttp/guzzle 7.10.2) by @dkd-kaehm in `#4660 <https://github.com/TYPO3-Solr/ext-solr/issues/4660>`_
+
+
 Release 12.1.2
 ==============
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -17,7 +17,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="12.1.2"
+	  release="12.1.3"
 	  version="12.1"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "ext-libxml": "*",
     "ext-pdo": "*",
     "ext-simplexml": "*",
-    "guzzlehttp/psr7": "<2.10.0",
     "solarium/solarium": "6.4.1",
     "typo3/cms-backend": "*",
     "typo3/cms-core": "^v12.4.3",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '12.1.2',
+    'version' => '12.1.3',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
This is a maintenance release for TYPO3 12 LTS that removes the
temporary `guzzlehttp/psr7 <2.10.0` pin introduced in 12.1.2.

This is the final regular release on the 12.1.x line before the
transition to EXT:solr ELTS 12 (if sufficiently funded).
Subsequent maintenance for TYPO3 12 LTS will be delivered through
the EXT:solr ELTS program. See https://www.typo3-solr.com for
ELTS subscription details.

Highlights since 12.1.2:

* [TASK] Remove `guzzlehttp/psr7 <2.10.0` pin — replaced by the
  upstream fix in `guzzlehttp/guzzle` 7.10.2, which casts
  `Content-Length` to a string in `PrepareBodyMiddleware`. The
  workaround pin introduced in 12.1.2 is no longer needed;
  `guzzlehttp/psr7` is pulled in transitively via
  `guzzlehttp/guzzle` again. (#4660 / @dkd-kaehm)

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/12.1/en-us/Releases/solr-release-12-1.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/12.1.3

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
  existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing
  development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4660