### PR TITLE
[DOCS] Update Indexing.rst: clearing documents only for current site

### DIFF
--- a/Documentation/Development/Indexing.rst
+++ b/Documentation/Development/Indexing.rst
@@ -155,10 +155,12 @@ If external data should be indexed or the RecordIndexer is not required, it is p
         * @throws \ApacheSolrForTypo3\Solr\NoSolrConnectionFoundException
         */
        public function clearIndex() {
+           $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+           $site = $siteRepository->getSiteByRootPageId($rootPageId);
            $connections = $this->connectionManager->getAllConnections();
            foreach ($connections as $connectionLanguage => $connection) {
                /** @var SolrConnection */
-               $connection->getWriteService()->deleteByType('custom_type');
+               $connection->getWriteService()->deleteByQuery('type:custom_type,site:'.$site->getDomain());
            }
        }
 


### PR DESCRIPTION
fixing example code:
when clearing documents only delete documents for matching type and site

# What this pr does

don't delete all documents for type, but only for type and matching site

# How to test

use one solr instance for multiple TYPO3 instances and index documents with same type for both instances.

all documents would be deleted but rebuild only for current site 

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
