### PR TITLE
[TASK] Make EXT:install an optional dependency

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use ApacheSolrForTypo3\Solr\Updates\SolrSearchCTypeMigration;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Install\Updates\AbstractListTypeToCTypeUpdate;
+
+return static function (ContainerConfigurator $configurator): void {
+    // EXT:install is optional; register the upgrade wizard only when it is available.
+    if (!class_exists(AbstractListTypeToCTypeUpdate::class)) {
+        return;
+    }
+
+    $configurator->services()
+        ->set(SolrSearchCTypeMigration::class)
+        ->autowire()
+        ->autoconfigure()
+        ->share(false);
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,7 +5,10 @@ services:
 
   ApacheSolrForTypo3\Solr\:
     resource: '../Classes/*'
-    exclude: '../Classes/Eid/*'
+    exclude:
+      - '../Classes/Eid/*'
+      # Upgrade wizards depend on EXT:install and are registered conditionally in Services.php
+      - '../Classes/Updates/*'
 
   backend_controller:
     namespace: ApacheSolrForTypo3\Solr\Controller\Backend\Search\
@@ -381,10 +384,3 @@ services:
     resource: '../Classes/Report/*'
     autoconfigure: true
     autowire: true
-
-  # Upgrade wizards
-  ApacheSolrForTypo3\Solr\Updates\:
-    resource: '../Classes/Updates/*'
-    autoconfigure: true
-    autowire: true
-    shared: false

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "typo3/cms-extbase": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-frontend": "*",
-    "typo3/cms-install": "*",
     "typo3/cms-reports": "*",
     "typo3/cms-scheduler": "*",
     "typo3/cms-tstemplate": "*"
@@ -44,10 +43,14 @@
     "dg/bypass-finals": "^1.9",
     "phpunit/phpunit": "^11.5.55",
     "typo3/cms-fluid-styled-content": "*",
+    "typo3/cms-install": "*",
     "typo3/coding-standards": "v0.8.0",
     "typo3/testing-framework": "^9.5.0",
     "phpstan/phpstan": "^1.11",
     "phpstan/phpstan-phpunit": "^1.3"
+  },
+  "suggest": {
+    "typo3/cms-install": "Required only to run the \"Apache Solr Search\" plugin to content element upgrade wizard."
   },
   "replace": {
     "apache-solr-for-typo3/solrfluid": "*",


### PR DESCRIPTION
## Problem

`typo3/cms-install` became a hard runtime requirement in v14. It was added together with the `list_type` → `CType` upgrade wizard `SolrSearchCTypeMigration`, which `extends AbstractListTypeToCTypeUpdate` from EXT:install. Because the wizard is autowired via `Configuration/Services.yaml` (`../Classes/Updates/*`), the DI container reflects on the class during compilation and fails with a *class not found* fatal when EXT:install is absent.

This forces EXT:install into every installation, which breaks hardened production setups that deliberately remove EXT:install.

## Change

- Move `typo3/cms-install` out of `require` into `require-dev` (so CI/tests keep it) and add a `suggest` entry.
- Exclude `../Classes/Updates/*` from the autowiring glob in `Services.yaml`.
- Add `Configuration/Services.php` that registers the upgrade wizard **only when** `AbstractListTypeToCTypeUpdate` exists. Core loads both `Services.php` and `Services.yaml` (see `ContainerBuilder`), so the regular service definitions are unaffected.

The upgrade wizard remains fully functional wherever EXT:install is present (which is required to run wizards anyway). When EXT:install is absent, the container builds cleanly and the wizard is simply skipped.

## Testing

CI quality stages run locally, all green:

- php-cs-fixer (CGL dry-run) — clean
- xml-lint — no errors
- phpstan — no errors
- unit tests — 954 OK
- `composer validate` — schema valid

DI container build verified with EXT:install present (`typo3 upgrade:list` compiles the container without errors).

No test added: the regression that matters (container builds when EXT:install is *absent*) is not reproducible in the test harness, since `typo3/cms-install` is always present in vendor via `require-dev`, and the repo has no existing upgrade-wizard/DI-registration tests to follow.