### PR TITLE
[BUGFIX] Skip languages absent on a resolved site for queued page item

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -124,6 +124,17 @@ readonly class IndexingService
         $success = true;
         $pageUserGroup = (int)($this->buildPageParameters($item)['pageUserGroup'] ?? 0);
         foreach ($solrConnections as $languageUid => $solrConnection) {
+            if (!$this->isLanguageApplicableForPage($item, $languageUid)) {
+                $this->logger->info(
+                    'Skipping language not configured on the resolved site',
+                    [
+                        'indexQueueItem' => $item->getIndexQueueUid(),
+                        'queueItemRootPageUid' => $item->getRootPageUid(),
+                        'language' => $languageUid,
+                    ],
+                );
+                continue;
+            }
             $accessGroups = $this->findUserGroupsForPage($item, $languageUid);
             if ($pageUserGroup > 0) {
                 // A page with fe_group restriction has no publicly-accessible content variants:
@@ -144,6 +155,17 @@ readonly class IndexingService
         }
 
         return $success;
+    }
+
+    protected function isLanguageApplicableForPage(Item $item, int $language): bool
+    {
+        try {
+            $pageSite = $this->siteFinder->getSiteByPageId($this->resolvePageUid($item));
+            $pageSite->getLanguageById($language);
+            return true;
+        } catch (\InvalidArgumentException | SiteNotFoundException) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
# What this pr does

In `IndexingService::getPageSolrConnections()`, intersect the connection list with the languages defined on the page's own site fetched via `SiteFinder::getSiteByPageId()` before returning it. Languages that the site of queue item advertises but the site of the page does not provide are filtered out. When at least one language gets dropped, the new code logs an info entry with the queue item UID, the queue item's root page UID, the page's site identifier, and the dropped language IDs. If the page does not resolve to any site `SiteNotFoundException`, the filter falls back to returning the unfiltered list, preserving the existing downstream failure mode rather than masking it here. 

# How to test

Provided functional tests sets up two nested sites that share the same Solr backend:

- outer site, root page 1, languages EN/DE/DA, DE+DA with EN fallback, all Solr-enabled
- inner site, root page 2 nested at pid=1, language EN only

The fixture pre-seeds a queue item against the outer root for a page that physically lives in the inner tree. 
After running `IndexService->indexItems()`, the test asserts:

- the queue item's errors column stays empty and indexed is greater than 0
- core_en received the page
- core_de and core_da did not receive the page

Without the filter, the queue item's indexed stays 0, because `indexPageItem()` returns false after the caught DE/DA exceptions, which the test catches.

Fixes: #4675