### PR TITLE
[BUGFIX] Fix Scheduler::__construct() call with missing 4th arg in integration tests

### DIFF
--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -24,6 +24,7 @@ use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Util\SiteUtility;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use Doctrine\DBAL\Exception as DBALException;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
@@ -649,6 +650,7 @@ abstract class IntegrationTestBase extends FunctionalTestCase
             $this->createMock(NullLogger::class),
             $this->createMock(TaskSerializer::class),
             $this->createMock(SchedulerTaskRepository::class),
+            $this->createMock(EventDispatcherInterface::class),
         );
 
         $scheduler->executeTask($task);

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -21,6 +21,7 @@ use ApacheSolrForTypo3\Solr\System\Records\Queue\EventQueueItemRepository;
 use ApacheSolrForTypo3\Solr\Task\EventQueueWorkerTask;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -66,6 +67,7 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
             $this->createMock(NullLogger::class),
             $this->createMock(TaskSerializer::class),
             $this->createMock(SchedulerTaskRepository::class),
+            $this->createMock(EventDispatcherInterface::class),
         );
         $scheduler->executeTask($task);
 
@@ -84,6 +86,7 @@ class EventQueueWorkerTaskTest extends IntegrationTestBase
             $this->createMock(NullLogger::class),
             $this->createMock(TaskSerializer::class),
             $this->createMock(SchedulerTaskRepository::class),
+            $this->createMock(EventDispatcherInterface::class),
         );
         $scheduler->executeTask($task);
 


### PR DESCRIPTION
TYPO3 cms-scheduler added EventDispatcherInterface as required 4th constructor
argument (https://github.com/TYPO3-CMS/scheduler/commit/61ad5689b8b73d078184966a291644baa0446c63).
