### PR TITLE
[BUGFIX:BP:13.1] Spellchecking: keep correct terms when offering corrections

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -127,10 +127,14 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             return $resultSet;
         }
 
+        $originalQuery = $this->resolveOriginalQuery($resultSet);
+
         $misspelledTerm = '';
-        foreach ($response->spellcheck->suggestions as $key => $suggestionData) {
+        foreach ($response->spellcheck->suggestions as $suggestionData) {
             if (is_string($suggestionData)) {
-                $misspelledTerm = $key;
+                // Flat NamedList alternates misspelled-term strings and suggestion objects;
+                // capture the term string so we can pair it with the next object.
+                $misspelledTerm = $suggestionData;
                 continue;
             }
 
@@ -146,13 +150,52 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             }
 
             foreach ($suggestionData->suggestion as $suggestedTerm) {
-                $suggestion = $this->createSuggestionFromResponseFragment($suggestionData, $suggestedTerm, $misspelledTerm);
+                $suggestion = $this->createSuggestionFromResponseFragment($suggestionData, $suggestedTerm, $misspelledTerm, $originalQuery);
                 //add it to the resultSet
                 $resultSet->addSpellCheckingSuggestion($suggestion);
             }
         }
 
+        foreach ($this->extractCollations($response->spellcheck?->collations ?? []) as $collation) {
+            $resultSet->addSpellCheckingCollation($collation);
+        }
+
         return $resultSet;
+    }
+
+    /**
+     * Extracts collated full-query strings from the spellcheck response.
+     *
+     * Solr returns collations as a NamedList. With json.nl=flat (EXT:solr default) it is a
+     * flat array of alternating "collation"/value entries. With other formats it can be an
+     * array of strings or — when spellcheck.collateExtendedResults=true — an array of objects
+     * carrying the corrected query under "collationQuery". All shapes are normalized here.
+     *
+     * @param array<int|string, mixed> $collations
+     * @return list<string>
+     */
+    private function extractCollations(array $collations): array
+    {
+        $extracted = [];
+        $expectLabel = true;
+        foreach ($collations as $entry) {
+            if ($expectLabel && $entry === 'collation') {
+                $expectLabel = false;
+                continue;
+            }
+            $expectLabel = true;
+
+            if (is_string($entry) && $entry !== '' && $entry !== 'collation') {
+                $extracted[] = $entry;
+                continue;
+            }
+
+            if (is_object($entry) && isset($entry->collationQuery) && is_string($entry->collationQuery) && $entry->collationQuery !== '') {
+                $extracted[] = $entry->collationQuery;
+            }
+        }
+
+        return $extracted;
     }
 
     /**
@@ -162,14 +205,71 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
         stdClass $suggestionData,
         string $suggestedTerm,
         string $misspelledTerm,
+        string $originalQuery,
     ): Suggestion {
-        $numFound = $suggestionData->numFound ?? 0;
-        $startOffset = $suggestionData->startOffset ?? 0;
-        $endOffset = $suggestionData->endOffset ?? 0;
+        $numFound = (int)($suggestionData->numFound ?? 0);
+        $startOffset = (int)($suggestionData->startOffset ?? 0);
+        $endOffset = (int)($suggestionData->endOffset ?? 0);
+
+        $fullQuery = $this->buildSuggestionFullQuery(
+            $originalQuery,
+            $misspelledTerm,
+            $suggestedTerm,
+            $startOffset,
+            $endOffset,
+        );
 
         // by now we avoid to use GeneralUtility::makeInstance, since we only create a value object
         // and the usage might be an overhead.
-        return new Suggestion($suggestedTerm, $misspelledTerm, $numFound, $startOffset, $endOffset);
+        return new Suggestion($suggestedTerm, $misspelledTerm, $numFound, $startOffset, $endOffset, $fullQuery);
+    }
+
+    /**
+     * Resolves the original user query that Solr saw when computing spellcheck offsets.
+     *
+     * Prefers `responseHeader.params.q` because the start/end offsets returned per suggestion
+     * are relative to that exact string. Falls back to the SearchRequest's raw user query
+     * (useful when tests only provide a request mock).
+     */
+    private function resolveOriginalQuery(SearchResultSet $resultSet): string
+    {
+        $response = $resultSet->getResponse();
+        $paramsQuery = $response->responseHeader->params->q ?? null;
+        if (is_string($paramsQuery) && $paramsQuery !== '') {
+            return $paramsQuery;
+        }
+
+        $searchRequest = $resultSet->getUsedSearchRequest();
+        return $searchRequest !== null ? $searchRequest->getRawUserQuery() : '';
+    }
+
+    /**
+     * Builds the full follow-up query by replacing only the misspelled term inside the
+     * original query, keeping every other (correctly spelled) term intact.
+     */
+    private function buildSuggestionFullQuery(
+        string $originalQuery,
+        string $misspelledTerm,
+        string $suggestedTerm,
+        int $startOffset,
+        int $endOffset,
+    ): string {
+        if ($originalQuery === '') {
+            return $suggestedTerm;
+        }
+
+        if ($endOffset > $startOffset && $endOffset <= strlen($originalQuery)) {
+            return substr($originalQuery, 0, $startOffset) . $suggestedTerm . substr($originalQuery, $endOffset);
+        }
+
+        if ($misspelledTerm === '') {
+            return $suggestedTerm;
+        }
+
+        $pattern = '/(?<![\\w-])' . preg_quote($misspelledTerm, '/') . '(?![\\w-])/u';
+        $replaced = preg_replace($pattern, $suggestedTerm, $originalQuery, 1);
+
+        return is_string($replaced) && $replaced !== '' ? $replaced : $suggestedTerm;
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/SearchResultSet.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSet.php
@@ -60,6 +60,11 @@ class SearchResultSet
      */
     protected array $spellCheckingSuggestions = [];
 
+    /**
+     * @var string[]
+     */
+    protected array $spellCheckingCollations = [];
+
     protected FacetCollection $facets;
 
     protected SortingCollection $sortings;
@@ -115,6 +120,37 @@ class SearchResultSet
     public function getSpellCheckingSuggestions(): array
     {
         return $this->spellCheckingSuggestions;
+    }
+
+    public function addSpellCheckingCollation(string $collation): void
+    {
+        if ($collation === '' || in_array($collation, $this->spellCheckingCollations, true)) {
+            return;
+        }
+        $this->spellCheckingCollations[] = $collation;
+    }
+
+    public function getHasSpellCheckingCollations(): bool
+    {
+        return $this->spellCheckingCollations !== [];
+    }
+
+    /**
+     * @param string[] $spellCheckingCollations
+     *
+     * @noinspection PhpUnused Used in Fluid-Templates/Partials {resultSet.spellCheckingCollations}
+     */
+    public function setSpellCheckingCollations(array $spellCheckingCollations): void
+    {
+        $this->spellCheckingCollations = $spellCheckingCollations;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSpellCheckingCollations(): array
+    {
+        return $this->spellCheckingCollations;
     }
 
     public function getFacets(): FacetCollection

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -244,7 +244,7 @@ class SearchResultSetService
         }
 
         // no corrections present
-        if (!$searchResultSet->getHasSpellCheckingSuggestions()) {
+        if (!$searchResultSet->getHasSpellCheckingCollations() && !$searchResultSet->getHasSpellCheckingSuggestions()) {
             return $searchResultSet;
         }
 
@@ -259,15 +259,14 @@ class SearchResultSetService
     protected function performAutoCorrection(SearchResultSet $searchResultSet): SearchResultSet
     {
         $searchRequest = $searchResultSet->getUsedSearchRequest();
-        $suggestions = $searchResultSet->getSpellCheckingSuggestions();
+        $corrections = $this->collectAutoCorrectionCandidates($searchResultSet);
 
         $maximumRuns = $this->typoScriptConfiguration->getSearchSpellcheckingNumberOfSuggestionsToTry();
         $runs = 0;
 
-        foreach ($suggestions as $suggestion) {
+        foreach ($corrections as $correction) {
             $runs++;
 
-            $correction = $suggestion->getSuggestion();
             $initialQuery = $searchRequest->getRawUserQuery();
 
             $searchRequest->setRawQueryString($correction);
@@ -284,6 +283,24 @@ class SearchResultSetService
             }
         }
         return $searchResultSet;
+    }
+
+    /**
+     * Returns the candidate queries to retry after a zero-hit search,
+     * preferring Solr's collations (the full query with all misspelled terms replaced)
+     * over per-suggestion full queries (original query with a single misspelled term replaced),
+     * so the correct terms from the original query are not dropped.
+     *
+     * @return string[]
+     */
+    protected function collectAutoCorrectionCandidates(SearchResultSet $searchResultSet): array
+    {
+        $candidates = $searchResultSet->getSpellCheckingCollations();
+        foreach ($searchResultSet->getSpellCheckingSuggestions() as $suggestion) {
+            $candidates[] = $suggestion->getFullQuery();
+        }
+
+        return array_values(array_unique(array_filter($candidates, static fn(string $candidate): bool => $candidate !== '')));
     }
 
     /**

--- a/Classes/Domain/Search/ResultSet/Spellchecking/Suggestion.php
+++ b/Classes/Domain/Search/ResultSet/Spellchecking/Suggestion.php
@@ -32,18 +32,22 @@ class Suggestion
 
     protected int $endOffset = 0;
 
+    protected string $fullQuery = '';
+
     public function __construct(
         string $suggestion = '',
         string $missSpelled = '',
         int $numFound = 1,
         int $startOffset = 0,
         int $endOffset = 0,
+        string $fullQuery = '',
     ) {
         $this->suggestion = $suggestion;
         $this->missSpelled = $missSpelled;
         $this->numFound = $numFound;
         $this->startOffset = $startOffset;
         $this->endOffset = $endOffset;
+        $this->fullQuery = $fullQuery !== '' ? $fullQuery : $suggestion;
     }
 
     public function getEndOffset(): int
@@ -69,5 +73,17 @@ class Suggestion
     public function getMissSpelled(): string
     {
         return $this->missSpelled;
+    }
+
+    /**
+     * Returns the original user query with the misspelled term replaced by the suggestion,
+     * so the other correctly-spelled terms are preserved when this suggestion is offered
+     * as a follow-up search. Falls back to the bare suggestion when no original query is known.
+     *
+     * @noinspection PhpUnused Used in Fluid-Templates/Partials {suggestion.fullQuery}
+     */
+    public function getFullQuery(): string
+    {
+        return $this->fullQuery;
     }
 }

--- a/Classes/System/Solr/ResponseAdapter.php
+++ b/Classes/System/Solr/ResponseAdapter.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\Solr\System\Solr;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
+use ApacheSolrForTypo3\Solr\System\Solr\ResponseStructure\SpellcheckSection;
 use Countable;
 use stdClass;
 
@@ -34,7 +35,7 @@ use stdClass;
  *
  * @property stdClass|null $facet_counts
  * @property stdClass|null $facets
- * @property stdClass|null $spellcheck
+ * @property SpellcheckSection|null $spellcheck
  * @property stdClass|null $response
  * @property stdClass|null $responseHeader
  * @property stdClass|null $highlighting

--- a/Classes/System/Solr/ResponseStructure/SpellcheckSection.php
+++ b/Classes/System/Solr/ResponseStructure/SpellcheckSection.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\System\Solr\ResponseStructure;
+
+use stdClass;
+
+/**
+ * Shape-only description of the "spellcheck" section produced by Solr.
+ *
+ * At runtime, the value lives as a {@see stdClass} returned by `json_decode`. This
+ * class exists exclusively so IDEs and static analyzers can autocomplete the well-known
+ * sub-fields when accessed through the {@see \ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter}
+ * magic getter.
+ *
+ * @internal
+ */
+class SpellcheckSection extends stdClass
+{
+    /**
+     * Flat NamedList of misspelled-term strings alternating with suggestion objects
+     * (when `json.nl=flat`, the EXT:solr default).
+     *
+     * @var array<int|string, mixed>|null
+     */
+    public ?array $suggestions = null;
+
+    /**
+     * Flat NamedList of collated full-query strings (the original query with all
+     * misspelled tokens replaced) when `spellcheck.collate=true`.
+     *
+     * @var array<int|string, mixed>|null
+     */
+    public ?array $collations = null;
+}

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -67,13 +67,21 @@
 					</f:else>
 				</f:if>
 
-				<f:if condition="{resultSet.hasSpellCheckingSuggestions}">
+				<f:if condition="{resultSet.hasSpellCheckingCollations}">
 					<f:then>
 						<f:translate key="didYouMean" extensionName="solr">Did you mean</f:translate>
-						<f:for each="{resultSet.spellCheckingSuggestions}" as="suggestion">
-							<f:link.page additionalParams="{q: suggestion.suggestion}">{suggestion.suggestion}</f:link.page>
+						<f:for each="{resultSet.spellCheckingCollations}" as="collation">
+							<f:link.page additionalParams="{q: collation}">{collation}</f:link.page>
 						</f:for> ?
 					</f:then>
+					<f:else>
+						<f:if condition="{resultSet.hasSpellCheckingSuggestions}">
+							<f:translate key="didYouMean" extensionName="solr">Did you mean</f:translate>
+							<f:for each="{resultSet.spellCheckingSuggestions}" as="suggestion">
+								<f:link.page additionalParams="{q: suggestion.fullQuery}">{suggestion.fullQuery}</f:link.page>
+							</f:for> ?
+						</f:if>
+					</f:else>
 				</f:if>
 
 				<f:if condition="{resultSet.allResultCount}">

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -194,6 +194,36 @@ class SearchControllerTest extends IntegrationTestBase
 
     #[Group('frontend')]
     #[Test]
+    public function didYouMeanLinkContainsAllSearchTermsForMultiWordQueryWithSingleTypo(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            plugin.tx_solr.search.spellchecking = 1
+            ',
+        );
+
+        $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $resultPage = (string)$this->executeFrontendSubRequest(
+            $this->getPreparedRequest()
+                ->withQueryParameter('tx_solr[q]', 'men shoo'),
+        )->getBody();
+
+        self::assertStringContainsString('Did you mean', $resultPage, 'Could not find did you mean in response');
+        // Issue #4659: the suggestion link must rebuild the full query including the correct terms,
+        // not drop them in favour of the corrected word alone.
+        self::assertMatchesRegularExpression(
+            '/q=men[^"\'<>]*shoes/',
+            $resultPage,
+            'The "did you mean" link must keep the correct term "men" alongside the corrected "shoes".',
+        );
+    }
+
+    #[Group('frontend')]
+    #[Test]
     public function canAutoCorrectATypo(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_data.csv');

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_multiple_collations.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_multiple_collations.json
@@ -1,0 +1,38 @@
+{
+    "responseHeader": {
+        "status": 0,
+        "QTime": 5,
+        "params": {
+            "spellcheck": "true",
+            "spellcheck.collate": "true",
+            "spellcheck.maxCollations": "2",
+            "json.nl": "flat",
+            "q": "hello formuller"
+        }
+    },
+    "response": {
+        "numFound": 0,
+        "start": 0,
+        "maxScore": 0.0,
+        "docs": []
+    },
+    "spellcheck": {
+        "suggestions": [
+            "formuller", {
+                "numFound": 2,
+                "startOffset": 6,
+                "endOffset": 15,
+                "suggestion": [
+                    "formular",
+                    "formula"
+                ]
+            }
+        ],
+        "collations": [
+            "collation",
+            "hello formular",
+            "collation",
+            "hello formula"
+        ]
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_multiword.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_multiword.json
@@ -1,0 +1,34 @@
+{
+    "responseHeader": {
+        "status": 0,
+        "QTime": 5,
+        "params": {
+            "spellcheck": "true",
+            "spellcheck.collate": "true",
+            "json.nl": "flat",
+            "q": "hello formuller"
+        }
+    },
+    "response": {
+        "numFound": 0,
+        "start": 0,
+        "maxScore": 0.0,
+        "docs": []
+    },
+    "spellcheck": {
+        "suggestions": [
+            "formuller", {
+                "numFound": 1,
+                "startOffset": 6,
+                "endOffset": 15,
+                "suggestion": [
+                    "formular"
+                ]
+            }
+        ],
+        "collations": [
+            "collation",
+            "hello formular"
+        ]
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_without_collations.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_without_collations.json
@@ -1,0 +1,30 @@
+{
+    "responseHeader": {
+        "status": 0,
+        "QTime": 5,
+        "params": {
+            "spellcheck": "true",
+            "spellcheck.collate": "false",
+            "json.nl": "flat",
+            "q": "tipo3"
+        }
+    },
+    "response": {
+        "numFound": 0,
+        "start": 0,
+        "maxScore": 0.0,
+        "docs": []
+    },
+    "spellcheck": {
+        "suggestions": [
+            "tipo3", {
+                "numFound": 1,
+                "startOffset": 0,
+                "endOffset": 5,
+                "suggestion": [
+                    "typo3"
+                ]
+            }
+        ]
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_without_offsets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_spellCheck_without_offsets.json
@@ -1,0 +1,28 @@
+{
+    "responseHeader": {
+        "status": 0,
+        "QTime": 5,
+        "params": {
+            "spellcheck": "true",
+            "spellcheck.collate": "false",
+            "json.nl": "flat",
+            "q": "hello formuller"
+        }
+    },
+    "response": {
+        "numFound": 0,
+        "start": 0,
+        "maxScore": 0.0,
+        "docs": []
+    },
+    "spellcheck": {
+        "suggestions": [
+            "formuller", {
+                "numFound": 1,
+                "suggestion": [
+                    "formular"
+                ]
+            }
+        ]
+    }
+}

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -54,12 +54,110 @@ class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         // before the reconstitution of the domain object from the response we expect that no spelling suggestions
         // are present
         self::assertFalse($searchResultSet->getHasSpellCheckingSuggestions());
+        self::assertFalse($searchResultSet->getHasSpellCheckingCollations());
 
         $processor = new ResultSetReconstitutionProcessor();
         $processor->process($searchResultSet);
 
         // after the reconstitution they should be present
         self::assertTrue($searchResultSet->getHasSpellCheckingSuggestions());
+        self::assertTrue($searchResultSet->getHasSpellCheckingCollations());
+        self::assertSame(['typo3'], $searchResultSet->getSpellCheckingCollations());
+    }
+
+    #[Test]
+    public function canReconstituteSpellCheckingCollationsForMultiWordQuery(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck_multiword.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        self::assertTrue($searchResultSet->getHasSpellCheckingCollations());
+        self::assertSame(
+            ['hello formular'],
+            $searchResultSet->getSpellCheckingCollations(),
+            'Collation must contain the full query with the misspelled term replaced, not just the suggestion',
+        );
+    }
+
+    #[Test]
+    public function canReconstituteMultipleSpellCheckingCollations(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck_multiple_collations.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        self::assertSame(
+            ['hello formular', 'hello formula'],
+            $searchResultSet->getSpellCheckingCollations(),
+        );
+    }
+
+    #[Test]
+    public function spellCheckingCollationsAreEmptyWhenNotProvidedInResponse(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck_without_collations.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        self::assertTrue($searchResultSet->getHasSpellCheckingSuggestions());
+        self::assertFalse($searchResultSet->getHasSpellCheckingCollations());
+    }
+
+    #[Test]
+    public function spellCheckingSuggestionExposesFullQueryReconstructedFromOffsets(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck_multiword.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        $suggestions = array_values($searchResultSet->getSpellCheckingSuggestions());
+        self::assertCount(1, $suggestions);
+        // Issue #4659: the fallback link must keep the correctly-spelled "hello"
+        // and only replace the misspelled "formuller" with the suggested "formular".
+        self::assertSame('hello formular', $suggestions[0]->getFullQuery());
+    }
+
+    #[Test]
+    public function spellCheckingSuggestionFullQueryFallsBackToWordReplacementWhenOffsetsMissing(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck_without_offsets.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        $suggestions = array_values($searchResultSet->getSpellCheckingSuggestions());
+        self::assertCount(1, $suggestions);
+        self::assertSame('hello formular', $suggestions[0]->getFullQuery());
+    }
+
+    #[Test]
+    public function spellCheckingSuggestionFullQueryDefaultsToSuggestionWhenOriginalQueryUnknown(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        $suggestions = array_values($searchResultSet->getSpellCheckingSuggestions());
+        // Original query "tipo3" is a single token; correcting it yields the bare suggestion.
+        self::assertSame('typo3', $suggestions[0]->getFullQuery());
+    }
+
+    #[Test]
+    public function spellCheckingSuggestionMissSpelledHoldsTheActualTermNotTheArrayIndex(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_spellCheck.json');
+
+        $processor = new ResultSetReconstitutionProcessor();
+        $processor->process($searchResultSet);
+
+        $suggestions = array_values($searchResultSet->getSpellCheckingSuggestions());
+        self::assertSame('tipo3', $suggestions[0]->getMissSpelled());
     }
 
     #[Test]

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -23,6 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\Parser\ResultParserRe
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Spellchecking\Suggestion;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -31,6 +32,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
 use Solarium\Component\Grouping;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -230,6 +232,55 @@ class SearchResultSetServiceTest extends SetUpUnitTestCase
             $searchResultSet->getSearchResults()->getCount(),
             'There should be a 7 search results when they are fetched without groups',
         );
+    }
+
+    #[Test]
+    public function autoCorrectionCandidatesPreferCollationsOverPerSuggestionFullQuery(): void
+    {
+        $resultSet = new SearchResultSet();
+        $resultSet->addSpellCheckingSuggestion(new Suggestion('formular', 'formuller', 1, 6, 15, 'hello formular'));
+        $resultSet->addSpellCheckingCollation('hello formular');
+
+        $candidates = $this->invokeCollectAutoCorrectionCandidates($resultSet);
+
+        self::assertSame(
+            ['hello formular'],
+            $candidates,
+            'Collation and per-suggestion fullQuery happen to match here, and duplicates must collapse to one candidate.',
+        );
+    }
+
+    #[Test]
+    public function autoCorrectionCandidatesUseFullQueryFromSuggestionWhenNoCollationIsAvailable(): void
+    {
+        $resultSet = new SearchResultSet();
+        $resultSet->addSpellCheckingSuggestion(new Suggestion('formular', 'formuller', 1, 6, 15, 'hello formular'));
+
+        $candidates = $this->invokeCollectAutoCorrectionCandidates($resultSet);
+
+        // The per-suggestion fullQuery is what preserves the correctly-spelled "hello" from the original query.
+        self::assertSame(['hello formular'], $candidates);
+    }
+
+    #[Test]
+    public function autoCorrectionCandidatesAreDeduplicatedAndFreeOfEmptyEntries(): void
+    {
+        $resultSet = new SearchResultSet();
+        $resultSet->setSpellCheckingCollations(['hello formular', '', 'hello formular']);
+        $resultSet->addSpellCheckingSuggestion(new Suggestion('formula', 'formuller', 1, 6, 15, 'hello formula'));
+
+        $candidates = $this->invokeCollectAutoCorrectionCandidates($resultSet);
+
+        self::assertSame(['hello formular', 'hello formula'], $candidates);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function invokeCollectAutoCorrectionCandidates(SearchResultSet $resultSet): array
+    {
+        $method = new ReflectionMethod(SearchResultSetService::class, 'collectAutoCorrectionCandidates');
+        return $method->invoke($this->searchResultSetService, $resultSet);
     }
 
     protected function assertAllInitialSearchesAreDisabled(): void


### PR DESCRIPTION
The "did you mean" link and the spellchecker auto-correction used to
drop every correctly-spelled term from a multi-word query, leaving
only the suggested replacement word — so a search for "hello formuller"
would offer "formular" instead of "hello formular".

The primary path now uses Solr's `spellcheck.collations` field, which
already contains the full corrected query. When Solr discards the
collation (e.g. because `spellcheck.maxCollationTries=1` filters out
collations that match no documents), a per-suggestion `fullQuery`
falls back to reconstructing the query from the suggestion's
`startOffset`/`endOffset` against `responseHeader.params.q`, with a
word-boundary `preg_replace` as a last-resort fallback.

Also fixes a latent bug where the misspelled term was captured from
the array index (integer 0) instead of the actual string in the
alternating flat NamedList.

`ResponseAdapter::$spellcheck` is now typed as `SpellcheckSection|null`
— a shape-only stdClass subclass — so IDEs and static analyzers can
autocomplete the well-known `suggestions` and `collations` fields.

Fixes: #4659
Ports: #4671