### PR TITLE
[TASK] Run tasts manually and/or daily on release-13.1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - "**"
   pull_request:
     branches: [ main, release-13.1.x ]
+  workflow_dispatch:
 
 env:
   IS_ON_GITHUB_ACTIONS: 'true'
@@ -38,7 +39,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v6
       # End: Workaround for issue with actions/checkout...
       -
@@ -97,7 +98,7 @@ jobs:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout current state of Branch
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -132,7 +133,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Checkout current state of Branch
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 2


### PR DESCRIPTION
This change allows to trigger the tests manually.
The `schedule:` main branch will trigger this job.

---

Most probably this change must be adjusted and force-pushed directly to `release-13.1.x`-Branch.
This PR is just for initial validation of yaml.