### PR TITLE
[TASK] Run tasts manually and/or daily on release-13.1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
   #   * create issue on GH or message via TYPO3 Slack bot, if tests failed
   schedule:
     - cron:  '23 19 * * *'
+  workflow_dispatch:
 
 env:
   IS_ON_GITHUB_ACTIONS: 'true'
@@ -27,6 +28,21 @@ env:
   BRANCH_NAME: 'main'
 
 jobs:
+  trigger-build-on-release-branches:
+    name: "Trigger build on release branches"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: write
+    steps:
+      - name: Remote-Workflow on release-13.1.x
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run ci.yml \
+            --ref release-13.1.x \
+            -f purpose="Test EXT:solr on release-13.1.x with the current state of TYPO3 13 to identify potential new issues."
+
   ci_bootstrapping:
     name: "Build and test docker image + Collect build matrix"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change allows to trigger the tests on release-13.1.x manually or as daily cron. 
Each trigger of build, will delegate the build for release-13.1.x as well.

---

Will be merged if syntax is ok, can be force-pushed in main, if something does not work.
### Note: Do not merge any PR in main until that component works as expected. 
