### PR TITLE
[BUGFIX] Prevent undefined array key warning in SettingsPreviewOnPlug…

### DIFF
--- a/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
+++ b/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
@@ -47,6 +47,7 @@ final readonly class SettingsPreviewOnPluginsEventListener
         if (
             $event->getTable() !== 'tt_content'
             || !str_starts_with($pluginsTtContentRecord['CType'], 'solr_pi_')
+            || !isset($pluginsTtContentRecord['pi_flexform'])
         ) {
             return;
         }

--- a/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
+++ b/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
@@ -50,6 +50,9 @@ final readonly class SettingsPreviewOnPluginsEventListener
         }
 
         $pluginsTtContentRecord = $event->getRecord()->toArray();
+        if (!isset($pluginsTtContentRecord['pi_flexform'])) {
+            return;
+        }
 
         $event->setPreviewContent(
             $this->getPreviewContent($event, $pluginsTtContentRecord),


### PR DESCRIPTION
…insEventListener

The EXT:solr plugin "Frequent searches" does not have flexform settings. Thus the array key `pi_flexform` does not exist.

Adding an additional check for the early return solves the  issue.

Resolves: TYPO3-Solr/ext-solr#4685
