### PR TITLE
[TASK] Prevent unnecessary complete loading of record in PreviewEventListener

### DIFF
--- a/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
+++ b/Classes/EventListener/Backend/SettingsPreviewOnPluginsEventListener.php
@@ -42,14 +42,14 @@ final readonly class SettingsPreviewOnPluginsEventListener
     )]
     public function __invoke(PageContentPreviewRenderingEvent $event): void
     {
-        $pluginsTtContentRecord = $event->getRecord()->toArray();
-
         if (
             $event->getTable() !== 'tt_content'
-            || !str_starts_with($pluginsTtContentRecord['CType'], 'solr_pi_')
+            || !str_starts_with($event->getRecordType(), 'solr_pi_')
         ) {
             return;
         }
+
+        $pluginsTtContentRecord = $event->getRecord()->toArray();
 
         $event->setPreviewContent(
             $this->getPreviewContent($event, $pluginsTtContentRecord),

--- a/Tests/Integration/EventListener/Backend/SettingsPreviewOnPluginsEventListenerTest.php
+++ b/Tests/Integration/EventListener/Backend/SettingsPreviewOnPluginsEventListenerTest.php
@@ -202,10 +202,9 @@ final class SettingsPreviewOnPluginsEventListenerTest extends IntegrationTestBas
     {
         $recordMock = $this->createMock(RecordInterface::class);
         $recordMock
-            ->expects(self::atLeastOnce())
+            ->expects(self::atMost(1))
             ->method('toArray')
             ->willReturn($record);
-
         $requestMock = $this->createMock(ServerRequestInterface::class);
 
         $pageLayoutContextMock = $this->createMock(PageLayoutContext::class);
@@ -216,7 +215,7 @@ final class SettingsPreviewOnPluginsEventListenerTest extends IntegrationTestBas
 
         return new PageContentPreviewRenderingEvent(
             'tt_content',
-            (string)($record[(string)($GLOBALS['TCA']['tt_content']['ctrl']['type'] ?? '')] ?? ''),
+            (string)$record['CType'] ?: '',
             $recordMock,
             $pageLayoutContextMock,
         );


### PR DESCRIPTION
# What this pr does

Because Record::toArray() loads all lazy relations, it is inefficient to call.

This change moves the call after check for correct solr pluign and makes correct use of PageContentPreviewRenderingEvent::getRecordType().

Also adjusts Unittest.

# How to test

- open layout-module at page with a sol-plugin and check for proper preview rendering.
- open layout-module at page with lots of CEs with lazy relations and check faster loading
