### PR TITLE
[BUGFIX] Keep public content access variant (c:0) on multi-value fe_group pages

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -128,11 +128,20 @@ readonly class IndexingService
         $pageUserGroup = (int)($this->buildPageParameters($item)['pageUserGroup'] ?? 0);
         foreach ($solrConnections as $languageUid => $solrConnection) {
             $accessGroups = $this->findUserGroupsForPage($item, $languageUid);
-            if ($pageUserGroup > 0) {
-                // A page with fe_group restriction has no publicly-accessible content variants:
-                // remove group 0 (which may originate from global template CEs, not page content).
-                // Ensure the page's own group is in accessGroups so restricted-but-eligible users
-                // can still find the page in search results.
+            // Only drop the public (c:0) content variant when the page actually contains
+            // access-restricted content. When the content is public, the page access element
+            // alone (e.g. "2:1,2", OR semantics over all page groups) already restricts the
+            // document; forcing the page's own group into the content access element instead
+            // would, for a multi-value fe_group, keep only the first group (via the (int) cast
+            // in buildPageParameters()) and exclude every other eligible group from the search
+            // results, because the content access element is matched with AND semantics.
+            $contentIsRestricted = array_filter($accessGroups, static fn(int $g): bool => $g > 0) !== [];
+            if ($pageUserGroup > 0 && $contentIsRestricted) {
+                // A page with fe_group restriction and access-restricted content has no
+                // publicly-accessible content variant: remove group 0 (which may originate from
+                // global template CEs, not page content). Ensure the page's own group is in
+                // accessGroups so restricted-but-eligible users can still find the page in search
+                // results, and no public (c:0) variant leaks the restricted content.
                 $accessGroups = array_values(array_filter($accessGroups, static fn(int $g): bool => $g !== 0));
                 if (!in_array($pageUserGroup, $accessGroups, true)) {
                     $accessGroups[] = $pageUserGroup;

--- a/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
+++ b/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
@@ -129,13 +129,49 @@ final class AccessProtectedContentTest extends IntegrationTestBase
             'fixture' => 'can_index_access_protected_page',
             'expectedNumFound' => 1,
             'expectedAccessFieldValues' => [
-                '2:1/c:1',
+                // public content on a restricted page keeps the c:0 content variant; the page
+                // access element ("2:1") alone restricts the document (consistent with the
+                // "page protected by extend to subpages" case below, which is c:0, too).
+                '2:1/c:0',
             ],
             'expectedContents' => [
                 'public content of protected page',
             ],
             'expectedNumFoundAnonymousUser' => 0,
             'userGroupToCheckAccessFilter' => '0,1',
+            'expectedNumFoundLoggedInUser' => 1,
+        ];
+
+        // A page restricted to several groups ("1,2") whose content is public must be findable
+        // by *each* of its groups. Before the fix the page's fe_group was cast with (int), so
+        // only "c:1" was written and group-2-only users lost the page. Now c:0 is kept and the
+        // page access element ("2:1,2", OR semantics) grants both groups.
+        yield 'page restricted to multiple groups, first group finds it' => [
+            'fixture' => 'can_index_multi_group_access_protected_page',
+            'expectedNumFound' => 1,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            'userGroupToCheckAccessFilter' => '0,1',
+            'expectedNumFoundLoggedInUser' => 1,
+        ];
+
+        yield 'page restricted to multiple groups, second group finds it' => [
+            'fixture' => 'can_index_multi_group_access_protected_page',
+            'expectedNumFound' => 1,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            // the second (previously dropped) group must find the page, too
+            'userGroupToCheckAccessFilter' => '0,2',
             'expectedNumFoundLoggedInUser' => 1,
         ];
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page.csv
@@ -1,0 +1,13 @@
+"fe_groups",
+,"uid","pid","title"
+,1,1,"group 1"
+,2,1,"group 2"
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp","fe_group"
+,2,1,0,1,"/protected_page","protected page","",1449151778,1449151778,"1,2"
+"tt_content",
+,"uid","pid","CType","header","fe_group"
+,11,"2","header","public content of protected page",0
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
+,4711,1,"pages",2,"pages",1449151778,0,0,0,0,0


### PR DESCRIPTION
## What was changed

On `fe_group`-restricted pages with **public** content, `IndexingService::indexPageItem()` no longer forces the page's own group into the content access rootline element.

`buildPageParameters()` casts the page `fe_group` with `(int)`, so for a multi-value `fe_group` (e.g. `"1,2"`) only the first group survived in the content access element (`c:1`). Because the `{!typo3access}` filter matches the content access element with **AND** semantics, users who are only in one of the other groups (e.g. group 2) no longer matched the document and lost the page in the search results — although the page access element (`2:1,2`, **OR** semantics) grants them access.

The public content variant (`c:0`) is now kept when the page content is public: the page access element alone restricts the document, and there is nothing to leak. This also makes directly `fe_group`-restricted pages consistent with pages protected via `extendToSubpages`, which already produce `c:0`.

When the content **is** access-restricted, the previous behaviour (introduced in #4641 to prevent `c:0` content leakage) is kept unchanged.

## Test

Adds a regression test in `AccessProtectedContentTest`: a page restricted to groups `"1,2"` with public content, asserting `access = 2:1,2/c:0` and that **both** group 1 and group 2 (previously dropped) find the page. The existing single-group case now expects `2:1/c:0` accordingly (access-equivalent, consistent with the `extendToSubpages` case).

## Known limitation (out of scope)

A page with a multi-value `fe_group` **and** access-restricted content still cannot grant each group independently: the per-group documents collide on the same Solr `id` (built from the union of all rootline groups), and multiple / comma-joined `c:` elements are AND-matched. Resolving that would require changing the document-id generation and is intentionally not part of this PR.

Fixes #4705