### PR TITLE
[BUGFIX] Limit TSFE cache growth during indexing

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -48,6 +48,14 @@ use TYPO3\CMS\Frontend\Page\PageInformation;
 class Tsfe implements SingletonInterface
 {
     /**
+     * Maximum number of TSFE/ServerRequest instances kept in the runtime
+     * caches below. Each cached TSFE holds a full unserialized TypoScript
+     * setup (easily ~10 MB per page), so an unbounded cache exhausts
+     * memory_limit during CLI indexing of record items spread over many pages.
+     */
+    protected const MAX_CACHED_INSTANCES = 10;
+
+    /**
      * @var TypoScriptFrontendController[]
      */
     protected array $tsfeCache = [];
@@ -81,6 +89,19 @@ class Tsfe implements SingletonInterface
     protected function initializeTsfe(int $pageId, int $language = 0, ?int $rootPageId = null): void
     {
         $cacheIdentifier = $this->getCacheIdentifier($pageId, $language, $rootPageId);
+
+        // Evict the oldest cached instances before a new entry is added, to
+        // keep memory usage bounded. Evicted instances remain fully usable
+        // for any code still holding a reference to them.
+        if (!isset($this->tsfeCache[$cacheIdentifier])) {
+            while (count($this->tsfeCache) >= self::MAX_CACHED_INSTANCES) {
+                $oldestCacheIdentifier = array_key_first($this->tsfeCache);
+                unset(
+                    $this->tsfeCache[$oldestCacheIdentifier],
+                    $this->serverRequestCache[$oldestCacheIdentifier],
+                );
+            }
+        }
 
         // Handle spacer and sys-folders, since they are not accessible in frontend, and TSFE can not be fully initialized on them.
         // Apart from this, the plugin.tx_solr.index.queue.[indexConfig].additionalPageIds is handled as well.


### PR DESCRIPTION
## Problem

`FrontendEnvironment\Tsfe` keeps one fully initialized TSFE and ServerRequest per page/language combination in the unbounded instance caches `$tsfeCache` / `$serverRequestCache`. Each cached TSFE holds its own unserialized TypoScript setup — commonly several megabytes per entry.

Long-running CLI processes that touch many different pages therefore grow linearly until they hit `memory_limit`:

* Index Queue Worker runs with record items spread over many pages (our real-world case: well over a thousand records, one per page, ~10 MB per item)
* Queue updates after `hidden`/`extendToSubtree` changes with many subpages — as described in #4138

The resulting OOM fatal is invisible in production contexts (`display_errors` off) and leaves the scheduler task marked as running, so all subsequent runs are skipped — indexing simply stops until the stale lock is cleared manually.

## Fix

Evict the oldest cached instances (FIFO, max. 10) before a new entry is added. All real cache reuse is temporally local — repeated lookups while indexing a single item, and consecutive items located on the same page — so a small window keeps every actual cache hit while capping memory usage. Evicted instances remain fully usable for code still holding a reference to them.

## Measurements

Index Queue Worker, 150 tt_content items located on 150 different pages (TYPO3 13.4.32, EXT:solr 13.1.3):

| | Peak memory |
|---|---|
| Before | 1562 MB (OOM at `memory_limit=256M` after ~19 items) |
| After | **104 MB** |

Runtime and indexing results are unchanged. Additionally verified with a full ~2,500-item queue on a production host with `memory_limit=256M`, which previously could not complete at all (worker died after ~19 record items) and now finishes cleanly even with `documentsToIndexLimit=415`.

## Notes

* This PR targets `release-13.1.x` because `main` no longer contains this class after the FrontendEnvironment refactoring. The fix is relevant for the maintained 13.x (and structurally identical 12.x) release branches.
* Fixes #4138 (same root cause, different trigger).
