### PR TITLE
[TASK] Update to PHPStan 2

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -33,7 +33,7 @@ use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 /**
  * Class SearchController
  *
- * @property AbstractTemplateView $view {@link AbstractTemplateView} is used in this scope. Line required by PhpStan.
+ * @property FluidViewAdapter $view {@link AbstractTemplateView} is used in this scope. Line required by PhpStan.
  */
 class SearchController extends AbstractBaseController
 {

--- a/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
+++ b/Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php
@@ -439,7 +439,7 @@ class DataUpdateHandler extends AbstractUpdateHandler
             // Clear existing index queue items to prevent mount point duplicates.
             // This needs to be done before the overlay handling, because handling an overlay record should
             // not trigger a deletion.
-            $isTranslation = !empty($record['sys_language_uid']) && $record['sys_language_uid'] !== 0;
+            $isTranslation = !empty($record['sys_language_uid']);
             if ($recordTable === 'pages' && !$isTranslation) {
                 $this->indexQueue->deleteItem('pages', $recordUid);
             }

--- a/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
+++ b/Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php
@@ -51,7 +51,7 @@ class DocumentEscapeService
             $fieldNames = array_keys($document->getFields() ?? []);
 
             foreach ($fieldNames as $fieldName) {
-                if (is_array($trustedSolrFields) && in_array($fieldName, $trustedSolrFields)) {
+                if (in_array($fieldName, $trustedSolrFields)) {
                     // we skip this field, since it was marked as secure
                     continue;
                 }

--- a/Classes/Domain/Search/SearchRequest.php
+++ b/Classes/Domain/Search/SearchRequest.php
@@ -572,7 +572,7 @@ class SearchRequest
         $this->stateChanged = false;
         $this->activeFacetContainer = new UrlFacetContainer(
             $this->argumentsAccessor,
-            $this->argumentNameSpace ?? self::DEFAULT_PLUGIN_NAMESPACE,
+            $this->argumentNameSpace,
             $this->contextTypoScriptConfiguration === null ?
                 UrlFacetContainer::PARAMETER_STYLE_INDEX :
                 $this->contextTypoScriptConfiguration->getSearchFacetingUrlParameterStyle(),

--- a/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
+++ b/Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php
@@ -97,7 +97,7 @@ class StatisticsWriterProcessor
             // @extensionScannerIgnoreLine
             'time_processing' => $response->debug->timing->process->time ?? 0,
             /** @phpstan-ignore nullCoalesce.expr */
-            'feuser_id' => isset($frontendUser?->user) ? (int)$frontendUser->user['uid'] ?? 0 : 0,
+            'feuser_id' => isset($frontendUser->user) ? (int)$frontendUser->user['uid'] ?? 0 : 0,
             'ip' => IpAnonymizationUtility::anonymizeIp($this->getUserIp(), $ipMaskLength),
             'page' => $page,
             'keywords' => $keywords,

--- a/Classes/Domain/Search/Uri/SearchUriBuilder.php
+++ b/Classes/Domain/Search/Uri/SearchUriBuilder.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\Event\Routing\AfterUriIsProcessedEvent;
 use ApacheSolrForTypo3\Solr\Event\Routing\BeforeCachedVariablesAreProcessedEvent;
 use ApacheSolrForTypo3\Solr\Event\Routing\BeforeVariableInCachedUrlAreReplacedEvent;
 use ApacheSolrForTypo3\Solr\Routing\RoutingService;
-use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Url\UrlHelper;
 use ApacheSolrForTypo3\Solr\Utility\ParameterSortingUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -108,7 +107,6 @@ class SearchUriBuilder
         $additionalArguments = [];
         if (
             ($typoScriptConfiguration = $previousSearchRequest->getContextTypoScriptConfiguration())
-            && $typoScriptConfiguration instanceof TypoScriptConfiguration
             && $typoScriptConfiguration->getSearchFacetingFacetLinkUrlParametersUseForFacetResetLinkUrl()
         ) {
             $additionalArguments = $this->getAdditionalArgumentsFromRequestConfiguration($previousSearchRequest);
@@ -130,7 +128,6 @@ class SearchUriBuilder
         $additionalArguments = [];
         if (
             ($typoScriptConfiguration = $previousSearchRequest->getContextTypoScriptConfiguration())
-            && $typoScriptConfiguration instanceof TypoScriptConfiguration
             && $typoScriptConfiguration->getSearchFacetingFacetLinkUrlParametersUseForFacetResetLinkUrl()
         ) {
             $additionalArguments = $this->getAdditionalArgumentsFromRequestConfiguration($previousSearchRequest);
@@ -153,7 +150,6 @@ class SearchUriBuilder
         $additionalArguments = [];
         if (
             ($typoScriptConfiguration = $previousSearchRequest->getContextTypoScriptConfiguration())
-            && $typoScriptConfiguration instanceof TypoScriptConfiguration
             && $typoScriptConfiguration->getSearchFacetingFacetLinkUrlParametersUseForFacetResetLinkUrl()
         ) {
             $additionalArguments = $this->getAdditionalArgumentsFromRequestConfiguration($previousSearchRequest);
@@ -428,10 +424,7 @@ class SearchUriBuilder
             return;
         }
 
-        if (
-            ($typoScriptConfiguration = $searchRequest->getContextTypoScriptConfiguration())
-            && $typoScriptConfiguration instanceof TypoScriptConfiguration
-        ) {
+        if ($typoScriptConfiguration = $searchRequest->getContextTypoScriptConfiguration()) {
             $pluginNameSpace = $typoScriptConfiguration->getSearchPluginNamespace();
             if (!empty($arguments[$pluginNameSpace]['filter']) && is_array($arguments[$pluginNameSpace]['filter'])) {
                 $arguments[$pluginNameSpace]['filter'] = ParameterSortingUtility::sortByType(

--- a/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
+++ b/Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php
@@ -52,7 +52,7 @@ final readonly class PostEnhancedUriProcessor
         $uri = $event->getUri();
         parse_str($uri->getQuery(), $queryParameters);
 
-        if (empty($queryParameters) || !is_array($queryParameters)) {
+        if (empty($queryParameters)) {
             $queryParameters = [];
         }
 

--- a/Classes/FrontendSimulation/FrontendAwareEnvironment.php
+++ b/Classes/FrontendSimulation/FrontendAwareEnvironment.php
@@ -293,7 +293,7 @@ class FrontendAwareEnvironment implements SingletonInterface
         }
 
         // TYPO3 core also checks site config before sys_template handling
-        $siteIsTypoScriptRoot = $site instanceof Site && $site->isTypoScriptRoot();
+        $siteIsTypoScriptRoot = $site->isTypoScriptRoot();
         if ($siteIsTypoScriptRoot) {
             return $site->getRootPageId();
         }

--- a/Classes/Middleware/SolrIndexingMiddleware.php
+++ b/Classes/Middleware/SolrIndexingMiddleware.php
@@ -360,7 +360,7 @@ readonly class SolrIndexingMiddleware implements MiddlewareInterface
 
             // free content mode language
             $site = $item->getSite();
-            if ($site instanceof Site && $language > 0 && $language !== -1) {
+            if ($site instanceof Site && $language > 0) {
                 $typo3site = $site->getTypo3SiteObject();
                 try {
                     $siteLanguage = $typo3site->getLanguageById($language);
@@ -477,7 +477,7 @@ readonly class SolrIndexingMiddleware implements MiddlewareInterface
     protected function processDocuments(array $documents, TypoScriptConfiguration $configuration): void
     {
         $processingInstructions = $configuration->getIndexFieldProcessingInstructionsConfiguration();
-        if (is_array($processingInstructions) && $processingInstructions !== []) {
+        if ($processingInstructions !== []) {
             $service = GeneralUtility::makeInstance(FieldProcessorService::class);
             $service->processDocuments($documents, $processingInstructions);
         }

--- a/Classes/Routing/RoutingService.php
+++ b/Classes/Routing/RoutingService.php
@@ -575,7 +575,7 @@ class RoutingService implements LoggerAwareInterface
                 $newQueryParams[] = $facetName . $separator . $facetValue;
             }
         }
-        $queryParams[$this->getPluginNamespace()]['filter'] = array_values($newQueryParams);
+        $queryParams[$this->getPluginNamespace()]['filter'] = $newQueryParams;
 
         return $this->cleanUpQueryParameters($queryParams);
     }

--- a/Classes/Search/FacetingComponent.php
+++ b/Classes/Search/FacetingComponent.php
@@ -211,7 +211,6 @@ class FacetingComponent implements LoggerAwareInterface
         $filtersByFacetName = [];
         if (
             ($typoScriptConfiguration = $searchRequest->getContextTypoScriptConfiguration())
-            && $typoScriptConfiguration instanceof TypoScriptConfiguration
             && $typoScriptConfiguration->getSearchFacetingUrlParameterStyle() === UrlFacetContainer::PARAMETER_STYLE_ASSOC
         ) {
             $filters = array_keys($filters);

--- a/Classes/System/Configuration/ConfigurationManager.php
+++ b/Classes/System/Configuration/ConfigurationManager.php
@@ -241,7 +241,7 @@ class ConfigurationManager implements SingletonInterface
         $pageUid = (int)(
             $request->getParsedBody()['id']
             ?? $request->getQueryParams()['id']
-            ?? $request->getAttribute('frontend.controller')?->id
+            ?? $request->getAttribute('frontend.controller')->id
             ?? $request->getAttribute('site')?->getRootPageId()
         );
 

--- a/Classes/System/Mvc/Backend/Service/ModuleDataStorageService.php
+++ b/Classes/System/Mvc/Backend/Service/ModuleDataStorageService.php
@@ -55,6 +55,8 @@ class ModuleDataStorageService implements SingletonInterface
 
     /**
      * Unsets not serializable module data.
+     *
+     * @param-out string $serializedModuleData
      */
     private function unsetModuleDataIfCanNotBeSerialized(?string &$serializedModuleData = null): void
     {

--- a/Classes/System/Solr/Parser/SchemaParser.php
+++ b/Classes/System/Solr/Parser/SchemaParser.php
@@ -53,7 +53,7 @@ class SchemaParser
     protected function parseManagedResourceId(stdClass $schema): ?string
     {
         $managedResourceId = null;
-        if (!is_object($schema) || !isset($schema->fieldTypes)) {
+        if (!isset($schema->fieldTypes)) {
             return null;
         }
 

--- a/Classes/System/Solr/Service/SolrAdminService.php
+++ b/Classes/System/Solr/Service/SolrAdminService.php
@@ -313,7 +313,7 @@ class SolrAdminService extends AbstractSolrService
 
     protected function initializeSynonymsUrl(): void
     {
-        if (trim($this->_synonymsUrl ?? '') !== '') {
+        if (trim($this->_synonymsUrl) !== '') {
             return;
         }
         $this->_synonymsUrl = $this->_constructUrl(self::SYNONYMS_SERVLET) . $this->getSchema()->getManagedResourceId();
@@ -321,7 +321,7 @@ class SolrAdminService extends AbstractSolrService
 
     protected function initializeStopWordsUrl(): void
     {
-        if (trim($this->_stopWordsUrl ?? '') !== '') {
+        if (trim($this->_stopWordsUrl) !== '') {
             return;
         }
 
@@ -337,7 +337,7 @@ class SolrAdminService extends AbstractSolrService
 
     protected function initializeVectorStorageUrl(): void
     {
-        if (trim($this->_vectorStoreUrl ?? '') !== '') {
+        if (trim($this->_vectorStoreUrl) !== '') {
             return;
         }
 

--- a/Classes/Utility/RoutingUtility.php
+++ b/Classes/Utility/RoutingUtility.php
@@ -40,7 +40,7 @@ class RoutingUtility
         // Symfony Route Compiler requires first literal to be non-integer
         if ($hash[0] === (string)(int)$hash[0]) {
             $hash[0] = str_replace(
-                range('0', '9'),
+                str_split('0123456789'),
                 range('o', 'x'),
                 $hash[0],
             );

--- a/Tests/Integration/Access/RootlineTest.php
+++ b/Tests/Integration/Access/RootlineTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class RootlineTest
  */
-class RootlineTest extends IntegrationTestBase
+final class RootlineTest extends IntegrationTestBase
 {
     #[Test]
     public function canGetAccessRootlineByPageId(): void

--- a/Tests/Integration/ConnectionManagerTest.php
+++ b/Tests/Integration/ConnectionManagerTest.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * This testcase can be used to check if the ConnectionManager can be used
  * as expected.
  */
-class ConnectionManagerTest extends IntegrationTestBase
+final class ConnectionManagerTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/ContentObject/ClassificationTest.php
+++ b/Tests/Integration/ContentObject/ClassificationTest.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * Tests for the SOLR_CLASSIFICATION cObj.
  */
-class ClassificationTest extends IntegrationTestBase
+final class ClassificationTest extends IntegrationTestBase
 {
     protected ContentObjectRenderer $contentObjectRenderer;
 
@@ -89,9 +89,7 @@ class ClassificationTest extends IntegrationTestBase
     }
 
     #[Test]
-    #[DataProvider(
-        methodName: 'excludePatternDataProvider',
-    )]
+    #[DataProvider('excludePatternDataProvider')]
     public function canExcludePatterns($input, $expectedOutput): void
     {
         $this->contentObjectRenderer->start(['content' => $input]);

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -32,7 +32,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * Class RelationTest
  */
-class RelationTest extends IntegrationTestBase
+final class RelationTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Integration/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 /**
  * Class IndexAdministrationModuleControllerTest
  */
-class IndexAdministrationModuleControllerTest extends IntegrationTestBase
+final class IndexAdministrationModuleControllerTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Controller/CategoryPathProvider.php
+++ b/Tests/Integration/Controller/CategoryPathProvider.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Frontend\Page\PageInformation;
  *
  * Test class that returns a fixture path list just for testing.
  */
-class CategoryPathProvider
+final class CategoryPathProvider
 {
     /**
      * Returns a list of paths concatenated with , only for testing

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -34,7 +34,7 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 /**
  * Integration testcase to test for the SearchController
  */
-class SearchControllerTest extends IntegrationTestBase
+final class SearchControllerTest extends IntegrationTestBase
 {
     /**
      * @var SearchController

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -26,7 +26,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
  * Integration testcase to test for {@link SuggestController}
  */
 #[Group('frontend')]
-class SuggestControllerTest extends IntegrationTestBase
+final class SuggestControllerTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the record indexer
  */
-class IndexServiceTest extends IntegrationTestBase
+final class IndexServiceTest extends IntegrationTestBase
 {
     /**
      * @inheritdoc
@@ -169,12 +169,14 @@ class IndexServiceTest extends IntegrationTestBase
 
             self::assertSame(
                 $sentinelBackendUser,
+                // @phpstan-ignore nullCoalesce.offset (indexItems() can unset this key on regression, PHPStan can't see that)
                 $GLOBALS['BE_USER'] ?? null,
                 '$GLOBALS[\'BE_USER\'] was not restored after sub-request indexing — '
                 . 'breaks scheduler module list rendering in BE web context (#4628).',
             );
             self::assertSame(
                 $sentinelRequest,
+                // @phpstan-ignore nullCoalesce.offset (indexItems() can unset this key on regression, PHPStan can't see that)
                 $GLOBALS['TYPO3_REQUEST'] ?? null,
                 '$GLOBALS[\'TYPO3_REQUEST\'] was not restored after sub-request indexing.',
             );
@@ -236,6 +238,7 @@ class IndexServiceTest extends IntegrationTestBase
             );
             self::assertSame(
                 $sentinelLanguageService,
+                // @phpstan-ignore nullCoalesce.offset (indexItems() can unset this key on regression, PHPStan can't see that)
                 $GLOBALS['LANG'] ?? null,
                 '$GLOBALS[\'LANG\'] was not restored after sub-request — '
                 . 'breaks BE module label localisation (#4628 follow-up).',
@@ -287,6 +290,7 @@ class IndexServiceTest extends IntegrationTestBase
             $indexService->indexItems(1);
 
             self::assertFalse(
+                // @phpstan-ignore function.impossibleType (indexItems() can re-add this key on regression, PHPStan can't see that)
                 array_key_exists('BE_USER', $GLOBALS),
                 '$GLOBALS[\'BE_USER\'] was unset before the sub-request and must remain absent afterwards '
                 . '(not be assigned null) — otherwise CLI multi-task scheduler runs see a fake null value '

--- a/Tests/Integration/Domain/Index/PageIndexer/PageUriBuilderTest.php
+++ b/Tests/Integration/Domain/Index/PageIndexer/PageUriBuilderTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Tests for checking if the uri is built for a page
  */
-class PageUriBuilderTest extends IntegrationTestBase
+final class PageUriBuilderTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
+++ b/Tests/Integration/Domain/Index/Queue/QueueItemRepositoryTest.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the QueueItemRepository
  */
-class QueueItemRepositoryTest extends IntegrationTestBase
+final class QueueItemRepositoryTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php
@@ -21,7 +21,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
+final class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
 {
     /**
      * @var Repository|null
@@ -47,6 +47,7 @@ class ApacheSolrDocumentRepositoryTest extends IntegrationTestBase
 
         self::assertIsArray($apacheSolrDocumentsCollection, 'Repository did not get Document collection from pageId 3.');
         self::assertNotEmpty($apacheSolrDocumentsCollection, 'Repository did not get apache solr documents from pageId 3.');
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (Document[] is only guaranteed by @return docblock, not the native array return type)
         self::assertInstanceOf(Document::class, $apacheSolrDocumentsCollection[0], 'ApacheSolrDocumentRepository returned not an array of type Document.');
     }
 

--- a/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class LastSearchesRepositoryTest extends IntegrationTestBase
+final class LastSearchesRepositoryTest extends IntegrationTestBase
 {
     protected LastSearchesRepository $lastSearchesRepository;
 

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
-class ResultSetReconstitutionProcessorTest extends IntegrationTestBase
+final class ResultSetReconstitutionProcessorTest extends IntegrationTestBase
 {
     protected bool $initializeDatabase = false;
 

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
-class SearchResultSetServiceTest extends IntegrationTestBase
+final class SearchResultSetServiceTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
+++ b/Tests/Integration/Domain/Search/StatisticsRepository/StatisticsRepositoryTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class StatisticsRepositoryTest extends IntegrationTestBase
+final class StatisticsRepositoryTest extends IntegrationTestBase
 {
     #[Test]
     public function canGetTopKeywordsWithHits(): void

--- a/Tests/Integration/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Integration/Domain/Site/SiteRepositoryTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to check if the SiteRepository class works as expected.
  */
-class SiteRepositoryTest extends IntegrationTestBase
+final class SiteRepositoryTest extends IntegrationTestBase
 {
     /**
      * @var SiteRepository

--- a/Tests/Integration/Domain/Site/SiteTest.php
+++ b/Tests/Integration/Domain/Site/SiteTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Site class tests
  */
-class SiteTest extends IntegrationTestBase
+final class SiteTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/EventListener/Backend/SettingsPreviewOnPluginsEventListenerTest.php
+++ b/Tests/Integration/EventListener/Backend/SettingsPreviewOnPluginsEventListenerTest.php
@@ -39,7 +39,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * configuration.
  * This testcase checks if the SummaryController produces the expected output.
  */
-class SettingsPreviewOnPluginsEventListenerTest extends IntegrationTestBase
+final class SettingsPreviewOnPluginsEventListenerTest extends IntegrationTestBase
 {
     private const FLEX_FORM_ARRAY = [
         'search' => [
@@ -97,9 +97,7 @@ class SettingsPreviewOnPluginsEventListenerTest extends IntegrationTestBase
     }
 
     #[Test]
-    #[DataProvider(
-        methodName: 'invalidCTypeDataProvider',
-    )]
+    #[DataProvider('invalidCTypeDataProvider')]
     public function previewWithInvalidCTypeWillNotBeRendered(string $cType): void
     {
         $subject = new SettingsPreviewOnPluginsEventListener(

--- a/Tests/Integration/Extbase/PersistenceEventListenerTest.php
+++ b/Tests/Integration/Extbase/PersistenceEventListenerTest.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
-class PersistenceEventListenerTest extends IntegrationTestBase
+final class PersistenceEventListenerTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
+++ b/Tests/Integration/FieldProcessor/CategoryUidToHierarchyTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Integration test for the CategoryUidToHierarchy
  */
-class CategoryUidToHierarchyTest extends IntegrationTestBase
+final class CategoryUidToHierarchyTest extends IntegrationTestBase
 {
     #[Test]
     public function canConvertToCategoryIdToHierarchy(): void

--- a/Tests/Integration/Fixtures/Extensions/fake_extension3/Classes/EventListeners/TestPageUriModification.php
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension3/Classes/EventListeners/TestPageUriModification.php
@@ -19,7 +19,7 @@ namespace ApacheSolrForTypo3\SolrFakeExtension3\EventListeners;
 
 use ApacheSolrForTypo3\Solr\Event\Indexing\AfterFrontendPageUriForIndexingHasBeenGeneratedEvent;
 
-class TestPageUriModification
+final class TestPageUriModification
 {
     public function __invoke(AfterFrontendPageUriForIndexingHasBeenGeneratedEvent $event): void
     {

--- a/Tests/Integration/FrontendEnvironment/TsfeTest.php
+++ b/Tests/Integration/FrontendEnvironment/TsfeTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class TsfeTest extends IntegrationTestBase
+final class TsfeTest extends IntegrationTestBase
 {
     #[Test]
     public function canInitializeFrontendEnvironmentForPageWithDifferentFeGroupsSettings(): void

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -41,7 +41,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * This testcase is used to check if the GarbageCollector can delete garbage from the
  * solr server as expected
  */
-class GarbageCollectorTest extends IntegrationTestBase
+final class GarbageCollectorTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
+++ b/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Verifies that the unified sub-request pipeline (IndexingService + SolrIndexingMiddleware)
  * correctly handles fe_group restrictions via UserGroupDetector and FrontendGroupsModifier.
  */
-class AccessProtectedContentTest extends IntegrationTestBase
+final class AccessProtectedContentTest extends IntegrationTestBase
 {
     protected ?Queue $indexQueue = null;
 

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Frontend\Page\CacheHashCalculator;
 /**
  * Testcase to check if we can index page documents using the SolrIndexingMiddleware
  */
-class PageIndexerTest extends IntegrationTestBase
+final class PageIndexerTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the record indexer
  */
-class IndexerTest extends IntegrationTestBase
+final class IndexerTest extends IntegrationTestBase
 {
     protected bool $skipImportRootPagesAndTemplatesForConfiguredSites = true;
 

--- a/Tests/Integration/IndexQueue/Initializer/PageTest.php
+++ b/Tests/Integration/IndexQueue/Initializer/PageTest.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to test the page queue initializer
  */
-class PageTest extends IntegrationTestBase
+final class PageTest extends IntegrationTestBase
 {
     /**
      * @var Page

--- a/Tests/Integration/IndexQueue/QueueTest.php
+++ b/Tests/Integration/IndexQueue/QueueTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to test the Queue
  */
-class QueueTest extends IntegrationTestBase
+final class QueueTest extends IntegrationTestBase
 {
     /**
      * @var Queue

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -43,7 +43,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the record monitor
  */
-class RecordMonitorTest extends IntegrationTestBase
+final class RecordMonitorTest extends IntegrationTestBase
 {
     protected array $testExtensionsToLoad = [
         'apache-solr-for-typo3/solr',

--- a/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
+++ b/Tests/Integration/Report/AccessFilterPluginInstalledStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 /**
  * Integration test for the Solr Access Filter status report
  */
-class AccessFilterPluginInstalledStatusTest extends IntegrationTestBase
+final class AccessFilterPluginInstalledStatusTest extends IntegrationTestBase
 {
     protected bool $initializeDatabase = false;
 

--- a/Tests/Integration/Report/SchemaStatusTest.php
+++ b/Tests/Integration/Report/SchemaStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 /**
  * Integration test for the schema status report
  */
-class SchemaStatusTest extends IntegrationTestBase
+final class SchemaStatusTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Report/SolrConfigStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 /**
  * Integration test for the config status report
  */
-class SolrConfigStatusTest extends IntegrationTestBase
+final class SolrConfigStatusTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Integration/Report/SolrConfigurationStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 /**
  * Integration test for the Solr configuration status report
  */
-class SolrConfigurationStatusTest extends IntegrationTestBase
+final class SolrConfigurationStatusTest extends IntegrationTestBase
 {
     /**
      * @inheritdoc

--- a/Tests/Integration/Report/SolrStatusTest.php
+++ b/Tests/Integration/Report/SolrStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 /**
  * Integration test for the Solr status report
  */
-class SolrStatusTest extends IntegrationTestBase
+final class SolrStatusTest extends IntegrationTestBase
 {
     #[Test]
     public function allStatusChecksShouldBeOkForValidSolrConnection(): void

--- a/Tests/Integration/Report/SolrVersionStatusTest.php
+++ b/Tests/Integration/Report/SolrVersionStatusTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Integration test for the Solr version test
  */
-class SolrVersionStatusTest extends IntegrationTestBase
+final class SolrVersionStatusTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Test class to perform a search on a real solr server
  */
-class SearchTest extends IntegrationTestBase
+final class SearchTest extends IntegrationTestBase
 {
     protected QueryBuilder $queryBuilder;
 

--- a/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
+++ b/Tests/Integration/System/Configuration/ConfigurationPageResolverTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ConfigurationPageResolverTest extends IntegrationTestBase
+final class ConfigurationPageResolverTest extends IntegrationTestBase
 {
     #[Test]
     public function canGetClosestPageIdWithActiveTemplate(): void

--- a/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Integration/System/Configuration/TypoScriptConfigurationTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class TypoScriptConfigurationTest extends IntegrationTestBase
+final class TypoScriptConfigurationTest extends IntegrationTestBase
 {
     protected bool $initializeDatabase = false;
 

--- a/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
+++ b/Tests/Integration/System/Records/Pages/PagesRepositoryTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Integration tests for PagesRepository.
  */
-class PagesRepositoryTest extends IntegrationTestBase
+final class PagesRepositoryTest extends IntegrationTestBase
 {
     /**
      * @var PagesRepository

--- a/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemCategory/SystemCategoryRepositoryTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Integration test for the SystemCategoryRepository
  */
-class SystemCategoryRepositoryTest extends IntegrationTestBase
+final class SystemCategoryRepositoryTest extends IntegrationTestBase
 {
     #[Test]
     public function canFindOneByParentCategory(): void

--- a/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
+++ b/Tests/Integration/System/Records/SystemTemplate/SystemTemplateRepositoryTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Integration test for the SystemTemplateRepository
  */
-class SystemTemplateRepositoryTest extends IntegrationTestBase
+final class SystemTemplateRepositoryTest extends IntegrationTestBase
 {
     #[Test]
     public function canFindOneClosestPageIdWithActiveTemplateByRootLine(): void

--- a/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception as MockObjectException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Curl;
 use Traversable;
@@ -31,7 +32,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to check if the solr admin service is working as expected.
  */
-class SolrAdminServiceTest extends IntegrationTestBase
+final class SolrAdminServiceTest extends IntegrationTestBase
 {
     protected bool $initializeDatabase = false;
 
@@ -43,7 +44,7 @@ class SolrAdminServiceTest extends IntegrationTestBase
     protected function setUp(): void
     {
         parent::setUp();
-        /** @var EventDispatcher $eventDispatcher */
+        /** @var EventDispatcher&MockObject $eventDispatcher */
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(
@@ -162,7 +163,6 @@ class SolrAdminServiceTest extends IntegrationTestBase
     {
         $pingRuntime = $this->solrAdminService->getPingRoundTripRuntime();
         self::assertGreaterThan(0, $pingRuntime, 'Ping runtime should be larger then 0');
-        self::assertTrue(is_float($pingRuntime), 'Ping runtime should be an integer');
     }
 
     #[Test]
@@ -195,7 +195,7 @@ class SolrAdminServiceTest extends IntegrationTestBase
     #[Test]
     public function canParseLanguageFromSchema(): void
     {
-        /** @var EventDispatcher $eventDispatcher */
+        /** @var EventDispatcher&MockObject $eventDispatcher */
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $adapter = new Curl();
         $client = new Client(

--- a/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Integration/System/Solr/Service/SolrWriteServiceTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase to check if the solr write service is working as expected.
  */
-class SolrWriteServiceTest extends IntegrationTestBase
+final class SolrWriteServiceTest extends IntegrationTestBase
 {
     protected SolrWriteService $solrWriteService;
 

--- a/Tests/Integration/System/Solr/SolrConnectionTest.php
+++ b/Tests/Integration/System/Solr/SolrConnectionTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Class SolrConnectionTest
  */
-class SolrConnectionTest extends IntegrationTestBase
+final class SolrConnectionTest extends IntegrationTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Integration/TSFETestBootstrapper.php
+++ b/Tests/Integration/TSFETestBootstrapper.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Frontend\Page\PageInformation;
 /**
  * Helper class to set up a ServerRequest for testing frontend scenarios
  */
-class TSFETestBootstrapper
+final class TSFETestBootstrapper
 {
     public function bootstrap(int $pageId): ServerRequest
     {

--- a/Tests/Integration/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/EventQueueWorkerTaskTest.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Scheduler\Task\TaskSerializer;
  * Test case to check if the scheduler task EventQueueWorkerTask can process
  * event queue entries
  */
-class EventQueueWorkerTaskTest extends IntegrationTestBase
+final class EventQueueWorkerTaskTest extends IntegrationTestBase
 {
     protected EventQueueItemRepository $eventQueue;
     protected Queue $indexQueue;

--- a/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Integration/Task/IndexQueueWorkerTaskTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TestCase to check if we can index from index queue worker task into a solr server
  */
-class IndexQueueWorkerTaskTest extends IntegrationTestBase
+final class IndexQueueWorkerTaskTest extends IntegrationTestBase
 {
     /**
      * @inheritdoc

--- a/Tests/Integration/Task/ReIndexTaskTest.php
+++ b/Tests/Integration/Task/ReIndexTaskTest.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TestCase to check if the index queue can be initialized by the ReIndex Task
  */
-class ReIndexTaskTest extends IntegrationTestBase
+final class ReIndexTaskTest extends IntegrationTestBase
 {
     /**
      * @inheritdoc

--- a/Tests/Integration/TestGarbageCollectorPostProcessor.php
+++ b/Tests/Integration/TestGarbageCollectorPostProcessor.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 /**
  * Class TestGarbageCollectorPostProcessor
  */
-class TestGarbageCollectorPostProcessor implements SingletonInterface, GarbageCollectorPostProcessor
+final class TestGarbageCollectorPostProcessor implements SingletonInterface, GarbageCollectorPostProcessor
 {
     protected bool $hookWasCalled = false;
 

--- a/Tests/Integration/ViewHelpers/Backend/IsStringViewHelperTest.php
+++ b/Tests/Integration/ViewHelpers/Backend/IsStringViewHelperTest.php
@@ -28,7 +28,7 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 /**
  * Testcase for the IsStringViewHelper
  */
-class IsStringViewHelperTest extends IntegrationTestBase
+final class IsStringViewHelperTest extends IntegrationTestBase
 {
     protected bool $initializeDatabase = false;
     protected RenderingContextFactory $renderingContextFactory;
@@ -55,9 +55,7 @@ class IsStringViewHelperTest extends IntegrationTestBase
     }
 
     #[Test]
-    #[DataProvider(
-        methodName: 'stringDataProvider',
-    )]
+    #[DataProvider('stringDataProvider')]
     public function isStringRendersThenOrElse(string|int|array $value, string $expectedString): void
     {
         $templateSource = sprintf('

--- a/Tests/Integration/ViewHelpers/SearchFormViewHelperTest.php
+++ b/Tests/Integration/ViewHelpers/SearchFormViewHelperTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class SearchFormViewHelperTest extends IntegrationTestBase
+final class SearchFormViewHelperTest extends IntegrationTestBase
 {
     protected RenderingContextFactory $renderingContextFactory;
     protected MockObject|TypoScriptConfiguration $typoScriptConfigurationMock;
@@ -90,9 +90,7 @@ class SearchFormViewHelperTest extends IntegrationTestBase
     }
 
     #[Test]
-    #[DataProvider(
-        methodName: 'methodDataProvider',
-    )]
+    #[DataProvider('methodDataProvider')]
     public function methodArgumentWillBePassedToFormTag(string $method, string $expectedString): void
     {
         $templateSource = sprintf('
@@ -129,9 +127,7 @@ class SearchFormViewHelperTest extends IntegrationTestBase
     }
 
     #[Test]
-    #[DataProvider(
-        methodName: 'pageUidDataProvider',
-    )]
+    #[DataProvider('pageUidDataProvider')]
     public function pageUidArgumentWillBeUsedToBuildActionUri(
         string $pageUidArgument,
         int $searchTargetPageUid,

--- a/Tests/Unit/AbstractIndexerTest.php
+++ b/Tests/Unit/AbstractIndexerTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for AbstractIndexer
  */
-class AbstractIndexerTest extends SetUpUnitTestCase
+final class AbstractIndexerTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testTypeIsNotAllowedOverride(): void

--- a/Tests/Unit/Access/RootlineElementTest.php
+++ b/Tests/Unit/Access/RootlineElementTest.php
@@ -25,7 +25,7 @@ use Traversable;
 /**
  * Testcase to verify the functionality of the RootlineElement
  */
-class RootlineElementTest extends SetUpUnitTestCase
+final class RootlineElementTest extends SetUpUnitTestCase
 {
     /**
      * @return Traversable<string, array{
@@ -115,9 +115,7 @@ class RootlineElementTest extends SetUpUnitTestCase
      * @throws RootlineElementFormatException
      */
     #[Test]
-    #[DataProvider(
-        methodName: 'validRootLineRePresentations',
-    )]
+    #[DataProvider('validRootLineRePresentations')]
     public function canParse(
         string $stringRepresentation,
         int $expectedType,

--- a/Tests/Unit/Access/RootlineTest.php
+++ b/Tests/Unit/Access/RootlineTest.php
@@ -24,7 +24,7 @@ use Traversable;
 /**
  * Testcase to verify the functionality of the Rootline
  */
-class RootlineTest extends SetUpUnitTestCase
+final class RootlineTest extends SetUpUnitTestCase
 {
     /**
      * @return Traversable<string, array{
@@ -52,9 +52,7 @@ class RootlineTest extends SetUpUnitTestCase
      * @param list<int> $expectedGroups
      */
     #[Test]
-    #[DataProvider(
-        methodName: 'rootLineDataProvider',
-    )]
+    #[DataProvider('rootLineDataProvider')]
     public function canParse(string $rootLineString, array $expectedGroups): void
     {
         $rootLine = new Rootline($rootLineString);

--- a/Tests/Unit/ConnectionManagerTest.php
+++ b/Tests/Unit/ConnectionManagerTest.php
@@ -37,7 +37,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * PHP Unit test for connection manager
  */
-class ConnectionManagerTest extends SetUpUnitTestCase
+final class ConnectionManagerTest extends SetUpUnitTestCase
 {
     protected ConnectionManager|MockObject $connectionManager;
     protected SolrLogManager|MockObject $logManagerMock;

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Tests for the SOLR_MULTIVALUE cObj.
  */
-class MultivalueTest extends SetUpContentObject
+final class MultivalueTest extends SetUpContentObject
 {
     protected function getTestableContentObjectClassName(): string
     {

--- a/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexAdministrationModuleControllerTest.php
@@ -28,7 +28,7 @@ use Solarium\Core\Client\Endpoint;
  *
  * @property IndexAdministrationModuleController|MockObject $controller
  */
-class IndexAdministrationModuleControllerTest extends SetUpSolrModuleControllerTestCase
+final class IndexAdministrationModuleControllerTest extends SetUpSolrModuleControllerTestCase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
+++ b/Tests/Unit/Controller/Backend/Search/IndexQueueModuleControllerTest.php
@@ -32,7 +32,7 @@ use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
  *
  * @property IndexQueueModuleController|MockObject $controller
  */
-class IndexQueueModuleControllerTest extends SetUpSolrModuleControllerTestCase
+final class IndexQueueModuleControllerTest extends SetUpSolrModuleControllerTestCase
 {
     protected Queue|MockObject $indexQueueMock;
     protected EventDispatcherInterface|MockObject $eventDispatcher;

--- a/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
+++ b/Tests/Unit/Domain/Index/Classification/ClassificationServiceTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Classification\ClassificationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class ClassificationServiceTest extends SetUpUnitTestCase
+final class ClassificationServiceTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetMatchingClassifications(): void

--- a/Tests/Unit/Domain/Index/IndexServiceTest.php
+++ b/Tests/Unit/Domain/Index/IndexServiceTest.php
@@ -31,7 +31,7 @@ use RuntimeException;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class IndexServiceTest extends SetUpUnitTestCase
+final class IndexServiceTest extends SetUpUnitTestCase
 {
     protected Site|MockObject $siteMock;
     protected Queue|MockObject $queueMock;

--- a/Tests/Unit/Domain/Index/PageIndexer/PageUriBuilderTest.php
+++ b/Tests/Unit/Domain/Index/PageIndexer/PageUriBuilderTest.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class PageUriBuilderTest extends SetUpUnitTestCase
+final class PageUriBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testPageIndexingUriFromPageItemAndLanguageId(): void

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/PageStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/PageStrategyTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\PageStrategy;
 /**
  * PageStrategy tests
  */
-class PageStrategyTest extends AbstractStrategyTestBase
+final class PageStrategyTest extends AbstractStrategyTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Index/Queue/GarbageRemover/RecordStrategyTest.php
+++ b/Tests/Unit/Domain/Index/Queue/GarbageRemover/RecordStrategyTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\GarbageRemover\RecordStrategy;
 /**
  * RecordStrategy tests
  */
-class RecordStrategyTest extends AbstractStrategyTestBase
+final class RecordStrategyTest extends AbstractStrategyTestBase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
+++ b/Tests/Unit/Domain/Index/Queue/QueueInitializerServiceTest.php
@@ -25,7 +25,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class QueueInitializerServiceTest extends SetUpUnitTestCase
+final class QueueInitializerServiceTest extends SetUpUnitTestCase
 {
     #[\PHPUnit\Framework\Attributes\Test]
     public function allIndexConfigurationsAreUsedWhenWildcardIsPassed(): void

--- a/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
+++ b/Tests/Unit/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolverTest.php
@@ -23,7 +23,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class RootPageResolverTest extends SetUpUnitTestCase
+final class RootPageResolverTest extends SetUpUnitTestCase
 {
     protected TwoLevelCache|MockObject $cacheMock;
     protected ConfigurationAwareRecordService|MockObject $recordServiceMock;

--- a/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
+++ b/Tests/Unit/Domain/Index/Queue/Statistic/QueueStatisticTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class QueueStatisticTest extends SetUpUnitTestCase
+final class QueueStatisticTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetFailedPercentage(): void

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/DataUpdateHandlerTest.php
@@ -36,7 +36,7 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 /**
  * Testcase for the DataUpdateHandler class.
  */
-class DataUpdateHandlerTest extends SetUpUpdateHandler
+final class DataUpdateHandlerTest extends SetUpUpdateHandler
 {
     private const DUMMY_PAGE_ID = 10;
 

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/DelayedProcessingEventListenerTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @property DelayedProcessingEventListener $listener
  */
-class DelayedProcessingEventListenerTest extends SetUpEventListener
+final class DelayedProcessingEventListenerTest extends SetUpEventListener
 {
     #[Test]
     public function canHandleEvents(): void

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingFinishedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 /**
  * Testcase for the DelayedProcessingFinishedEvent
  */
-class DelayedProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
+final class DelayedProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
 {
     protected const EVENT_CLASS = DelayedProcessingFinishedEvent::class;
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/DelayedProcessingQueuingFinishedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 /**
  * Testcase for the DelayedProcessingQueuingFinishedEvent
  */
-class DelayedProcessingQueuingFinishedEventTest extends SetUpProcessingFinishedEvent
+final class DelayedProcessingQueuingFinishedEventTest extends SetUpProcessingFinishedEvent
 {
     protected const EVENT_CLASS = DelayedProcessingQueuingFinishedEvent::class;
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/Events/ProcessingFinishedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\EventListener\Event
 /**
  * Testcase for the ProcessingFinishedEvent
  */
-class ProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
+final class ProcessingFinishedEventTest extends SetUpProcessingFinishedEvent
 {
     protected const EVENT_CLASS = ProcessingFinishedEvent::class;
 }

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php
@@ -39,7 +39,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @property ImmediateProcessingEventListener $listener
  */
-class ImmediateProcessingEventListenerTest extends SetUpEventListener
+final class ImmediateProcessingEventListenerTest extends SetUpEventListener
 {
     protected function setUp(): void
     {
@@ -117,7 +117,7 @@ class ImmediateProcessingEventListenerTest extends SetUpEventListener
         $this->listener->__invoke($event);
         if ($eventHandled) {
             self::assertTrue($dispatchedEvent instanceof ProcessingFinishedEvent);
-            /** @var DataUpdateEventInterface|StoppableEventInterface $dataUpdateEvent */
+            /** @var DataUpdateEventInterface&StoppableEventInterface $dataUpdateEvent */
             $dataUpdateEvent = $dispatchedEvent->getDataUpdateEvent();
             self::assertEquals($dataUpdateEvent, $event);
             self::assertTrue($dataUpdateEvent->isPropagationStopped());

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/NoProcessingEventListenerTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
  *
  * @property NoProcessingEventListener $listener;
  */
-class NoProcessingEventListenerTest extends SetUpEventListener
+final class NoProcessingEventListenerTest extends SetUpEventListener
 {
     #[Test]
     public function canHandleEvents(): void

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/ContentElementDeletedEventTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the ContentElementDeletedEvent
  */
-class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
+final class ContentElementDeletedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = ContentElementDeletedEvent::class;
     protected const EVENT_TEST_TABLE = 'tt_content';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/PageMovedEventTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the PageMovedEvent
  */
-class PageMovedEventTest extends SetUpDataUpdateEvent
+final class PageMovedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = PageMovedEvent::class;
     protected const EVENT_TEST_TABLE = 'pages';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordDeletedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordDelete
 /**
  * Testcase for the RecordDeletedEvent
  */
-class RecordDeletedEventTest extends SetUpDataUpdateEvent
+final class RecordDeletedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = RecordDeletedEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordGarbageCheckEventTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the RecordGarbageCheckEvent
  */
-class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
+final class RecordGarbageCheckEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = RecordGarbageCheckEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordInsertedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordInsertedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordInsert
 /**
  * Testcase for the RecordInsertedEvent
  */
-class RecordInsertedEventTest extends SetUpDataUpdateEvent
+final class RecordInsertedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = RecordInsertedEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordMovedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordMovedE
 /**
  * Testcase for the RecordMovedEvent
  */
-class RecordMovedEventTest extends SetUpDataUpdateEvent
+final class RecordMovedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = RecordMovedEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/RecordUpdatedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\RecordUpdate
 /**
  * Testcase for the RecordUpdatedEvent
  */
-class RecordUpdatedEventTest extends SetUpDataUpdateEvent
+final class RecordUpdatedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = RecordUpdatedEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/Events/VersionSwappedEventTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Domain\Index\Queue\UpdateHandler\Events\VersionSwapp
 /**
  * Testcase for the VersionSwappedEvent
  */
-class VersionSwappedEventTest extends SetUpDataUpdateEvent
+final class VersionSwappedEventTest extends SetUpDataUpdateEvent
 {
     protected const EVENT_CLASS = VersionSwappedEvent::class;
     protected const EVENT_TEST_TABLE = 'tx_foo_bar';

--- a/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
+++ b/Tests/Unit/Domain/Index/Queue/UpdateHandler/GarbageHandlerTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the GarbageHandler class.
  */
-class GarbageHandlerTest extends SetUpUpdateHandler
+final class GarbageHandlerTest extends SetUpUpdateHandler
 {
     protected GarbageHandler $garbageHandler;
 

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php
@@ -22,7 +22,6 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ApacheSolrDocument\Builder;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
 use ApacheSolrForTypo3\Solr\Domain\Variants\IdBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
-use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use ApacheSolrForTypo3\Solr\Typo3PageContentExtractor;
 use PHPUnit\Framework\Attributes\Test;
@@ -35,7 +34,7 @@ use TYPO3\CMS\Frontend\Page\PageInformation;
 /**
  * Testcase for the Builder of ApacheSolrDocument
  */
-class BuilderTest extends SetUpUnitTestCase
+final class BuilderTest extends SetUpUnitTestCase
 {
     public const FAKE_PAGE_RECORD = [
         'pid' => 4710,
@@ -95,7 +94,6 @@ class BuilderTest extends SetUpUnitTestCase
         $pageContent = '<html><body>Test content</body></html>';
         $document = $this->documentBuilder->fromPage($pageInformation, $pageArguments, $siteLanguage, $pageContent, 'http://www.typo3-solr.com', $fakeRootLine);
 
-        self::assertInstanceOf(Document::class, $document, 'Expect to get an ' . Document::class . ' back');
         self::assertSame('siteHash/pages/4711', $document['id'], 'Builder did not use documentId from mock');
     }
 

--- a/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
+++ b/Tests/Unit/Domain/Search/ApacheSolrDocument/RepositoryTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Test cases for ApacheSolrDocumentRepository
  */
-class RepositoryTest extends SetUpUnitTestCase
+final class RepositoryTest extends SetUpUnitTestCase
 {
     protected Search $search;
     protected ConnectionManager $solrConnectionManager;

--- a/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/FrequentSearches/FrequentSearchesServiceTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
-class FrequentSearchesServiceTest extends SetUpUnitTestCase
+final class FrequentSearchesServiceTest extends SetUpUnitTestCase
 {
     protected FrequentSearchesService|MockObject $frequentSearchesService;
     protected AbstractFrontend|MockObject $cacheMock;

--- a/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
+++ b/Tests/Unit/Domain/Search/Highlight/SiteHighlighterUrlModifierTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
-class SiteHighlighterUrlModifierTest extends SetUpUnitTestCase
+final class SiteHighlighterUrlModifierTest extends SetUpUnitTestCase
 {
     public static function canModifyDataProvider(): Traversable
     {

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesRepositoryTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class LastSearchesRepositoryTest extends SetUpUnitTestCase
+final class LastSearchesRepositoryTest extends SetUpUnitTestCase
 {
     protected LastSearchesRepository|MockObject $lastSearchesRepositoryMock;
 

--- a/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
+++ b/Tests/Unit/Domain/Search/LastSearches/LastSearchesServiceTest.php
@@ -23,7 +23,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class LastSearchesServiceTest extends SetUpUnitTestCase
+final class LastSearchesServiceTest extends SetUpUnitTestCase
 {
     protected LastSearchesService|MockObject $lastSearchesService;
     protected FrontendUserSession|MockObject $sessionMock;

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
-class EscapeHelperTest extends SetUpUnitTestCase
+final class EscapeHelperTest extends SetUpUnitTestCase
 {
     public static function escapeQueryDataProvider(): Traversable
     {

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/BigramPhraseFieldsTest.php
@@ -19,7 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\BigramPhraseFie
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class BigramPhraseFieldsTest extends SetUpUnitTestCase
+final class BigramPhraseFieldsTest extends SetUpUnitTestCase
 {
     #[Test]
     public function buildFromEmptyStringCreatesEmptyArrayOnBuild(): void

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/GroupingTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class GroupingTest extends SetUpUnitTestCase
+final class GroupingTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuildSortingFromConfiguration(): void

--- a/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
+++ b/Tests/Unit/Domain/Search/Query/ParameterBuilder/QueryFieldsTest.php
@@ -19,7 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\QueryFields;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class QueryFieldsTest extends SetUpUnitTestCase
+final class QueryFieldsTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuildFromString(): void

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -52,7 +52,7 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 use function str_starts_with;
 
-class QueryBuilderTest extends SetUpUnitTestCase
+final class QueryBuilderTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $configurationMock;
     protected SolrLogManager|MockObject $loggerMock;

--- a/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
+++ b/Tests/Unit/Domain/Search/Query/SuggestQueryTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Tests the ApacheSolrForTypo3\Solr\SuggestQuery class
  */
-class SuggestQueryTest extends SetUpUnitTestCase
+final class SuggestQueryTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testSuggestQueryDoesNotUseFieldCollapsing(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultFacetQueryBuilderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class DefaultFacetQueryBuilderTest
  */
-class DefaultFacetQueryBuilderTest extends SetUpUnitTestCase
+final class DefaultFacetQueryBuilderTest extends SetUpUnitTestCase
 {
     /**
      * Whe nothing is set, no exclude tags should be set.

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/DefaultUrlDecoderTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class DefaultUrlEncoderTest
  */
-class DefaultUrlDecoderTest extends SetUpUnitTestCase
+final class DefaultUrlDecoderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canDecode(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetCollectionTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class FacetCollectionTest
  */
-class FacetCollectionTest extends SetUpUnitTestCase
+final class FacetCollectionTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canAddAndRetrieveFacetByKey(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/FacetRegistryTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Testcases for the Facet parser registry
  */
-class FacetRegistryTest extends SetUpUnitTestCase
+final class FacetRegistryTest extends SetUpUnitTestCase
 {
     /**
      * Initialize a RendererRegistry and mock createRendererInstance()

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParserTest.php
@@ -26,7 +26,7 @@ use Traversable;
 /**
  * Class HierarchyFacetParserTest
  */
-class HierarchyFacetParserTest extends SetUpFacetParser
+final class HierarchyFacetParserTest extends SetUpFacetParser
 {
     #[Test]
     public function facetIsCreated(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyUrlDecoderTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for query parser range
  */
-class HierarchyUrlDecoderTest extends SetUpUnitTestCase
+final class HierarchyUrlDecoderTest extends SetUpUnitTestCase
 {
     protected HierarchyUrlDecoder $parser;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/NodeTest.php
@@ -26,7 +26,7 @@ use function array_map;
 /**
  * Testcase to test the Node class
  */
-class NodeTest extends SetUpUnitTestCase
+final class NodeTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetHasParentNode(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionCollectionTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Unit test for the OptionsFacet
  */
-class OptionCollectionTest extends SetUpUnitTestCase
+final class OptionCollectionTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParserTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class OptionsFacetParserTest extends SetUpUnitTestCase
+final class OptionsFacetParserTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canListFloatValuesAsOptionsFromSolrResponse(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetQueryBuilderTest.php
@@ -25,7 +25,7 @@ use Traversable;
 /**
  * Testcase for the dateRange queryBuilder
  */
-class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
+final class OptionsFacetQueryBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuildSortParameter(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Unit test for the OptionsFacet
  */
-class OptionsFacetTest extends SetUpUnitTestCase
+final class OptionsFacetTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/OptionCollectionTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test for the QueryGroupFacet options collection
  */
-class OptionCollectionTest extends SetUpUnitTestCase
+final class OptionCollectionTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetManualSortedCopy(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParserTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class QueryGroupFacetParserTest
  */
-class QueryGroupFacetParserTest extends SetUpFacetParser
+final class QueryGroupFacetParserTest extends SetUpFacetParser
 {
     protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile, array $facetConfiguration, array $activeFilters = []): SearchResultSet
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetQueryBuilderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the dateRange queryBuilder
  */
-class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
+final class QueryGroupFacetQueryBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuildQueryGroupFacetWithKeepAllOptionsOnSelection(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Unit test for the QueryGroupFacet
  */
-class QueryGroupFacetTest extends SetUpUnitTestCase
+final class QueryGroupFacetTest extends SetUpUnitTestCase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetParserTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class DateRangeFacetParserTest
  */
-class DateRangeFacetParserTest extends SetUpFacetParser
+final class DateRangeFacetParserTest extends SetUpFacetParser
 {
     #[Test]
     public function facetIsCreated(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeFacetQueryBuilderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the dateRange queryBuilder
  */
-class DateRangeFacetQueryBuilderTest extends SetUpUnitTestCase
+final class DateRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuild(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class DateRangeTest
  */
-class DateRangeTest extends SetUpUnitTestCase
+final class DateRangeTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canHandleHalfOpenDateRanges(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/DateRange/DateRangeUrlDecoderTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for query parser range
  */
-class DateRangeUrlDecoderTest extends SetUpUnitTestCase
+final class DateRangeUrlDecoderTest extends SetUpUnitTestCase
 {
     protected DateRangeUrlDecoder $rangeParser;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetParserTest.php
@@ -27,7 +27,7 @@ use Traversable;
 /**
  * Class DateRangeFacetParserTest
  */
-class NumericRangeFacetParserTest extends SetUpFacetParser
+final class NumericRangeFacetParserTest extends SetUpFacetParser
 {
     /**
      * Returns a basic facet configuration

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeFacetQueryBuilderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the numericRange queryBuilder
  */
-class NumericRangeFacetQueryBuilderTest extends SetUpUnitTestCase
+final class NumericRangeFacetQueryBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuild(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RangeBased/NumericRange/NumericRangeUrlDecoderTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for query parser range
  */
-class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
+final class NumericRangeUrlDecoderTest extends SetUpUnitTestCase
 {
     protected NumericRangeUrlDecoder $rangeParser;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RenderingInstructions/FormatDateTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use Exception;
 use PHPUnit\Framework\Attributes\Test;
 
-class FormatDateTest extends SetUpUnitTestCase
+final class FormatDateTest extends SetUpUnitTestCase
 {
     public function setUp(): void
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/RequirementsServiceTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to test the RequirementsService
  */
-class RequirementsServiceTest extends SetUpUnitTestCase
+final class RequirementsServiceTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/SortingExpressionTest.php
@@ -26,7 +26,7 @@ use Traversable;
 /**
  * Unit test for the SortingExpression
  */
-class SortingExpressionTest extends SetUpUnitTestCase
+final class SortingExpressionTest extends SetUpUnitTestCase
 {
     public static function canBuildSortExpressionDataProvider(): Traversable
     {

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestFacet.php
@@ -6,7 +6,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetItemCollection;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\Hierarchy\NodeCollection;
 
-class TestFacet extends AbstractFacet
+final class TestFacet extends AbstractFacet
 {
     /**
      * The implementation of this method should return a "flatten" collection of all items.

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestPackage.php
@@ -19,7 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet\Facets\Test
 
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetPackage;
 
-class TestPackage extends AbstractFacetPackage
+final class TestPackage extends AbstractFacetPackage
 {
     /**
      * @return string

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/TestPackage/TestParser.php
@@ -6,9 +6,9 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\AbstractFacetParser;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
-class TestParser extends AbstractFacetParser
+final class TestParser extends AbstractFacetParser
 {
-    public function parse(SearchResultSet $resultSet, string $facetName, array $facetConfiguration): ?AbstractFacet
+    public function parse(SearchResultSet $resultSet, string $facetName, array $facetConfiguration): AbstractFacet
     {
         return new TestFacet($resultSet, $facetName, 'testField');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Facets/UrlFacetContainerTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcases for the url data bag
  */
-class UrlFacetContainerTest extends SetUpUnitTestCase
+final class UrlFacetContainerTest extends SetUpUnitTestCase
 {
     /**
      * Test data for index based url parameters

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupCollectionTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the GroupCollection class
  */
-class GroupCollectionTest extends SetUpUnitTestCase
+final class GroupCollectionTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetByGroupName(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupItemTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the Group class
  */
-class GroupItemTest extends SetUpUnitTestCase
+final class GroupItemTest extends SetUpUnitTestCase
 {
     protected GroupItem $groupItem;
     protected Group $parentGroup;

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/GroupTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the Group class
  */
-class GroupTest extends SetUpUnitTestCase
+final class GroupTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testCanGroupName(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/DefaultParserTest.php
@@ -31,7 +31,7 @@ use Solarium\Component\Grouping;
 /**
  * Unit test case for the SearchResult.
  */
-class DefaultParserTest extends SetUpUnitTestCase
+final class DefaultParserTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $configurationMock;
     protected DefaultResultParser $parser;

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/GroupedResultsParserTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase to test the GroupedResultsParser.
  */
-class GroupedResultsParserTest extends SetUpUnitTestCase
+final class GroupedResultsParserTest extends SetUpUnitTestCase
 {
     protected GroupedResultParser $parser;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/ResultParserRegistryTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Unit test case for the ResultParserRegistryTest.
  */
-class ResultParserRegistryTest extends SetUpUnitTestCase
+final class ResultParserRegistryTest extends SetUpUnitTestCase
 {
     protected ResultParserRegistry $registry;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/Parser/TestResultParser.php
@@ -23,7 +23,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 /**
  * Fake test parser
  */
-class TestResultParser extends AbstractResultParser
+final class TestResultParser extends AbstractResultParser
 {
     /**
      * @inheritDoc

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultCollectionTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the SearchResultCollection.
  */
-class SearchResultCollectionTest extends SetUpUnitTestCase
+final class SearchResultCollectionTest extends SetUpUnitTestCase
 {
     protected SearchResultCollection $searchResultCollection;
 

--- a/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Result/SearchResultTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the SearchResult.
  */
-class SearchResultTest extends SetUpUnitTestCase
+final class SearchResultTest extends SetUpUnitTestCase
 {
     protected SearchResult $searchResult;
 

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
  */
-class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
+final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
 {
     protected function initializeSearchResultSetFromFakeResponse(string $fixtureFile): SearchResultSet
     {

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -35,7 +35,7 @@ use Solarium\Component\Grouping;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class SearchResultSetServiceTest extends SetUpUnitTestCase
+final class SearchResultSetServiceTest extends SetUpUnitTestCase
 {
     protected SearchResultSetService $searchResultSetService;
     protected TypoScriptConfiguration|MockObject $configurationMock;

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -38,7 +38,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class SearchResultSetTest extends SetUpUnitTestCase
+final class SearchResultSetTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $configurationMock;
     protected Search|MockObject $searchMock;

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingHelperTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Class SortingHelperTest
  */
-class SortingHelperTest extends SetUpUnitTestCase
+final class SortingHelperTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetSortFieldFromUrlParameter(): void

--- a/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Sorting/SortingTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
  */
-class SortingTest extends SetUpUnitTestCase
+final class SortingTest extends SetUpUnitTestCase
 {
     protected Sorting $sorting;
     protected SearchResultSet $resultSetMock;

--- a/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
+++ b/Tests/Unit/Domain/Search/Score/ScoreCalculationServiceTest.php
@@ -19,7 +19,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\Score\ScoreCalculationService;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class ScoreCalculationServiceTest extends SetUpUnitTestCase
+final class ScoreCalculationServiceTest extends SetUpUnitTestCase
 {
     protected ScoreCalculationService $scoreCalculationService;
 

--- a/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestBuilderTest.php
@@ -23,7 +23,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class SearchRequestBuilderTest extends SetUpUnitTestCase
+final class SearchRequestBuilderTest extends SetUpUnitTestCase
 {
     protected FrontendUserSession|MockObject $sessionMock;
     protected TypoScriptConfiguration|MockObject $configurationMock;

--- a/Tests/Unit/Domain/Search/SearchRequestTest.php
+++ b/Tests/Unit/Domain/Search/SearchRequestTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class SearchRequestTest extends SetUpUnitTestCase
+final class SearchRequestTest extends SetUpUnitTestCase
 {
     protected SearchRequest $searchRequest;
 

--- a/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
+++ b/Tests/Unit/Domain/Search/Statistics/StatisticsWriterProcessorTest.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 /**
  * Unit test case for the StatisticsWriterProcessor.
  */
-class StatisticsWriterProcessorTest extends SetUpUnitTestCase
+final class StatisticsWriterProcessorTest extends SetUpUnitTestCase
 {
     protected StatisticsRepository|MockObject $statisticsRepositoryMock;
     protected SiteRepository|MockObject $siteRepositoryMock;

--- a/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
+++ b/Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php
@@ -48,7 +48,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class SuggestServiceTest extends SetUpUnitTestCase
+final class SuggestServiceTest extends SetUpUnitTestCase
 {
     protected SuggestService|MockObject $suggestService;
     protected SearchResultSetService|MockObject $searchResultSetServiceMock;
@@ -125,9 +125,9 @@ class SuggestServiceTest extends SetUpUnitTestCase
 
         $searchStub = new class ($this->createMock(SolrConnection::class)) extends Search implements SingletonInterface {
             public static SuggestServiceTest $suggestServiceTest;
-            public function search(Query $query, $offset = 0, $limit = 10): ?ResponseAdapter
+            public function search(Query $query, $offset = 0, $limit = 10): ResponseAdapter
             {
-                /** @var ResponseAdapter|MockBuilder $mockObject */
+                /** @var ResponseAdapter|MockObject $mockObject */
                 $mockObject = self::$suggestServiceTest->provideMockBuilderInObjectsScope(ResponseAdapter::class)
                     ->onlyMethods([])->disableOriginalConstructor()->getMock();
                 return $mockObject;
@@ -149,7 +149,7 @@ class SuggestServiceTest extends SetUpUnitTestCase
         self::assertSame($expectedSuggestions, $suggestions, 'Suggest did not return status false');
     }
 
-    public function provideMockBuilderInObjectsScope(string $className): ResponseAdapter|MockBuilder
+    public function provideMockBuilderInObjectsScope(string $className): MockBuilder
     {
         return parent::getMockBuilder($className);
     }

--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -32,7 +32,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
  */
-class SearchUriBuilderTest extends SetUpUnitTestCase
+final class SearchUriBuilderTest extends SetUpUnitTestCase
 {
     protected SearchUriBuilder|MockObject $searchUrlBuilder;
     protected UriBuilder|MockObject $extBaseUriBuilderMock;

--- a/Tests/Unit/Domain/Site/SiteHashServiceTest.php
+++ b/Tests/Unit/Domain/Site/SiteHashServiceTest.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  *
  * The unit test is used to make sure that the SiteHashService works as expected when the calls to Site:: are mocked
  */
-class SiteHashServiceTest extends SetUpUnitTestCase
+final class SiteHashServiceTest extends SetUpUnitTestCase
 {
     protected EventDispatcherInterface|MockObject $eventDispatcherMock;
 

--- a/Tests/Unit/Domain/Site/SiteRepositoryTest.php
+++ b/Tests/Unit/Domain/Site/SiteRepositoryTest.php
@@ -36,7 +36,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * The unit test is used to make sure that the SiteRepository works as expected
  */
-class SiteRepositoryTest extends SetUpUnitTestCase
+final class SiteRepositoryTest extends SetUpUnitTestCase
 {
     protected TwoLevelCache|MockObject $cacheMock;
     protected RootPageResolver|MockObject $rootPageResolverMock;

--- a/Tests/Unit/Domain/Variants/IdBuilderTest.php
+++ b/Tests/Unit/Domain/Variants/IdBuilderTest.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 /**
  * Testcase to check if the IdBuilder can be used to build proper variantIds.
  */
-class IdBuilderTest extends SetUpUnitTestCase
+final class IdBuilderTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canBuildVariantId(): void

--- a/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
+++ b/Tests/Unit/FieldProcessor/PathToHierarchyTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * tests the path to hierarchy processing
  */
-class PathToHierarchyTest extends SetUpUnitTestCase
+final class PathToHierarchyTest extends SetUpUnitTestCase
 {
     protected PathToHierarchy $processor;
 

--- a/Tests/Unit/FieldProcessor/ServiceTest.php
+++ b/Tests/Unit/FieldProcessor/ServiceTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * tests the processing Service class
  */
-class ServiceTest extends SetUpUnitTestCase
+final class ServiceTest extends SetUpUnitTestCase
 {
     protected Document $documentMock;
     protected Service $service;

--- a/Tests/Unit/FieldProcessor/TestFieldProcessor.php
+++ b/Tests/Unit/FieldProcessor/TestFieldProcessor.php
@@ -4,7 +4,7 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\FieldProcessor;
 
 use ApacheSolrForTypo3\Solr\FieldProcessor\FieldProcessor;
 
-class TestFieldProcessor implements FieldProcessor
+final class TestFieldProcessor implements FieldProcessor
 {
     public function process(array $values): array
     {

--- a/Tests/Unit/GarbageCollectorTest.php
+++ b/Tests/Unit/GarbageCollectorTest.php
@@ -32,7 +32,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the GarbageCollector class.
  */
-class GarbageCollectorTest extends SetUpUnitTestCase
+final class GarbageCollectorTest extends SetUpUnitTestCase
 {
     protected GarbageCollector $garbageCollector;
     protected TCAService|MockObject $tcaServiceMock;

--- a/Tests/Unit/HtmlContentExtractorTest.php
+++ b/Tests/Unit/HtmlContentExtractorTest.php
@@ -23,7 +23,7 @@ use Traversable;
 /**
  * Tests the HtmlContentExtractor
  */
-class HtmlContentExtractorTest extends SetUpUnitTestCase
+final class HtmlContentExtractorTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetTagContent(): void

--- a/Tests/Unit/IndexQueue/AbstractIndexerTest.php
+++ b/Tests/Unit/IndexQueue/AbstractIndexerTest.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectFactory;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
-class AbstractIndexerTest extends SetUpUnitTestCase
+final class AbstractIndexerTest extends SetUpUnitTestCase
 {
     protected ContentObjectFactory|MockObject $contentObjectFactoryMock;
     protected ContentObjectRenderer $contentObjectRenderer;

--- a/Tests/Unit/IndexQueue/FrontendHelper/PageFieldMappingIndexerTest.php
+++ b/Tests/Unit/IndexQueue/FrontendHelper/PageFieldMappingIndexerTest.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectFactory;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
-class PageFieldMappingIndexerTest extends SetUpUnitTestCase
+final class PageFieldMappingIndexerTest extends SetUpUnitTestCase
 {
     protected ContentObjectFactory|MockObject $contentObjectFactoryMock;
     protected ContentObjectRenderer $contentObjectRenderer;

--- a/Tests/Unit/IndexQueue/IndexerTest.php
+++ b/Tests/Unit/IndexQueue/IndexerTest.php
@@ -44,7 +44,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Class IndexerTest
  */
-class IndexerTest extends SetUpUnitTestCase
+final class IndexerTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {
@@ -201,7 +201,7 @@ class IndexerTest extends SetUpUnitTestCase
             {
                 $this->site = $site;
             }
-            public function getSite(): ?Site
+            public function getSite(): Site
             {
                 return $this->site;
             }

--- a/Tests/Unit/IndexQueue/IndexingResultCollectorTest.php
+++ b/Tests/Unit/IndexQueue/IndexingResultCollectorTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
-class IndexingResultCollectorTest extends SetUpUnitTestCase
+final class IndexingResultCollectorTest extends SetUpUnitTestCase
 {
     #[Test]
     public function finalizeUserGroupsReturnsPublicGroupWhenNoGroupsCollected(): void

--- a/Tests/Unit/IndexQueue/ItemTest.php
+++ b/Tests/Unit/IndexQueue/ItemTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
-class ItemTest extends SetUpUnitTestCase
+final class ItemTest extends SetUpUnitTestCase
 {
     /**
      * Returns minimal valid metadata for creating an Item

--- a/Tests/Unit/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Unit/IndexQueue/RecordMonitorTest.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 /**
  * Testcase for the RecordMonitor class.
  */
-class RecordMonitorTest extends SetUpUnitTestCase
+final class RecordMonitorTest extends SetUpUnitTestCase
 {
     protected RecordMonitor $recordMonitor;
     protected EventDispatcherInterface|MockObject $eventDispatcherMock;

--- a/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
+++ b/Tests/Unit/Middleware/SolrRoutingMiddlewareTest.php
@@ -41,7 +41,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
  * Test case to validate the behaviour of the middle ware
  */
 #[CoversClass(SolrRoutingMiddleware::class)]
-class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
+final class SolrRoutingMiddlewareTest extends SetUpUnitTestCase
 {
     protected RoutingService|MockObject $routingServiceMock;
     protected $responseOutputHandler;

--- a/Tests/Unit/Report/SiteHandlingStatusTest.php
+++ b/Tests/Unit/Report/SiteHandlingStatusTest.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
 
-class SiteHandlingStatusTest extends SetUpUnitTestCase
+final class SiteHandlingStatusTest extends SetUpUnitTestCase
 {
     /**
      * Creates a SiteHandlingStatus instance with mocked dependencies.

--- a/Tests/Unit/Report/SolrConfigurationStatusTest.php
+++ b/Tests/Unit/Report/SolrConfigurationStatusTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Reports\Status;
 /**
  * Testcase for the SolrConfigurationStatus class.
  */
-class SolrConfigurationStatusTest extends SetUpUnitTestCase
+final class SolrConfigurationStatusTest extends SetUpUnitTestCase
 {
     protected SolrConfigurationStatus|MockObject $report;
 

--- a/Tests/Unit/Routing/RoutingServiceTest.php
+++ b/Tests/Unit/Routing/RoutingServiceTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Core\Site\Entity\Site;
  * Unit test to cover functions inside the routing service
  */
 #[CoversClass(RoutingService::class)]
-class RoutingServiceTest extends SetUpUnitTestCase
+final class RoutingServiceTest extends SetUpUnitTestCase
 {
     protected Site $site;
 

--- a/Tests/Unit/Search/ElevationComponentTest.php
+++ b/Tests/Unit/Search/ElevationComponentTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Elevation class
  */
-class ElevationComponentTest extends SetUpUnitTestCase
+final class ElevationComponentTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canModifyQuery(): void

--- a/Tests/Unit/Search/FacetingComponentTest.php
+++ b/Tests/Unit/Search/FacetingComponentTest.php
@@ -36,7 +36,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Tests the ApacheSolrForTypo3\Solr\Query\Modifier\Faceting class
  */
-class FacetingComponentTest extends SetUpUnitTestCase
+final class FacetingComponentTest extends SetUpUnitTestCase
 {
     private function getQueryParametersFromExecutedFacetingModifier(
         TypoScriptConfiguration $fakeConfiguration,

--- a/Tests/Unit/Search/RelevanceComponentTest.php
+++ b/Tests/Unit/Search/RelevanceComponentTest.php
@@ -31,7 +31,7 @@ use Solarium\QueryType\Select\RequestBuilder;
 /**
  * Testcase for RelevanceComponent
  */
-class RelevanceComponentTest extends SetUpUnitTestCase
+final class RelevanceComponentTest extends SetUpUnitTestCase
 {
     /**
      * @param $query

--- a/Tests/Unit/Search/SortingComponentTest.php
+++ b/Tests/Unit/Search/SortingComponentTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Testcase for SortingComponent
  */
-class SortingComponentTest extends SetUpUnitTestCase
+final class SortingComponentTest extends SetUpUnitTestCase
 {
     protected Query|MockObject $query;
     protected SearchRequest|MockObject $searchRequestMock;

--- a/Tests/Unit/SearchTest.php
+++ b/Tests/Unit/SearchTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class SearchTest extends SetUpUnitTestCase
+final class SearchTest extends SetUpUnitTestCase
 {
     protected SolrConnection|MockObject $solrConnectionMock;
     protected SolrReadService|MockObject $solrReadServiceMock;

--- a/Tests/Unit/SetUpUnitTestCase.php
+++ b/Tests/Unit/SetUpUnitTestCase.php
@@ -16,7 +16,6 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit;
 
 use ApacheSolrForTypo3\Solr\System\ContentObject\ContentObjectService;
-use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
@@ -134,17 +133,12 @@ abstract class SetUpUnitTestCase extends UnitTestCase
      * @param string $name Name of the property to be injected
      * @param mixed $dependency The dependency to inject – usually an object but can also be any other type
      * @throws RuntimeException
-     * @throws InvalidArgumentException
      */
     protected function inject(
         object $target,
         string $name,
         mixed $dependency,
     ): void {
-        if (!is_object($target)) {
-            throw new InvalidArgumentException('Wrong type for argument $target, must be object.', 1476107338);
-        }
-
         $objectReflection = new ReflectionObject($target);
         $methodNamePart = strtoupper($name[0]) . substr($name, 1);
         if ($objectReflection->hasMethod('set' . $methodNamePart)) {

--- a/Tests/Unit/System/Cache/TwoLevelCacheTest.php
+++ b/Tests/Unit/System/Cache/TwoLevelCacheTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 /**
  * Unit testcase to check if the two level cache is working as expected.
  */
-class TwoLevelCacheTest extends SetUpUnitTestCase
+final class TwoLevelCacheTest extends SetUpUnitTestCase
 {
     protected TwoLevelCache $twoLevelCache;
     protected FrontendInterface|MockObject $secondLevelCacheMock;

--- a/Tests/Unit/System/Configuration/ConfigurationManagerTest.php
+++ b/Tests/Unit/System/Configuration/ConfigurationManagerTest.php
@@ -21,7 +21,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ConfigurationManagerTest extends SetUpUnitTestCase
+final class ConfigurationManagerTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {

--- a/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/ExtensionConfigurationTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExis
  *
  * ext_conf_template.txt
  */
-class ExtensionConfigurationTest extends SetUpUnitTestCase
+final class ExtensionConfigurationTest extends SetUpUnitTestCase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/System/Configuration/TypoScriptConfigurationTest.php
@@ -26,7 +26,7 @@ use Traversable;
 /**
  * Testcase to check if the configuration object can be used as expected
  */
-class TypoScriptConfigurationTest extends SetUpUnitTestCase
+final class TypoScriptConfigurationTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration $configuration;
 

--- a/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
+++ b/Tests/Unit/System/ContentObject/ContentObjectServiceTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * Testcase for ContentObjectService
  */
-class ContentObjectServiceTest extends SetUpUnitTestCase
+final class ContentObjectServiceTest extends SetUpUnitTestCase
 {
     protected ContentObjectRenderer|MockObject $contentObjectRendererMock;
     protected ContentObjectService $contentObjectService;

--- a/Tests/Unit/System/Data/DateTimeTest.php
+++ b/Tests/Unit/System/Data/DateTimeTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\Test;
 
-class DateTimeTest extends SetUpUnitTestCase
+final class DateTimeTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testCanWrapDateTimeAndConvertToString(): void

--- a/Tests/Unit/System/DateTime/FormatServiceTest.php
+++ b/Tests/Unit/System/DateTime/FormatServiceTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for FormatService
  */
-class FormatServiceTest extends SetUpUnitTestCase
+final class FormatServiceTest extends SetUpUnitTestCase
 {
     protected FormatService $formatService;
 

--- a/Tests/Unit/System/Logging/DebugWriterTest.php
+++ b/Tests/Unit/System/Logging/DebugWriterTest.php
@@ -22,7 +22,7 @@ use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LogLevel;
 
-class DebugWriterTest extends SetUpUnitTestCase
+final class DebugWriterTest extends SetUpUnitTestCase
 {
     #[Test]
     public function testDebugMessageIsWrittenForMessageFromSolr(): void

--- a/Tests/Unit/System/Page/RootlineTest.php
+++ b/Tests/Unit/System/Page/RootlineTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the ArrayAccessor helper class.
  */
-class RootlineTest extends SetUpUnitTestCase
+final class RootlineTest extends SetUpUnitTestCase
 {
     #[Test]
     public function getRootPageIdReturnUidOfRootPage(): void

--- a/Tests/Unit/System/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/System/Service/ConfigurationServiceTest.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ConfigurationServiceTest extends SetUpUnitTestCase
+final class ConfigurationServiceTest extends SetUpUnitTestCase
 {
     public static function escapeFilterDataProvider(): Traversable
     {

--- a/Tests/Unit/System/Session/FrontendUserSessionTest.php
+++ b/Tests/Unit/System/Session/FrontendUserSessionTest.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 /**
  * Testcase for the SchemaParser class.
  */
-class FrontendUserSessionTest extends SetUpUnitTestCase
+final class FrontendUserSessionTest extends SetUpUnitTestCase
 {
     protected FrontendUserAuthentication|MockObject $feUserMock;
     protected FrontendUserSession $session;

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -16,14 +16,13 @@
 namespace ApacheSolrForTypo3\Solr\Tests\Unit\System\Solr\Parser;
 
 use ApacheSolrForTypo3\Solr\System\Solr\Parser\SchemaParser;
-use ApacheSolrForTypo3\Solr\System\Solr\Schema\Schema;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Testcase for the SchemaParser class.
  */
-class SchemaParserTest extends SetUpUnitTestCase
+final class SchemaParserTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canParseLanguage(): void
@@ -46,6 +45,7 @@ class SchemaParserTest extends SetUpUnitTestCase
     {
         $parser = new SchemaParser();
         $schema = $parser->parseJson('{}');
-        self::assertInstanceOf(Schema::class, $schema, 'Can not get schema object from empty response');
+        self::assertSame('core_en', $schema->getManagedResourceId(), 'Expected default managed resource id when no schema property in response.');
+        self::assertSame('', $schema->getName(), 'Expected default empty name when no schema property in response.');
     }
 }

--- a/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/StopWordParserTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for StopWordParser
  */
-class StopWordParserTest extends SetUpUnitTestCase
+final class StopWordParserTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canParseStopWords(): void

--- a/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SynonymParserTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for StopWordParser
  */
-class SynonymParserTest extends SetUpUnitTestCase
+final class SynonymParserTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canParseSynonyms(): void

--- a/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrAdminServiceTest.php
@@ -29,7 +29,7 @@ use function json_encode;
 /**
  * Tests the SolrAdminService class
  */
-class SolrAdminServiceTest extends SetUpUnitTestCase
+final class SolrAdminServiceTest extends SetUpUnitTestCase
 {
     protected SolrAdminService|MockObject $adminService;
     protected Client|MockObject $clientMock;

--- a/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrReadServiceTest.php
@@ -36,7 +36,7 @@ use Traversable;
 /**
  * Tests the ApacheSolrForTypo3\Solr\SolrService class
  */
-class SolrReadServiceTest extends SetUpUnitTestCase
+final class SolrReadServiceTest extends SetUpUnitTestCase
 {
     protected Request|MockObject $requestMock;
     protected Response|MockObject $responseMock;

--- a/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
+++ b/Tests/Unit/System/Solr/Service/SolrWriteServiceTest.php
@@ -32,7 +32,7 @@ use Traversable;
 /**
  * Tests the ApacheSolrForTypo3\Solr\SolrService class
  */
-class SolrWriteServiceTest extends SetUpUnitTestCase
+final class SolrWriteServiceTest extends SetUpUnitTestCase
 {
     protected Response|MockObject $responseMock;
     protected Result|MockObject $resultMock;

--- a/Tests/Unit/System/Solr/SolrConnectionTest.php
+++ b/Tests/Unit/System/Solr/SolrConnectionTest.php
@@ -37,7 +37,7 @@ use Traversable;
 /**
  * Class SolrConnectionTest
  */
-class SolrConnectionTest extends SetUpUnitTestCase
+final class SolrConnectionTest extends SetUpUnitTestCase
 {
     /**
      * @param Endpoint|null $readEndpoint

--- a/Tests/Unit/System/TCA/TCAServiceTest.php
+++ b/Tests/Unit/System/TCA/TCAServiceTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase to test the TCAService.
  */
-class TCAServiceTest extends SetUpUnitTestCase
+final class TCAServiceTest extends SetUpUnitTestCase
 {
     /**
      * When a deleted record is passed (has 1 in the TCA deleted field, this should be detected).

--- a/Tests/Unit/System/Url/UrlHelperTest.php
+++ b/Tests/Unit/System/Url/UrlHelperTest.php
@@ -24,7 +24,7 @@ use Traversable;
 /**
  * Testcase to check the functionallity of the UrlHelper
  */
-class UrlHelperTest extends SetUpUnitTestCase
+final class UrlHelperTest extends SetUpUnitTestCase
 {
     /**
      * Note: TYPO3 14.0 Breaking Change #108084 changed URI behavior - rootless paths

--- a/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
+++ b/Tests/Unit/System/UserFunctions/FlexFormUserFunctionsTest.php
@@ -19,7 +19,7 @@ use ApacheSolrForTypo3\Solr\System\UserFunctions\FlexFormUserFunctions;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-class FlexFormUserFunctionsTest extends SetUpUnitTestCase
+final class FlexFormUserFunctionsTest extends SetUpUnitTestCase
 {
     #[Test]
     public function whenNoFacetsAreConfiguredAllSolrFieldsShouldBeAvailableAsFilter(): void

--- a/Tests/Unit/System/Util/ArrayAccessorTest.php
+++ b/Tests/Unit/System/Util/ArrayAccessorTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for the ArrayAccessor helper class.
  */
-class ArrayAccessorTest extends SetUpUnitTestCase
+final class ArrayAccessorTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGet(): void

--- a/Tests/Unit/System/Util/SiteUtilityTest.php
+++ b/Tests/Unit/System/Util/SiteUtilityTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 /**
  * Testcase for the SiteUtilityTest helper class.
  */
-class SiteUtilityTest extends SetUpUnitTestCase
+final class SiteUtilityTest extends SetUpUnitTestCase
 {
     protected function tearDown(): void
     {

--- a/Tests/Unit/System/Validator/PathTest.php
+++ b/Tests/Unit/System/Validator/PathTest.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Testcase for the Path helper class.
  */
-class PathTest extends SetUpUnitTestCase
+final class PathTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canIsValidSolrPathisValidPath(): void

--- a/Tests/Unit/Task/EventQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/EventQueueWorkerTaskTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Scheduler\Scheduler;
 /**
  * Testcase for EventQueueWorkerTask
  */
-class EventQueueWorkerTaskTest extends SetUpUnitTestCase
+final class EventQueueWorkerTaskTest extends SetUpUnitTestCase
 {
     protected EventQueueWorkerTask $task;
 

--- a/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
+++ b/Tests/Unit/Task/IndexQueueWorkerTaskTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for IndexQueueWorkerTask
  */
-class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
+final class IndexQueueWorkerTaskTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable(): void

--- a/Tests/Unit/Task/OptimizeIndexTaskTest.php
+++ b/Tests/Unit/Task/OptimizeIndexTaskTest.php
@@ -18,16 +18,17 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Task;
 use ApacheSolrForTypo3\Solr\Task\OptimizeIndexTask;
 use ApacheSolrForTypo3\Solr\Tests\Unit\SetUpUnitTestCase;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for OptimizeIndexTask
  */
-class OptimizeIndexTaskTest extends SetUpUnitTestCase
+final class OptimizeIndexTaskTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable(): void
     {
-        /** @var OptimizeIndexTask $indexQueuerWorker */
+        /** @var OptimizeIndexTask&MockObject $indexQueuerWorker */
         $indexQueuerWorker = $this->getMockBuilder(OptimizeIndexTask::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getSite'])

--- a/Tests/Unit/Task/ReIndexTaskTest.php
+++ b/Tests/Unit/Task/ReIndexTaskTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * Testcase for ReIndexTask
  */
-class ReIndexTaskTest extends SetUpUnitTestCase
+final class ReIndexTaskTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetErrorMessageInAdditionalInformationWhenSiteNotAvailable(): void

--- a/Tests/Unit/Typo3PageContentExtractorTest.php
+++ b/Tests/Unit/Typo3PageContentExtractorTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Tests the TYPO3 page content extractor
  */
-class Typo3PageContentExtractorTest extends SetUpUnitTestCase
+final class Typo3PageContentExtractorTest extends SetUpUnitTestCase
 {
     protected TypoScriptConfiguration|MockObject $typoScripConfigurationMock;
 

--- a/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/HighlightingResultViewHelperTest.php
@@ -31,7 +31,7 @@ use stdClass;
 use Traversable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class HighlightingResultViewHelperTest extends SetUpUnitTestCase
+final class HighlightingResultViewHelperTest extends SetUpUnitTestCase
 {
     public static function canRenderCreateHighlightSnippedDataProvider(): Traversable
     {

--- a/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Document/RelevanceViewHelperTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class RelevanceViewHelperTest extends SetUpUnitTestCase
+final class RelevanceViewHelperTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canCalculateRelevance(): void

--- a/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Area/GroupViewHelperTest.php
@@ -26,7 +26,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-class GroupViewHelperTest extends SetUpUnitTestCase
+final class GroupViewHelperTest extends SetUpUnitTestCase
 {
     /**
      * @throws MockObjectException

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelFilterViewHelperTest.php
@@ -25,7 +25,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-class LabelFilterViewHelperTest extends SetUpUnitTestCase
+final class LabelFilterViewHelperTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canMakeOnlyExpectedFacetsAvailableInStaticContext(): void

--- a/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Facet/Options/Group/Prefix/LabelPrefixesViewHelperTest.php
@@ -25,7 +25,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
+final class LabelPrefixesViewHelperTest extends SetUpUnitTestCase
 {
     #[Test]
     public function canGetPrefixesSortedByOrderInCollection(): void

--- a/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/AddFacetItemViewHelperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
+final class AddFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     #[Test]
     public function addFacetItemWillUseUriBuilderAsExpected(): void

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveAllFacetsViewHelperTest.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
-class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
+final class RemoveAllFacetsViewHelperTest extends SetUpFacetItemViewHelper
 {
     #[Test]
     public function setFacetItemWillUseUriBuilderAsExpected(): void

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetItemViewHelperTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetItemViewHelper;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class RemoveFacetItemViewHelperTest extends SetUpFacetItemViewHelper
+final class RemoveFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     #[Test]
     public function removeFacetItemWillUseUriBuilderAsExpected(): void

--- a/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/RemoveFacetViewHelperTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\RemoveFacetViewHelper;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class RemoveFacetViewHelperTest extends SetUpFacetItemViewHelper
+final class RemoveFacetViewHelperTest extends SetUpFacetItemViewHelper
 {
     #[Test]
     public function removeFacetWillUseUriBuilderAsExpected(): void

--- a/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/Facet/SetFacetItemViewHelperTest.php
@@ -20,7 +20,7 @@ use ApacheSolrForTypo3\Solr\ViewHelpers\Uri\Facet\SetFacetItemViewHelper;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class SetFacetItemViewHelperTest extends SetUpFacetItemViewHelper
+final class SetFacetItemViewHelperTest extends SetUpFacetItemViewHelper
 {
     #[Test]
     public function setFacetItemWillUseUriBuilderAsExpected(): void

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
     "typo3/cms-fluid-styled-content": "*",
     "typo3/coding-standards": "v0.8.0",
     "typo3/testing-framework": "^9.5.0",
-    "phpstan/phpstan": "^1.11",
-    "phpstan/phpstan-phpunit": "^1.3"
+    "phpstan/phpstan": "^2.1.34",
+    "phpstan/phpstan-phpunit": "^2.0.18"
   },
   "replace": {
     "apache-solr-for-typo3/solrfluid": "*",


### PR DESCRIPTION
### Use positional argument for PHPUnit DataProvider attribute

DataProvider's constructor is marked @no-named-arguments, so calling it with methodName: '...' fails PHPStan 2 with `argument.named`.
Switch all occurrences to the positional form.

* `Tests/Integration/ContentObject/ClassificationTest.php:93`
* `Tests/Integration/EventListener/Backend/SettingsPreviewOnPluginsEventListenerTest.php:101`
* `Tests/Integration/ViewHelpers/Backend/IsStringViewHelperTest.php:59`
* `Tests/Integration/ViewHelpers/SearchFormViewHelperTest.php:94,133`
* `Tests/Unit/Access/RootlineElementTest.php:119`
* `Tests/Unit/Access/RootlineTest.php:56`

### Remove dead null-coalescing on non-nullable URL properties

`$_synonymsUrl`, `$_stopWordsUrl` and `$_vectorStoreUrl` are all typed `string` with a `''` default,
so they can never be null and the `?? ''` fallback was always dead code under PHPStan 2.

* `Classes/System/Solr/Service/SolrAdminService.php:316,324,340`

### Remove dead instanceof checks in SearchUriBuilder

`getContextTypoScriptConfiguration()` returns `?TypoScriptConfiguration`, so once the truthy assignment check passes the value
is already guaranteed to be a TypoScriptConfiguration instance under PHPStan 2.

* `Classes/Domain/Search/Uri/SearchUriBuilder.php:111,133,156,433`

### Remove is_array/is_object checks already guaranteed by types

* `DocumentEscapeService`
* `PostEnhancedUriProcessor`
* `SchemaParser` and
* `SetUpUnitTestCase::inject()`
all guarded against a type their parameter/return declarations already exclude, which PHPStan 2 now flags as dead code.

* `Classes/Domain/Search/ResultSet/Result/Parser/DocumentEscapeService.php:54`
* `Classes/EventListener/EnhancedRouting/PostEnhancedUriProcessor.php:55`
* `Classes/System/Solr/Parser/SchemaParser.php:56`
* `Tests/Unit/SetUpUnitTestCase.php:144`

### Remove dead comparisons in SolrIndexingMiddleware

`$language > 0` already excludes `-1`, and `getIndexFieldProcessingInstructionsConfiguration()`
always returns a non-nullable array, making the extra `!== -1` and `is_array()` checks unreachable under PHPStan 2.

* `Classes/Middleware/SolrIndexingMiddleware.php:363,480`

### Remove dead instanceof checks in FrontendAwareEnvironment and FacetingComponent

`SiteFinder::getSiteByPageId()` returns a non-nullable Site, and the `FacetingComponent` check
follows the same guaranteed-narrowing pattern as SearchUriBuilder: once the truthy assignment passes,
the value can only be a `TypoScriptConfiguration` per its return type.

* `Classes/FrontendSimulation/FrontendAwareEnvironment.php:296`
* `Classes/Search/FacetingComponent.php:214`

### Fix always-true assertInstanceOf findings in tests

`Builder::fromPage()` and `SchemaParser::parseJson()` both have native, non-nullable return types,
so the type assertions were truly redundant - removed them.
SchemaParserTest's empty-response test also gained meaningful assertions on the default Schema values
instead of being left with none.

`ApacheSolrDocumentRepositoryTest`'s assertion is kept: its `Document[]` guarantee comes only from a `@return` docblock,
not the native array return type, so PHPStan's certainty doesn't hold at runtime - marked with a targeted `@phpstan-ignore` instead.

* `Tests/Unit/Domain/Search/ApacheSolrDocument/BuilderTest.php:98`
* `Tests/Unit/System/Solr/Parser/SchemaParserTest.php:49`
* `Tests/Integration/Domain/Search/ApacheSolrDocument/ApacheSolrDocumentRepositoryTest.php:50`

### Fix mock @var docblock types and drop redundant is_float check

`createMock()`/`getMockBuilder()` return `MockObject` natively;
the correct convention already used elsewhere in this suite is `@var Type|MockObject`
(the phpstan-phpunit extension converts this to an intersection type).
Several tests were missing the MockObject part, and one used the wrong class (MockBuilder).
`ImmediateProcessingEventListenerTest` needed an explicit intersection since the union-to-intersection conversion only
applies to `MockObject/Stub`.

Also removed `self::assertTrue(is_float(...))` in `SolrAdminServiceTest` - `getPingRoundTripRuntime()`
has a native float return type, so the check was dead code.

* `Tests/Integration/System/Solr/Service/SolrAdminServiceTest.php:47,165,199`
* `Tests/Unit/Domain/Index/Queue/UpdateHandler/EventListener/ImmediateProcessingEventListenerTest.php:121`
* `Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php:131`
* `Tests/Unit/Task/OptimizeIndexTaskTest.php:31`

### Suppress PHPStan false positives in IndexServiceTest global-restore checks

These 4 findings all stem from PHPStan assuming `indexItems()` cannot mutate `$GLOBALS` between setup and assertion.
That assumption is false: `IndexingService.php` genuinely does `unset($GLOBALS['BE_USER'])` etc. in its restore path,
which is precisely the regression these tests guard against (#4628).
Removing the checks or trusting the narrowing would silently defeat the tests,
so they're suppressed with targeted `@phpstan-ignore` comments instead.

* `Tests/Integration/Domain/Index/IndexServiceTest.php:172,178,239,290`

### Narrow always-non-null return types on anonymous test overrides

Both anonymous class overrides always return a non-null value, and covariant return narrowing from the parent's
nullable `Search::search()`/`Item::getSite()` to a non-nullable subtype is valid PHP.

* `Tests/Unit/Domain/Search/Suggest/SuggestServiceTest.php:128`
* `Tests/Unit/IndexQueue/IndexerTest.php:204`

### Remove redundant !== 0 check in DataUpdateHandler

`!empty(\$record['sys_language_uid'])` already excludes 0 (along with `'0', '', null, false`),
making the trailing `!== 0` comparison dead code.

* `Classes/Domain/Index/Queue/UpdateHandler/DataUpdateHandler.php:442`

### Remove dead null-coalescing on non-nullable argumentNameSpace

`\$argumentNameSpace` is typed string with a default, so it can never be `null` and the `??` fallback was always dead code.

* `Classes/Domain/Search/SearchRequest.php:575`

### Remove unnecessary nullsafe operator in StatisticsWriterProcessor

The preceding `@var` annotation already types `$frontendUser` as non-nullable, making the `?->` in `isset()` redundant.
Behaviorally identical either way, since `isset()` never errors on a null base.

* `Classes/Domain/Search/Statistics/StatisticsWriterProcessor.php:100`

### Remove no-op array_values() call in RoutingService

`$newQueryParams` is only ever built via `[]` appends in the preceding loop, so it's already a list and array_values() had no effect.

* `Classes/Routing/RoutingService.php:578`

### Remove redundant nullsafe operator before ?? in ConfigurationManager

The `??` operator already suppresses `null`/`undefined` access on its left operand the same way `isset()` does,
so the preceding `?->id` was doing nothing extra.

* `Classes/System/Configuration/ConfigurationManager.php:244`

### Add @param-out tag to unsetModuleDataIfCanNotBeSerialized

The method never assigns null to the by-ref parameter - it always ends up as either `''` or an unchanged string - so
its out-type can be narrowed while keeping the nullable in-type for callers passing mixed module data.

* `Classes/System/Mvc/Backend/Service/ModuleDataStorageService.php:59`

### Correct @property docblock type for SearchController::$view

68944878c fixed the FluidViewAdapter import namespace but left the `@property` docblock referencing AbstractTemplateView instead.
Relates: #4519

* `Classes/Controller/SearchController.php:36`
