### PR TITLE
[FEATURE] Log the PID where the request failed

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -333,6 +333,7 @@ readonly class IndexingService
                 $this->logger->error(
                     'Sub-request returned error status',
                     [
+                        'pid' => $item->getItemPid(),
                         'statusCode' => $statusCode,
                         'item' => $item->getIndexQueueUid(),
                         'action' => $instructions->getAction(),


### PR DESCRIPTION
# What this pr does
We log the page id when the server returns a status code bigger then 400.

# How to test
Install EXT:news.
Create a new page and add the news detail plugin.
Make sure the the page properties include this page to the search.
Indexing the new page will force the News extension to create a 404 response.
As soon as the page is indexed, your log aggregator will show the page id in the context field.

Fixes: #4711
