### PR TITLE
[TASK] refactor scheduler tasks to TYPO3 14 api and allow migration

### DIFF
--- a/Classes/Task/AbstractSolrTask.php
+++ b/Classes/Task/AbstractSolrTask.php
@@ -41,6 +41,20 @@ abstract class AbstractSolrTask extends AbstractTask
      */
     protected string|int|null $rootPageId = null;
 
+    public function getTaskParameters(): array
+    {
+        return [
+            'rootPageId' => $this->rootPageId,
+        ];
+    }
+
+    public function setTaskParameters(array $parameters): void
+    {
+        if (isset($parameters['rootPageId'])) {
+            $this->rootPageId = (int)$parameters['rootPageId'];
+        }
+    }
+
     public function getRootPageId(): string|int|null
     {
         return $this->rootPageId;

--- a/Classes/Task/EventQueueWorkerTask.php
+++ b/Classes/Task/EventQueueWorkerTask.php
@@ -41,6 +41,21 @@ final class EventQueueWorkerTask extends AbstractTask
      */
     protected int $limit = self::DEFAULT_PROCESSING_LIMIT;
 
+    public function getTaskParameters(): array
+    {
+        $taskParameters = parent::getTaskParameters();
+        $taskParameters['limit'] = $this->limit;
+        return $taskParameters;
+    }
+
+    public function setTaskParameters(array $parameters): void
+    {
+        parent::setTaskParameters($parameters);
+        if (isset($parameters['limit'])) {
+            $this->limit = (int)$parameters['limit'];
+        }
+    }
+
     /**
      * Works through the indexing queue and indexes the queued items into Solr.
      *

--- a/Classes/Task/IndexQueueWorkerTask.php
+++ b/Classes/Task/IndexQueueWorkerTask.php
@@ -32,6 +32,21 @@ class IndexQueueWorkerTask extends AbstractSolrTask implements ProgressProviderI
 {
     protected ?int $documentsToIndexLimit = null;
 
+    public function getTaskParameters(): array
+    {
+        $taskParameters = parent::getTaskParameters();
+        $taskParameters['documentsToIndexLimit'] = $this->documentsToIndexLimit;
+        return $taskParameters;
+    }
+
+    public function setTaskParameters(array $parameters): void
+    {
+        parent::setTaskParameters($parameters);
+        if (isset($parameters['documentsToIndexLimit'])) {
+            $this->documentsToIndexLimit = (int)$parameters['documentsToIndexLimit'];
+        }
+    }
+
     /**
      * Works through the indexing queue and indexes the queued items into Solr and returns TRUE on success,
      * FALSE if no items were indexed or none were found.

--- a/Classes/Task/OptimizeIndexTask.php
+++ b/Classes/Task/OptimizeIndexTask.php
@@ -32,6 +32,21 @@ class OptimizeIndexTask extends AbstractSolrTask
      */
     protected array $coresToOptimizeIndex = [];
 
+    public function getTaskParameters(): array
+    {
+        $taskParameters = parent::getTaskParameters();
+        $taskParameters['coresToOptimizeIndex'] = $this->coresToOptimizeIndex;
+        return $taskParameters;
+    }
+
+    public function setTaskParameters(array $parameters): void
+    {
+        parent::setTaskParameters($parameters);
+        if (isset($parameters['coresToOptimizeIndex'])) {
+            $this->coresToOptimizeIndex = $parameters['coresToOptimizeIndex'];
+        }
+    }
+
     /**
      * Optimizes all Solr indexes for selected cores and returns TRUE if the execution was successful
      *

--- a/Classes/Task/ReIndexTask.php
+++ b/Classes/Task/ReIndexTask.php
@@ -34,6 +34,21 @@ class ReIndexTask extends AbstractSolrTask
      */
     protected array $indexingConfigurationsToReIndex = [];
 
+    public function getTaskParameters(): array
+    {
+        $taskParameters = parent::getTaskParameters();
+        $taskParameters['indexingConfigurationsToReIndex'] = $this->indexingConfigurationsToReIndex;
+        return $taskParameters;
+    }
+
+    public function setTaskParameters(array $parameters): void
+    {
+        parent::setTaskParameters($parameters);
+        if (isset($parameters['indexingConfigurationsToReIndex'])) {
+            $this->indexingConfigurationsToReIndex = $parameters['indexingConfigurationsToReIndex'];
+        }
+    }
+
     /**
      * Purges/commits all Solr indexes, initializes the Index Queue
      * and returns TRUE if the execution was successful

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -42,6 +42,20 @@ Parallel Solr Worker Cores for Integration Tests
 Integration tests now use parallel Solr worker cores via paratest, significantly
 improving test execution speed.
 
+Scheduler Tasks Support TYPO3 14 Migration to New Task Storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+EXT:solr's scheduler tasks (``EventQueueWorkerTask``, ``IndexQueueWorkerTask``, ``OptimizeIndexTask``, ``ReIndexTask``)
+now implement :php:`getTaskParameters()` / :php:`setTaskParameters()`,
+so TYPO3 core's :php:`\TYPO3\CMS\Scheduler\Migration\SchedulerDatabaseStorageMigration`
+can migrate them to the new task storage without failing.
+
+.. important::
+   If your EXT:solr scheduler tasks were not yet migrated before updating to EXT:solr 14.0.0-RC1,
+   mark ``schedulerDatabaseStorageMigration`` as undone in the Upgrade module and run it again.
+
+See `#4525 <https://github.com/TYPO3-Solr/ext-solr/issues/4525>`_.
+
 Event Listener Migration to PHP Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
TYPO3 provides `\TYPO3\CMS\Scheduler\Migration\SchedulerDatabaseStorageMigration`,
which migrates all scheduler tasks to new structures.
This change makes it possible to migrate the EXT:solr tasks without fails.
The users must mark the  `schedulerDatabaseStorageMigration` as undone and rerun it,
if EXT:solr tasks were not migrated befor EXT:solr 14.0.0-RC1

Fixes: #4525