### PR TITLE
[BUGFIX:BP:13.1] Fix undefined array key exception

### DIFF
--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -42,7 +42,7 @@ class FlexFormUserFunctions
      */
     public function getFacetFieldsFromSchema(array &$parentInformation): void
     {
-        $pageRecord = $parentInformation['flexParentDatabaseRow'];
+        $pageRecord = $parentInformation['flexParentDatabaseRow'] ?? '';
         // @todo: Fix type hinting issue properly on whole call chain.
         $configuredFacets = $this->getConfiguredFacetsForPage($pageRecord['pid'] ?? null);
 
@@ -139,7 +139,7 @@ class FlexFormUserFunctions
      */
     public function getAvailableTemplates(array &$parentInformation): void
     {
-        $pageRecord = $parentInformation['flexParentDatabaseRow'];
+        $pageRecord = $parentInformation['flexParentDatabaseRow'] ?? '';
         if (!is_array($pageRecord) || !isset($pageRecord['pid'])) {
             $parentInformation['items'] = [];
             return;


### PR DESCRIPTION
Fixes undefined array key exceptions.
In some contexts `flexParentDatabaseRow` is not set.

Happens if:
1. a flexform setting of a search element is edited
2. trying to access the history of the just edited search element

Fixes: #4616
Ports: #4698