### PR TITLE
[BUGFIX] Ensure correct overlay handling for related records

### DIFF
--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -328,6 +328,10 @@ class Relation extends AbstractContentObject
             $relatedRecord = $this->getFrontendOverlayService($parentContentObject)->getOverlay($foreignTableName, $relatedRecord);
         }
 
+        if ($relatedRecord === null) {
+            return [];
+        }
+
         $contentObject = clone $parentContentObject;
         $contentObject->start($relatedRecord, $foreignTableName);
         $values = [$contentObject->stdWrapValue('foreignLabel', $this->configuration, $relatedRecord[$foreignTableLabelField] ?? '')];


### PR DESCRIPTION
Prevents a fatal TypeError,
when indexing a translated record via
SOLR_RELATION (ApacheSolrForTypo3\Solr\ContentObject\Relation) whose related foreign-table record has no translation for the current language, while indexing.

# What this pr does
Fall back to original language record instead of throwing error.

# How to test
See bugreport.

Fixes: #4696 