### PR TITLE
[TASK] Finalize site hash by site-identifier strategy

### DIFF
--- a/Classes/Domain/Search/ApacheSolrDocument/Builder.php
+++ b/Classes/Domain/Search/ApacheSolrDocument/Builder.php
@@ -67,9 +67,9 @@ class Builder
 
         $document->setField('id', $documentId);
         $document->setField('site', $site->getSiteIdentifier());
-        $document->setField('typo3Context_stringS', (string)Environment::getContext());
+        $document->setField('typo3Context', (string)Environment::getContext());
         $document->setField('siteHash', $site->getSiteHash());
-        $document->setField('domain_stringS', $site->getDomain());
+        $document->setField('domain', $site->getDomain());
         $document->setField('appKey', 'EXT:solr');
         $document->setField('type', 'pages');
 
@@ -129,9 +129,9 @@ class Builder
         $document->setField('appKey', 'EXT:solr');
 
         $document->setField('site', $site->getSiteIdentifier());
-        $document->setField('typo3Context_stringS', (string)Environment::getContext());
+        $document->setField('typo3Context', (string)Environment::getContext());
         $document->setField('siteHash', $site->getSiteHash());
-        $document->setField('domain_stringS', $site->getDomain());
+        $document->setField('domain', $site->getDomain());
 
         // uid, pid
         $document->setField('uid', $itemRecord['uid']);

--- a/Classes/Report/SchemaStatus.php
+++ b/Classes/Report/SchemaStatus.php
@@ -39,7 +39,7 @@ class SchemaStatus extends AbstractSolrStatus
      *
      * Must be updated when changing the schema.
      */
-    public const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-14-0-0--20260123';
+    public const RECOMMENDED_SCHEMA_VERSION = 'tx_solr-14-0-0--20260717';
 
     /**
      * Compiles a collection of schema version checks against each configured

--- a/Classes/Report/SolrConfigStatus.php
+++ b/Classes/Report/SolrConfigStatus.php
@@ -40,7 +40,7 @@ class SolrConfigStatus extends AbstractSolrStatus
      *
      * Must be updated when changing the solrconfig.
      */
-    public const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-14-0-0--20260123';
+    public const RECOMMENDED_SOLRCONFIG_VERSION = 'tx_solr-14-0-0--20260717';
 
     /**
      * Compiles a collection of solrconfig version checks against each configured

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -214,6 +214,15 @@ removed, as it has been superseded by
 If you upgrade from < 13.1, it is recommended to re-index all solr cores
 completely.
 
+Finalization: the ``domain_stringS`` and ``typo3Context_stringS`` dynamic fields
+previously written by :php:`Builder` have been replaced by dedicated schema fields
+``domain`` and ``typo3Context``. The ``domain`` field allows building inter-site
+URLs without bootstrapping TYPO3 sites within search contexts, and ``typo3Context``
+distinguishes documents by the environment they were indexed from. Re-index to
+populate the new fields.
+
+See `#4411 <https://github.com/TYPO3-Solr/ext-solr/issues/4411>`_.
+
 
 !!! QueueInitializationServiceAwareInterface and related Queue methods removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -429,6 +438,7 @@ Since EXT:solr 9 and Apache Solr 7 dynamic fields based on trie fields are marke
 All Changes
 -----------
 
+*   [TASK] Finalize site hash by site-identifier: add ``domain``/``typo3Context`` schema fields, drop ``_stringS`` suffixes in Builder by @dkd-kaehm in `#4411 <https://github.com/TYPO3-Solr/ext-solr/issues/4411>`_
 *   [TASK] Remove guzzlehttp/psr7 <2.10.0 pin (upstream fix in guzzlehttp/guzzle 7.10.2) by @dkd-kaehm in `#4660 <https://github.com/TYPO3-Solr/ext-solr/issues/4660>`_
 *   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4661 <https://github.com/TYPO3-Solr/ext-solr/pull/4661>`_
 *   [BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS by @amirarends in `#4603 <https://github.com/TYPO3-Solr/ext-solr/pull/4603>`_

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/arabic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/armenian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/basque/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/brazilian_portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/bulgarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/burmese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/catalan/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/chinese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/czech/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/danish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/galician/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/general_schema_fields.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/general_schema_fields.xml
@@ -55,6 +55,8 @@
 	-->
 	<field name="site"     type="string" indexed="true" stored="true" docValues="true" />
 	<field name="siteHash" type="string" indexed="true" stored="true" docValues="true" />
+    <field name="typo3Context" type="string" indexed="true" stored="true" docValues="true" />
+    <field name="domain" type="string" indexed="true" stored="true" docValues="true" />
 
 	<!--
 		The application key which will come in handy as soon as other

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/generic/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/greek/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hindi/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/indonesian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/irish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/japanese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/khmer/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/korean/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/lao/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/latvia/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/latvia/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/norwegian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/persian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/romanian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/russian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/serbian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/serbian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/solrconfig.xml
@@ -1,4 +1,4 @@
-<config name="tx_solr-14-0-0--20260123">
+<config name="tx_solr-14-0-0--20260717">
 
 	<luceneMatchVersion>10.0.0</luceneMatchVersion>
 

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/swedish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/thai/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/ukrainian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-14-0-0--20260123" version="1.6">
+<schema name="tx_solr-14-0-0--20260717" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/Tests/Unit/System/Solr/Parser/Fixtures/schema.json
+++ b/Tests/Unit/System/Solr/Parser/Fixtures/schema.json
@@ -3,7 +3,7 @@
     "status":0,
     "QTime":0},
   "schema":{
-    "name":"tx_solr-14-0-0--20260123",
+    "name":"tx_solr-14-0-0--20260717",
     "version":1.6,
     "uniqueKey":"id",
     "fieldTypes":[{

--- a/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
+++ b/Tests/Unit/System/Solr/Parser/SchemaParserTest.php
@@ -37,7 +37,7 @@ final class SchemaParserTest extends SetUpUnitTestCase
     {
         $parser = new SchemaParser();
         $schema = $parser->parseJson(self::getFixtureContentByName('schema.json'));
-        self::assertSame('tx_solr-14-0-0--20260123', $schema->getName(), 'Could not parser name from schema response');
+        self::assertSame('tx_solr-14-0-0--20260717', $schema->getName(), 'Could not parser name from schema response');
     }
 
     #[Test]


### PR DESCRIPTION
Adds dedicated domain and typo3Context Solr schema fields, replacing the ad-hoc `domain_stringS`/`typo3Context_stringS` fields written by Builder. Bumps the recommended schema/solrconfig version stamp for the schema change and documents it in the 14.0 release notes.

Fixes: #4411