### PR TITLE
[Release] 14.0.0-RC1

### DIFF
--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -438,7 +438,18 @@ Since EXT:solr 9 and Apache Solr 7 dynamic fields based on trie fields are marke
 All Changes
 -----------
 
+*   [BUGFIX] Fix leaked language Context aspect between indexing sub-requests by @BastiLu in `#4703 <https://github.com/TYPO3-Solr/ext-solr/issues/4703>`_
 *   [TASK] Finalize site hash by site-identifier: add ``domain``/``typo3Context`` schema fields, drop ``_stringS`` suffixes in Builder by @dkd-kaehm in `#4411 <https://github.com/TYPO3-Solr/ext-solr/issues/4411>`_
+*   !!![TASK] Update solarium/solarium requirement from 6.4.1 to 7.0.0 — removes ``AbstractQueryBuilder::removeOperator()`` and ``removeAlternativeQuery()`` without alternatives by @dependabot in `#4713 <https://github.com/TYPO3-Solr/ext-solr/pull/4713>`_
+*   [TASK] Prevent unnecessary complete loading of record in SettingsPreviewOnPluginsEventListener by @un3us in `#4691 <https://github.com/TYPO3-Solr/ext-solr/pull/4691>`_
+*   [BUGFIX] Fix undefined array key exception in flexParentDatabaseRow by @BastiLu in `#4698 <https://github.com/TYPO3-Solr/ext-solr/pull/4698>`_
+*   [BUGFIX] Don't leak page title state between indexing sub-requests by @amirarends in `#4700 <https://github.com/TYPO3-Solr/ext-solr/issues/4700>`_
+*   [FEATURE] Log the PID where the request failed by @guelzow in `#4711 <https://github.com/TYPO3-Solr/ext-solr/issues/4711>`_
+*   [BUGFIX] Spellchecking: keep correct terms when offering corrections by @dkd-kaehm in `#4659 <https://github.com/TYPO3-Solr/ext-solr/issues/4659>`_
+*   [TASK] Refactor scheduler tasks to TYPO3 14 API and allow migration by @dkd-kaehm in `#4525 <https://github.com/TYPO3-Solr/ext-solr/issues/4525>`_
+*   [TASK] Update to PHPStan 2 by @dkd-kaehm in `#4710 <https://github.com/TYPO3-Solr/ext-solr/pull/4710>`_
+*   [DOCS] Update Indexing.rst: clearing documents only for current site by @pi-phi in `#4672 <https://github.com/TYPO3-Solr/ext-solr/pull/4672>`_
+*   [BUGFIX] Fix Scheduler::__construct() call with missing 4th arg in integration tests by @dkd-kaehm in `#4678 <https://github.com/TYPO3-Solr/ext-solr/pull/4678>`_
 *   [TASK] Remove guzzlehttp/psr7 <2.10.0 pin (upstream fix in guzzlehttp/guzzle 7.10.2) by @dkd-kaehm in `#4660 <https://github.com/TYPO3-Solr/ext-solr/issues/4660>`_
 *   [BUGFIX] Pin guzzlehttp/psr7 to <2.10.0 by @dkd-kaehm in `#4661 <https://github.com/TYPO3-Solr/ext-solr/pull/4661>`_
 *   [BUGFIX] Do not resolve TypoScriptConfiguration for deleted page in WS by @amirarends in `#4603 <https://github.com/TYPO3-Solr/ext-solr/pull/4603>`_

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,7 +19,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="14.0.0-beta3"
+	  release="14.0.0-RC1"
 	  version="14.0"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0-or-later",
   "keywords": ["typo3", "TYPO3 CMS", "solr", "search"],
   "homepage": "https://www.typo3-solr.com",
-  "version": "14.0.0-beta3",
+  "version": "14.0.0-RC1",
   "authors": [
     {
       "name": "dkd Internet Service GmbH",


### PR DESCRIPTION
This is the first release candidate for EXT:solr 14 LTS.

Highlights since 14.0.0-beta3:

* [BUGFIX] Fix leaked language Context aspect between indexing sub-requests — the language aspect set for one page's sub-request was still active when the next page's sub-request ran, causing translated pages to be indexed under the wrong language context. (#4717 / @BastiLu, resolves #4703)

* [TASK] Finalize site hash by site-identifier strategy — adds dedicated `domain`/`typo3Context` Solr schema fields, replacing the ad-hoc `domain_stringS`/`typo3Context_stringS` fields written by `Builder`, and bumps the recommended schema/solrconfig version stamp. (#4719 / @dkd-kaehm, fixes #4411)

* [BUGFIX] Don't leak page title state between indexing sub-requests — `PageTitleProviderManager` is a stateful singleton whose per-provider cache still held the previous page's title when the next page's document was built during long-lived `IndexingService` runs. (#4701 / @amirarends, fixes #4700)

* [BUGFIX] Fix undefined array key exception — `flexParentDatabaseRow` is not always set, e.g. when accessing the record history of a just-edited search flexform element. (#4698 / @BastiLu)

* [TASK] Refactor scheduler tasks to the TYPO3 14 API and allow migration — implements `getTaskParameters()`/`setTaskParameters()` so TYPO3 core's `SchedulerDatabaseStorageMigration` can migrate EXT:solr tasks without failing. Users must re-run the migration if EXT:solr tasks were not migrated before this release. (#4715 / @dkd-kaehm, fixes #4525)

* [BUGFIX] Spellchecking: keep correct terms when offering corrections — the "did you mean" link and auto-correction used to drop every correctly-spelled term from a multi-word query. (#4671 / @dkd-kaehm, fixes #4659)

* [FEATURE] Log the PID where the request failed. (#4712 / @guelzow, fixes #4711)

* [TASK] Update to PHPStan 2, incl. fixing a `str_replace()` search array type mismatch in `RoutingUtility::buildHash`. (#4710 / @dkd-kaehm)

* [TASK] Prevent unnecessary complete loading of record in `SettingsPreviewOnPluginsEventListener`. (#4691 / @un3us)

* !!![TASK] Update solarium/solarium requirement from 6.4.1 to 7.0.0 — removes `AbstractQueryBuilder::removeOperator()` and `removeAlternativeQuery()` without alternatives. (#4713 / @dependabot)

* [BUGFIX] Fix `Scheduler::__construct()` call with missing 4th arg in integration tests. (#4678 / @dkd-kaehm)

* [DOCS] Update Indexing.rst: clearing documents only for current site. (#4672 / @pi-phi)

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/14.0/en-us/Releases/solr-release-14-0.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/14.0.0-RC1

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Relates: #4411, #4525, #4659, #4700, #4703, #4711