### PR TITLE
[BUGFIX] Disable page cache before page indexing sub-requests

### DIFF
--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -46,6 +46,7 @@ use TYPO3\CMS\Core\PageTitle\PageTitleProviderManager;
 use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Cache\CacheInstruction;
 use TYPO3\CMS\Frontend\Http\Application as FrontendApplication;
 
 /**
@@ -271,6 +272,13 @@ readonly class IndexingService
 
             $request = $this->buildServerRequest($item, $language);
             $request = $request->withAttribute('solr.indexingInstructions', $instructions);
+
+            // Disable the page cache BEFORE the frontend middleware chain runs.
+            // PrepareTypoScriptFrontendRendering reads this attribute to decide
+            // whether the page may be served from the page cache.
+            $cacheInstruction = new CacheInstruction();
+            $cacheInstruction->disableCache('Apache Solr for TYPO3 page indexing requires full TypoScript');
+            $request = $request->withAttribute('frontend.cache.instruction', $cacheInstruction);
 
             // Snapshot global/singleton state that the frontend sub-request
             // would otherwise clobber, so the BE web context (e.g. scheduler

--- a/Tests/Integration/IndexQueue/Fixtures/indexingSimpleCacheablePageStillReachesSolr.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/indexingSimpleCacheablePageStillReachesSolr.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","slug","title","tstamp"
+,3,1,1,"/subpage","Sub page in site 1",1007007007
+,4,3,1,"/subpage/subsubpage","Subsubpage in site 1",1007007007
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","item_pid","indexing_configuration","errors","indexed","changed"
+# scheduled [3] subpage
+#,3,1,"pages",3,3,"pages","",0,1449151778
+# scheduled [4] subsubpage
+,4,1,"pages",4,4,"pages","",0,1449151778

--- a/Tests/Integration/IndexQueue/IndexingServiceTest.php
+++ b/Tests/Integration/IndexQueue/IndexingServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue;
+
+use ApacheSolrForTypo3\Solr\Domain\Index\IndexService;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\IndexQueue\IndexingService;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Fixtures\IndexingServiceForTesting;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+class IndexingServiceTest extends IntegrationTestBase
+{
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'caching' => [
+                'cacheConfigurations' => [
+                    // Set pages cache database backend, testing-framework sets this to NullBackend by default.
+                    'pages' => [
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                    ],
+                    'hash' => [
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                    ],
+                    'rootline' => [
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    protected Queue $indexQueue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->indexQueue = $this->get(Queue::class);
+    }
+
+    #[Test]
+    public function indexingSimpleCacheablePageStillReachesSolr(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/indexingSimpleCacheablePageStillReachesSolr.csv');
+        $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
+
+        // trigger page cache
+        $response = $this->executeFrontendSubRequest((new InternalRequest('http://testone.site/'))->withPageId(4));
+        $body = (string)$response->getBody();
+        self::assertStringContainsString('Subsubpage in site 1', $body);
+        $dbConnection = $this->getConnectionPool()->getConnectionForTable('cache_pages');
+        $cacheIdentifier = $dbConnection->executeQuery('SELECT identifier FROM cache_pages WHERE identifier LIKE "4_%";')->fetchOne();
+        $cache = $this->get(CacheManager::class)->getCache('pages')->get($cacheIdentifier);
+        self::assertStringContainsString('Subsubpage in site 1', $cache['content']);
+
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $site = $siteRepository->getSiteByRootPageId(1);
+
+        GeneralUtility::setContainer($this->getContainer());
+        /**
+         * @noinspection PhpPossiblePolymorphicInvocationInspection
+         * @phpstan-ignore method.notFound
+         */
+        $this->getContainer()->set(
+            IndexingService::class,
+            IndexingServiceForTesting::fromProductionService($this->getContainer()->get(IndexingService::class)),
+        );
+        $indexService = GeneralUtility::makeInstance(IndexService::class, $site);
+        $indexService->indexItems(1);
+
+        $this->waitToBeVisibleInSolr();
+        $solrContent = file_get_contents($this->getSolrCoreUrl('core_en') . '/select?q=*:*');
+        self::assertStringContainsString(
+            '"numFound":1',
+            $solrContent,
+            'Page was not indexed - likely FrontendTypoScript::getSetupArray() '
+            . 'throwing during content extraction after the internal find-user-groups '
+            . 'sub-request already warmed the page cache.',
+        );
+        self::assertStringContainsString(
+            'Subsubpage in site 1',
+            $solrContent,
+            'Wrong Page was indexed - likely paratests use wrong Apache Solr Server core.',
+        );
+    }
+}


### PR DESCRIPTION
Resolves #4721

# What this pr does

Fixes `indexPage` sub-requests failing with a 500 (`RuntimeException: Setup array has not been initialized`) for every page that has a valid page cache entry.

`IndexingService::executeSubRequest()` now sets a disabled `CacheInstruction` as request attribute before dispatching the sub-request into the frontend application, so `PrepareTypoScriptFrontendRendering` bypasses the page cache and always computes the full TypoScript setup.

# How to test

1. Open an indexable page in the frontend as anonymous visitor (writes a page cache entry).
2. Run the index queue worker for that page → fails with `Sub-request returned error status` before this patch, succeeds after.
3. Setting the instruction early also keeps the existing behaviour of never *storing* indexing renders in the page cache (same `CacheInstruction` semantics as before, just applied in time).

Fixes: #4721
