### PR TITLE
[BUGFIX] Keep public content findable on mixed multi-value fe_group pages

### DIFF
--- a/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
+++ b/Classes/EventListener/PageIndexer/FrontendGroupsModifier.php
@@ -85,6 +85,28 @@ final readonly class FrontendGroupsModifier
         ) {
             $groups[] = (int)$instructions->getParameter('pageUserGroup');
         }
+
+        // Mixed-content pages: restrict the faked render groups to the current
+        // content-access variant, so a public (c:0) variant of a page-restricted page
+        // does not render - and thus index - content restricted to a subset of the page
+        // groups. The stored access tag comes from the accessRootline, not from these
+        // faked groups, so trimming changes only which content is rendered into the
+        // document, never which groups may find it.
+        $contentRestrictedGroups = array_values(array_filter(
+            (array)($instructions->getParameter('contentRestrictedGroups') ?? []),
+            static fn(int $group): bool => $group > 0,
+        ));
+        if ($contentRestrictedGroups !== []) {
+            $currentUserGroup = $instructions->getUserGroup();
+            $groups = array_values(array_filter(
+                $groups,
+                static fn(int $group): bool => !in_array($group, $contentRestrictedGroups, true),
+            ));
+            if ($currentUserGroup > 0 && !in_array($currentUserGroup, $groups, true)) {
+                $groups[] = $currentUserGroup;
+            }
+        }
+
         $groupData = [];
         foreach ($groups as $groupUid) {
             if (in_array($groupUid, [-2, -1])) {

--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -125,31 +125,55 @@ readonly class IndexingService
         }
 
         $success = true;
-        $pageUserGroup = (int)($this->buildPageParameters($item)['pageUserGroup'] ?? 0);
+        $pageUserGroups = $this->buildPageParameters($item)['pageUserGroups'] ?? [];
+        $pageIsRestricted = $pageUserGroups !== [];
         foreach ($solrConnections as $languageUid => $solrConnection) {
             $accessGroups = $this->findUserGroupsForPage($item, $languageUid);
-            // Only drop the public (c:0) content variant when the page actually contains
-            // access-restricted content. When the content is public, the page access element
-            // alone (e.g. "2:1,2", OR semantics over all page groups) already restricts the
-            // document; forcing the page's own group into the content access element instead
-            // would, for a multi-value fe_group, keep only the first group (via the (int) cast
-            // in buildPageParameters()) and exclude every other eligible group from the search
-            // results, because the content access element is matched with AND semantics.
-            $contentIsRestricted = array_filter($accessGroups, static fn(int $g): bool => $g > 0) !== [];
-            if ($pageUserGroup > 0 && $contentIsRestricted) {
-                // A page with fe_group restriction and access-restricted content has no
-                // publicly-accessible content variant: remove group 0 (which may originate from
-                // global template CEs, not page content). Ensure the page's own group is in
-                // accessGroups so restricted-but-eligible users can still find the page in search
-                // results, and no public (c:0) variant leaks the restricted content.
-                $accessGroups = array_values(array_filter($accessGroups, static fn(int $g): bool => $g !== 0));
-                if (!in_array($pageUserGroup, $accessGroups, true)) {
-                    $accessGroups[] = $pageUserGroup;
+            $contentRestrictedGroups = array_values(array_filter(
+                $accessGroups,
+                static fn(int $group): bool => $group > 0,
+            ));
+            $contentIsRestricted = $contentRestrictedGroups !== [];
+
+            // Content-restricted groups whose content must be kept out of the public
+            // (c:0) variant of a mixed page. Empty unless we build such a variant below.
+            $renderRestrictedGroups = [];
+
+            if ($pageIsRestricted && $contentIsRestricted) {
+                // Mixed page: restricted to several groups on page level, content public
+                // except for elements restricted to a subset of those groups. Index the
+                // restricted content variant(s) and - when there are page groups without
+                // own restricted content - an additional public (c:0) variant, so those
+                // groups still find the page's public content while the restricted content
+                // stays on its c:<group> variant.
+                //
+                // This does not reintroduce the leak #4641 guarded against: each
+                // content-access group produces its own document id, so there is no
+                // collision, and the c:0 variant is rendered without the restricted
+                // content (see FrontendGroupsModifier, which trims the faked render groups
+                // for this variant). When every page group also carries restricted content
+                // ($publicRenderGroups === []) no public variant is emitted, matching the
+                // previous behaviour.
+                $publicRenderGroups = array_diff($pageUserGroups, $contentRestrictedGroups);
+                $accessGroups = $contentRestrictedGroups;
+                if ($publicRenderGroups !== []) {
+                    array_unshift($accessGroups, 0);
                 }
+                $renderRestrictedGroups = $contentRestrictedGroups;
             }
+            // Public content on a restricted page keeps its c:0 variant (see #4706);
+            // unrestricted pages are unchanged.
+
             foreach ($accessGroups as $userGroup) {
+                $userGroup = (int)$userGroup;
                 $accessRootline = $this->buildAccessRootline($item, $languageUid, $userGroup);
-                if (!$this->executePageIndexingSubRequest($item, $languageUid, $userGroup, $accessRootline)) {
+                if (!$this->executePageIndexingSubRequest(
+                    $item,
+                    $languageUid,
+                    $userGroup,
+                    $accessRootline,
+                    $renderRestrictedGroups,
+                )) {
                     $success = false;
                 }
             }
@@ -224,14 +248,21 @@ readonly class IndexingService
         int $language,
         int $userGroup,
         string $accessRootline,
+        array $contentRestrictedGroups = [],
     ): bool {
+        $parameters = $this->buildPageParameters($item);
+        if ($contentRestrictedGroups !== []) {
+            // Read by FrontendGroupsModifier to trim the faked render groups for this
+            // variant, so a public (c:0) variant renders no access-restricted content.
+            $parameters['contentRestrictedGroups'] = $contentRestrictedGroups;
+        }
         $instructions = new IndexingInstructions(
             items: [$item],
             action: IndexingInstructions::ACTION_INDEX_PAGE,
             language: $language,
             userGroup: $userGroup,
             accessRootline: $accessRootline,
-            parameters: $this->buildPageParameters($item),
+            parameters: $parameters,
         );
 
         $response = $this->executeSubRequest($item, $language, $instructions);
@@ -479,6 +510,14 @@ readonly class IndexingService
             $pageRecord = $item->getRecord();
             if (!empty($pageRecord[$feGroupColumn])) {
                 $params['pageUserGroup'] = (int)$pageRecord[$feGroupColumn];
+                // Full multi-value fe_group list. The single (int) pageUserGroup above keeps
+                // only the first group; indexPageItem() needs the complete list to decide
+                // which page groups have no own restricted content and therefore require a
+                // public (c:0) content variant.
+                $params['pageUserGroups'] = array_values(array_filter(
+                    GeneralUtility::intExplode(',', (string)$pageRecord[$feGroupColumn], true),
+                    static fn(int $group): bool => $group > 0,
+                ));
             }
         }
 

--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -128,11 +128,20 @@ readonly class IndexingService
         $pageUserGroup = (int)($this->buildPageParameters($item)['pageUserGroup'] ?? 0);
         foreach ($solrConnections as $languageUid => $solrConnection) {
             $accessGroups = $this->findUserGroupsForPage($item, $languageUid);
-            if ($pageUserGroup > 0) {
-                // A page with fe_group restriction has no publicly-accessible content variants:
-                // remove group 0 (which may originate from global template CEs, not page content).
-                // Ensure the page's own group is in accessGroups so restricted-but-eligible users
-                // can still find the page in search results.
+            // Only drop the public (c:0) content variant when the page actually contains
+            // access-restricted content. When the content is public, the page access element
+            // alone (e.g. "2:1,2", OR semantics over all page groups) already restricts the
+            // document; forcing the page's own group into the content access element instead
+            // would, for a multi-value fe_group, keep only the first group (via the (int) cast
+            // in buildPageParameters()) and exclude every other eligible group from the search
+            // results, because the content access element is matched with AND semantics.
+            $contentIsRestricted = array_filter($accessGroups, static fn(int $g): bool => $g > 0) !== [];
+            if ($pageUserGroup > 0 && $contentIsRestricted) {
+                // A page with fe_group restriction and access-restricted content has no
+                // publicly-accessible content variant: remove group 0 (which may originate from
+                // global template CEs, not page content). Ensure the page's own group is in
+                // accessGroups so restricted-but-eligible users can still find the page in search
+                // results, and no public (c:0) variant leaks the restricted content.
                 $accessGroups = array_values(array_filter($accessGroups, static fn(int $g): bool => $g !== 0));
                 if (!in_array($pageUserGroup, $accessGroups, true)) {
                     $accessGroups[] = $pageUserGroup;

--- a/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
+++ b/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
@@ -175,6 +175,47 @@ final class AccessProtectedContentTest extends IntegrationTestBase
             'expectedNumFoundLoggedInUser' => 1,
         ];
 
+        // A page restricted to several groups ("1,2") whose content is public EXCEPT for one
+        // element restricted to a subset (group 2) must be findable by every page group through
+        // a public (c:0) variant, while the restricted element stays on its own c:2 variant.
+        // The c:0 variant must not leak the restricted element. Two documents are produced with
+        // distinct ids (the content access group is part of the id), so this does not reintroduce
+        // the leak #4641 guarded against.
+        yield 'mixed page: page group without own restricted content finds public variant only' => [
+            'fixture' => 'can_index_multi_group_access_protected_page_with_protected_content',
+            'expectedNumFound' => 2,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+                '2:1,2/c:2',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+                'public content of protected pageprotected content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            // group 1 has no own restricted content -> matches only the public (c:0) variant,
+            // not the group-2 content (c:2)
+            'userGroupToCheckAccessFilter' => '0,1',
+            'expectedNumFoundLoggedInUser' => 1,
+        ];
+
+        yield 'mixed page: restricted group finds public and restricted variant' => [
+            'fixture' => 'can_index_multi_group_access_protected_page_with_protected_content',
+            'expectedNumFound' => 2,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+                '2:1,2/c:2',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+                'public content of protected pageprotected content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            // group 2 additionally matches its c:2 variant -> finds both documents
+            'userGroupToCheckAccessFilter' => '0,2',
+            'expectedNumFoundLoggedInUser' => 2,
+        ];
+
         yield 'page for any login(-2)' => [
             'fixture' => 'can_index_access_protected_page_show_at_any_login',
             'expectedNumFound' => 1,
@@ -193,7 +234,10 @@ final class AccessProtectedContentTest extends IntegrationTestBase
             'fixture' => 'can_index_access_protected_page_with_protected_contents',
             'expectedNumFound' => 2,
             'expectedAccessFieldValues' => [
-                '2:1/c:1',
+                // public content keeps the c:0 variant (consistent with the plain "protected
+                // page" and "extend to subpages" cases); the page access element ("2:1") alone
+                // gates it. The group-2 element gets its own c:2 variant.
+                '2:1/c:0',
                 '2:1/c:2',
             ],
             'expectedContents' => [
@@ -209,7 +253,7 @@ final class AccessProtectedContentTest extends IntegrationTestBase
             'fixture' => 'can_index_access_protected_page_with_protected_contents',
             'expectedNumFound' => 2,
             'expectedAccessFieldValues' => [
-                '2:1/c:1',
+                '2:1/c:0',
                 '2:1/c:2',
             ],
             'expectedContents' => [

--- a/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
+++ b/Tests/Integration/IndexQueue/AccessProtectedContentTest.php
@@ -129,13 +129,49 @@ final class AccessProtectedContentTest extends IntegrationTestBase
             'fixture' => 'can_index_access_protected_page',
             'expectedNumFound' => 1,
             'expectedAccessFieldValues' => [
-                '2:1/c:1',
+                // public content on a restricted page keeps the c:0 content variant; the page
+                // access element ("2:1") alone restricts the document (consistent with the
+                // "page protected by extend to subpages" case below, which is c:0, too).
+                '2:1/c:0',
             ],
             'expectedContents' => [
                 'public content of protected page',
             ],
             'expectedNumFoundAnonymousUser' => 0,
             'userGroupToCheckAccessFilter' => '0,1',
+            'expectedNumFoundLoggedInUser' => 1,
+        ];
+
+        // A page restricted to several groups ("1,2") whose content is public must be findable
+        // by *each* of its groups. Before the fix the page's fe_group was cast with (int), so
+        // only "c:1" was written and group-2-only users lost the page. Now c:0 is kept and the
+        // page access element ("2:1,2", OR semantics) grants both groups.
+        yield 'page restricted to multiple groups, first group finds it' => [
+            'fixture' => 'can_index_multi_group_access_protected_page',
+            'expectedNumFound' => 1,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            'userGroupToCheckAccessFilter' => '0,1',
+            'expectedNumFoundLoggedInUser' => 1,
+        ];
+
+        yield 'page restricted to multiple groups, second group finds it' => [
+            'fixture' => 'can_index_multi_group_access_protected_page',
+            'expectedNumFound' => 1,
+            'expectedAccessFieldValues' => [
+                '2:1,2/c:0',
+            ],
+            'expectedContents' => [
+                'public content of protected page',
+            ],
+            'expectedNumFoundAnonymousUser' => 0,
+            // the second (previously dropped) group must find the page, too
+            'userGroupToCheckAccessFilter' => '0,2',
             'expectedNumFoundLoggedInUser' => 1,
         ];
 

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page.csv
@@ -1,0 +1,13 @@
+"fe_groups",
+,"uid","pid","title"
+,1,1,"group 1"
+,2,1,"group 2"
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp","fe_group"
+,2,1,0,1,"/protected_page","protected page","",1449151778,1449151778,"1,2"
+"tt_content",
+,"uid","pid","CType","header","fe_group"
+,11,"2","header","public content of protected page",0
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
+,4711,1,"pages",2,"pages",1449151778,0,0,0,0,0

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page_with_protected_content.csv
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_multi_group_access_protected_page_with_protected_content.csv
@@ -1,0 +1,14 @@
+"fe_groups",
+,"uid","pid","title"
+,1,1,"group 1"
+,2,1,"group 2"
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","subtitle","crdate","tstamp","fe_group"
+,2,1,0,1,"/protected_page","protected page","",1449151778,1449151778,"1,2"
+"tt_content",
+,"uid","pid","CType","header","fe_group","sorting"
+,11,"2","header","public content of protected page",0,10
+,13,"2","header","protected content of protected page",2,20
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","indexed","errors"
+,4711,1,"pages",2,"pages",1449151778,0,0,0,0,0


### PR DESCRIPTION
## What & why

Follow-up to #4705 / #4706. #4706 keeps the public `c:0` content variant when a
multi-value `fe_group` page's content is **entirely public**. This PR handles the
**mixed** case that #4706 left out of scope: a page restricted to several groups
on page level (e.g. `fe_group="1,2"`) whose content is public **except** for one
or more elements restricted to a subset of those groups (e.g. one element for
group `2`).

Previously only a single `c:<group>` document was produced for such a page, so
the other page groups lost the page in search entirely — although they should
still find its public content.

## Why the earlier "out of scope" reasoning does not apply

The scope note in #4706 assumed the groups would have to be packed into a single
comma-joined content element (`c:0,1`, AND-matched). That is avoidable: the
content-access group is already part of the Solr document id
(`getDocumentIdGroups()` → page document id), so emitting **one document per
content-access group** — exactly what already happens for *unrestricted* pages
with mixed content — produces distinct ids, not a collision:

```
…/pages/2/0/0/0  →  access: 2:1,2/c:0   (public content only)
…/pages/2/0/0/2  →  access: 2:1,2/c:2   (incl. the group-2 element)
```

## How

- `IndexingService::indexPageItem()` — for a page-restricted page with restricted
  content, index the restricted content variant(s) **and**, when there are page
  groups without own restricted content, an additional public `c:0` variant.
  `buildPageParameters()` now also exposes the full multi-value `fe_group` list so
  the decision can consider every page group, not just the first.
- `FrontendGroupsModifier` — for the indexing sub-request, trim the faked render
  groups per content-access variant: drop the genuinely content-restricted groups
  and re-add only the current variant's group. So the `c:0` variant renders the
  public content **only** (no leak), while `c:<group>` still carries its restricted
  content. The stored `access` tag comes from the `accessRootline`, not from these
  faked groups, so trimming changes only *which content is rendered*, never *which
  groups may find the document*.

When every page group also carries its own restricted content, no public variant
is emitted (unchanged behaviour).

## Tests

`AccessProtectedContentTest` gains a `can_index_multi_group_access_protected_page_with_protected_content`
fixture (page `fe_group="1,2"`, one public element + one element restricted to
group 2) and two cases asserting:

- two documents `2:1,2/c:0` (public content only) and `2:1,2/c:2` (incl. the
  restricted element),
- a group-1 user (no own restricted content) finds only the public variant,
- a group-2 user finds both.

The existing `protected page with protected content` cases now expect `c:0` (not
`c:<pageGroup>`) for their public variant — this makes them consistent with the
plain `protected page` and `extend to subpages` cases, which already use `c:0`
(the same consistency #4706 aimed for).

## Note

Stacked on #4706 — until that merges, this PR's diff also shows the #4706 commit;
the mixed-content change itself is the last commit. Happy to rebase once #4706 is in.
