### PR TITLE
[FEATURE] Add facet option 'allowedValues'

### DIFF
--- a/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/AbstractFacetParser.php
@@ -156,4 +156,18 @@ abstract class AbstractFacetParser implements FacetParserInterface
         $excludedValue = GeneralUtility::trimExplode(',', $facetConfiguration['excludeValues']);
         return in_array((string)$value, $excludedValue);
     }
+
+    /**
+     * Checks whether the facet value is included (whitelist).
+     * If includeValues is not configured, all values are considered included.
+     */
+    protected function getIsIncludedFacetValue(string|int $value, array $facetConfiguration): bool
+    {
+        if (!isset($facetConfiguration['includeValues'])) {
+            return true;
+        }
+
+        $includedValues = GeneralUtility::trimExplode(',', $facetConfiguration['includeValues']);
+        return in_array((string)$value, $includedValues);
+    }
 }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Hierarchy/HierarchyFacetParser.php
@@ -67,6 +67,9 @@ class HierarchyFacetParser extends AbstractFacetParser
         }
 
         foreach ($nodesToCreate as $value => $count) {
+            if (!$this->getIsIncludedFacetValue($value, $facetConfiguration)) {
+                continue;
+            }
             if ($this->getIsExcludedFacetValue($value, $facetConfiguration)) {
                 continue;
             }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/Options/OptionsFacetParser.php
@@ -73,6 +73,9 @@ class OptionsFacetParser extends AbstractFacetParser
 
         $optionsToCreate = $this->getMergedFacetValueFromSearchRequestAndSolrResponse($optionsFromSolrResponse, $optionsFromRequest);
         foreach ($optionsToCreate as $optionsValue => $count) {
+            if (!$this->getIsIncludedFacetValue($optionsValue, $facetConfiguration)) {
+                continue;
+            }
             if ($this->getIsExcludedFacetValue($optionsValue, $facetConfiguration)) {
                 continue;
             }

--- a/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
+++ b/Classes/Domain/Search/ResultSet/Facets/OptionBased/QueryGroup/QueryGroupFacetParser.php
@@ -73,6 +73,9 @@ class QueryGroupFacetParser extends AbstractFacetParser
                     continue;
                 }
 
+                if (!$this->getIsIncludedFacetValue($query, $facetConfiguration)) {
+                    continue;
+                }
                 if ($this->getIsExcludedFacetValue($query, $facetConfiguration)) {
                     continue;
                 }

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -1131,6 +1131,19 @@ Defines a comma separated list of options that are excluded (The value needs to 
 
 Important: This setting only makes sense for option based facets (option, query, hierarchy)
 
+faceting.facets.[facetName].includeValues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.faceting.facets.[facetName].includeValues
+:Since: 13.0
+:Required: no
+
+Defines a comma separated list of options that should be the only ones included in the facet.
+All other options will be hidden.
+
+Important: This setting only makes sense for option based facets (option, query, hierarchy)
+
 
 faceting.facets.[facetName].facetLimit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
+++ b/Tests/Unit/Domain/Search/ResultSet/Fixtures/fake_solr_response_with_multiple_fields_facets.json
@@ -80,6 +80,18 @@
         {
           "val": "event",
           "count": 1
+        },
+        {
+          "val": "news",
+          "count": 5
+        },
+        {
+          "val": "projects",
+          "count": 3
+        },
+        {
+          "val": "members",
+          "count": 2
         }
       ]
     },

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -266,7 +266,7 @@ final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
                 'type.' => [
                     'label' => 'My Type',
                     'field' => 'type_stringS',
-                    'excludeValues' => 'somethingelse, page, whatever',
+                    'excludeValues' => 'somethingelse, page, whatever, news, projects, members',
                 ],
             ],
         ];
@@ -280,6 +280,36 @@ final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
         self::assertCount(1, $optionFacet->getOptions());
         self::assertSame('event', $optionFacet->getOptions()->getByPosition(0)->getValue(), 'Skipping configured value not working as expected');
+    }
+
+    #[Test]
+    public function canFilterOptionsWithIncludeValues(): void
+    {
+        $searchResultSet = $this->initializeSearchResultSetFromFakeResponse('fake_solr_response_with_multiple_fields_facets.json');
+
+        self::assertEquals([], $searchResultSet->getFacets()->getArrayCopy());
+
+        $facetConfiguration = [
+            'showEmptyFacets' => 1,
+            'facets.' => [
+                'type.' => [
+                    'label' => 'My Type',
+                    'field' => 'type_stringS',
+                    'includeValues' => 'page, event',
+                ],
+            ],
+        ];
+
+        $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
+        $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
+        $processor->process($searchResultSet);
+
+        self::assertCount(1, $searchResultSet->getFacets());
+
+        $optionFacet = $searchResultSet->getFacets()->getByPosition(0);
+        self::assertCount(2, $optionFacet->getOptions());
+        self::assertSame('page', $optionFacet->getOptions()->getByPosition(0)->getValue());
+        self::assertSame('event', $optionFacet->getOptions()->getByPosition(1)->getValue());
     }
 
     #[Test]
@@ -399,7 +429,10 @@ final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('page', $option1->getValue());
 
         $option2 = $optionFacet->getOptions()->getByPosition(1);
-        self::assertSame('event', $option2->getValue());
+        self::assertSame('news', $option2->getValue());
+
+        $option3 = $optionFacet->getOptions()->getByPosition(2);
+        self::assertSame('projects', $option3->getValue());
     }
 
     #[Test]
@@ -431,7 +464,10 @@ final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertSame('event', $option1->getValue());
 
         $option2 = $optionFacet->getOptions()->getByPosition(1);
-        self::assertSame('page', $option2->getValue());
+        self::assertSame('members', $option2->getValue());
+
+        $option3 = $optionFacet->getOptions()->getByPosition(2);
+        self::assertSame('projects', $option3->getValue());
     }
 
     #[Test]
@@ -501,7 +537,7 @@ final class ResultSetReconstitutionProcessorTest extends SetUpUnitTestCase
         self::assertCount(3, $searchResultSet->getFacets());
 
         $facets = $searchResultSet->getFacets();
-        self::assertCount(2, $facets->getByPosition(0)->getOptions());
+        self::assertCount(5, $facets->getByPosition(0)->getOptions());
     }
 
     #[Test]


### PR DESCRIPTION
# What this pr does

Adds a new allowedValues facet configuration option that acts as a allow-list — only the specified values are shown in the facet, all others are hidden. Works alongside the existing excludeValues ban-list: include filters first, then exclude removes from that set.

If not set, all values are allowed. For backwards compatibility.

# Usage

```
plugin.tx_solr.search.faceting.facets {
    category {
        field = category_stringM
        label = Category
        allowedValues = abc, def
    }
}
```

Resolves: #4724
