### PR TITLE
[BUGFIX] Prevent PHP warning when building the access rootline for uncollected Index Queue pages

### DIFF
--- a/Classes/Access/Rootline.php
+++ b/Classes/Access/Rootline.php
@@ -151,8 +151,11 @@ class Rootline
         $pageSelector = GeneralUtility::makeInstance(PageRepository::class);
 
         // current page
+        // getPage() returns an empty array if the page does not match the enable-fields
+        // constraint (e.g. deleted, hidden or outside its start-/endtime), which is expected
+        // for Index Queue items that have not been garbage collected yet.
         $currentPageRecord = $pageSelector->getPage($pageId, true);
-        if ($currentPageRecord['fe_group']) {
+        if (!empty($currentPageRecord['fe_group'])) {
             $accessRootline->push(GeneralUtility::makeInstance(
                 RootlineElement::class,
                 $currentPageRecord['uid'] . RootlineElement::PAGE_ID_GROUP_DELIMITER . $currentPageRecord['fe_group'],

--- a/Tests/Integration/Access/Fixtures/deleted_page.csv
+++ b/Tests/Integration/Access/Fixtures/deleted_page.csv
@@ -1,0 +1,4 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","hidden","deleted","slug","extendToSubpages","title","fe_group","tstamp"
+,1,0,1,1,0,0,"/",1,"Root page visible but extended to subpages",,1007007007
+,10,1,0,1,0,1,"/deleted",0,"Deleted",4711,1007007007

--- a/Tests/Integration/Access/RootlineTest.php
+++ b/Tests/Integration/Access/RootlineTest.php
@@ -23,4 +23,15 @@ final class RootlineTest extends IntegrationTestBase
         $accessRootline = Rootline::getAccessRootlineByPageId(1);
         self::assertSame('', (string)$accessRootline, 'Access rootline for non protected page should be empty');
     }
+
+    #[Test]
+    public function canGetAccessRootlineByPageIdForDeletedPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/deleted_page.csv');
+
+        // getPage() returns an empty array for a deleted page, this must not
+        // trigger a PHP warning for the missing "fe_group" array key.
+        $accessRootline = Rootline::getAccessRootlineByPageId(10);
+        self::assertSame('', (string)$accessRootline, 'Access rootline for a deleted page should be empty');
+    }
 }


### PR DESCRIPTION
# What this pr does

`Rootline::getAccessRootlineByPageId()` calls `PageRepository::getPage($pageId, true)` to load the current page for the access rootline. `getPage()` returns an **empty array** whenever the page does not pass the enable-fields constraint (deleted, hidden, or outside its start-/endtime), `$disableGroupAccessCheck` only skips the frontend-group check, not those constraints.

Index Queue items whose page has since been deleted or hidden are still periodically picked up by the Index Queue Worker. For those items, accessing `$currentPageRecord['fe_group']` on an empty array triggers `PHP Warning: Undefined array key "fe_group"`, which is converted into an exception by the error handler and aborts indexing of that item entirely (logged as `Failed indexing Index Queue item X`).

This PR guards the access with `!empty(...)`, so a missing/empty page record simply results in no access-rootline element being added (treated as unprotected) instead of throwing a warning that aborts the item. Indexing still correctly fails afterwards for such pages (e.g. `SiteNotFoundException`, since a deleted page's rootline no longer resolves to a site), but via the existing, expected error path instead of an uncaught PHP warning.

## Background

Found on a production instance where the `pages`-Index Queue Worker (scheduled every 15 minutes) logged this warning on a recurring basis. Root cause on that instance: ~90 stale Index Queue items pointed to pages that had since been deleted or were hidden/`no_search`-flagged, but the corresponding queue rows were never cleaned up (likely because the deletions happened outside the regular `DataHandler`, so `GarbageCollector` never ran). Every worker cycle re-attempted to index those items and hit this code path. Re-initializing the affected Index Queue configuration works around the *symptom* (removes the stale rows), but the underlying `getPage()`-empty-array case is a legitimate, generally reachable edge case (e.g. also hit for pages hidden or time-restricted between garbage collection and the next worker run) that ext-solr should handle gracefully regardless.

# How to test

- Added `Tests/Integration/Access/RootlineTest::canGetAccessRootlineByPageIdForDeletedPage` with fixture `deleted_page.csv`, covering a page with `deleted=1`.
- Manually reproduced against a production DB snapshot: an Index Queue item pointing to a deleted page produced `PHP Warning: Undefined array key "fe_group" in Rootline.php line 155` on every Index Queue Worker run. After applying the fix, the same item no longer triggers the warning, indexing fails cleanly with the expected `SiteNotFoundException` instead.

Fixes: #4727