### PR TITLE
[CLEANUP] Remove unneeded dependency on fluid-styled-content

### DIFF
--- a/Configuration/Sets/Solr/config.yaml
+++ b/Configuration/Sets/Solr/config.yaml
@@ -1,4 +1,2 @@
 name: apache-solr-for-typo3/solr
 label: "Solr search - Base Configuration"
-dependencies:
-  - typo3/fluid-styled-content


### PR DESCRIPTION
Dependency is removed only from the site set and valid for non-development installations. Development installation requires typo3/cms-fluid-styled-content due to integration tests.

Close #4708

# What this pr does

This PR removed a dependency on EXT:fluid_styled_content from sitesets. Solr extension does use anything from fluid_styled_content extension but requiring fluid_styled_content siteset broke installation of alternatives to fluid_styled_content.

# How to test

Via code review.

Fixes: #4708
