### PR TITLE
[TASK] Remove obsolete "addRootLineFields" setting

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -225,13 +225,6 @@ use TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask;
      */
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['enhancers']['SolrFacetMaskAndCombineEnhancer'] = SolrFacetMaskAndCombineEnhancer::class;
 
-    // add solr field to rootline fields
-    if (($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] ?? '') === '') {
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] = 'no_search_sub_entries';
-    } else {
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',no_search_sub_entries';
-    }
-
     /**
      * Registers an authentication service to authorize / grant the indexer to
      * access protected pages.


### PR DESCRIPTION
The option FE/addRootLineFields was removed in TYPO3 v13 and is no longer evaluated in TYPO3 Core.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.2/Deprecation-103752-ObsoleteGLOBALSTYPO3_CONF_VARSFEaddRootLineFields.html

Resolves #4405
