### PR TITLE
[BUGFIX] Apply ASCII folding before stemming in all language schemas

### DIFF
--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/dutch/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/dutch/schema.xml
@@ -64,8 +64,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -87,8 +87,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -116,8 +116,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -137,8 +137,8 @@
 					protected="dutch/protwords.txt"
 			/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Dutch" protected="dutch/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/english/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/english/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
-			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -84,8 +84,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,8 +115,8 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
-			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -137,8 +137,8 @@
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
 			<filter class="solr.EnglishPossessiveFilterFactory"/>
-			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="English" protected="english/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/finnish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/finnish/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,8 +86,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -116,8 +116,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -137,8 +137,8 @@
 					preserveOriginal="1"
 					protected="finnish/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Finnish" protected="finnish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/french/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/french/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,8 +86,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -117,8 +117,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -139,8 +139,8 @@
 					preserveOriginal="1"
 					protected="french/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="French" protected="french/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/german/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/german/schema.xml
@@ -70,9 +70,9 @@
 				onlyLongestMatch="false"
 			/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -93,9 +93,9 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -131,9 +131,9 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -159,9 +159,9 @@
 					preserveOriginal="1"
 					protected="german/protwords.txt"
 			/>
+			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.GermanNormalizationFilterFactory"/>
 			<filter class="solr.SnowballPorterFilterFactory" language="German2" protected="german/protwords.txt"/>
-			<filter class="solr.ASCIIFoldingFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hungarian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/hungarian/schema.xml
@@ -61,8 +61,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -82,8 +82,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -112,8 +112,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -133,8 +133,8 @@
 					preserveOriginal="1"
 					protected="hungarian/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Hungarian" protected="hungarian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/irish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/irish/schema.xml
@@ -62,8 +62,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -83,8 +83,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -113,8 +113,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -134,8 +134,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Irish" protected="irish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/italian/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/italian/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,8 +86,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -116,8 +116,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -137,8 +137,8 @@
 					preserveOriginal="1"
 					protected="italian/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Italian" protected="italian/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/polish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/polish/schema.xml
@@ -62,8 +62,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -85,8 +85,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,8 +115,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -136,8 +136,8 @@
 					preserveOriginal="1"
 					protected="polish/protwords.txt"
 			/>
-			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.StempelPolishStemFilterFactory"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/portuguese/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/portuguese/schema.xml
@@ -62,8 +62,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -84,8 +84,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -114,8 +114,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -135,8 +135,8 @@
 					preserveOriginal="1"
 					protected="portuguese/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Portuguese" protected="portuguese/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/spanish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/spanish/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -86,8 +86,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -115,8 +115,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -136,8 +136,8 @@
 					preserveOriginal="1"
 					protected="spanish/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Spanish" protected="spanish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/turkish/schema.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/turkish/schema.xml
@@ -63,8 +63,8 @@
 			<filter class="solr.FlattenGraphFilterFactory"/>
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -85,8 +85,8 @@
 			<filter class="solr.ManagedSynonymGraphFilterFactory" managed="${solr.core.name}" />
 			<filter class="solr.ManagedStopFilterFactory" managed="${solr.core.name}"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>
@@ -113,8 +113,8 @@
 			/>
 			<filter class="solr.FlattenGraphFilterFactory"/>
 
-			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 		<analyzer type="query">
@@ -132,8 +132,8 @@
 					preserveOriginal="1"
 					protected="turkish/protwords.txt"
 			/>
-			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.ASCIIFoldingFilterFactory"/>
+			<filter class="solr.SnowballPorterFilterFactory" language="Turkish" protected="turkish/protwords.txt"/>
 			<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
 		</analyzer>
 	</fieldType>


### PR DESCRIPTION
# What this pr does

Move `ASCIIFoldingFilterFactory` to directly before the stemming stage.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
For german it must stay *after* `DictionaryCompoundWordTokenFilterFactory`:  `german-common-nouns.txt` is itself spelled with umlauts, so folding before the splitter orphans 410 of its 3870 entries (searching "Ämter" stops finding "Gesundheitsämter") while foreign words fold into german-looking strings and gain bogus subwords (`ångström` → angst/strom, so a search for "Strom" returns it). No other language ships a compound dictionary.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
Occurrences with `preserveOriginal="true"` need no change — they emit both the folded and unfolded token, so no divergence is possible.          

# How to test

Deploy the changed configset and reload the core and reindex.


End-to-end test:
Search for indexed words with accents.
e.g.

indexed word `café`
search: cafe
before -> no match                                                                                                                                                                                                                                                 
after: -> it matches 

You can check this also via solr analyses:

 curl -sG 'http://localhost:8983/solr/core_de/analysis/field' \                                                                                                                                                                                                                                               
        --data-urlencode 'analysis.fieldtype=text' \                                                                                                                                                                                                                                                               
        --data-urlencode 'analysis.fieldvalue=café' \                                                                                                                                                                                                                                                              
        --data-urlencode 'analysis.query=cafe' \                                                                                                                                                                                                                                                                   
        --data-urlencode 'wt=json' \                                                                                                                                                                                                                                                                               
      | jq -r '.analysis.field_types.text                                                                                                                                                                                                                                                                          
               | "index: \(.index[-1]|map(.text)|join(",")) | query: \(.query[-1]|map(.text)|join(","))"'                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
      before:  index: cafe | query: caf     <- differ, so no match                                                                                                                                                                                                                                                 
      after:   index: caf  | query: caf     <- equal, so it matches                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
  Same check for the other languages by swapping core and value:                                                                                                                                                                                                                                                   
  `résumé`/`resume` and `crème`/`creme` (german), `żółty`/`zolty` (polish,                                                                                                                                                                                                                                         
  fieldtype `text`), `informação`/`informacao` (portuguese),                                                                                                                                                                                                                                                       
  `yılları`/`yillari` (turkish).                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  Regression check for german compound splitting — `amt` must still appear:                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
      ...&analysis.fieldvalue=Gesundheitsämter&analysis.query=Ämter                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
  And no bogus subwords — index tokens for `ångström` must be `angstrom`                                                                                                                                                                                                                                           
  alone, not `angst,angstrom,strom`:                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                   
      ...&analysis.fieldvalue=ångström&analysis.query=Strom                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
  End-to-end (optional): reindex and search the unaccented spelling; the                                                                                                                                                                                                                                           
  accented document should now be returned.                                         


Fixes: #4740
