### PR TITLE
[SECURITY] 11.6.6 ELTS — Fix CVE-2026-56092, CVE-2026-56093, CVE-2026-56094, CVE-2026-56095, CVE-2026-56096

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,13 +114,13 @@ jobs:
       # Workaround for issue with actions/checkout "wrong PR commit checkout". See: ci_bootstrapping job
       - name: Checkout current state of Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout current state of Branch
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
       # End: Workaround for issue with actions/checkout...

--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -71,7 +71,13 @@ class Classification extends AbstractContentObject
         /** @var $classificationService ClassificationService */
         $classificationService = GeneralUtility::makeInstance(ClassificationService::class);
 
-        return serialize($classificationService->getMatchingClassNames((string)$data, $classifications));
+        return json_encode(
+            $classificationService->getMatchingClassNames(
+                (string)$data,
+                $classifications
+            ),
+            JSON_THROW_ON_ERROR
+        );
     }
 
     /**

--- a/Classes/ContentObject/Multivalue.php
+++ b/Classes/ContentObject/Multivalue.php
@@ -43,7 +43,7 @@ class Multivalue extends AbstractContentObject
      *
      * Turns a list of values into an array that can then be used to fill
      * multivalued fields in a Solr document. The array is returned in
-     * serialized form as content objects are expected to return strings.
+     * JSON-encoded form as content objects are expected to return strings.
      *
      * @inheritDoc
      * @noinspection PhpMissingReturnTypeInspection, because foreign source inheritance See {@link AbstractContentObject::render()}
@@ -79,6 +79,9 @@ class Multivalue extends AbstractContentObject
             $listAsArray = array_unique($listAsArray);
         }
 
-        return serialize($listAsArray);
+        return json_encode(
+            $listAsArray,
+            JSON_THROW_ON_ERROR
+        );
     }
 }

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -119,8 +119,11 @@ class Relation extends AbstractContentObject
             $singleValueGlue = !empty($conf['singleValueGlue']) ? trim($conf['singleValueGlue'], '|') : ', ';
             $result = implode($singleValueGlue, $relatedItems);
         } else {
-            // multi value, need to serialize as content objects must return strings
-            $result = serialize($relatedItems);
+            // multi value, need to JSON-encode as content objects must return strings
+            $result = json_encode(
+                $relatedItems,
+                JSON_THROW_ON_ERROR
+            );
         }
 
         return $result;

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -22,13 +22,17 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use ApacheSolrForTypo3\Solr\Util;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
+use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException;
 use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException;
 use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotReturnException;
 use TYPO3\CMS\Fluid\View\TemplateView;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
 use TYPO3Fluid\Fluid\View\ViewInterface;
+use UnexpectedValueException;
 
 /**
  * Class SearchController
@@ -199,6 +203,8 @@ class SearchController extends AbstractBaseController
      *
      * @param string $documentId
      * @return ResponseInterface
+     * @throws PropagateResponseException
+     * @throws PageNotFoundException
      */
     public function detailAction(string $documentId = ''): ResponseInterface
     {
@@ -211,6 +217,13 @@ class SearchController extends AbstractBaseController
             $this->view->assign('document', $document);
         } catch (SolrUnavailableException $e) {
             return $this->handleSolrUnavailable();
+        } catch (UnexpectedValueException $e) {
+            $response = GeneralUtility::makeInstance(ErrorController::class)
+                ->pageNotFoundAction(
+                    $GLOBALS['TYPO3_REQUEST'],
+                    'The requested document was not found.'
+                );
+            throw new PropagateResponseException($response, 1750684800);
         }
         return $this->htmlResponse();
     }

--- a/Classes/Domain/Search/Query/Helper/EscapeService.php
+++ b/Classes/Domain/Search/Query/Helper/EscapeService.php
@@ -27,12 +27,13 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper;
 class EscapeService
 {
     /**
-     * Quote and escape search strings
+     * Escapes Lucene syntax in $string. $allowOperatorSyntax=false also
+     * escapes the SolrJ-special chars `| & ;`.
      *
      * @param string|int|float $string String to escape
      * @return string|int|float The escaped/quoted string
      */
-    public static function escape($string)
+    public static function escape($string, bool $allowOperatorSyntax = true)
     {
         // when we have a numeric string only, nothing needs to be done
         if (is_numeric($string)) {
@@ -41,16 +42,16 @@ class EscapeService
 
         // when no whitespaces are in the query we can also just escape the special characters
         if (preg_match('/\W/', $string) != 1) {
-            return static::escapeSpecialCharacters($string);
+            return static::escapeSpecialCharacters($string, $allowOperatorSyntax);
         }
 
         // when there are no quotes inside the query string we can also just escape the whole string
         $hasQuotes = strrpos($string, '"') !== false;
         if (!$hasQuotes) {
-            return static::escapeSpecialCharacters($string);
+            return static::escapeSpecialCharacters($string, $allowOperatorSyntax);
         }
 
-        $result = static::tokenizeByQuotesAndEscapeDependingOnContext($string);
+        $result = static::tokenizeByQuotesAndEscapeDependingOnContext($string, $allowOperatorSyntax);
 
         return $result;
     }
@@ -74,8 +75,10 @@ class EscapeService
      * @param string $string
      * @return string
      */
-    protected static function tokenizeByQuotesAndEscapeDependingOnContext(string $string): string
-    {
+    protected static function tokenizeByQuotesAndEscapeDependingOnContext(
+        string $string,
+        bool $allowOperatorSyntax = true
+    ): string {
         $result = '';
         $quotesCount = substr_count($string, '"');
         $isEvenAmountOfQuotes = $quotesCount % 2 === 0;
@@ -95,7 +98,7 @@ class EscapeService
             if ($isInQuote && !$isLastQuote) {
                 $result .= static::escapePhrase($segment);
             } else {
-                $result .= static::escapeSpecialCharacters($segment);
+                $result .= static::escapeSpecialCharacters($segment, $allowOperatorSyntax);
             }
 
             $segmentsIndex++;
@@ -120,20 +123,32 @@ class EscapeService
     }
 
     /**
-     * Escapes characters with special meanings in Lucene query syntax.
-     *
-     * @param string $value Unescaped - "dirty" - string
-     * @return string Escaped - "clean" - string
+     * Escapes Lucene special chars. Legacy mode keeps `+ - && || ! * ?`;
+     * strict mode additionally escapes `| & ;`. `+ - ! * ?` and whitespace
+     * stay literal in both modes.
      */
-    protected static function escapeSpecialCharacters(string $value): string
+    protected static function escapeSpecialCharacters(string $value, bool $allowOperatorSyntax = true): string
     {
-        // list taken from http://lucene.apache.org/core/4_4_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description
-        // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
-        // of which we escape: ( ) { } [ ] ^ " ~ : \ /
-        // and explicitly don't escape: + - && || ! * ?
-        $pattern = '/(\\(|\\)|\\{|\\}|\\[|\\]|\\^|"|~|\:|\\\\|\\/)/';
-        $replace = '\\\$1';
+        if ($allowOperatorSyntax) {
+            // list taken from https://lucene.apache.org/core/9_10_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
+            // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+            // of which we escape: ( ) { } [ ] ^ " ~ : \ /
+            // and explicitly don't escape: + - && || ! * ?
+            $pattern = '/(\\(|\\)|\\{|\\}|\\[|\\]|\\^|"|~|\:|\\\\|\\/)/';
+            return preg_replace($pattern, '\\\$1', $value);
+        }
 
-        return preg_replace($pattern, $replace, $value);
+        $escapeChars = '\\():^[]"{}~|&;/';
+        $result = '';
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+            // @TODO: With only PHP 8 support, replace this with str_contains()
+            if (strpos($escapeChars, $char) !== false) {
+                $result .= '\\';
+            }
+            $result .= $char;
+        }
+        return $result;
     }
 }

--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\AbstractQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use Solarium\Component\Highlighting\HighlightingInterface as SolariumHighlightingInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -135,10 +136,16 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
     }
 
     /**
-     * @return bool
+     * @deprecated Highlighting::getUseFastVectorHighlighter() is deprecated and will be removed in v14.
+     *             The Unified Highlighter is now used unconditionally; the return value has no effect on the built query.
      */
     public function getUseFastVectorHighlighter(): bool
     {
+        trigger_error(
+            'Highlighting::getUseFastVectorHighlighter() is deprecated and will be removed in v14. '
+            . 'The Unified Highlighter is now used unconditionally; the return value has no effect on the built query.',
+            E_USER_DEPRECATED,
+        );
         return $this->fragmentSize >= 18;
     }
 
@@ -182,23 +189,17 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
             return $parentBuilder;
         }
 
-        $query->getHighlighting()->setFragSize($this->getFragmentSize());
-        $query->getHighlighting()->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
-
-        if ($this->getUseFastVectorHighlighter()) {
-            $query->getHighlighting()->setUseFastVectorHighlighter(true);
-            $query->getHighlighting()->setTagPrefix($this->getPrefix());
-            $query->getHighlighting()->setTagPostfix($this->getPostfix());
-            $query->getHighlighting()->setMethod('fastVector');
-        } else {
-            $query->getHighlighting()->setUseFastVectorHighlighter(false);
-            $query->getHighlighting()->setTagPrefix('');
-            $query->getHighlighting()->setTagPostfix('');
-        }
+        $highlighting = $query->getHighlighting();
+        $highlighting->setFragSize($this->getFragmentSize());
+        $highlighting->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
+        $highlighting->setMethod(SolariumHighlightingInterface::METHOD_UNIFIED);
+        $highlighting->setOffsetSource(SolariumHighlightingInterface::OFFSETSOURCE_ANALYSIS);
+        $highlighting->setBoundaryScannerType('WORD');
+        $highlighting->setFragsizeIsMinimum(false);
 
         if ($this->getPrefix() !== '' && $this->getPostfix() !== '') {
-            $query->getHighlighting()->setSimplePrefix($this->getPrefix());
-            $query->getHighlighting()->setSimplePostfix($this->getPostfix());
+            $highlighting->setSimplePrefix($this->getPrefix());
+            $highlighting->setSimplePostfix($this->getPostfix());
         }
 
         return $parentBuilder;

--- a/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
@@ -48,6 +48,17 @@ class QueryFields implements ParameterBuilderInterface
     }
 
     /**
+     * Field names without boost factors — for parameters that accept a plain
+     * field list (e.g. edismax `uf`), where boost suffixes are invalid.
+     *
+     * @return string[]
+     */
+    public function getFieldNames(): array
+    {
+        return array_keys($this->queryFields);
+    }
+
+    /**
      * Creates the string representation
      *
      * @param string $delimiter

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -131,6 +131,7 @@ class QueryBuilder extends AbstractQueryBuilder
                 ->useResultsPerPage($resultsPerPage)
                 ->useReturnFieldsFromTypoScript()
                 ->useQueryFieldsFromTypoScript()
+                ->useUserFieldsFromTypoScript()
                 ->useInitialQueryFromTypoScript()
                 ->useFiltersFromTypoScript()
                 ->useFilterArray($additionalFiltersFromRequest)
@@ -298,6 +299,39 @@ class QueryBuilder extends AbstractQueryBuilder
     public function useQueryFieldsFromTypoScript(): QueryBuilder
     {
         return $this->useQueryFields(QueryFields::fromString($this->typoScriptConfiguration->getSearchQueryQueryFields()));
+    }
+
+    /**
+     * Whitelist the fields a Solr field-selector (`field:value`) may target.
+     * Defaults to the `qf` field list so non-whitelisted fields cannot disclose
+     * arbitrary schema fields. Reads qf back from the query rather than
+     * re-fetching it from TypoScript to avoid a second configuration lookup.
+     *
+     * A scalar `userFields = ...` replaces the derived list outright. When the
+     * scalar is empty, `userFields.add` and `userFields.remove` are applied as
+     * comma-separated deltas on top of the qf-derived base list.
+     */
+    public function useUserFieldsFromTypoScript(): AbstractQueryBuilder
+    {
+        $explicit = $this->typoScriptConfiguration->getSearchQueryUserFields();
+        if ($explicit !== '') {
+            $this->queryToBuild->getEDisMax()->setUserFields($explicit);
+            return $this;
+        }
+
+        $qfString = (string)$this->queryToBuild->getEDisMax()->getQueryFields();
+        $base = $qfString === '' ? [] : QueryFields::fromString($qfString, ' ')->getFieldNames();
+
+        $config = $this->typoScriptConfiguration->getSearchQueryUserFieldsConfiguration();
+        $add = GeneralUtility::trimExplode(',', (string)($config['add'] ?? ''), true);
+        $remove = GeneralUtility::trimExplode(',', (string)($config['remove'] ?? ''), true);
+
+        $fields = array_values(array_diff(array_unique(array_merge($base, $add)), $remove));
+
+        if ($fields !== []) {
+            $this->queryToBuild->getEDisMax()->setUserFields(implode(' ', $fields));
+        }
+        return $this;
     }
 
     /**

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\BigramPhraseFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Elevation;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Faceting;
@@ -127,7 +128,12 @@ class QueryBuilder extends AbstractQueryBuilder
             $this->logger->log(SolrLogManager::INFO, 'Received search query', [$rawQuery]);
         }
 
-        return $this->newSearchQuery($rawQuery)
+        $escapedQuery = $rawQuery === '' ? '' : (string)EscapeService::escape(
+            $rawQuery,
+            $this->typoScriptConfiguration->getSearchQueryAllowSolrOperatorSyntax()
+        );
+
+        return $this->newSearchQuery($escapedQuery)
                 ->useResultsPerPage($resultsPerPage)
                 ->useReturnFieldsFromTypoScript()
                 ->useQueryFieldsFromTypoScript()

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -52,6 +52,14 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 class QueryBuilder extends AbstractQueryBuilder
 {
     /**
+     * System-owned filter names that request additionalFilters must not set.
+     */
+    protected const RESERVED_FILTER_NAMES_FROM_REQUEST = [
+        'siteHash',
+        'access',
+    ];
+
+    /**
      * Additional filters, which will be added to the query, as well as to
      * suggest queries.
      *
@@ -140,7 +148,7 @@ class QueryBuilder extends AbstractQueryBuilder
                 ->useUserFieldsFromTypoScript()
                 ->useInitialQueryFromTypoScript()
                 ->useFiltersFromTypoScript()
-                ->useFilterArray($additionalFiltersFromRequest)
+                ->useFilterArray($this->removeReservedFiltersFromRequest($additionalFiltersFromRequest))
                 ->useFacetingFromTypoScript()
                 ->useVariantsFromTypoScript()
                 ->useGroupingFromTypoScript()
@@ -172,10 +180,23 @@ class QueryBuilder extends AbstractQueryBuilder
             ->useOmitHeader();
 
         if (!empty($additionalFilters)) {
-            $this->useFilterArray($additionalFilters);
+            $this->useFilterArray($this->removeReservedFiltersFromRequest($additionalFilters));
         }
 
         return $this->queryToBuild;
+    }
+
+    /**
+     * Strips system-owned filter names from request additionalFilters so
+     * frontend input cannot preempt the siteHash/access boundary.
+     */
+    protected function removeReservedFiltersFromRequest(array $additionalFilters): array
+    {
+        return array_filter(
+            $additionalFilters,
+            static fn ($filterName): bool => !in_array($filterName, self::RESERVED_FILTER_NAMES_FROM_REQUEST, true),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**
@@ -388,6 +409,7 @@ class QueryBuilder extends AbstractQueryBuilder
         }
 
         $siteHashFilterString = implode(' OR ', $filters);
+        $this->queryToBuild->removeFilterQuery('siteHash');
         return $this->useFilter($siteHashFilterString, 'siteHash');
     }
 

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequestAware;
 use ApacheSolrForTypo3\Solr\Domain\Variants\VariantsProcessor;
 use ApacheSolrForTypo3\Solr\Query\Modifier\Modifier;
 use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\Search\AccessComponent;
 use ApacheSolrForTypo3\Solr\Search\QueryAware;
 use ApacheSolrForTypo3\Solr\Search\SearchAware;
 use ApacheSolrForTypo3\Solr\Search\SearchComponentManager;
@@ -99,6 +100,8 @@ class SearchResultSetService
      */
     protected ObjectManagerInterface $objectManager;
 
+    protected AccessComponent $accessComponent;
+
     /**
      * @param TypoScriptConfiguration $configuration
      * @param Search $search
@@ -106,6 +109,7 @@ class SearchResultSetService
      * @param SearchResultBuilder|null $resultBuilder
      * @param QueryBuilder|null $queryBuilder
      * @param ObjectManagerInterface|null $objectManager
+     * @param AccessComponent|null $accessComponent
      */
     public function __construct(
         TypoScriptConfiguration $configuration,
@@ -113,7 +117,8 @@ class SearchResultSetService
         ?SolrLogManager $solrLogManager = null,
         ?SearchResultBuilder $resultBuilder = null,
         ?QueryBuilder $queryBuilder = null,
-        ?ObjectManagerInterface $objectManager = null
+        ?ObjectManagerInterface $objectManager = null,
+        ?AccessComponent $accessComponent = null
     ) {
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
@@ -121,6 +126,7 @@ class SearchResultSetService
         $this->searchResultBuilder = $resultBuilder ?? GeneralUtility::makeInstance(SearchResultBuilder::class);
         $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, $configuration, $solrLogManager);
         $this->objectManager = $objectManager ?? GeneralUtility::makeInstance(ObjectManager::class);
+        $this->accessComponent = $accessComponent ?? GeneralUtility::makeInstance(AccessComponent::class, $this->queryBuilder);
     }
 
     /**
@@ -424,6 +430,13 @@ class SearchResultSetService
     {
         /* @var $query SearchQuery */
         $query = $this->queryBuilder->newSearchQuery($documentId)->useQueryFields(QueryFields::fromString('id'))->getQuery();
+
+        // Enforce the same siteHash and frontend user access filters as the regular search path:
+        //   the by-id lookup must not be less restricted than resultsAction.
+        $this->accessComponent->setSearchConfiguration($this->typoScriptConfiguration->getSearchConfiguration());
+        $this->accessComponent->setQuery($query);
+        $this->accessComponent->initializeSearchComponent();
+
         $response = $this->search->search($query, 0, 1);
         $parsedData = $response->getParsedData();
         // @extensionScannerIgnoreLine

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -152,6 +152,20 @@ class Tsfe implements SingletonInterface
                 $userGroups = explode(',', $pageRecord['fe_group']);
             } else {
                 $userGroups = [0, -1];
+
+                // Check rootline for feGroups from page with extendToSubpages set
+                $rootline = BackendUtility::BEgetRootLine($pageId);
+                // remove the current page from the rootline
+                array_shift($rootline);
+                foreach ($rootline as $page) {
+                    // Skip root node, invalid pages and pages which do not define extendToSubpages
+                    if ((int)($page['uid'] ?? 0) <= 0 || !($page['extendToSubpages'] ?? false)) {
+                        continue;
+                    }
+                    $userGroups = explode(',', $page['fe_group']);
+                    // Stop as soon as a page in the rootline has extendToSubpages set
+                    break;
+                }
             }
             $feUser->user = ['uid' => 0, 'username' => '', 'usergroup' => implode(',', $userGroups) ];
             $feUser->fetchGroupData();

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -20,6 +20,7 @@
 namespace ApacheSolrForTypo3\Solr\FrontendEnvironment;
 
 use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
+use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -198,7 +199,17 @@ class Tsfe implements SingletonInterface
                 $tsfe->absRefPrefix = self::getAbsRefPrefixFromTSFE($tsfe);
                 $tsfe->calculateLinkVars([]);
             } catch (Throwable $exception) {
-                // @todo: logging
+                $logger = GeneralUtility::makeInstance(SolrLogManager::class, __CLASS__);
+                $logger->log(
+                    SolrLogManager::WARNING,
+                    'TSFE initialization failed',
+                    [
+                        'pageId' => $pageId,
+                        'language' => $language,
+                        'exception' => $exception->getMessage(),
+                        'trace' => $exception->getTraceAsString(),
+                    ]
+                );
                 $this->serverRequestCache[$cacheIdentifier] = null;
                 $this->tsfeCache[$cacheIdentifier] = null;
                 // Restore backend user, happens when initializeTsfe() is called from Backend context

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -159,7 +159,11 @@ abstract class AbstractIndexer
                 $solrFieldName
             )
             ) {
-                $fieldValue = unserialize($fieldValue);
+                // SOLR_MULTIVALUE / SOLR_RELATION / SOLR_CLASSIFICATION return their multi-value payload as a JSON-encoded array.
+                $decodedFieldValue = json_decode($fieldValue, true);
+                if (is_array($decodedFieldValue)) {
+                    $fieldValue = $decodedFieldValue;
+                }
             }
         } elseif (
             substr($indexingConfiguration[$solrFieldName], 0, 1) === '<'
@@ -187,7 +191,11 @@ abstract class AbstractIndexer
                 $solrFieldName
             )
             ) {
-                $fieldValue = unserialize($fieldValue);
+                // SOLR_MULTIVALUE / SOLR_RELATION / SOLR_CLASSIFICATION return their multi-value payload as a JSON-encoded array.
+                $decodedFieldValue = json_decode($fieldValue, true);
+                if (is_array($decodedFieldValue)) {
+                    $fieldValue = $decodedFieldValue;
+                }
             }
         } else {
             $indexingFieldName = $indexingConfiguration[$solrFieldName] ?? null;

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -145,7 +145,11 @@ class PageFieldMappingIndexer implements SubstitutePageIndexer
             );
 
             if (AbstractIndexer::isSerializedValue($pageIndexingConfiguration, $solrFieldName)) {
-                $fieldValue = unserialize($fieldValue);
+                // SOLR_MULTIVALUE / SOLR_RELATION / SOLR_CLASSIFICATION return their multi-value payload as a JSON-encoded array.
+                $decodedFieldValue = json_decode($fieldValue, true);
+                if (is_array($decodedFieldValue)) {
+                    $fieldValue = $decodedFieldValue;
+                }
             }
         } else {
             $fieldValue = $pageRecord[$pageIndexingConfiguration[$solrFieldName]];

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -20,7 +20,6 @@ namespace ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Domain\Repository\PageRepositoryGetPageHookInterface;
-use TYPO3\CMS\Core\Domain\Repository\PageRepositoryGetPageOverlayHookInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectPostInitHookInterface;
@@ -35,8 +34,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 class UserGroupDetector extends AbstractFrontendHelper implements
     SingletonInterface,
     ContentObjectPostInitHookInterface,
-    PageRepositoryGetPageHookInterface,
-    PageRepositoryGetPageOverlayHookInterface
+    PageRepositoryGetPageHookInterface
 {
     /**
      * This frontend helper's executed action.
@@ -73,7 +71,6 @@ class UserGroupDetector extends AbstractFrontendHelper implements
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_checkEnableFields'][__CLASS__] = UserGroupDetector::class . '->checkEnableFields';
 
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPage'][__CLASS__] = UserGroupDetector::class;
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getPageOverlay'][__CLASS__] = UserGroupDetector::class;
 
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['postInit'][__CLASS__] = UserGroupDetector::class;
     }
@@ -132,26 +129,6 @@ class UserGroupDetector extends AbstractFrontendHelper implements
     ) {
         $disableGroupAccessCheck = true;
         $parentObject->where_groupAccess = ''; // just to be on the safe side
-    }
-
-    /**
-     * Modifies page records so that when checking for access through fe groups
-     * no groups or extendToSubpages flag is found and thus access is granted.
-     *
-     * @param array $pageInput Page record
-     * @param int $lUid Overlay language ID
-     * @param PageRepository $parent Parent \TYPO3\CMS\Core\Domain\Repository\PageRepository object
-     */
-    public function getPageOverlay_preProcess(
-        &$pageInput,
-        &$lUid,
-        PageRepository $parent
-    ) {
-        if (!is_array($pageInput)) {
-            return;
-        }
-        $pageInput['fe_group'] = '';
-        $pageInput['extendToSubpages'] = '0';
     }
 
     // execution

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1411,6 +1411,29 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Whitelist of fields a Solr field-selector (`field:value`) may target.
+     * Empty value defers to the edismax default, which is the `qf` field list.
+     *
+     * plugin.tx_solr.search.query.userFields
+     */
+    public function getSearchQueryUserFields(string $defaultIfEmpty = ''): string
+    {
+        return (string)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.userFields', $defaultIfEmpty);
+    }
+
+    /**
+     * Returns the userFields sub-key configuration (`add`, `remove`) used to
+     * derive the edismax `uf` list from the `qf` defaults when no scalar
+     * override is given.
+     *
+     * plugin.tx_solr.search.query.userFields.
+     */
+    public function getSearchQueryUserFieldsConfiguration(array $defaultIfEmpty = []): array
+    {
+        return $this->getObjectByPathOrDefault('plugin.tx_solr.search.query.userFields.', $defaultIfEmpty);
+    }
+
+    /**
      * This method is used to check if a phrase search is enabled or not
      *
      * plugin.tx_solr.search.query.phrase = 1

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1365,6 +1365,21 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns whether the well-known Lucene operators `+ - && || ! * ?` pass
+     * through `tx_solr[q]`. Default 1 — selector (`:`), range (`[ ]`) and
+     * grouping (`( ) { } ^ " ~ \ /`) characters are still escaped, so field
+     * enumeration and range injection cannot reach Solr; only wildcard and
+     * boolean operator syntax survives. Set to 0 for strict mode.
+     *
+     * plugin.tx_solr.search.query.allowSolrOperatorSyntax
+     */
+    public function getSearchQueryAllowSolrOperatorSyntax(string $defaultIfEmpty = '1'): bool
+    {
+        $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.allowSolrOperatorSyntax', $defaultIfEmpty);
+        return $this->getBool($result);
+    }
+
+    /**
      * Returns the filter configuration array
      *
      * plugin.tx_solr.search.query.filter.

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -74,6 +74,10 @@ plugin.tx_solr {
     query {
       allowEmptyQuery = 0
 
+      // 1 (default): `+ - && || ! * ?` pass through; 0: also escape `| & ;`.
+      // Selector/range chars (`: [ ] ( ) { } ^ " ~ \ /`) are escaped in both.
+      allowSolrOperatorSyntax = 1
+
       allowedSites = __solr_current_site
 
       // qf parameter http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29

--- a/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
+++ b/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+PATH_SOLRCONFIG="${SOLR_HOME}/configsets/ext_solr_11_6_0_elts/conf"
+PATH_AND_FILENAME_SOLRCONFIG="${PATH_SOLRCONFIG}/solrconfig.xml"
+PATH_AND_FILENAME_BACKUP="${PATH_SOLRCONFIG}/solrconfig.xml.Backup-SST-235567"
+
+PATCH_MARKER='CVE SST 235567 2026050810000025'
+PATCH_COMMENT="<!-- ${PATCH_MARKER}: Unified Highlighter set, closes FieldExistsQuery HTTP 500 oracle -->"
+
+# SST-235567 / 2026050810000025 — align /select and /browse highlighter
+# defaults with the EXT:solr Layer-3 fix (Unified Highlighter). The FastVector
+# Highlighter rewrote `field:*` queries to FieldExistsQuery and crashed with
+# HTTP 500, turning the response into a field-existence oracle on the
+# indexed schema.
+#
+# Idempotency: skip migration if either the patch marker is already present
+# (script ran before) or `hl.method=original` is no longer present (fresh
+# install from a patched configset, or manual edit).
+
+if ! grep -q "${PATCH_MARKER}" "${PATH_AND_FILENAME_SOLRCONFIG}" \
+	&& grep -q '<str name="hl.method">original</str>' "${PATH_AND_FILENAME_SOLRCONFIG}"; then
+	echo "The Apache Solr instance is affected on SST-235567"
+	echo "  migrating /select and /browse handler highlighter defaults to Unified Highlighter"
+
+	cp "${PATH_AND_FILENAME_SOLRCONFIG}" "${PATH_AND_FILENAME_BACKUP}"
+
+	# /select: replace hl.method=original with the Unified Highlighter set
+	# preceded by the patch marker comment.
+	# shellcheck disable=SC1004
+	sed -i "/<str name=\"hl.method\">original<\/str>/c\\
+			${PATCH_COMMENT}\\
+			<str name=\"hl.method\">unified</str>\\
+			<str name=\"hl.offsetSource\">ANALYSIS</str>\\
+			<str name=\"hl.bs.type\">WORD</str>\\
+			<str name=\"hl.fragsizeIsMinimum\">false</str>" "${PATH_AND_FILENAME_SOLRCONFIG}"
+
+	# /browse: append the patch marker comment + Unified Highlighter set
+	# after hl.simple.post.
+	# shellcheck disable=SC1004
+	sed -i "/<str name=\"hl.simple.post\">&lt;\/b&gt;<\/str>/a\\
+			${PATCH_COMMENT}\\
+			<str name=\"hl.method\">unified</str>\\
+			<str name=\"hl.offsetSource\">ANALYSIS</str>\\
+			<str name=\"hl.bs.type\">WORD</str>\\
+			<str name=\"hl.fragsizeIsMinimum\">false</str>" "${PATH_AND_FILENAME_SOLRCONFIG}"
+fi

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -126,6 +126,11 @@ Version 3.0 introduced a couple more magic keywords that get replaced:
 - **__all** Adds all domains as allowed sites
 - \* (asterisk character) Everything is allowed as siteHash (same as no siteHash check). This option should only be used when you need a search across multiple system and you know the impact of turning of the siteHash check.
 
+**Security note (since fix for CVE-2026-56094):** the ``siteHash`` filter is a security boundary, not a user-facing search option.
+It cannot be set or overridden through request-provided ``tx_solr[additionalFilters]`` — the reserved names ``siteHash`` and ``access`` are stripped from request input before the query is built.
+To search across sites, use the ``allowedSites`` setting above; passing a ``siteHash`` filter from the frontend has no effect.
+
+
 query.allowSolrOperatorSyntax
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -160,6 +160,55 @@ The boost take influence on what score a document gets when searching and thus h
 
 By default if a search term is found in the content field the documents gets scored / ranked higher as if a term was found in the title or keywords field. Although the default should provide a good setting, you can play around with the boost values to find the best ranking for your content.
 
+query.userFields
+~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields
+:Default: (empty — derived from ``query.queryFields``)
+:Since: 11.6.6, 12.1.4, 13.1.4
+
+Whitelist of fields that a Solr field-selector (``field:value``) in ``tx_solr[q]`` may target.
+By default the whitelist is derived from ``query.queryFields`` — only fields listed in ``qf`` are addressable via selector.
+Selectors against fields outside the whitelist are treated as literal terms and silently miss.
+
+A scalar value replaces the derived whitelist with a whitespace-separated list of field names:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.userFields = title content fileExtension
+
+Alternatively the ``add`` and ``remove`` sub-keys apply comma-separated deltas on top of the qf-derived base list (used only when the scalar value is empty):
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.userFields {
+        add = customField, fileExtension
+        remove = abstract
+    }
+
+query.userFields.add
+~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields.add
+:Default: (empty)
+:Since: 11.6.6, 12.1.4, 13.1.4
+
+Comma-separated list of field names to add to the qf-derived user-field whitelist.
+Applied only when the scalar ``query.userFields`` value is empty.
+
+query.userFields.remove
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields.remove
+:Default: (empty)
+:Since: 11.6.6, 12.1.4, 13.1.4
+
+Comma-separated list of field names to remove from the qf-derived user-field whitelist.
+Applied only when the scalar ``query.userFields`` value is empty.
+
 query.returnFields
 ~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -126,6 +126,21 @@ Version 3.0 introduced a couple more magic keywords that get replaced:
 - **__all** Adds all domains as allowed sites
 - \* (asterisk character) Everything is allowed as siteHash (same as no siteHash check). This option should only be used when you need a search across multiple system and you know the impact of turning of the siteHash check.
 
+query.allowSolrOperatorSyntax
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.query.allowSolrOperatorSyntax
+:Default: 1
+:Options: 0,1
+:Since: 11.6.6, 12.1.4, 13.1.4
+
+Controls how much Solr/Lucene query syntax survives in ``tx_solr[q]``.
+Selector, range, grouping and metacharacters (``: [ ] ( ) { } ^ " ~ \ /``) are always escaped at the user-input boundary regardless of this setting, so field-targeted enumeration and range injection cannot reach Solr.
+
+* ``1`` (default) — the well-known Lucene operators ``+ - && || ! * ?`` pass through, so the documented wildcard and boolean operator UX (``apple*``, ``+foo -bar``) keeps working.
+* ``0`` — strict mode; the additional SolrJ specials ``| & ;`` are also escaped. ``+ - ! * ?`` and whitespace stay literal, so required/prohibited terms, ``NOT`` and the wildcard UX still function.
+
 query.getParameter
 ~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Releases/Archive/Index.rst
+++ b/Documentation/Releases/Archive/Index.rst
@@ -13,6 +13,7 @@ Archive
     :glob:
 
     solr-release-11-5
+    solr-release-11-2
     solr-release-11-1
     solr-release-11-0
     solr-release-10-0

--- a/Documentation/Releases/Archive/solr-release-10-0.rst
+++ b/Documentation/Releases/Archive/solr-release-10-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-10:
 
 =============

--- a/Documentation/Releases/Archive/solr-release-11-0.rst
+++ b/Documentation/Releases/Archive/solr-release-11-0.rst
@@ -1,4 +1,4 @@
-..  index:: Releases
+..  index:: Archive
 .. _releases-11:
 
 =============

--- a/Documentation/Releases/Archive/solr-release-11-1.rst
+++ b/Documentation/Releases/Archive/solr-release-11-1.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-11-1:
 
 =============

--- a/Documentation/Releases/Archive/solr-release-11-2.rst
+++ b/Documentation/Releases/Archive/solr-release-11-2.rst
@@ -1,4 +1,4 @@
-..  index:: Releases
+..  index:: Archive
 .. _releases-11-2:
 
 =============

--- a/Documentation/Releases/Archive/solr-release-3-0.rst
+++ b/Documentation/Releases/Archive/solr-release-3-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-3-0:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-3-1.rst
+++ b/Documentation/Releases/Archive/solr-release-3-1.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-3-1:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-4-0.rst
+++ b/Documentation/Releases/Archive/solr-release-4-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-4-0:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-5-0.rst
+++ b/Documentation/Releases/Archive/solr-release-5-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-5-0:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-5-1.rst
+++ b/Documentation/Releases/Archive/solr-release-5-1.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-5-1:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-6-0.rst
+++ b/Documentation/Releases/Archive/solr-release-6-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-6-0:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-6-1.rst
+++ b/Documentation/Releases/Archive/solr-release-6-1.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-6-1:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-7-0.rst
+++ b/Documentation/Releases/Archive/solr-release-7-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-7:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-8-0.rst
+++ b/Documentation/Releases/Archive/solr-release-8-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-8:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-8-1.rst
+++ b/Documentation/Releases/Archive/solr-release-8-1.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-8.1:
 
 ============

--- a/Documentation/Releases/Archive/solr-release-9-0.rst
+++ b/Documentation/Releases/Archive/solr-release-9-0.rst
@@ -1,3 +1,4 @@
+..  index:: Archive
 .. _releases-archive-9:
 
 ============

--- a/Documentation/Releases/Index.rst
+++ b/Documentation/Releases/Index.rst
@@ -13,5 +13,4 @@ Releases
     :glob:
 
     solr-release-11-6
-    solr-release-11-2
     Archive/Index

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -105,6 +105,28 @@ The response is uniform, so it cannot be used to probe whether a restricted docu
 As defence in depth, review whether your templates still expose ``data-document-id`` and mask it where the document id should not be publicly visible.
 
 
+!!! Security: page indexer no longer forges access fields on page records (CVE-2026-56092)
+-------------------------------------------------------------------------------------------
+
+During a page-indexer sub-request, EXT:solr forced ``fe_group`` and ``extendToSubpages`` to public
+values on every ``pages`` record it touched, so the indexer itself would not be blocked by access
+restrictions.
+
+On TYPO3 11 those forged values were written into the shared ``rootline`` cache. No anonymous-access
+bypass could be reproduced on this branch: the override only applies while a translated view is being
+resolved, whereas a visitor of an untranslated page is served — and cached — from the original record,
+and where a translation does exist the language overlay replaces the forged fields with the translated
+page's own values. The corrupted entries are wrong regardless, and a manually corrupted entry *is*
+honoured by the frontend access check, so this is fixed rather than tolerated. On TYPO3 13 the same
+override reached the entries visitors do read, which is where the reported disclosure occurred.
+
+The indexer no longer forges these fields. The access bypass it needs during indexing was already
+provided safely, without touching any persisted cache, by EXT:solr's other, unaffected mechanisms.
+
+**Flush the rootline cache after updating.** Entries written by earlier 11.6.x releases keep the forged
+values until they are rebuilt.
+
+
 All Changes
 -----------
 (filled at release time)

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -1,9 +1,11 @@
-..  index:: Archive
+..  index:: Releases
 .. _releases-11-6:
 
 =============
 Releases 11.6
 =============
+
+..  include:: HintAboutOutdatedChangelog.rst.txt
 
 Release 11.6.5 ELTS
 ===================

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -58,6 +58,21 @@ Two new TypoScript settings govern how user input on ``tx_solr[q]`` is parsed:
 See :ref:`configuration.reference.solrsearch` for full reference details.
 
 
+!!! Breaking: multi-value cObjs now use JSON transport
+------------------------------------------------------
+
+The ``SOLR_MULTIVALUE``, ``SOLR_RELATION`` and ``SOLR_CLASSIFICATION`` content objects now return their
+multi-value payload as ``json_encode($array)`` instead of ``serialize($array)``, and the indexer decodes
+it with ``json_decode()`` instead of ``unserialize()``.
+Because ``json_decode()`` never reconstructs PHP objects, the indexer can no longer be turned into a PHP
+object-injection sink by an attacker who can influence an indexed record field.
+
+Third-party content objects that returned ``serialize($array)`` for a multi-value Solr field must switch
+to ``json_encode($array)``; no other change is required.
+The same applies to extensions registering a ``SerializedValueDetector`` through
+``$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue']``: the flagged field is now
+JSON-decoded, so its content object must emit JSON as well.
+
 All Changes
 -----------
 (filled at release time)

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -73,6 +73,22 @@ The same applies to extensions registering a ``SerializedValueDetector`` through
 ``$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue']``: the flagged field is now
 JSON-decoded, so its content object must emit JSON as well.
 
+
+!!! Security: additionalFilters can no longer preempt the siteHash filter
+-------------------------------------------------------------------------
+
+Request-provided ``tx_solr[additionalFilters]`` could register a named ``siteHash`` filter that ``AbstractQueryBuilder::useFilter()`` refused to overwrite,
+so the system ``siteHash`` filter added later by ``AccessComponent`` was dropped.
+In a shared-Solr-core multi-site installation this let an anonymous visitor of one site read public documents of another site sharing the same core (CVE-2026-56094).
+
+EXT:solr now strips the reserved filter names ``siteHash`` and ``access`` from request-provided ``additionalFilters`` before they reach the query,
+and applies the system ``siteHash`` filter with remove-then-set semantics so request input can no longer preempt it.
+Filters that integrators set server-side — TypoScript ``plugin.tx_solr.search.query.filter.``, plugin/FlexForm, or PSR-14 events — are unaffected.
+
+**Impact for integrators:** a frontend request can no longer override ``siteHash`` (or ``access``) through ``tx_solr[additionalFilters]``.
+Cross-site search must be configured server-side via ``plugin.tx_solr.search.query.allowedSites`` as documented in :ref:`configuration.reference.solrsearch`.
+
+
 All Changes
 -----------
 (filled at release time)

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -7,6 +7,47 @@ Releases 11.6
 
 ..  include:: HintAboutOutdatedChangelog.rst.txt
 
+Release 11.6.6 ELTS
+===================
+
+This is a security release for TYPO3 11.5 ELTS.
+
+!!! All earlier 11.6.x releases stay vulnerable and will not be re-published
+-----------------------------------------------------------------------------
+
+11.6.6 is the only release of this branch that is published publicly.
+Releases 11.6.0 to 11.6.5 are affected by the CVEs fixed in this release and will **not** be
+re-published with a fix, so there is no patched 11.6.5 or earlier to move to — upgrade to 11.6.6.
+
+!!! Solarium raised to 6.2.4
+-----------------------------
+
+``solarium/solarium`` is raised from 6.2.3 to 6.2.4. This branch needs it to enforce the fix in PHP at all:
+6.2.3 ships no ``HighlightingInterface``, no ``setOffsetSource()`` and no ``setFragsizeIsMinimum()``,
+and its request builder emits ``h1.method`` instead of ``hl.method``, so the Unified Highlighter
+never reached Solr. Composer resolves this on update; installations that pin ``solarium/solarium``
+themselves must allow 6.2.4.
+
+!!! Recommendation: align existing Solr volumes with the new configset
+----------------------------------------------------------------------
+
+The ``ext_solr_11_6_0_elts`` configset now sets the Unified Highlighter as default on both the ``/select`` and ``/browse`` request handlers.
+Solr volumes created from older configsets default to the legacy highlighter and remain vulnerable to the ``FieldExistsQuery`` HTTP 500 oracle
+when queried directly (bypassing EXT:solr).
+Run the bundled migration script against the existing configset to align the defaults;
+the script is idempotent and writes a ``solrconfig.xml.Backup-SST-235567`` backup next to the modified file:
+
+*   ``Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh``
+
+EXT:solr itself enforces the Unified Highlighter unconditionally in PHP, so this configset alignment is a defence-in-depth measure
+for clients that query Solr directly.
+
+
+All Changes
+-----------
+(filled at release time)
+
+
 Release 11.6.5 ELTS
 ===================
 

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -43,6 +43,21 @@ EXT:solr itself enforces the Unified Highlighter unconditionally in PHP, so this
 for clients that query Solr directly.
 
 
+!!! New: TypoScript settings for query-syntax handling
+-------------------------------------------------------
+
+Two new TypoScript settings govern how user input on ``tx_solr[q]`` is parsed:
+
+* ``plugin.tx_solr.search.query.userFields`` — whitelist of fields a Solr field-selector (``field:value``) may target.
+  By default derived from ``query.queryFields``; selectors against other fields are now treated as literal terms and silently miss.
+  Sites that rely on selectors against non-``qf`` fields must extend the whitelist via a scalar override or the ``add`` / ``remove`` sub-keys.
+* ``plugin.tx_solr.search.query.allowSolrOperatorSyntax`` — toggle for operator-syntax passthrough.
+  Default ``1`` keeps the documented ``+ - && || ! * ?`` UX functional; set to ``0`` for strict mode (additionally escapes ``| & ;``).
+  Selector, range and grouping characters (``: [ ] ( ) { } ^ " ~ \ /``) are always escaped regardless.
+
+See :ref:`configuration.reference.solrsearch` for full reference details.
+
+
 All Changes
 -----------
 (filled at release time)

--- a/Documentation/Releases/solr-release-11-6.rst
+++ b/Documentation/Releases/solr-release-11-6.rst
@@ -89,6 +89,22 @@ Filters that integrators set server-side — TypoScript ``plugin.tx_solr.search.
 Cross-site search must be configured server-side via ``plugin.tx_solr.search.query.allowedSites`` as documented in :ref:`configuration.reference.solrsearch`.
 
 
+!!! Security: detail view enforces site and access restrictions (CVE-2026-56093)
+--------------------------------------------------------------------------------
+
+The ``detail`` action of the ``pi_results`` plugin looked up a document by its ``documentId`` without applying the current site's ``siteHash`` filter
+or the frontend user-group access filter.
+An anonymous visitor who knew or guessed a valid ``documentId`` could therefore retrieve access-restricted documents through the detail view
+— a path that was less restricted than the regular search.
+
+The direct ``documentId`` lookup now applies the same ``siteHash`` and frontend user-group filters as the normal search path.
+A ``documentId`` that resolves to no accessible document — unknown, from another site, or restricted for the current visitor
+— yields the site's configured 404 page.
+The response is uniform, so it cannot be used to probe whether a restricted document exists.
+
+As defence in depth, review whether your templates still expose ``data-document-id`` and mask it where the document id should not be publicly visible.
+
+
 All Changes
 -----------
 (filled at release time)

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,14 +11,14 @@
 	  project-contact="https://typo3.slack.com/archives/C02FF05Q4"
 	  project-repository="https://github.com/TYPO3-Solr/ext-solr"
 	  project-issues="https://github.com/TYPO3-Solr/ext-solr/issues"
-	  edit-on-github-branch="main"
+	  edit-on-github-branch="release-11.6.x"
 	  edit-on-github="TYPO3-Solr/ext-solr"
 	  typo3-core-preferred="stable"
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="13.0.0"
-	  version="13.0"
+	  release="11.6.6"
+	  version="11.6"
 	  copyright="since 2009 by dkd &amp; contributors"
   />
 </guides>

--- a/Resources/Private/Solr/configsets/ext_solr_11_6_0_elts/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_11_6_0_elts/conf/solrconfig.xml
@@ -146,7 +146,10 @@
 			<int name="hl.snippets">3</int>
 			<str name="hl.mergeContiguous">true</str>
 			<str name="hl.requireFieldMatch">true</str>
-			<str name="hl.method">original</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 
 			<str name="f.content.hl.alternateField">content</str>
 			<str name="f.content.hl.maxAlternateFieldLength">200</str>
@@ -218,6 +221,10 @@
 			<str name="hl.encoder">html</str>
 			<str name="hl.simple.pre">&lt;b&gt;</str>
 			<str name="hl.simple.post">&lt;/b&gt;</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 		</lst>
 		<arr name="last-components">
 			<str>spellcheck</str>

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -188,21 +188,21 @@ class RelationTest extends IntegrationTest
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation' => [
-            serialize(['Third category', 'Second category']),
+            json_encode(['Third category', 'Second category']),
             'tx_fakeextension_domain_model_foo',
             2,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation and keep duplicates' => [
-            serialize(['Third category', 'Second category', 'Second category']),
+            json_encode(['Third category', 'Second category', 'Second category']),
             'tx_fakeextension_domain_model_foo',
             3,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation and remove duplicates' => [
-            serialize(['Third category', 'Second category']),
+            json_encode(['Third category', 'Second category']),
             'tx_fakeextension_domain_model_foo',
             3,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1, 'removeDuplicateValues' => 1],
@@ -216,7 +216,7 @@ class RelationTest extends IntegrationTest
         ];
 
         yield 'Can resolve uids of m:n relation for multi value field, with 2 items' => [
-            serialize(['11', '10']),
+            json_encode(['11', '10']),
             'tx_fakeextension_domain_model_foo',
             2,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'uid', 'multiValue' => 1],
@@ -294,7 +294,7 @@ class RelationTest extends IntegrationTest
         ];
 
         yield 'Can resolve related categories of related records 1:n relation (multi value)' => [
-            serialize(['Second category', 'Second category']),
+            json_encode(['Second category', 'Second category']),
             'tx_fakeextension_domain_model_foo',
             1,
             ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.main_category', 'multiValue' => 1],

--- a/Tests/Integration/Security/AdditionalFiltersSiteHashBypassTest.php
+++ b/Tests/Integration/Security/AdditionalFiltersSiteHashBypassTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Tests\Integration\Controller\AbstractFrontendControllerTest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression guard for TYPO3 Security Team Ticket #2026052010000029 (CVE-2026-56094).
+ *
+ * Asserts the secure behavior: a request-supplied `tx_solr[additionalFilters][siteHash]` must not preempt the system siteHash filter.
+ * In a shared-core multi-site install that bypass would let anonymous visitors of one site read public documents of another site in the same core.
+ *
+ * @group frontend
+ * @group security
+ */
+class AdditionalFiltersSiteHashBypassTest extends AbstractFrontendControllerTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Shared core: both testone.site and testtwo.site map to core_en (EN).
+
+        $this->importDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.xml');
+
+        // Site 1: enable indexing and render the pi_results plugin on page 2022.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            '
+        );
+        // Site 2 (template uid 111) needs indexing enabled too.
+        $this->addTypoScriptToTemplateRecord(
+            111,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            '
+        );
+    }
+
+    /**
+     * Primary guard: an injected additionalFilters[siteHash] on the results page must not leak Site 2 documents into a Site 1 search response.
+     *
+     * @test
+     */
+    public function crossSiteDocumentMustNotLeakViaAdditionalFiltersSiteHash(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+
+        // Page 2 → Site 1, Page 112 → Site 2; both indexed into the shared core_en.
+        // indexPageIds() resolves the site per page id; indexPages() would render both under
+        // testone.site and leave the Site 2 document without indexed content.
+        $this->indexPageIds([2, 112]);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(2);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getSiteOneRequest()
+                ->withQueryParameter('tx_solr[q]', '*')
+                ->withQueryParameter('tx_solr[additionalFilters][siteHash]', '*:*')
+        )->getBody();
+
+        self::assertStringContainsString(
+            'Found 1 result',
+            $response,
+            'CVE-2026-56094: expected exactly the single Site 1 document — guards against a vacuous pass.'
+        );
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'CVE-2026-56094: own Site 1 document must be present in the Site 1 search response.'
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicDoc',
+            $response,
+            'CVE-2026-56094: cross-site document title from Site 2 leaked into Site 1 search response.'
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicBody',
+            $response,
+            'CVE-2026-56094: cross-site document body marker from Site 2 leaked into Site 1 search response.'
+        );
+    }
+
+    /**
+     * Suggest top-results variant: addTopResultsToSuggestions() copies the request additionalFilters into a regular search,
+     * so the injected siteHash must not leak Site 2 documents into the suggest JSON either.
+     *
+     * @test
+     */
+    public function suggestTopResultsMustNotLeakCrossSiteDocument(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+        $this->indexPageIds([2, 112]);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(2);
+
+        // Enable suggest top-results endpoint on both sites' templates.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            @import \'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript\'
+            '
+        );
+        $this->addTypoScriptToTemplateRecord(
+            111,
+            /* @lang TYPO3_TypoScript */
+            '
+            @import \'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript\'
+            '
+        );
+
+        // "sharedCrossSiteToken" is in both sites' bodytexts, so without the siteHash filter the top-results search would match both sites.
+        $response = (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/en/'))
+                ->withPageId(1)
+                ->withQueryParameter('type', '7384')
+                ->withQueryParameter('tx_solr[queryString]', 'sharedCrossSiteToken')
+                ->withQueryParameter('tx_solr[additionalFilters][siteHash]', '*:*')
+        )->getBody();
+
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'CVE-2026-56094: own Site 1 document must be present in the suggest top-results.'
+        );
+        self::assertSame(
+            1,
+            substr_count($response, '"link":'),
+            'CVE-2026-56094: suggest top-results must contain exactly one document (the Site 1 one).'
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicDoc',
+            $response,
+            'CVE-2026-56094: suggest top-results leaked the title of a Site 2 document into a Site 1 suggest response.'
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicBody',
+            $response,
+            'CVE-2026-56094: suggest top-results leaked the body marker of a Site 2 document into a Site 1 suggest response.'
+        );
+    }
+
+    /**
+     * Baseline: additionalFilters[access] is already neutralized by useUserAccessGroups() (remove-then-set), so the restricted document stays hidden.
+     * Passes before and after the fix.
+     *
+     * 11.6 uses indexPageIds() with an explicit fe_group list — the branch's equivalent of 12.1's
+     * indexPages($ids, $frontendUserId) — so page 13 gets its access rootline indexed.
+     *
+     * @test
+     */
+    public function accessRestrictedDocumentMustNotLeakViaAdditionalFiltersAccess(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+
+        // Site 1 public page 2 + access-restricted page 13 (fe_group=1).
+        $this->indexPageIds([2, 13], [1]);
+        $this->waitToBeVisibleInSolr();
+        $this->assertSolrContainsDocumentCount(2);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getSiteOneRequest()
+                ->withQueryParameter('tx_solr[q]', '*')
+                ->withQueryParameter('tx_solr[additionalFilters][access]', '*:*')
+        )->getBody();
+
+        self::assertStringContainsString(
+            'Found 1 result',
+            $response,
+            'Baseline: expected exactly the single public Site 1 document — guards against a vacuous pass.'
+        );
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'Baseline: public Site 1 document must be present in the search response.'
+        );
+        self::assertStringNotContainsString(
+            'SiteOneRestrictedDoc',
+            $response,
+            'Baseline broken: additionalFilters[access] succeeded in bypassing the access filter — please re-verify QueryBuilder::useUserAccessGroups().'
+        );
+        self::assertStringNotContainsString(
+            'SiteOneRestrictedBody',
+            $response,
+            'Baseline broken: additionalFilters[access] disclosed restricted content body.'
+        );
+    }
+
+    protected function getSiteOneRequest(int $pageId = 2022): InternalRequest
+    {
+        return (new InternalRequest('http://testone.site/'))->withPageId($pageId);
+    }
+}

--- a/Tests/Integration/Security/DetailActionAccessBypassTest.php
+++ b/Tests/Integration/Security/DetailActionAccessBypassTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Controller\AbstractFrontendControllerTest;
+use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
+use JsonException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Regression-guard test for CVE-2026-56093 (detailAction access-control bypass).
+ *
+ * Asserts the SECURE behavior: {@link SearchController::detailAction()} MUST NOT disclose access-restricted documents to anonymous visitors.
+ * The same siteHash and frontend-user-group access filters that the AccessComponent applies on the normal search path
+ * must also constrain the direct documentId lookup.
+ *
+ * On 11.6.x {@link SearchResultSetService::getDocumentById()} builds a direct Solr lookup query without running any
+ * search component, so AccessComponent never applies and restricted documents leak through.
+ * The primary test method therefore FAILS before the fix — that failure IS the deterministic vulnerability reproduction.
+ *
+ * @group frontend
+ * @group security
+ */
+class DetailActionAccessBypassTest extends AbstractFrontendControllerTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Plugin "pi_results" (search results + detail) on page 2022, reused from controller fixtures.
+        $this->importDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.xml');
+        // Mirrors SearchControllerTest's plugin bootstrap: enable indexing and
+        // render the pi_results plugin on page 2022.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            '
+        );
+    }
+
+    /**
+     * PRIMARY regression guard.
+     *
+     * An anonymous visitor calls the cacheable detail action with the documentId of a fe_group-restricted page.
+     * The detailAction MUST refuse to render the protected document; {@link SearchResultSetService::getDocumentById()}
+     * must apply the same access and siteHash filters that AccessComponent applies on the normal search path.
+     *
+     * @test
+     */
+    public function detailActionMustNotDiscloseAccessRestrictedDocumentToAnonymousVisitor(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/detailaction_access_bypass.csv');
+
+        // Index public (uid 2) + restricted (uid 3) pages as fe_user 1, which belongs to fe_group 1;
+        // the restricted page therefore reaches Solr with an "access" field that mandates
+        // membership in group 1.
+        $this->indexPagesAsFrontendUser([2, 3], 1);
+        $this->assertSolrContainsDocumentCount(2);
+
+        $restrictedDocumentId = $this->fetchSolrDocumentIdByTitle('RestrictedSecretAreaLoggedInOnly');
+        self::assertNotEmpty(
+            $restrictedDocumentId,
+            'Restricted page was not indexed into Solr; precondition for the test is broken.'
+        );
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getPreparedRequest()
+                ->withQueryParameter('tx_solr[action]', 'detail')
+                ->withQueryParameter('tx_solr[documentId]', $restrictedDocumentId)
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'RestrictedSecretAreaLoggedInOnly',
+            $response,
+            'CVE-2026-56093: detailAction disclosed the title of an access-restricted document to an anonymous visitor.'
+        );
+        self::assertStringNotContainsString(
+            'CLASSIFIED_BANK_DETAILS_MARKER_ABC123',
+            $response,
+            'CVE-2026-56093: detailAction disclosed the body of an access-restricted document to an anonymous visitor.'
+        );
+    }
+
+    /**
+     * COMPARISON BASELINE.
+     *
+     * The same restricted document, queried through the normal (non-cacheable) results action, is NOT disclosed
+     * because the {@link AccessComponent} applies the frontend user access filter.
+     * This test confirms that the bypass observed above is specific to the detailAction code path and not a general indexing/access-field bug.
+     *
+     * @test
+     */
+    public function normalResultsActionDoesNotDiscloseAccessRestrictedDocumentToAnonymousVisitor(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/detailaction_access_bypass.csv');
+        $this->indexPagesAsFrontendUser([2, 3], 1);
+        $this->assertSolrContainsDocumentCount(2);
+
+        // Search for a public-content keyword so the search-term echo in the response template
+        // cannot accidentally satisfy a substring assertion. The restricted document's title
+        // and the surrounding restricted-content phrase remain the indicators of disclosure.
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getPreparedRequest()
+                ->withQueryParameter('tx_solr[q]', '*')
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'RestrictedSecretAreaLoggedInOnly',
+            $response,
+            'Normal resultsAction unexpectedly disclosed the title of the restricted document — the comparison baseline is invalid.'
+        );
+        self::assertStringNotContainsString(
+            'CLASSIFIED_BANK_DETAILS_MARKER_ABC123',
+            $response,
+            'Normal resultsAction unexpectedly disclosed a marker from the restricted document body — the comparison baseline is invalid.'
+        );
+    }
+
+    /**
+     * Indexes pages with a logged-in frontend user, so an fe_group-protected page actually renders
+     * and reaches Solr with its own access rootline.
+     *
+     * 11.6 has no helper that can do this — {@link AbstractFrontendControllerTest::indexPages()} renders
+     * the sub-request anonymously and never sets the access rootline, while
+     * {@link IntegrationTest::indexPageIds()} runs `determineId()` before simulating the user groups, so both
+     * silently fall back to the site root for a protected page. This is the 11.6 equivalent of 12.1's
+     * `indexPages($ids, $frontendUserId)`.
+     */
+    protected function indexPagesAsFrontendUser(array $importPageIds, int $frontendUserId): void
+    {
+        /** @var Tsfe $tsfeFactory */
+        $tsfeFactory = GeneralUtility::makeInstance(Tsfe::class);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId($frontendUserId);
+
+        foreach ($importPageIds as $importPageId) {
+            $fakeTSFE = $tsfeFactory->getTsfeByPageIdAndLanguageId($importPageId);
+            $GLOBALS['TSFE'] = $fakeTSFE;
+            $fakeTSFE->newCObj();
+
+            $response = $this->executeFrontendSubRequest(
+                (new InternalRequest('http://testone.site/'))->withPageId($importPageId),
+                $requestContext
+            );
+            $fakeTSFE->content = (string)$response->getBody();
+
+            /** @var Typo3PageIndexer $pageIndexer */
+            $pageIndexer = GeneralUtility::makeInstance(Typo3PageIndexer::class, $fakeTSFE);
+            $indexQueueItemMock = $this->createMock(Item::class);
+            $indexQueueItemMock->expects(self::any())
+                ->method('getIndexingConfigurationName')
+                ->willReturn('pages');
+            $pageIndexer->setIndexQueueItem($indexQueueItemMock);
+            $pageIndexer->setPageAccessRootline(Rootline::getAccessRootlineByPageId($importPageId));
+            $pageIndexer->indexPage();
+        }
+
+        $this->waitToBeVisibleInSolr();
+        unset($GLOBALS['TSFE']);
+    }
+
+    /**
+     * Resolves the Solr documentId of an indexed page by issuing a REST query against Solr directly.
+     * The id format is constructed by {@link Util::getDocumentId()} as `<siteHash>/<table>/<uid>/<typeNum>/<language>/<accessGroups>`,
+     * but the exact accessGroups segment depends on the runtime indexing context — querying Solr avoids brittle assumptions.
+     *
+     * @throws JsonException
+     */
+    protected function fetchSolrDocumentIdByTitle(string $title): string
+    {
+        $url = sprintf(
+            '%s/solr/core_en/select?q=*:*&fl=id&wt=json&fq=%s',
+            $this->getSolrConnectionUriAuthority(),
+            urlencode('title:"' . $title . '"')
+        );
+        $body = file_get_contents($url);
+        if ($body === false) {
+            self::fail('Could not query Solr at ' . $url);
+        }
+        $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        return (string)($data['response']['docs'][0]['id'] ?? '');
+    }
+}

--- a/Tests/Integration/Security/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv
+++ b/Tests/Integration/Security/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/site-one-public","SiteOnePublicDoc",,""
+,4,1,0,254,"/site-one-fe-users","FE Users Folder",,"fe_users"
+,13,1,0,1,"/site-one-restricted","SiteOneRestrictedDoc","1",""
+,112,111,0,1,"/site-two-public","SiteTwoPublicDoc",,""
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,201,2,0,"text","Site one public marker","sharedCrossSiteToken SiteOnePublicBody only meant to be searchable from site one",0,10
+,213,13,0,"text","Site one restricted marker","sharedCrossSiteToken SiteOneRestrictedBody restricted to fe_group 1",0,10
+,1121,112,0,"text","Site two public marker","sharedCrossSiteToken SiteTwoPublicBody must NOT be returned when searching from site one",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"SiteOneRestrictedReaders"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"siteone_member","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/CVE2026_56095SerializedValueDetector.php
+++ b/Tests/Integration/Security/Fixtures/CVE2026_56095SerializedValueDetector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\SerializedValueDetector;
+
+/**
+ * Stands in for a third-party extension registering itself in
+ * `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue']`.
+ *
+ * On 11.6.x this hook is the only way attacker-influenced cObj output reaches the decode step:
+ * `AbstractIndexer::isSerializedValue()` otherwise accepts only the three own multi-value cObjs,
+ * whose payload is EXT:solr's own array of strings. 12.1.x decodes unconditionally and needs no detector.
+ */
+final class CVE2026_56095SerializedValueDetector implements SerializedValueDetector
+{
+    /**
+     * Solr field the indexing configuration maps to the attacker-influenced record column.
+     */
+    public const FLAGGED_SOLR_FIELD = 'sortSubTitle_stringS';
+
+    public function isSerializedValue(array $indexingConfiguration, $solrFieldName): bool
+    {
+        return $solrFieldName === self::FLAGGED_SOLR_FIELD;
+    }
+}

--- a/Tests/Integration/Security/Fixtures/CVE2026_56095_deserialization.csv
+++ b/Tests/Integration/Security/Fixtures/CVE2026_56095_deserialization.csv
@@ -1,0 +1,6 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","description"
+,2,1,0,1,"/payload-host","PayloadHostPageSST235568","REPLACED-AT-RUNTIME-WITH-SERIALIZED-GADGET-BYTES"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","sorting"
+,201,2,0,"text","Plain header SST 235568","Plain bodytext of the payload host page",10

--- a/Tests/Integration/Security/Fixtures/Gadget/CVE2026_56095CanaryGadget.php
+++ b/Tests/Integration/Security/Fixtures/Gadget/CVE2026_56095CanaryGadget.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures\Gadget;
+
+/**
+ * Test-only canary for CVE-2026-56095: its magic methods write a marker file, proving the indexer ran unserialize() on attacker-controlled bytes.
+ * PUBLIC properties keep the payload byte-stable through the TEXT cObj stdWrap pipeline
+ * (private-property gadgets like GuzzleHttp\Cookie\FileCookieJar carry NUL bytes that stdWrap mangles).
+ */
+final class CVE2026_56095CanaryGadget
+{
+    public string $canaryPath = '';
+    public string $canaryMarker = '';
+
+    public function __wakeup(): void
+    {
+        // fires synchronously during unserialize(), before later indexer logic could mask the side effect
+        if ($this->canaryPath !== '') {
+            @file_put_contents(
+                $this->canaryPath . '.wakeup',
+                $this->canaryMarker
+            );
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($this->canaryPath !== '') {
+            @file_put_contents(
+                $this->canaryPath,
+                $this->canaryMarker
+            );
+        }
+    }
+}

--- a/Tests/Integration/Security/Fixtures/cve_2026_56092_rootline_poisoning.csv
+++ b/Tests/Integration/Security/Fixtures/cve_2026_56092_rootline_poisoning.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","extendToSubpages","module"
+,3,1,0,1,"/parent-restricted-area","ParentRestrictedAreaCVE202656092","1","1",""
+,5,3,0,1,"/parent-restricted-area/child","ChildPageInRestrictedAreaCVE202656092","0","0",""
+,4,1,0,254,"/fe-users-cve202656092","FE Users Folder CVE-2026-56092",,"0","fe_users"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,301,3,0,"text","Parent restricted CVE-2026-56092 header","ROOTLINE_POISON_PARENT_MARKER_PQR234 — parent page content",0,10
+,501,5,0,"text","Child restricted CVE-2026-56092 header","ROOTLINE_POISON_CHILD_MARKER_STU567 — only visible because parent page extendToSubpages=1 + fe_group=1",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"RestrictedReadersCVE202656092"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"member_cve202656092","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/detailaction_access_bypass.csv
+++ b/Tests/Integration/Security/Fixtures/detailaction_access_bypass.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/public-baseline","PublicBaselinePage",,""
+,3,1,0,1,"/classified-area","RestrictedSecretAreaLoggedInOnly","1",""
+,4,1,0,254,"/restricted-fe-users","FE Users Folder",,"fe_users"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,21,2,0,"text","Public baseline content","Open to anyone visiting the public baseline page",0,10
+,31,3,0,"text","Classified header for logged-in users","CLASSIFIED_BANK_DETAILS_MARKER_ABC123 content must never be visible to anonymous visitors",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"RestrictedReaders"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"restricted_member","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
+++ b/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/alpha","markeralpha235567",,""
+,3,1,0,1,"/beta","markerbeta235567",,""
+,4,1,0,1,"/gamma","markergamma235567",,""
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,201,2,0,"text","alpha header","body of the alpha test page; unique token bodyalpha235567",0,10
+,301,3,0,"text","beta header","body of the beta test page; unique token bodybeta235567",0,10
+,401,4,0,"text","gamma header","body of the gamma test page; unique token bodygamma235567",0,10

--- a/Tests/Integration/Security/InsecureDeserializationOfCObjOutputTest.php
+++ b/Tests/Integration/Security/InsecureDeserializationOfCObjOutputTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageFieldMappingIndexer;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Controller\AbstractFrontendControllerTest;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures\CVE2026_56095SerializedValueDetector;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures\Gadget\CVE2026_56095CanaryGadget;
+
+/**
+ * Regression guard for CVE-2026-56095 (SST #2026011610000017): the EXT:solr indexer must not run unserialize() on
+ * attacker-controlled bytes returned by a cObj.
+ * A record field is rendered through a TEXT cObj that carries serialized canary bytes;
+ * the canary's magic method writing a marker file is the proof the sink fired.
+ * The JSON fix makes json_decode() the only decode step, so no PHP object is ever reconstructed.
+ * Fails on vulnerable code, passes after the fix — no assertion inversion.
+ *
+ * 11.6 specifics: the sink sits behind `AbstractIndexer::isSerializedValue()`, which accepts only the three
+ * own multi-value cObjs — whose payload is EXT:solr's own array of strings — or a field flagged through the
+ * `detectSerializedValue` hook. That hook is therefore the reachable path here and the test registers a
+ * detector for it. 12.1.x decodes every cObj result unconditionally and needs no detector.
+ *
+ * @group frontend
+ * @group security
+ */
+class InsecureDeserializationOfCObjOutputTest extends AbstractFrontendControllerTest
+{
+    /**
+     * Marker path the canary writes to; randomized per test to avoid cross-run races.
+     */
+    private string $canaryPath = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->canaryPath = sys_get_temp_dir() . '/CVE-2026-56095-poc-marker-' . bin2hex(random_bytes(8));
+        @unlink($this->canaryPath);
+
+        // production wiring: PageIndexer::activate() registers this helper, which indexes
+        // plugin.tx_solr.index.queue.pages.fields; indexPages() skips the frontend-helper activation
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class] = PageFieldMappingIndexer::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][CVE2026_56095SerializedValueDetector::class] = CVE2026_56095SerializedValueDetector::class;
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->canaryPath);
+        @unlink($this->canaryPath . '.wakeup');
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['Indexer']['indexPageSubstitutePageDocument'][PageFieldMappingIndexer::class],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['detectSerializedValue'][CVE2026_56095SerializedValueDetector::class]
+        );
+        parent::tearDown();
+    }
+
+    /**
+     * Baseline: a benign field value must not create the canary marker — guards against false positives.
+     *
+     * @test
+     */
+    public function indexingAPageWithoutAnyDeserializationGadgetMustNotInvokeMagicMethods(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE2026_56095_deserialization.csv');
+
+        // baseline runs with a benign value, not the CSV placeholder bytes
+        $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->update(
+                'pages',
+                ['description' => 'plain benign baseline content for SST 235568'],
+                ['uid' => 2]
+            );
+
+        $this->configureIndexingPipelineForDescription();
+        $this->indexPages([2]);
+        $this->assertSolrContainsDocumentCount(1);
+
+        self::assertFileDoesNotExist(
+            $this->canaryPath,
+            'Baseline assumption broken: the canary file was created even without a gadget payload — the test infrastructure is not reliable.'
+        );
+        self::assertFileDoesNotExist(
+            $this->canaryPath . '.wakeup',
+            'Baseline assumption broken: the canary .wakeup file was created without a gadget payload.'
+        );
+    }
+
+    /**
+     * Primary guard: an attacker-controlled record field carrying serialized canary bytes is indexed via a TEXT cObj.
+     * On vulnerable code unserialize() runs and the canary's __wakeup writes the marker; the JSON fix prevents it.
+     *
+     * @test
+     */
+    public function unserializeOfCObjOutputMustNotInvokeMagicMethodsOnAttackerControlledObject(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE2026_56095_deserialization.csv');
+
+        $payload = $this->buildCanaryGadgetPayload();
+
+        $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->update(
+                'pages',
+                ['description' => $payload],
+                ['uid' => 2]
+            );
+
+        $this->configureIndexingPipelineForDescription();
+        $this->indexPages([2]);
+
+        // __wakeup fires synchronously during unserialize() inside the indexer run, so it is observable here;
+        // __destruct may run only at shutdown, after the assertion.
+        self::assertFileDoesNotExist(
+            $this->canaryPath . '.wakeup',
+            'SST 235568: EXT:solr indexer pipeline ran unserialize() on attacker-controlled bytes; '
+            . 'the canary class\'s __wakeup magic method executed and wrote ' . $this->canaryPath . '.wakeup.'
+        );
+    }
+
+    /**
+     * Builds the serialized canary payload, clearing the local instance's path first so its destructor writes nothing here.
+     */
+    private function buildCanaryGadgetPayload(): string
+    {
+        $gadget = new CVE2026_56095CanaryGadget();
+        $gadget->canaryPath = $this->canaryPath;
+        $gadget->canaryMarker = 'CVE_2026_56095_GADGET_FIRED_FROM_INDEXER';
+        $payload = serialize($gadget);
+
+        // clear the local instance's path so its destructor writes nothing; the serialized string keeps the real path
+        $gadget->canaryPath = '';
+        unset($gadget);
+        @unlink($this->canaryPath);
+
+        return $payload;
+    }
+
+    /**
+     * Maps the flagged Solr field to the `description` column via TEXT cObj, forcing the indexer's cObj decode path.
+     */
+    private function configureIndexingPipelineForDescription(): void
+    {
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            plugin.tx_solr.index.queue.pages.fields {
+                ' . CVE2026_56095SerializedValueDetector::FLAGGED_SOLR_FIELD . ' = TEXT
+                ' . CVE2026_56095SerializedValueDetector::FLAGGED_SOLR_FIELD . '.field = description
+            }
+            '
+        );
+    }
+}

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Controller\AbstractFrontendControllerTest;
+use ApacheSolrForTypo3\Solr\Tests\Integration\TSFETestBootstrapper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression guard for SST #2026050810000025:
+ * the highlighter must not surface `field:*` queries as a Solr HTTP 500 field-existence oracle.
+ *
+ * @group frontend
+ * @group security
+ */
+class QueryInjectionViaRawSolrSyntaxTest extends AbstractFrontendControllerTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.xml');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            '
+        );
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sst_2026050810000025_query_injection.csv');
+        $this->indexPages([2, 3, 4]);
+        $this->assertSolrContainsDocumentCount(3);
+    }
+
+    /**
+     * @test
+     */
+    public function literalTokenSearchReturnsExpectedDocument(): void
+    {
+        $response = $this->executeSearch('markeralpha235567');
+        self::assertStringContainsString(
+            'markeralpha235567',
+            $response,
+            'Sanity check failed: literal-token search for the alpha marker did not return the alpha document.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function existingFieldWildcardMustNotTriggerSolrCommunicationException(): void
+    {
+        GeneralUtility::makeInstance(TSFETestBootstrapper::class)->bootstrap(1);
+        $configuration = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => [
+                'query.' => ['queryFields' => 'content,title'],
+                'results.' => [
+                    'resultsHighlighting' => 1,
+                    'resultsHighlighting.' => [
+                        'fragmentSize' => 50,
+                        'wrap' => '<mark>|</mark>',
+                    ],
+                ],
+            ]]],
+        ]);
+        $query = (new QueryBuilder($configuration))->buildSearchQuery('siteHash:*');
+        try {
+            GeneralUtility::makeInstance(Search::class)->search($query);
+        } catch (SolrCommunicationException $e) {
+            self::fail('SST 235567: highlighter raised ' . get_class($e) . ' — ' . $e->getMessage());
+        }
+    }
+
+    protected function executeSearch(string $rawQuery): string
+    {
+        return (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/'))
+                ->withPageId(2022)
+                ->withQueryParameter('tx_solr[q]', $rawQuery)
+        )->getBody();
+    }
+}

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -74,6 +74,58 @@ class QueryInjectionViaRawSolrSyntaxTest extends AbstractFrontendControllerTest
     }
 
     /**
+     * Second control: a selector against a field that *is* in `qf` must keep working.
+     * The literal-token control above never parses a `field:value` selector, so it cannot
+     * tell "selector neutralised into a literal term" apart from "selectors stopped working" —
+     * i.e. a `uf` whitelist set too narrowly. Green before and after the fix.
+     *
+     * @test
+     */
+    public function fieldSelectorOnWhitelistedFieldStillReturnsExpectedDocument(): void
+    {
+        $response = $this->executeSearch('title:markeralpha235567');
+        self::assertStringContainsString(
+            'markeralpha235567',
+            $response,
+            'Selector on the whitelisted field "title" no longer returns the alpha document — the uf whitelist is too narrow.'
+        );
+    }
+
+    /**
+     * PDF §3.1 — `siteHash:*` must not enumerate documents via field selector.
+     *
+     * @test
+     */
+    public function wildcardFieldEnumerationOperatorMustNotEnumerateIndexedDocuments(): void
+    {
+        $response = $this->executeSearch('siteHash:*');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567 / PDF §3.1: siteHash:* field enumeration leaked ' . $marker
+            );
+        }
+    }
+
+    /**
+     * Combined field-selector + range against the hex-hash siteHash field must not match the test corpus.
+     *
+     * @test
+     */
+    public function fieldSelectorOperatorMustNotTargetArbitraryIndexedField(): void
+    {
+        $response = $this->executeSearch('siteHash:[0 TO 9]');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567: field-selector range query against siteHash leaked ' . $marker
+            );
+        }
+    }
+
+    /**
      * @test
      */
     public function existingFieldWildcardMustNotTriggerSolrCommunicationException(): void

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -109,6 +109,53 @@ class QueryInjectionViaRawSolrSyntaxTest extends AbstractFrontendControllerTest
     }
 
     /**
+     * PDF §3.2 — prefix wildcard must not enable per-character value extraction.
+     *
+     * @test
+     */
+    public function prefixWildcardOperatorMustNotEnableBlindValueExtraction(): void
+    {
+        $response = $this->executeSearch('title:markeralpha*');
+        self::assertStringNotContainsString(
+            'markeralpha235567',
+            $response,
+            'SST 235567 / PDF §3.2: prefix-wildcard (title:markeralpha*) leaked the alpha document.'
+        );
+    }
+
+    /**
+     * PDF §3.3 — `?` wildcard must not enable length detection on indexed values.
+     *
+     * @test
+     */
+    public function singleCharWildcardOperatorMustNotEnableLengthDetection(): void
+    {
+        $response = $this->executeSearch('title:markeralpha?35567');
+        self::assertStringNotContainsString(
+            'markeralpha235567',
+            $response,
+            'SST 235567 / PDF §3.3: single-character wildcard (?) leaked the alpha document.'
+        );
+    }
+
+    /**
+     * PDF §3.4 — range query must not enable binary-search value extraction.
+     *
+     * @test
+     */
+    public function rangeQueryOperatorMustNotEnableBinarySearchExtraction(): void
+    {
+        $response = $this->executeSearch('title:[m TO n]');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567 / PDF §3.4: range query (title:[m TO n]) leaked ' . $marker
+            );
+        }
+    }
+
+    /**
      * Combined field-selector + range against the hex-hash siteHash field must not match the test corpus.
      *
      * @test

--- a/Tests/Integration/Security/RootlineCachePoisoningTest.php
+++ b/Tests/Integration/Security/RootlineCachePoisoningTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Access\Rootline;
+use ApacheSolrForTypo3\Solr\Domain\Index\Queue\QueueInitializationService;
+use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
+use ApacheSolrForTypo3\Solr\IndexQueue\Queue;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Regression guard for CVE-2026-56092: indexer sub-requests must not leave forged
+ * `fe_group=''`/`extendToSubpages='0'` values in the rootline cache, where later anonymous
+ * requests would read them and grant access.
+ *
+ * TYPO3 11 does persist the forgery: `RootlineUtility::getRecordArray()` stores what
+ * `PageRepository::getPageOverlay()` returns, and `getPagesOverlay()` iterates its input by
+ * reference, so the `getPageOverlay` hook this branch registered ended up in `cache_rootline`.
+ * `rootlineCacheMustNotContainListenerMutatedRecordAfterPageIndexing` reproduces exactly that
+ * and fails before the removal.
+ *
+ * The two disclosure cases pass before and after on this branch, and guard against
+ * reintroduction rather than reproducing a bypass that existed here. Measured reason: TYPO3 11
+ * overlays only when a translated view is requested (`RootlineUtility::getRecordArray()` skips it
+ * for the original record), so the forgery lands on the cache entry of the translated view, while
+ * a visitor of an untranslated page is served — and cached — from the original record. Where a
+ * translation does exist, the overlay merge replaces the forged fields with the translated page's
+ * own values. A hand-poisoned entry for the original record *is* honoured by the frontend access
+ * check, so the mechanism is not harmless; the indexer simply never wrote the entry a visitor reads.
+ *
+ * @group security
+ */
+class RootlineCachePoisoningTest extends IntegrationTest
+{
+    protected $configurationToUseInTestInstance = [
+        'SYS' => [
+            'exceptionalErrors' => E_WARNING | E_RECOVERABLE_ERROR | E_DEPRECATED | E_USER_DEPRECATED,
+            // FunctionalTestCase defaults this to NullBackend, which would mask the pollution.
+            'caching' => [
+                'cacheConfigurations' => [
+                    'rootline' => [
+                        'backend' => Typo3DatabaseBackend::class,
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/cve_2026_56092_rootline_poisoning.csv');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            '
+        );
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('rootline')->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    /**
+     * Page 5 is restricted only through its parent's `extendToSubpages`.
+     *
+     * @test
+     */
+    public function anonymousVisitorMustNotReachAccessRestrictedPageAfterPageIndexing(): void
+    {
+        $this->indexPagesAsProductionIndexerDoes([5], 1);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/de/parent-restricted-area/child'))->withPageId(5)
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'ROOTLINE_POISON_CHILD_MARKER_STU567',
+            $response,
+            'Anonymous visitor reached the restricted page after indexing.'
+        );
+    }
+
+    /**
+     * Primary guard: cached rootline records must still carry the values from the database.
+     *
+     * @test
+     */
+    public function rootlineCacheMustNotContainListenerMutatedRecordAfterPageIndexing(): void
+    {
+        $this->indexPagesAsProductionIndexerDoes([5], 1);
+
+        $rows = $this->getConnectionPool()
+            ->getConnectionForTable('cache_rootline')
+            ->select(['identifier', 'content'], 'cache_rootline')
+            ->fetchAllAssociative();
+
+        self::assertNotEmpty(
+            $rows,
+            'cache_rootline is empty after indexing — backend override likely did not take effect.'
+        );
+
+        // Serialized PHP; concatenated so one assertion covers every entry.
+        $aggregated = '';
+        foreach ($rows as $row) {
+            $aggregated .= (string)$row['content'];
+        }
+
+        self::assertStringNotContainsString(
+            's:8:"fe_group";s:0:"";',
+            $aggregated,
+            'Rootline cache persisted the listener-forced empty fe_group.'
+        );
+        self::assertStringNotContainsString(
+            's:16:"extendToSubpages";s:1:"0";',
+            $aggregated,
+            'Rootline cache persisted the listener-forced extendToSubpages="0".'
+        );
+    }
+
+    /**
+     * Indexing restricted pages is a supported feature and must survive the removal.
+     *
+     * @test
+     */
+    public function pageRestrictedOnlyViaInheritedExtendToSubpagesIsStillIndexed(): void
+    {
+        $this->indexPagesAsProductionIndexerDoes([5], 1);
+
+        $solrContent = (string)file_get_contents(
+            $this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*'
+        );
+        self::assertStringContainsString(
+            'ROOTLINE_POISON_CHILD_MARKER_STU567',
+            $solrContent,
+            'Indexer must still retrieve the content of a page restricted only via inherited extendToSubpages.'
+        );
+    }
+
+    /**
+     * A cache warmed by a legitimate request must stay clean once indexing runs.
+     *
+     * @test
+     */
+    public function cacheWarmupByAuthenticatedRequestBeforeIndexingPreservesAccessRestriction(): void
+    {
+        // User 1 is a member of fe_group 1.
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+        $this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/de/parent-restricted-area/child'))->withPageId(5),
+            $context
+        );
+
+        $this->indexPagesAsProductionIndexerDoes([5], 1);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/de/parent-restricted-area/child'))->withPageId(5)
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'ROOTLINE_POISON_CHILD_MARKER_STU567',
+            $response,
+            'Anonymous visitor reached the restricted page despite a pre-warmed, clean cache.'
+        );
+    }
+
+    /**
+     * Mirrors PageIndexer::index(): two separate sub-requests, findUserGroups first. Only that
+     * phase activates UserGroupDetector, and activating it from the test process instead would
+     * hit another container instance than the hook resolves, leaving the assertions vacuous.
+     *
+     * @param int[] $pageIds
+     */
+    protected function indexPagesAsProductionIndexerDoes(array $pageIds, ?int $frontendUserId = null): void
+    {
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        foreach ($pageIds as $pageId) {
+            $site = $siteFinder->getSiteByPageId($pageId);
+            $queueItem = $this->addPageToIndexQueue($pageId);
+            // Index a translated view, not the original: TYPO3 11 only runs the page overlay — and
+            // therefore the forging hook — for a translated request, so indexing the original record
+            // would leave the hook cold and the primary guard would pass without proving anything.
+            $frontendUrl = (string)$site->getRouter()->generateUri($pageId, ['_language' => 1]);
+            // PageIndexer::getAccessRootline() memoises this per item/language in a static cache, so
+            // production computes it once from clean state. Recomputing it per phase would read the
+            // rootline the findUserGroups phase just poisoned and yield no access groups at all.
+            $accessRootline = (string)Rootline::getAccessRootlineByPageId($queueItem->getRecordUid());
+            $this->executeIndexerSubRequest($frontendUrl, $queueItem, $accessRootline, $frontendUserId, ['findUserGroups'], true);
+            $this->executeIndexerSubRequest($frontendUrl, $queueItem, $accessRootline, $frontendUserId, ['indexPage']);
+        }
+        $this->waitToBeVisibleInSolr('core_de');
+    }
+
+    /**
+     * 11.6 has no shared enqueue helper, so the queue is filled through the production
+     * "Initialize index queue" path — the one the incident report's recipe uses.
+     *
+     * `Queue::updateItem()` cannot be used here: it goes through `addNewItem()`, whose
+     * `isAllowedPageType()` check needs a TSFE, and `Tsfe::getTsfeByPageIdAndLanguageId()`
+     * grants itself access from the page's *own* `fe_group` only. Page 5 is restricted purely
+     * through its parent's `extendToSubpages`, so TSFE building fails, the exception is
+     * swallowed and the item is silently skipped.
+     */
+    protected function addPageToIndexQueue(int $pageId): Item
+    {
+        /** @var Queue $indexQueue */
+        $indexQueue = GeneralUtility::makeInstance(Queue::class);
+        $indexQueue->setQueueInitializationService(GeneralUtility::makeInstance(QueueInitializationService::class));
+        $indexQueue->getQueueInitializationService()->initializeBySiteAndIndexConfiguration(
+            GeneralUtility::makeInstance(SiteRepository::class)->getSiteByPageId($pageId),
+            'pages'
+        );
+        $items = $indexQueue->getItems('pages', $pageId);
+
+        self::assertNotEmpty($items, 'Page ' . $pageId . ' could not be added to the index queue.');
+
+        return $items[0];
+    }
+
+    /**
+     * Request shape of PageIndexerTest::executePageIndexer(), plus control over the rootline
+     * cache the rendering sub-request sees.
+     *
+     * Flush on the findUserGroups phase only: computing the access rootline warms the cache
+     * here, so without it the sub-request reads a clean entry and the poisoning stays hidden.
+     * Flushing on indexPage as well would let that phase rebuild cleanly and overwrite the
+     * poisoned entry.
+     *
+     * @param string[] $actions
+     */
+    private function executeIndexerSubRequest(
+        string $url,
+        Item $item,
+        string $accessRootline,
+        ?int $frontendUserId,
+        array $actions,
+        bool $flushRootlineCacheBeforeRendering = false
+    ): void {
+        $request = new InternalRequest($url);
+
+        /** @var PageIndexerRequest $indexerRequest */
+        $indexerRequest = GeneralUtility::makeInstance(PageIndexerRequest::class);
+        $indexerRequest->setIndexQueueItem($item);
+        $indexerRequest->setParameter('accessRootline', $accessRootline);
+        $indexerRequest->setParameter('item', $item->getIndexQueueUid());
+        foreach ($actions as $action) {
+            $indexerRequest->addAction($action);
+        }
+        foreach ($indexerRequest->getHeaders() as $header) {
+            [$headerName, $headerValue] = GeneralUtility::trimExplode(':', $header, true, 2);
+            $request = $request->withAddedHeader($headerName, $headerValue);
+        }
+
+        if ($flushRootlineCacheBeforeRendering) {
+            GeneralUtility::makeInstance(CacheManager::class)->getCache('rootline')->flush();
+        }
+
+        $requestContext = $frontendUserId !== null
+            ? (new InternalRequestContext())->withFrontendUserId($frontendUserId)
+            : null;
+        $this->executeFrontendSubRequest($request, $requestContext)->getBody()->rewind();
+    }
+}

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -56,7 +56,7 @@ class ClassificationTest extends UnitTest
         ];
 
         $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize(['cms']);
+        $expected = json_encode(['cms']);
         self::assertEquals($expected, $actual);
     }
 
@@ -98,7 +98,7 @@ class ClassificationTest extends UnitTest
         ];
 
         $actual = $this->contentObject->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize($expectedOutput);
+        $expected = json_encode($expectedOutput);
         self::assertEquals($expected, $actual);
     }
 

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -35,12 +35,24 @@ class MultivalueTest extends UnitTest
     /**
      * @test
      */
-    public function convertsCommaSeparatedListFromRecordToSerializedArrayOfTrimmedValues()
+    public function convertsCommaSeparatedListFromRecordToJsonEncodedArrayOfTrimmedValues()
     {
         $GLOBALS['TSFE']->cObjectDepthCounter = 2;
 
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
+        $expected = json_encode(
+            [
+                'abc',
+                'def',
+                'ghi',
+                'jkl',
+                'mno',
+                'pqr',
+                'stu',
+                'vwx',
+                'yz',
+            ]
+        );
 
         $this->contentObject->start(['list' => $list]);
 
@@ -58,10 +70,22 @@ class MultivalueTest extends UnitTest
     /**
      * @test
      */
-    public function convertsCommaSeparatedListFromValueToSerializedArrayOfTrimmedValues()
+    public function convertsCommaSeparatedListFromValueToJsonEncodedArrayOfTrimmedValues()
     {
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
+        $expected = json_encode(
+            [
+                'abc',
+                'def',
+                'ghi',
+                'jkl',
+                'mno',
+                'pqr',
+                'stu',
+                'vwx',
+                'yz',
+            ]
+        );
 
         $this->contentObject->start([]);
 

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -42,6 +42,8 @@ class EscapeHelperTest extends UnitTest
             '&& character is kept' => ['input' => 'hello && world', 'expectedOutput' => 'hello && world'],
             '! character is kept' => ['input' => 'hello !world', 'expectedOutput' => 'hello !world'],
             '* character is kept' => ['input' => 'hello *world', 'expectedOutput' => 'hello *world'],
+            'lone asterisk match-all stays literal' => ['input' => '*', 'expectedOutput' => '*'],
+            '*:* match-all gets colon escaped' => ['input' => '*:*', 'expectedOutput' => '*\:*'],
             '? character is kept' => ['input' => 'hello ?world', 'expectedOutput' => 'hello ?world'],
             'ö character is kept' => ['input' => 'schöner tag', 'expectedOutput' => 'schöner tag'],
             'numeric is kept' => ['input' => 42, 'expectedOutput' => 42],
@@ -55,10 +57,68 @@ class EscapeHelperTest extends UnitTest
      * @dataProvider escapeQueryDataProvider
      * @test
      */
-    public function canEscapeAsExpected($input, $expectedOutput)
+    public function escapesOnlySelectorAndRangeCharactersWhenOperatorSyntaxIsAllowed($input, $expectedOutput)
     {
-        $escapeHelper = new EscapeService();
-        $output = $escapeHelper::escape($input);
-        self::assertSame($expectedOutput, $output, 'Query was not escaped as expected');
+        self::assertSame(
+            $expectedOutput,
+            EscapeService::escape($input, true),
+            'Legacy-mode escape (allowOperatorSyntax=true) did not produce expected output'
+        );
+    }
+
+    /**
+     * @dataProvider escapeQueryDataProvider
+     * @test
+     */
+    public function escapeDefaultMirrorsAllowedOperatorSyntaxMode($input, $expectedOutput)
+    {
+        self::assertSame(
+            $expectedOutput,
+            EscapeService::escape($input),
+            'Default escape() call must behave as legacy mode (allowOperatorSyntax=true)'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function escapeQueryWithoutOperatorSyntaxDataProvider()
+    {
+        return [
+            'empty stays empty' => ['input' => '', 'expectedOutput' => ''],
+            'plain word stays plain' => ['input' => 'foo', 'expectedOutput' => 'foo'],
+            'numeric is kept' => ['input' => 42, 'expectedOutput' => 42],
+            'whitespace is preserved literally' => ['input' => 'foo bar baz', 'expectedOutput' => 'foo bar baz'],
+            'umlaut is preserved' => ['input' => 'schöner tag', 'expectedOutput' => 'schöner tag'],
+            'plus operator passes through (required term)' => ['input' => '+foo', 'expectedOutput' => '+foo'],
+            'minus operator passes through (prohibited term)' => ['input' => '-foo', 'expectedOutput' => '-foo'],
+            'bang operator passes through (NOT)' => ['input' => '!foo', 'expectedOutput' => '!foo'],
+            'asterisk wildcard passes through (prefix search)' => ['input' => 'foo*', 'expectedOutput' => 'foo*'],
+            'lone asterisk match-all stays literal' => ['input' => '*', 'expectedOutput' => '*'],
+            '*:* match-all has only colon escaped' => ['input' => '*:*', 'expectedOutput' => '*\:*'],
+            'question mark wildcard passes through (single-char)' => ['input' => 'foo?', 'expectedOutput' => 'foo?'],
+            'double ampersand is escaped char by char' => ['input' => 'a && b', 'expectedOutput' => 'a \&\& b'],
+            'double pipe is escaped char by char' => ['input' => 'a || b', 'expectedOutput' => 'a \|\| b'],
+            'single ampersand is escaped' => ['input' => 'a&b', 'expectedOutput' => 'a\&b'],
+            'single pipe is escaped' => ['input' => 'a|b', 'expectedOutput' => 'a\|b'],
+            'semicolon is escaped' => ['input' => 'a;b', 'expectedOutput' => 'a\;b'],
+            'field selector wildcard has only colon escaped' => ['input' => 'siteHash:*', 'expectedOutput' => 'siteHash\:*'],
+            'range query is fully escaped' => ['input' => 'title:[a TO z]', 'expectedOutput' => 'title\:\[a TO z\]'],
+            'rounded brackets are escaped' => ['input' => 'hello (world)', 'expectedOutput' => 'hello \(world\)'],
+            'tilde is escaped' => ['input' => 'foo~2', 'expectedOutput' => 'foo\~2'],
+            'backslash is escaped' => ['input' => 'a\b', 'expectedOutput' => 'a\\\\b'],
+            'slash is escaped' => ['input' => 'a/b', 'expectedOutput' => 'a\/b'],
+            'quoted phrase keeps inner operator literal' => ['input' => '"foo *bar"', 'expectedOutput' => '"foo *bar"'],
+        ];
+    }
+
+    /**
+     * @dataProvider escapeQueryWithoutOperatorSyntaxDataProvider
+     * @test
+     */
+    public function escapesEveryLuceneSpecialCharacterWhenOperatorSyntaxIsDisallowed($input, $expectedOutput)
+    {
+        $output = EscapeService::escape($input, false);
+        self::assertSame($expectedOutput, $output, 'Strict-mode escape did not produce expected output');
     }
 }

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -360,75 +360,42 @@ class QueryBuilderTest extends UnitTest
         $highlighting->setIsEnabled(true);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        self::assertSame('[A]', $queryParameters['hl.tag.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.tag.post'], 'Can set highlighting hl.tag.post');
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
+        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.simple.pre');
+        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.simple.post');
     }
 
     /**
      * @test
      */
-    public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed()
+    public function unifiedHighlighterIsUsedWhenHighlightingIsEnabled(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting.']['wrap'] = '[A]|[B]';
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
-        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
-
-        $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
-        $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
-        $highlighting->setFragmentSize(17);
-        $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
-        $queryParameters = $this->getAllQueryParameters($query);
-
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting field list');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting field list');
-        self::assertEmpty($queryParameters['hl.tag.pre'], 'When the highlighting fragment size is to small hl.tag.pre should not be used because FastVectoreHighlighter will not be used');
-        self::assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
-    }
-
-    /**
-     * @test
-     */
-    public function canUseFastVectorHighlighting()
-    {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(200);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Enable highlighting did not set the "hl.method" query parameter to "unified"');
     }
 
     /**
      * @test
      */
-    public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18()
+    public function unifiedHighlighterIsUsedEvenForSmallFragmentSize(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(0);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('false', $queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Highlighting did not stay on the Unified highlighter for small fragmentSize');
     }
 
     /**

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -139,6 +139,38 @@ class QueryBuilderTest extends UnitTest
     /**
      * @test
      */
+    public function buildSearchQueryDerivesUserFieldsFromQueryFieldsByDefault(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('title content', $this->getAllQueryParameters($query)['uf'], 'The userFields default did not derive the qf field names without boosts');
+    }
+
+    /**
+     * @test
+     */
+    public function buildSearchQueryRespectsScalarUserFieldsOverride(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryUserFields')->willReturn('description teaser');
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('description teaser', $this->getAllQueryParameters($query)['uf'], 'The userFields scalar override was not applied as the full whitelist');
+    }
+
+    /**
+     * @test
+     */
+    public function buildSearchQueryAppliesAddAndRemoveSubKeysToQueryFieldDerivedUserFields(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryUserFieldsConfiguration')->willReturn(['add' => 'description', 'remove' => 'title']);
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('content description', $this->getAllQueryParameters($query)['uf'], 'The userFields add/remove deltas were not applied on top of the qf-derived base list');
+    }
+
+    /**
+     * @test
+     */
     public function buildSearchQueryInitializesTrigramPhraseFields()
     {
         $this->configurationMock->expects(self::once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-simplexml": "*",
-    "solarium/solarium": "6.2.3",
+    "solarium/solarium": "6.2.4",
     "typo3/cms-backend": "*",
     "typo3/cms-core": "^11.5.14",
     "typo3/cms-extbase": "*",


### PR DESCRIPTION
This is the first 11.6.x release published in this public repository. 11.6.0 through 11.6.5 were ELTS-only and are affected by the CVEs below; those releases will **not** be re-published with a fix, so there is no patched 11.6.5-or-earlier to move to — upgrade straight to 11.6.6.

Fixes five vulnerabilities:

* **CVE-2026-56092** — Page indexer no longer forges access fields on page records (not reproducible as an anonymous-access bypass on this branch — see note below; fixed regardless)
* **CVE-2026-56093** — Detail view enforces site and access restrictions
* **CVE-2026-56094** — `additionalFilters` can no longer preempt the `siteHash` filter
* **CVE-2026-56095** — Multi-value cObjs switch to JSON transport (closes a PHP object-injection sink)
* **CVE-2026-56096** — User-controlled Solr query syntax is escaped/whitelisted; closes an FVH `FieldExistsQuery` HTTP 500 oracle

### CVE-2026-56092 — rootline cache poisoning (not reproducible as a bypass on 11.6, fixed regardless)

During a page-indexer sub-request, EXT:solr forced `fe_group` and `extendToSubpages` to public values on every `pages` record it touched, and those forged values were written into the shared rootline cache. On TYPO3 11, no anonymous-access bypass could be reproduced: the override only applies while a translated view is being resolved, whereas a visitor of an untranslated page is served — and cached — from the original record, and where a translation exists the language overlay replaces the forged fields with the translated page's own values. The corrupted cache entries are wrong regardless, and a manually corrupted entry *is* honoured by the frontend access check, so this is fixed rather than tolerated.

The indexer no longer forges these fields. **Flush the rootline cache after updating** — entries written by earlier 11.6.x releases keep the forged values until rebuilt.

### CVE-2026-56093 — detail view access bypass

The `detail` action of the `pi_results` plugin looked up a document by its `documentId` without applying the current site's `siteHash` filter or the frontend user-group access filter. An anonymous visitor who knew or guessed a valid `documentId` could retrieve access-restricted documents through the detail view — a path less restricted than regular search.

The direct lookup now applies the same `siteHash` and frontend user-group filters as the normal search path. A `documentId` that resolves to no accessible document yields the site's configured 404 page, uniformly, so it can't be used to probe existence.

### CVE-2026-56094 — additionalFilters siteHash bypass

Request-provided `tx_solr[additionalFilters]` could register a named `siteHash` filter that the query builder refused to overwrite, so the system `siteHash` filter added later was dropped. In a shared-Solr-core multi-site installation this let an anonymous visitor of one site read public documents of another site sharing the same core.

EXT:solr now strips the reserved filter names `siteHash` and `access` from request-provided `additionalFilters` before they reach the query, and applies the system `siteHash` filter with remove-then-set semantics.

### CVE-2026-56095 — object-injection via serialize()

The `SOLR_MULTIVALUE`, `SOLR_RELATION` and `SOLR_CLASSIFICATION` content objects returned their multi-value payload as `serialize($array)`, and the indexer decoded it with `unserialize()` — a PHP object-injection sink for anyone who could influence an indexed record field. Both sides now use `json_encode()`/`json_decode()`, which never reconstructs PHP objects.

**Breaking:** third-party content objects returning `serialize($array)` for a multi-value Solr field must switch to `json_encode($array)`.

### CVE-2026-56096 — query-syntax injection / FVH oracle

User input on `tx_solr[q]` reached Solr's query parser and the Fast Vector Highlighter without sufficient escaping, allowing field-selector/operator injection and an HTTP 500 oracle via `FieldExistsQuery` against the legacy highlighter. Query syntax is now escaped/whitelisted by default (new `plugin.tx_solr.search.query.userFields` / `allowSolrOperatorSyntax` TypoScript settings govern the exact behaviour), and the Unified Highlighter is enforced unconditionally in PHP.

**Operational recommendation:** existing Solr volumes should be migrated to the updated `ext_solr_11_6_0_elts` configset (bundled idempotent migration script under `Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/`) as defence-in-depth for clients that query Solr directly.

### Also in this release

* `solarium/solarium` raised from 6.2.3 to 6.2.4 — required in PHP to actually enforce the Unified Highlighter: 6.2.3 ships no `HighlightingInterface`, no `setOffsetSource()`, no `setFragsizeIsMinimum()`, and its request builder emits `h1.method` (typo) instead of `hl.method`, so the Unified Highlighter never actually reached Solr. Composer resolves this automatically; installations pinning `solarium/solarium` themselves must allow 6.2.4.
* Minor CI/docs maintenance commits (GitHub Actions warnings, docs metadata).

---

Full write-up for all five is already on this branch in `Documentation/Releases/solr-release-11-6.rst`.
