### PR TITLE
[SECURITY] 13.1.4 — Fix CVE-2026-56092, CVE-2026-56093, CVE-2026-56094, CVE-2026-56095, CVE-2026-56096

### DIFF
--- a/Classes/ContentObject/Classification.php
+++ b/Classes/ContentObject/Classification.php
@@ -21,6 +21,8 @@ use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
 
+use function json_encode;
+
 /**
  * A content object (cObj) to classify content based on a configuration.
  *
@@ -73,7 +75,13 @@ class Classification extends AbstractContentObject
         /** @var ClassificationService $classificationService */
         $classificationService = GeneralUtility::makeInstance(ClassificationService::class);
 
-        return serialize($classificationService->getMatchingClassNames((string)$data, $classifications));
+        return json_encode(
+            $classificationService->getMatchingClassNames(
+                (string)$data,
+                $classifications,
+            ),
+            JSON_THROW_ON_ERROR,
+        );
     }
 
     /**

--- a/Classes/ContentObject/Multivalue.php
+++ b/Classes/ContentObject/Multivalue.php
@@ -18,6 +18,8 @@ namespace ApacheSolrForTypo3\Solr\ContentObject;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
 
+use function json_encode;
+
 /**
  * A content object (cObj) to turn comma separated strings into an array to be
  * used in a multi value field in a Solr document.
@@ -41,7 +43,7 @@ class Multivalue extends AbstractContentObject
      *
      * Turns a list of values into an array that can then be used to fill
      * multivalued fields in a Solr document. The array is returned in
-     * serialized form as content objects are expected to return strings.
+     * JSON-encoded form as content objects are expected to return strings.
      *
      * @noinspection PhpMissingReturnTypeInspection, because foreign source inheritance See {@link AbstractContentObject::render()}
      */
@@ -76,6 +78,9 @@ class Multivalue extends AbstractContentObject
             $listAsArray = array_unique($listAsArray);
         }
 
-        return serialize($listAsArray);
+        return json_encode(
+            $listAsArray,
+            JSON_THROW_ON_ERROR,
+        );
     }
 }

--- a/Classes/ContentObject/Relation.php
+++ b/Classes/ContentObject/Relation.php
@@ -30,6 +30,8 @@ use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\Exception\ContentRenderingException;
 
+use function json_encode;
+
 /**
  * A content object (cObj) to resolve relations between database records
  *
@@ -91,8 +93,11 @@ class Relation extends AbstractContentObject
             $singleValueGlue = !empty($conf['singleValueGlue']) ? trim($conf['singleValueGlue'], '|') : ', ';
             $result = implode($singleValueGlue, $relatedItems);
         } else {
-            // multi value, need to serialize as content objects must return strings
-            $result = serialize($relatedItems);
+            // multi value, need to JSON-encode as content objects must return strings
+            $result = json_encode(
+                $relatedItems,
+                JSON_THROW_ON_ERROR,
+            );
         }
 
         return $result;

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -25,10 +25,14 @@ use ApacheSolrForTypo3\Solr\Pagination\ResultsPagination;
 use ApacheSolrForTypo3\Solr\Pagination\ResultsPaginator;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrUnavailableException;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
+use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\View\FluidViewAdapter;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
 use TYPO3Fluid\Fluid\View\AbstractTemplateView;
+use UnexpectedValueException;
 
 /**
  * Class SearchController
@@ -223,6 +227,9 @@ class SearchController extends AbstractBaseController
      * This action allows to render a detailView with data from solr.
      *
      * @noinspection PhpUnused Is used by plugin.
+     *
+     * @throws PropagateResponseException
+     * @throws PageNotFoundException
      */
     public function detailAction(string $documentId = ''): ResponseInterface
     {
@@ -239,6 +246,13 @@ class SearchController extends AbstractBaseController
             $this->view->assignMultiple($values);
         } catch (SolrUnavailableException) {
             return $this->handleSolrUnavailable();
+        } catch (UnexpectedValueException) {
+            $response = GeneralUtility::makeInstance(ErrorController::class)
+                ->pageNotFoundAction(
+                    $this->request,
+                    'The requested document was not found.',
+                );
+            throw new PropagateResponseException($response, 1750684800);
         }
         return $this->htmlResponse();
     }

--- a/Classes/Domain/Search/Query/AbstractQueryBuilder.php
+++ b/Classes/Domain/Search/Query/AbstractQueryBuilder.php
@@ -439,6 +439,8 @@ abstract class AbstractQueryBuilder
 
     abstract public function useQueryFieldsFromTypoScript(): self;
 
+    abstract public function useUserFieldsFromTypoScript(): self;
+
     abstract public function useFiltersFromTypoScript(): self;
 
     abstract public function useHighlightingFromTypoScript(): self;

--- a/Classes/Domain/Search/Query/Helper/EscapeService.php
+++ b/Classes/Domain/Search/Query/Helper/EscapeService.php
@@ -25,10 +25,13 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper;
 class EscapeService
 {
     /**
-     * Quotes and escapes given string
+     * Escapes Lucene syntax in $string. $allowOperatorSyntax=false also
+     * escapes the SolrJ-special chars `| & ;`.
      */
-    public static function escape(float|int|string $string): float|int|string
-    {
+    public static function escape(
+        float|int|string $string,
+        bool $allowOperatorSyntax = true,
+    ): float|int|string {
         // when we have a numeric string only, nothing needs to be done
         if (is_numeric($string)) {
             return $string;
@@ -36,16 +39,16 @@ class EscapeService
 
         // when no whitespaces are in the query we can also just escape the special characters
         if (preg_match('/\W/', $string) != 1) {
-            return static::escapeSpecialCharacters($string);
+            return static::escapeSpecialCharacters($string, $allowOperatorSyntax);
         }
 
         // when there are no quotes inside the query string we can also just escape the whole string
         $hasQuotes = strrpos($string, '"') !== false;
         if (!$hasQuotes) {
-            return static::escapeSpecialCharacters($string);
+            return static::escapeSpecialCharacters($string, $allowOperatorSyntax);
         }
 
-        return static::tokenizeByQuotesAndEscapeDependingOnContext($string);
+        return static::tokenizeByQuotesAndEscapeDependingOnContext($string, $allowOperatorSyntax);
     }
 
     /**
@@ -61,8 +64,10 @@ class EscapeService
      * This method is used to escape the content in the query string surrounded by quotes
      * different, then when it is not in a quoted context.
      */
-    protected static function tokenizeByQuotesAndEscapeDependingOnContext(string $string): string
-    {
+    protected static function tokenizeByQuotesAndEscapeDependingOnContext(
+        string $string,
+        bool $allowOperatorSyntax = true,
+    ): string {
         $result = '';
         $quotesCount = substr_count($string, '"');
         $isEvenAmountOfQuotes = $quotesCount % 2 === 0;
@@ -82,7 +87,7 @@ class EscapeService
             if ($isInQuote && !$isLastQuote) {
                 $result .= static::escapePhrase($segment);
             } else {
-                $result .= static::escapeSpecialCharacters($segment);
+                $result .= static::escapeSpecialCharacters($segment, $allowOperatorSyntax);
             }
 
             $segmentsIndex++;
@@ -104,20 +109,31 @@ class EscapeService
     }
 
     /**
-     * Escapes characters with special meanings in Lucene query syntax.
-     *
-     * @param string $value Unescaped - "dirty" - string
-     * @return string Escaped - "clean" - string
+     * Escapes Lucene special chars. Legacy mode keeps `+ - && || ! * ?`;
+     * strict mode additionally escapes `| & ;`. `+ - ! * ?` and whitespace
+     * stay literal in both modes.
      */
-    protected static function escapeSpecialCharacters(string $value): string
+    protected static function escapeSpecialCharacters(string $value, bool $allowOperatorSyntax = true): string
     {
-        // list taken from http://lucene.apache.org/core/4_4_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description
-        // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
-        // of which we escape: ( ) { } [ ] ^ " ~ : \ /
-        // and explicitly don't escape: + - && || ! * ?
-        $pattern = '/(\\(|\\)|\\{|\\}|\\[|\\]|\\^|"|~|\:|\\\\|\\/)/';
-        $replace = '\\\$1';
+        if ($allowOperatorSyntax) {
+            // list taken from https://lucene.apache.org/core/9_10_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
+            // which mentions: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+            // of which we escape: ( ) { } [ ] ^ " ~ : \ /
+            // and explicitly don't escape: + - && || ! * ?
+            $pattern = '/(\\(|\\)|\\{|\\}|\\[|\\]|\\^|"|~|\:|\\\\|\\/)/';
+            return preg_replace($pattern, '\\\$1', $value);
+        }
 
-        return preg_replace($pattern, $replace, $value);
+        $escapeChars = '\\():^[]"{}~|&;/';
+        $result = '';
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+            if (str_contains($escapeChars, $char)) {
+                $result .= '\\';
+            }
+            $result .= $char;
+        }
+        return $result;
     }
 }

--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\AbstractQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use Solarium\Component\Highlighting\HighlightingInterface as SolariumHighlightingInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -92,8 +93,17 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
         $this->postfix = $postfix;
     }
 
+    /**
+     * @deprecated Highlighting::getUseFastVectorHighlighter() is deprecated and will be removed in v14.
+     *             The Unified Highlighter is now used unconditionally; the return value has no effect on the built query.
+     */
     public function getUseFastVectorHighlighter(): bool
     {
+        trigger_error(
+            'Highlighting::getUseFastVectorHighlighter() is deprecated and will be removed in v14. ' .
+            'The Unified Highlighter is now used unconditionally; the return value has no effect on the built query.',
+            E_USER_DEPRECATED,
+        );
         return $this->fragmentSize >= 18;
     }
 
@@ -126,23 +136,17 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
             return $parentBuilder;
         }
 
-        $query->getHighlighting()->setFragSize($this->getFragmentSize());
-        $query->getHighlighting()->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
-
-        if ($this->getUseFastVectorHighlighter()) {
-            $query->getHighlighting()->setUseFastVectorHighlighter(true);
-            $query->getHighlighting()->setTagPrefix($this->getPrefix());
-            $query->getHighlighting()->setTagPostfix($this->getPostfix());
-            $query->getHighlighting()->setMethod('fastVector');
-        } else {
-            $query->getHighlighting()->setUseFastVectorHighlighter(false);
-            $query->getHighlighting()->setTagPrefix('');
-            $query->getHighlighting()->setTagPostfix('');
-        }
+        $highlighting = $query->getHighlighting();
+        $highlighting->setFragSize($this->getFragmentSize());
+        $highlighting->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
+        $highlighting->setMethod(SolariumHighlightingInterface::METHOD_UNIFIED);
+        $highlighting->setOffsetSource(SolariumHighlightingInterface::OFFSETSOURCE_ANALYSIS);
+        $highlighting->setBoundaryScannerType('WORD');
+        $highlighting->setFragsizeIsMinimum(false);
 
         if ($this->getPrefix() !== '' && $this->getPostfix() !== '') {
-            $query->getHighlighting()->setSimplePrefix($this->getPrefix());
-            $query->getHighlighting()->setSimplePostfix($this->getPostfix());
+            $highlighting->setSimplePrefix($this->getPrefix());
+            $highlighting->setSimplePostfix($this->getPostfix());
         }
 
         return $parentBuilder;

--- a/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/QueryFields.php
@@ -39,6 +39,17 @@ class QueryFields implements ParameterBuilderInterface
     }
 
     /**
+     * Field names without boost factors — for parameters that accept a plain
+     * field list (e.g. edismax `uf`), where boost suffixes are invalid.
+     *
+     * @return string[]
+     */
+    public function getFieldNames(): array
+    {
+        return array_keys($this->queryFields);
+    }
+
+    /**
      * Creates the string representation
      */
     public function toString(string $delimiter = ' '): string

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -105,6 +105,7 @@ class QueryBuilder extends AbstractQueryBuilder
             $this->newSearchQuery($rawQuery)
                 ->useReturnFieldsFromTypoScript()
                 ->useQueryFieldsFromTypoScript()
+                ->useUserFieldsFromTypoScript()
                 ->useInitialQueryFromTypoScript()
                 ->useFiltersFromTypoScript()
                 ->useHighlightingFromTypoScript()
@@ -275,6 +276,39 @@ class QueryBuilder extends AbstractQueryBuilder
     public function useQueryFieldsFromTypoScript(): AbstractQueryBuilder
     {
         return $this->useQueryFields(QueryFields::fromString($this->typoScriptConfiguration->getSearchQueryQueryFields()));
+    }
+
+    /**
+     * Whitelist the fields a Solr field-selector (`field:value`) may target.
+     * Defaults to the `qf` field list so non-whitelisted fields cannot disclose
+     * arbitrary schema fields. Reads qf back from the query rather than
+     * re-fetching it from TypoScript to avoid a second configuration lookup.
+     *
+     * A scalar `userFields = ...` replaces the derived list outright. When the
+     * scalar is empty, `userFields.add` and `userFields.remove` are applied as
+     * comma-separated deltas on top of the qf-derived base list.
+     */
+    public function useUserFieldsFromTypoScript(): AbstractQueryBuilder
+    {
+        $explicit = $this->typoScriptConfiguration->getSearchQueryUserFields();
+        if ($explicit !== '') {
+            $this->queryToBuild->getEDisMax()->setUserFields($explicit);
+            return $this;
+        }
+
+        $qfString = (string)$this->queryToBuild->getEDisMax()->getQueryFields();
+        $base = $qfString === '' ? [] : QueryFields::fromString($qfString, ' ')->getFieldNames();
+
+        $config = $this->typoScriptConfiguration->getSearchQueryUserFieldsConfiguration();
+        $add = GeneralUtility::trimExplode(',', (string)($config['add'] ?? ''), true);
+        $remove = GeneralUtility::trimExplode(',', (string)($config['remove'] ?? ''), true);
+
+        $fields = array_values(array_diff(array_unique(array_merge($base, $add)), $remove));
+
+        if ($fields !== []) {
+            $this->queryToBuild->getEDisMax()->setUserFields(implode(' ', $fields));
+        }
+        return $this;
     }
 
     /**

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -49,6 +49,14 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 class QueryBuilder extends AbstractQueryBuilder
 {
     /**
+     * System-owned filter names that request additionalFilters must not set.
+     */
+    protected const RESERVED_FILTER_NAMES_FROM_REQUEST = [
+        'siteHash',
+        'access',
+    ];
+
+    /**
      * Additional filters, which will be added to the query, as well as to suggest queries.
      */
     protected array $additionalFilters = [];
@@ -122,7 +130,7 @@ class QueryBuilder extends AbstractQueryBuilder
         return $this
                 ->setRawQueryTerm($rawQuery)
                 ->useResultsPerPage($resultsPerPage)
-                ->useFilterArray($additionalFiltersFromRequest)
+                ->useFilterArray($this->removeReservedFiltersFromRequest($additionalFiltersFromRequest))
                 ->useFacetingFromTypoScript()
                 ->useVariantsFromTypoScript()
                 ->useGroupingFromTypoScript()
@@ -168,10 +176,23 @@ class QueryBuilder extends AbstractQueryBuilder
             ->useOmitHeader();
 
         if (!empty($additionalFilters)) {
-            $this->useFilterArray($additionalFilters);
+            $this->useFilterArray($this->removeReservedFiltersFromRequest($additionalFilters));
         }
 
         return $this->queryToBuild;
+    }
+
+    /**
+     * Strips system-owned filter names from request additionalFilters so
+     * frontend input cannot preempt the siteHash/access boundary.
+     */
+    protected function removeReservedFiltersFromRequest(array $additionalFilters): array
+    {
+        return array_filter(
+            $additionalFilters,
+            static fn(int|string $filterName): bool => !in_array($filterName, self::RESERVED_FILTER_NAMES_FROM_REQUEST, true),
+            ARRAY_FILTER_USE_KEY,
+        );
     }
 
     /**
@@ -354,6 +375,7 @@ class QueryBuilder extends AbstractQueryBuilder
         }
 
         $siteHashFilterString = implode(' OR ', $filters);
+        $this->queryToBuild->removeFilterQuery('siteHash');
         return $this->useFilter($siteHashFilterString, 'siteHash');
     }
 

--- a/Classes/Domain/Search/Query/QueryBuilder.php
+++ b/Classes/Domain/Search/Query/QueryBuilder.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Domain\Search\Query;
 
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\Helper\EscapeService;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\BigramPhraseFields;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Elevation;
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Faceting;
@@ -102,7 +103,11 @@ class QueryBuilder extends AbstractQueryBuilder
         if ($this->typoScriptConfiguration->isPureVectorSearchEnabled()) {
             $this->preparePureVectorSearch($rawQuery);
         } else {
-            $this->newSearchQuery($rawQuery)
+            $escapedQuery = $rawQuery === '' ? '' : (string)EscapeService::escape(
+                $rawQuery,
+                $this->typoScriptConfiguration->getSearchQueryAllowSolrOperatorSyntax(),
+            );
+            $this->newSearchQuery($escapedQuery)
                 ->useReturnFieldsFromTypoScript()
                 ->useQueryFieldsFromTypoScript()
                 ->useUserFieldsFromTypoScript()

--- a/Classes/Domain/Search/ResultSet/SearchResultSetService.php
+++ b/Classes/Domain/Search/ResultSet/SearchResultSetService.php
@@ -29,13 +29,16 @@ use ApacheSolrForTypo3\Solr\Domain\Variants\VariantsProcessor;
 use ApacheSolrForTypo3\Solr\Event\Search\AfterInitialSearchResultSetHasBeenCreatedEvent;
 use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchHasBeenExecutedEvent;
 use ApacheSolrForTypo3\Solr\Event\Search\AfterSearchQueryHasBeenPreparedEvent;
+use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\Search\AccessComponent;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrIncompleteResponseException;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use UnexpectedValueException;
 
@@ -61,6 +64,8 @@ class SearchResultSetService
 
     protected EventDispatcherInterface $eventDispatcher;
 
+    protected AccessComponent $accessComponent;
+
     public function __construct(
         TypoScriptConfiguration $configuration,
         Search $search,
@@ -68,6 +73,7 @@ class SearchResultSetService
         ?SearchResultBuilder $resultBuilder = null,
         ?QueryBuilder $queryBuilder = null,
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?AccessComponent $accessComponent = null,
     ) {
         $this->search = $search;
         $this->typoScriptConfiguration = $configuration;
@@ -75,6 +81,7 @@ class SearchResultSetService
         $this->searchResultBuilder = $resultBuilder ?? GeneralUtility::makeInstance(SearchResultBuilder::class);
         $this->queryBuilder = $queryBuilder ?? GeneralUtility::makeInstance(QueryBuilder::class, $configuration, $solrLogManager);
         $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $this->accessComponent = $accessComponent ?? GeneralUtility::makeInstance(AccessComponent::class, $this->queryBuilder);
     }
 
     public function getIsSolrAvailable(bool $useCache = true): bool
@@ -305,11 +312,26 @@ class SearchResultSetService
 
     /**
      * Retrieves a single document from solr by document id.
+     *
+     * @throws AspectNotFoundException
+     * @throws InvalidArgumentException
      */
     public function getDocumentById(string $documentId): SearchResult
     {
         /** @var SearchQuery $query */
         $query = $this->queryBuilder->newSearchQuery($documentId)->useQueryFields(QueryFields::fromString('id'))->getQuery();
+
+        // Enforce the same siteHash and frontend user access filters as the regular search path:
+        //   the by-id lookup must not be less restricted than resultsAction.
+        $event = new AfterSearchQueryHasBeenPreparedEvent(
+            $query,
+            GeneralUtility::makeInstance(SearchRequest::class, [], 0, 0, $this->typoScriptConfiguration),
+            $this->search,
+            $this->typoScriptConfiguration,
+        );
+        ($this->accessComponent)($event);
+        $query = $event->getQuery();
+
         $response = $this->search->search($query, 0, 1);
         $parsedData = $response->getParsedData();
         // @extensionScannerIgnoreLine

--- a/Classes/IndexQueue/AbstractIndexer.php
+++ b/Classes/IndexQueue/AbstractIndexer.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use Doctrine\DBAL\Exception as DBALException;
 use JsonException;
-use Throwable;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
@@ -34,6 +33,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+use function json_decode;
 
 /**
  * An abstract indexer class to collect a few common methods shared with other
@@ -181,14 +182,13 @@ abstract class AbstractIndexer
                 $indexingConfiguration[$solrFieldName . '.'],
             );
 
-            try {
-                $unserializedFieldValue = @unserialize($fieldValue);
-                if (is_array($unserializedFieldValue) || is_object($unserializedFieldValue)) {
-                    $fieldValue = $unserializedFieldValue;
-                }
-            } catch (Throwable) {
-                // Evil catch, but anyway do nothing to prevent fluting the logs on indexing.
-                // If the cObject implementation do not provide data the fields are not present in index, which will be noticed and fixed by devs/integrators.
+            // SOLR_MULTIVALUE / SOLR_RELATION / SOLR_CLASSIFICATION return their multi-value payload as a JSON-encoded array.
+            $decodedFieldValue = json_decode(
+                $fieldValue,
+                true,
+            );
+            if (is_array($decodedFieldValue)) {
+                $fieldValue = $decodedFieldValue;
             }
         } else {
             $indexingFieldName = $indexingConfiguration[$solrFieldName] ?? null;

--- a/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
+++ b/Classes/IndexQueue/FrontendHelper/PageFieldMappingIndexer.php
@@ -23,9 +23,10 @@ use ApacheSolrForTypo3\Solr\IndexQueue\AbstractIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\InvalidFieldNameException;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
-use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+use function json_decode;
 
 /**
  * Indexer to add / overwrite page document fields as defined in
@@ -120,14 +121,13 @@ class PageFieldMappingIndexer
                 $pageIndexingConfiguration[$solrFieldName . '.'],
             );
 
-            try {
-                $unserializedFieldValue = @unserialize($fieldValue);
-                if (is_array($unserializedFieldValue) || is_object($unserializedFieldValue)) {
-                    $fieldValue = $unserializedFieldValue;
-                }
-            } catch (Throwable) {
-                // Evil catch, but anyway do nothing to prevent fluting the logs on indexing.
-                // If the cObject implementation do not provide data the fields are not present in index, which will be noticed and fixed by devs/integrators.
+            // SOLR_MULTIVALUE / SOLR_RELATION / SOLR_CLASSIFICATION return their multi-value payload as a JSON-encoded array.
+            $decodedFieldValue = json_decode(
+                $fieldValue,
+                true,
+            );
+            if (is_array($decodedFieldValue)) {
+                $fieldValue = $decodedFieldValue;
             }
         } else {
             $fieldValue = $pageRecord[$pageIndexingConfiguration[$solrFieldName]] ?? null;

--- a/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
+++ b/Classes/IndexQueue/FrontendHelper/UserGroupDetector.php
@@ -23,7 +23,6 @@ use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Domain\Access\RecordAccessGrantedEvent;
 use TYPO3\CMS\Core\Domain\Event\BeforePageIsRetrievedEvent;
-use TYPO3\CMS\Core\Domain\Event\BeforeRecordLanguageOverlayEvent;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\Event\AfterContentObjectRendererInitializedEvent;
@@ -120,25 +119,6 @@ class UserGroupDetector implements FrontendHelper, SingletonInterface
         if ($this->activated) {
             $event->skipGroupAccessCheck();
         }
-    }
-
-    /**
-     * Modifies page records so that when checking for access through fe groups
-     * no groups or extendToSubpages flag is found and thus access is granted.
-     */
-    #[AsEventListener]
-    public function getPageOverlay_preProcess(BeforeRecordLanguageOverlayEvent $event): void
-    {
-        if (!$this->activated) {
-            return;
-        }
-        if ($event->getTable() !== 'pages') {
-            return;
-        }
-        $pageInput = $event->getRecord();
-        $pageInput['fe_group'] = '';
-        $pageInput['extendToSubpages'] = '0';
-        $event->setRecord($pageInput);
     }
 
     // execution

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1127,6 +1127,21 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Returns whether the well-known Lucene operators `+ - && || ! * ?` pass
+     * through `tx_solr[q]`. Default 1 — selector (`:`), range (`[ ]`) and
+     * grouping (`( ) { } ^ " ~ \ /`) characters are still escaped, so field
+     * enumeration and range injection cannot reach Solr; only wildcard and
+     * boolean operator syntax survives. Set to 0 for strict mode.
+     *
+     * plugin.tx_solr.search.query.allowSolrOperatorSyntax
+     */
+    public function getSearchQueryAllowSolrOperatorSyntax(string $defaultIfEmpty = '1'): bool
+    {
+        $result = $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.allowSolrOperatorSyntax', $defaultIfEmpty);
+        return $this->getBool($result);
+    }
+
+    /**
      * Returns the filter configuration array
      *
      * plugin.tx_solr.search.query.filter.

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1165,6 +1165,29 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Whitelist of fields a Solr field-selector (`field:value`) may target.
+     * Empty value defers to the edismax default, which is the `qf` field list.
+     *
+     * plugin.tx_solr.search.query.userFields
+     */
+    public function getSearchQueryUserFields(string $defaultIfEmpty = ''): string
+    {
+        return (string)$this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.userFields', $defaultIfEmpty);
+    }
+
+    /**
+     * Returns the userFields sub-key configuration (`add`, `remove`) used to
+     * derive the edismax `uf` list from the `qf` defaults when no scalar
+     * override is given.
+     *
+     * plugin.tx_solr.search.query.userFields.
+     */
+    public function getSearchQueryUserFieldsConfiguration(array $defaultIfEmpty = []): array
+    {
+        return $this->getObjectByPathOrDefault('plugin.tx_solr.search.query.userFields.', $defaultIfEmpty);
+    }
+
+    /**
      * This method is used to check if a phrase search is enabled or not
      *
      * plugin.tx_solr.search.query.phrase = 1

--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -75,6 +75,10 @@ plugin.tx_solr {
       type = 0
       allowEmptyQuery = 0
 
+      // 1 (default): `+ - && || ! * ?` pass through; 0: also escape `| & ;`.
+      // Selector/range chars (`: [ ] ( ) { } ^ " ~ \ /`) are escaped in both.
+      allowSolrOperatorSyntax = 1
+
       allowedSites = __solr_current_site
 
       // qf parameter http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29

--- a/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
+++ b/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+PATH_SOLRCONFIG="${SOLR_HOME}/configsets/ext_solr_13_1_0/conf"
+PATH_AND_FILENAME_SOLRCONFIG="${PATH_SOLRCONFIG}/solrconfig.xml"
+PATH_AND_FILENAME_BACKUP="${PATH_SOLRCONFIG}/solrconfig.xml.Backup-SST-235567"
+
+PATCH_MARKER='CVE SST 235567 2026050810000025'
+PATCH_COMMENT="<!-- ${PATCH_MARKER}: Unified Highlighter set, closes FieldExistsQuery HTTP 500 oracle -->"
+
+# SST-235567 / 2026050810000025 — align /select and /browse highlighter
+# defaults with the EXT:solr Layer-3 fix (Unified Highlighter). The FastVector
+# Highlighter rewrote `field:*` queries to FieldExistsQuery and crashed with
+# HTTP 500, turning the response into a field-existence oracle on the
+# indexed schema.
+#
+# Idempotency: skip migration if either the patch marker is already present
+# (script ran before) or `hl.method=original` is no longer present (fresh
+# install from a patched configset, or manual edit).
+
+if ! grep -q "${PATCH_MARKER}" "${PATH_AND_FILENAME_SOLRCONFIG}" \
+	&& grep -q '<str name="hl.method">original</str>' "${PATH_AND_FILENAME_SOLRCONFIG}"; then
+	echo "The Apache Solr instance is affected on SST-235567"
+	echo "  migrating /select and /browse handler highlighter defaults to Unified Highlighter"
+
+	cp "${PATH_AND_FILENAME_SOLRCONFIG}" "${PATH_AND_FILENAME_BACKUP}"
+
+	# /select: replace hl.method=original with the Unified Highlighter set
+	# preceded by the patch marker comment.
+	# shellcheck disable=SC1004
+	sed -i "/<str name=\"hl.method\">original<\/str>/c\\
+			${PATCH_COMMENT}\\
+			<str name=\"hl.method\">unified</str>\\
+			<str name=\"hl.offsetSource\">ANALYSIS</str>\\
+			<str name=\"hl.bs.type\">WORD</str>\\
+			<str name=\"hl.fragsizeIsMinimum\">false</str>" "${PATH_AND_FILENAME_SOLRCONFIG}"
+
+	# /browse: append the patch marker comment + Unified Highlighter set
+	# after hl.simple.post.
+	# shellcheck disable=SC1004
+	sed -i "/<str name=\"hl.simple.post\">&lt;\/b&gt;<\/str>/a\\
+			${PATCH_COMMENT}\\
+			<str name=\"hl.method\">unified</str>\\
+			<str name=\"hl.offsetSource\">ANALYSIS</str>\\
+			<str name=\"hl.bs.type\">WORD</str>\\
+			<str name=\"hl.fragsizeIsMinimum\">false</str>" "${PATH_AND_FILENAME_SOLRCONFIG}"
+fi

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -203,6 +203,55 @@ The boost take influence on what score a document gets when searching and thus h
 
 By default if a search term is found in the content field the documents gets scored / ranked higher as if a term was found in the title or keywords field. Although the default should provide a good setting, you can play around with the boost values to find the best ranking for your content.
 
+query.userFields
+~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields
+:Default: (empty — derived from ``query.queryFields``)
+:Since: 13.1.4
+
+Whitelist of fields that a Solr field-selector (``field:value``) in ``tx_solr[q]`` may target.
+By default the whitelist is derived from ``query.queryFields`` — only fields listed in ``qf`` are addressable via selector.
+Selectors against fields outside the whitelist are treated as literal terms and silently miss.
+
+A scalar value replaces the derived whitelist with a whitespace-separated list of field names:
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.userFields = title content fileExtension
+
+Alternatively the ``add`` and ``remove`` sub-keys apply comma-separated deltas on top of the qf-derived base list (used only when the scalar value is empty):
+
+.. code-block:: typoscript
+
+    plugin.tx_solr.search.query.userFields {
+        add = customField, fileExtension
+        remove = abstract
+    }
+
+query.userFields.add
+~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields.add
+:Default: (empty)
+:Since: 13.1.4
+
+Comma-separated list of field names to add to the qf-derived user-field whitelist.
+Applied only when the scalar ``query.userFields`` value is empty.
+
+query.userFields.remove
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: String
+:TS Path: plugin.tx_solr.search.query.userFields.remove
+:Default: (empty)
+:Since: 13.1.4
+
+Comma-separated list of field names to remove from the qf-derived user-field whitelist.
+Applied only when the scalar ``query.userFields`` value is empty.
+
 query.returnFields
 ~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -169,6 +169,21 @@ Version 3.0 introduced a couple more magic keywords that get replaced:
 - **__all** Adds all domains as allowed sites
 - \* (asterisk character) Everything is allowed as siteHash (same as no siteHash check). This option should only be used when you need a search across multiple system and you know the impact of turning of the siteHash check.
 
+query.allowSolrOperatorSyntax
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: Boolean
+:TS Path: plugin.tx_solr.search.query.allowSolrOperatorSyntax
+:Default: 1
+:Options: 0,1
+:Since: 13.1.4
+
+Controls how much Solr/Lucene query syntax survives in ``tx_solr[q]``.
+Selector, range, grouping and metacharacters (``: [ ] ( ) { } ^ " ~ \ /``) are always escaped at the user-input boundary regardless of this setting, so field-targeted enumeration and range injection cannot reach Solr.
+
+* ``1`` (default) — the well-known Lucene operators ``+ - && || ! * ?`` pass through, so the documented wildcard and boolean operator UX (``apple*``, ``+foo -bar``) keeps working.
+* ``0`` — strict mode; the additional SolrJ specials ``| & ;`` are also escaped. ``+ - ! * ?`` and whitespace stay literal, so required/prohibited terms, ``NOT`` and the wildcard UX still function.
+
 query.getParameter
 ~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -169,6 +169,11 @@ Version 3.0 introduced a couple more magic keywords that get replaced:
 - **__all** Adds all domains as allowed sites
 - \* (asterisk character) Everything is allowed as siteHash (same as no siteHash check). This option should only be used when you need a search across multiple system and you know the impact of turning of the siteHash check.
 
+**Security note (since fix for CVE-2026-56094):** the ``siteHash`` filter is a security boundary, not a user-facing search option.
+It cannot be set or overridden through request-provided ``tx_solr[additionalFilters]`` — the reserved names ``siteHash`` and ``access`` are stripped from request input before the query is built.
+To search across sites, use the ``allowedSites`` setting above; passing a ``siteHash`` filter from the frontend has no effect.
+
+
 query.allowSolrOperatorSyntax
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -86,6 +86,21 @@ The response is uniform, so it cannot be used to probe whether a restricted docu
 As defence in depth, review whether your templates still expose ``data-document-id`` and mask it where the document id should not be publicly visible.
 
 
+!!! Security: page indexer no longer poisons the rootline cache (CVE-2026-56092)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+During a page-indexer sub-request, EXT:solr forced ``fe_group`` and ``extendToSubpages`` to public
+values on every ``pages`` record it touched, so the indexer itself would not be blocked by access
+restrictions. TYPO3 Core persists that same record into the shared, cross-request ``rootline`` cache.
+
+An anonymous visitor could therefore reach a page whose access restriction was only inherited via
+``extendToSubpages`` from an ancestor page, for as long as the poisoned cache entry survived —
+the restricted area's own root page (which carries its ``fe_group`` directly) was not affected.
+
+The indexer no longer forges these fields. The access bypass it needed during indexing was already
+provided safely, without touching any persisted cache, by EXT:solr's other, unaffected listeners.
+
+
 All Changes
 -----------
 

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -55,6 +55,22 @@ Third-party content objects that returned ``serialize($array)`` for a multi-valu
 to ``json_encode($array)``; no other change is required.
 
 
+
+!!! Security: additionalFilters can no longer preempt the siteHash filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Request-provided ``tx_solr[additionalFilters]`` could register a named ``siteHash`` filter that ``AbstractQueryBuilder::useFilter()`` refused to overwrite,
+so the system ``siteHash`` filter added later by ``AccessComponent`` was dropped.
+In a shared-Solr-core multi-site installation this let an anonymous visitor of one site read public documents of another site sharing the same core (CVE-2026-56094).
+
+EXT:solr now strips the reserved filter names ``siteHash`` and ``access`` from request-provided ``additionalFilters`` before they reach the query,
+and applies the system ``siteHash`` filter with remove-then-set semantics so request input can no longer preempt it.
+Filters that integrators set server-side — TypoScript ``plugin.tx_solr.search.query.filter.``, plugin/FlexForm, or PSR-14 events — are unaffected.
+
+**Impact for integrators:** a frontend request can no longer override ``siteHash`` (or ``access``) through ``tx_solr[additionalFilters]``.
+Cross-site search must be configured server-side via ``plugin.tx_solr.search.query.allowedSites`` as documented in :ref:`configuration.reference.solrsearch`.
+
+
 All Changes
 -----------
 

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -6,6 +6,32 @@ Releases 13.1
 
 ..  include:: HintAboutOutdatedChangelog.rst.txt
 
+Release 13.1.4
+==============
+
+This is a security release for TYPO3 13 LTS.
+
+
+!!! Recommendation: align existing Solr volumes with the new configset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ext_solr_13_1_0`` configset now sets the Unified Highlighter as default on both the ``/select`` and ``/browse`` request handlers.
+Solr volumes created from older configsets default to the legacy highlighter and remain vulnerable to the ``FieldExistsQuery`` HTTP 500 oracle
+when queried directly (bypassing EXT:solr).
+Run the bundled migration script against the existing configset to align the defaults;
+the script is idempotent and writes a ``solrconfig.xml.Backup-SST-235567`` backup next to the modified file:
+
+*   ``Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh``
+
+EXT:solr itself enforces the Unified Highlighter unconditionally in PHP, so this configset alignment is a defence-in-depth measure
+for clients that query Solr directly.
+
+All Changes
+-----------
+
+(filled at release time)
+
+
 Release 13.1.3
 ==============
 

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -41,6 +41,20 @@ Two new TypoScript settings govern how user input on ``tx_solr[q]`` is parsed:
 
 See :ref:`configuration.reference.solrsearch` for full reference details.
 
+
+!!! Breaking: multi-value cObjs now use JSON transport
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``SOLR_MULTIVALUE``, ``SOLR_RELATION`` and ``SOLR_CLASSIFICATION`` content objects now return their
+multi-value payload as ``json_encode($array)`` instead of ``serialize($array)``, and the indexer decodes
+it with ``json_decode()`` instead of ``unserialize()``.
+Because ``json_decode()`` never reconstructs PHP objects, the indexer can no longer be turned into a PHP
+object-injection sink by an attacker who can influence an indexed record field.
+
+Third-party content objects that returned ``serialize($array)`` for a multi-value Solr field must switch
+to ``json_encode($array)``; no other change is required.
+
+
 All Changes
 -----------
 

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -55,7 +55,6 @@ Third-party content objects that returned ``serialize($array)`` for a multi-valu
 to ``json_encode($array)``; no other change is required.
 
 
-
 !!! Security: additionalFilters can no longer preempt the siteHash filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,6 +68,22 @@ Filters that integrators set server-side — TypoScript ``plugin.tx_solr.search.
 
 **Impact for integrators:** a frontend request can no longer override ``siteHash`` (or ``access``) through ``tx_solr[additionalFilters]``.
 Cross-site search must be configured server-side via ``plugin.tx_solr.search.query.allowedSites`` as documented in :ref:`configuration.reference.solrsearch`.
+
+
+!!! Security: detail view enforces site and access restrictions (CVE-2026-56093)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``detail`` action of the ``pi_results`` plugin looked up a document by its ``documentId`` without applying the current site's ``siteHash`` filter
+or the frontend user-group access filter.
+An anonymous visitor who knew or guessed a valid ``documentId`` could therefore retrieve access-restricted documents through the detail view
+— a path that was less restricted than the regular search.
+
+The direct ``documentId`` lookup now applies the same ``siteHash`` and frontend user-group filters as the normal search path.
+A ``documentId`` that resolves to no accessible document — unknown, from another site, or restricted for the current visitor
+— yields the site's configured 404 page.
+The response is uniform, so it cannot be used to probe whether a restricted document exists.
+
+As defence in depth, review whether your templates still expose ``data-document-id`` and mask it where the document id should not be publicly visible.
 
 
 All Changes

--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -26,6 +26,21 @@ the script is idempotent and writes a ``solrconfig.xml.Backup-SST-235567`` backu
 EXT:solr itself enforces the Unified Highlighter unconditionally in PHP, so this configset alignment is a defence-in-depth measure
 for clients that query Solr directly.
 
+
+!!! New: TypoScript settings for query-syntax handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two new TypoScript settings govern how user input on ``tx_solr[q]`` is parsed:
+
+* ``plugin.tx_solr.search.query.userFields`` — whitelist of fields a Solr field-selector (``field:value``) may target.
+  By default derived from ``query.queryFields``; selectors against other fields are now treated as literal terms and silently miss.
+  Sites that rely on selectors against non-``qf`` fields must extend the whitelist via a scalar override or the ``add`` / ``remove`` sub-keys.
+* ``plugin.tx_solr.search.query.allowSolrOperatorSyntax`` — toggle for operator-syntax passthrough.
+  Default ``1`` keeps the documented ``+ - && || ! * ?`` UX functional; set to ``0`` for strict mode (additionally escapes ``| & ;``).
+  Selector, range and grouping characters (``: [ ] ( ) { } ^ " ~ \ /``) are always escaped regardless.
+
+See :ref:`configuration.reference.solrsearch` for full reference details.
+
 All Changes
 -----------
 

--- a/Resources/Private/Solr/configsets/ext_solr_13_1_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_13_1_0/conf/solrconfig.xml
@@ -146,7 +146,10 @@
 			<int name="hl.snippets">3</int>
 			<str name="hl.mergeContiguous">true</str>
 			<str name="hl.requireFieldMatch">true</str>
-			<str name="hl.method">original</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 
 			<str name="f.content.hl.alternateField">content</str>
 			<str name="f.content.hl.maxAlternateFieldLength">200</str>
@@ -218,6 +221,10 @@
 			<str name="hl.encoder">html</str>
 			<str name="hl.simple.pre">&lt;b&gt;</str>
 			<str name="hl.simple.post">&lt;/b&gt;</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 		</lst>
 		<arr name="last-components">
 			<str>spellcheck</str>

--- a/Tests/Integration/ContentObject/RelationTest.php
+++ b/Tests/Integration/ContentObject/RelationTest.php
@@ -30,6 +30,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
+use function json_encode;
+
 /**
  * Class RelationTest
  */
@@ -174,21 +176,37 @@ class RelationTest extends IntegrationTestBase
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation' => [
-            serialize(['Third category', 'Second category']),
+            json_encode(
+                [
+                    'Third category',
+                    'Second category',
+                ],
+            ),
             'tx_fakeextension_domain_model_foo',
             2,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation and keep duplicates' => [
-            serialize(['Third category', 'Second category', 'Second category']),
+            json_encode(
+                [
+                    'Third category',
+                    'Second category',
+                    'Second category',
+                ],
+            ),
             'tx_fakeextension_domain_model_foo',
             3,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1],
         ];
 
         yield 'Can resolve titles of the main categories of the related records in m:n relation and remove duplicates' => [
-            serialize(['Third category', 'Second category']),
+            json_encode(
+                [
+                    'Third category',
+                    'Second category',
+                ],
+            ),
             'tx_fakeextension_domain_model_foo',
             3,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'main_category', 'multiValue' => 1, 'removeDuplicateValues' => 1],
@@ -202,7 +220,12 @@ class RelationTest extends IntegrationTestBase
         ];
 
         yield 'Can resolve uids of m:n relation for multi value field, with 2 items' => [
-            serialize(['11', '10']),
+            json_encode(
+                [
+                    '11',
+                    '10',
+                ],
+            ),
             'tx_fakeextension_domain_model_foo',
             2,
             ['localField' => 'mm_assignments', 'foreignLabelField' => 'uid', 'multiValue' => 1],
@@ -268,7 +291,12 @@ class RelationTest extends IntegrationTestBase
         ];
 
         yield 'Can resolve related categories of related records 1:n relation (multi value)' => [
-            serialize(['Second category', 'Second category']),
+            json_encode(
+                [
+                    'Second category',
+                    'Second category',
+                ],
+            ),
             'tx_fakeextension_domain_model_foo',
             1,
             ['localField' => 'inline_relations', 'foreignLabelField' => 'mm_assignments.main_category', 'multiValue' => 1],

--- a/Tests/Integration/Security/AdditionalFiltersSiteHashBypassTest.php
+++ b/Tests/Integration/Security/AdditionalFiltersSiteHashBypassTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression guard for TYPO3 Security Team Ticket #2026052010000029 (CVE-2026-56094).
+ *
+ * Asserts the secure behavior: a request-supplied `tx_solr[additionalFilters][siteHash]` must not preempt the system siteHash filter.
+ * In a shared-core multi-site install that bypass would let anonymous visitors of one site read public documents of another site in the same core.
+ */
+#[Group('frontend')]
+#[Group('security')]
+class AdditionalFiltersSiteHashBypassTest extends IntegrationTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        // Shared core: both testone.site and testtwo.site map to core_en (EN).
+
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.csv');
+
+        // Site 1: enable indexing and render the pi_results plugin on page 2022.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            ',
+        );
+        // Site 2 (template uid 111) needs indexing enabled too.
+        $this->addTypoScriptToTemplateRecord(
+            111,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            ',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    /**
+     * Primary guard: an injected additionalFilters[siteHash] on the results page must not leak Site 2 documents into a Site 1 search response.
+     */
+    #[Test]
+    public function crossSiteDocumentMustNotLeakViaAdditionalFiltersSiteHash(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+
+        // Page 2 → Site 1, Page 112 → Site 2; both indexed into the shared core_en.
+        $this->indexPages([2, 112]);
+        $this->assertSolrContainsDocumentCount(2);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getSiteOneRequest()
+                ->withQueryParameter('tx_solr[q]', '*')
+                ->withQueryParameter('tx_solr[additionalFilters][siteHash]', '*:*'),
+        )->getBody();
+
+        self::assertStringContainsString(
+            'Found 1 result',
+            $response,
+            'CVE-2026-56094: expected exactly the single Site 1 document — guards against a vacuous pass.',
+        );
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'CVE-2026-56094: own Site 1 document must be present in the Site 1 search response.',
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicDoc',
+            $response,
+            'CVE-2026-56094: cross-site document title from Site 2 leaked into Site 1 search response.',
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicBody',
+            $response,
+            'CVE-2026-56094: cross-site document body marker from Site 2 leaked into Site 1 search response.',
+        );
+    }
+
+    /**
+     * Suggest top-results variant: addTopResultsToSuggestions() copies the request additionalFilters into a regular search,
+     * so the injected siteHash must not leak Site 2 documents into the suggest JSON either.
+     */
+    #[Test]
+    public function suggestTopResultsMustNotLeakCrossSiteDocument(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+        $this->indexPages([2, 112]);
+        $this->assertSolrContainsDocumentCount(2);
+
+        // Enable suggest top-results endpoint on both sites' templates.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            @import \'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript\'
+            ',
+        );
+        $this->addTypoScriptToTemplateRecord(
+            111,
+            /* @lang TYPO3_TypoScript */
+            '
+            @import \'EXT:solr/Configuration/TypoScript/Examples/Suggest/setup.typoscript\'
+            ',
+        );
+
+        // "sharedCrossSiteToken" is in both sites' bodytexts, so without the siteHash filter the top-results search would match both sites.
+        $response = (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/en/'))
+                ->withPageId(1)
+                ->withQueryParameter('type', '7384')
+                ->withQueryParameter('tx_solr[queryString]', 'sharedCrossSiteToken')
+                ->withQueryParameter('tx_solr[additionalFilters][siteHash]', '*:*'),
+        )->getBody();
+
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'CVE-2026-56094: own Site 1 document must be present in the suggest top-results.',
+        );
+        self::assertSame(
+            1,
+            substr_count($response, '"link":'),
+            'CVE-2026-56094: suggest top-results must contain exactly one document (the Site 1 one).',
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicDoc',
+            $response,
+            'CVE-2026-56094: suggest top-results leaked the title of a Site 2 document into a Site 1 suggest response.',
+        );
+        self::assertStringNotContainsString(
+            'SiteTwoPublicBody',
+            $response,
+            'CVE-2026-56094: suggest top-results leaked the body marker of a Site 2 document into a Site 1 suggest response.',
+        );
+    }
+
+    /**
+     * Baseline: additionalFilters[access] is already neutralized by useUserAccessGroups() (remove-then-set), so the restricted document stays hidden.
+     * Passes before and after the fix.
+     */
+    #[Test]
+    public function accessRestrictedDocumentMustNotLeakViaAdditionalFiltersAccess(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv');
+
+        // Site 1 public page 2 + access-restricted page 13 (fe_group=1).
+        $this->indexPages([2, 13], 1);
+        $this->assertSolrContainsDocumentCount(2);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getSiteOneRequest()
+                ->withQueryParameter('tx_solr[q]', '*')
+                ->withQueryParameter('tx_solr[additionalFilters][access]', '*:*'),
+        )->getBody();
+
+        self::assertStringContainsString(
+            'Found 1 result',
+            $response,
+            'Baseline: expected exactly the single public Site 1 document — guards against a vacuous pass.',
+        );
+        self::assertStringContainsString(
+            'SiteOnePublicDoc',
+            $response,
+            'Baseline: public Site 1 document must be present in the search response.',
+        );
+        self::assertStringNotContainsString(
+            'SiteOneRestrictedDoc',
+            $response,
+            'Baseline broken: additionalFilters[access] succeeded in bypassing the access filter — please re-verify QueryBuilder::useUserAccessGroups().',
+        );
+        self::assertStringNotContainsString(
+            'SiteOneRestrictedBody',
+            $response,
+            'Baseline broken: additionalFilters[access] disclosed restricted content body.',
+        );
+    }
+
+    protected function getSiteOneRequest(int $pageId = 2022): InternalRequest
+    {
+        return (new InternalRequest('http://testone.site/'))->withPageId($pageId);
+    }
+}

--- a/Tests/Integration/Security/DetailActionAccessBypassTest.php
+++ b/Tests/Integration/Security/DetailActionAccessBypassTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use JsonException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression-guard test for CVE-2026-56093 (detailAction access-control bypass).
+ *
+ * Asserts the SECURE behavior: {@link SearchController::detailAction()} MUST NOT disclose access-restricted documents to anonymous visitors.
+ * The same siteHash and frontend-user-group access filters that the AccessComponent applies on the normal search path
+ * must also constrain the direct documentId lookup.
+ *
+ * On release-13.1.x {@link SearchResultSetService::getDocumentById()} builds a direct Solr lookup query
+ * without dispatching the {@link AfterSearchQueryHasBeenPreparedEvent}, so AccessComponent never runs and restricted documents leak through.
+ * The primary test method therefore FAILS on the current branch — that failure IS the deterministic vulnerability reproduction.
+ */
+#[Group('frontend')]
+#[Group('security')]
+class DetailActionAccessBypassTest extends IntegrationTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        // Plugin "pi_results" (search results + detail) on page 2022, reused from controller fixtures.
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.csv');
+        // Mirrors SearchControllerTest::bootstrapSearchResultsPluginOnPage(): enable indexing and
+        // render the pi_results plugin on page 2022.
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            ',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    /**
+     * PRIMARY regression guard.
+     *
+     * An anonymous visitor calls the cacheable detail action with the documentId of a fe_group-restricted page.
+     * The detailAction MUST refuse to render the protected document; {@link SearchResultSetService::getDocumentById()}
+     * must apply the same access and siteHash filters that AccessComponent applies on the normal search path.
+     */
+    #[Test]
+    public function detailActionMustNotDiscloseAccessRestrictedDocumentToAnonymousVisitor(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/detailaction_access_bypass.csv');
+
+        // Index public (uid 2) + restricted (uid 3) pages in the context of fe_user 1
+        // which belongs to fe_group 1; the restricted page therefore reaches Solr with
+        // an "access" field that mandates membership in group 1.
+        $this->indexPages([2, 3], 1);
+        $this->assertSolrContainsDocumentCount(2);
+
+        $restrictedDocumentId = $this->fetchSolrDocumentIdByTitle('RestrictedSecretAreaLoggedInOnly');
+        self::assertNotEmpty(
+            $restrictedDocumentId,
+            'Restricted page was not indexed into Solr; precondition for the test is broken.',
+        );
+
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getPreparedRequest()
+                ->withQueryParameter('tx_solr[action]', 'detail')
+                ->withQueryParameter('tx_solr[documentId]', $restrictedDocumentId),
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'RestrictedSecretAreaLoggedInOnly',
+            $response,
+            'CVE-2026-56093: detailAction disclosed the title of an access-restricted document to an anonymous visitor.',
+        );
+        self::assertStringNotContainsString(
+            'CLASSIFIED_BANK_DETAILS_MARKER_ABC123',
+            $response,
+            'CVE-2026-56093: detailAction disclosed the body of an access-restricted document to an anonymous visitor.',
+        );
+    }
+
+    /**
+     * COMPARISON BASELINE.
+     *
+     * The same restricted document, queried through the normal (non-cacheable) results action, is NOT disclosed
+     * because the {@link AccessComponent} event listener applies the frontend user access filter.
+     * This test confirms that the bypass observed above is specific to the detailAction code path and not a general indexing/access-field bug.
+     */
+    #[Test]
+    public function normalResultsActionDoesNotDiscloseAccessRestrictedDocumentToAnonymousVisitor(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/detailaction_access_bypass.csv');
+        $this->indexPages([2, 3], 1);
+        $this->assertSolrContainsDocumentCount(2);
+
+        // Search for a public-content keyword so the search-term echo in the response template
+        // cannot accidentally satisfy a substring assertion. The restricted document's title
+        // and the surrounding restricted-content phrase remain the indicators of disclosure.
+        $response = (string)$this->executeFrontendSubRequest(
+            $this->getPreparedRequest()
+                ->withQueryParameter('tx_solr[q]', '*'),
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'RestrictedSecretAreaLoggedInOnly',
+            $response,
+            'Normal resultsAction unexpectedly disclosed the title of the restricted document — the comparison baseline is invalid.',
+        );
+        self::assertStringNotContainsString(
+            'CLASSIFIED_BANK_DETAILS_MARKER_ABC123',
+            $response,
+            'Normal resultsAction unexpectedly disclosed a marker from the restricted document body — the comparison baseline is invalid.',
+        );
+    }
+
+    /**
+     * Resolves the Solr documentId of an indexed page by issuing a REST query against Solr directly.
+     * The id format is constructed by {@link Util::getDocumentId()} as `<siteHash>/<table>/<uid>/<typeNum>/<language>/<accessGroups>`,
+     * but the exact accessGroups segment depends on the runtime indexing context — querying Solr avoids brittle assumptions.
+     *
+     * @throws JsonException
+     */
+    protected function fetchSolrDocumentIdByTitle(string $title): string
+    {
+        $url = sprintf(
+            '%s/solr/core_en/select?q=*:*&fl=id&wt=json&fq=%s',
+            $this->getSolrConnectionUriAuthority(),
+            urlencode('title:"' . $title . '"'),
+        );
+        $body = file_get_contents($url);
+        if ($body === false) {
+            self::fail('Could not query Solr at ' . $url);
+        }
+        $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        return (string)($data['response']['docs'][0]['id'] ?? '');
+    }
+
+    protected function getPreparedRequest(int $pageId = 2022): InternalRequest
+    {
+        return (new InternalRequest('http://testone.site/'))->withPageId($pageId);
+    }
+}

--- a/Tests/Integration/Security/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv
+++ b/Tests/Integration/Security/Fixtures/CVE-2026-56094_additionalfilters_sitehash.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/site-one-public","SiteOnePublicDoc",,""
+,4,1,0,254,"/site-one-fe-users","FE Users Folder",,"fe_users"
+,13,1,0,1,"/site-one-restricted","SiteOneRestrictedDoc","1",""
+,112,111,0,1,"/site-two-public","SiteTwoPublicDoc",,""
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,201,2,0,"text","Site one public marker","sharedCrossSiteToken SiteOnePublicBody only meant to be searchable from site one",0,10
+,213,13,0,"text","Site one restricted marker","sharedCrossSiteToken SiteOneRestrictedBody restricted to fe_group 1",0,10
+,1121,112,0,"text","Site two public marker","sharedCrossSiteToken SiteTwoPublicBody must NOT be returned when searching from site one",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"SiteOneRestrictedReaders"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"siteone_member","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/CVE2026_56095_deserialization.csv
+++ b/Tests/Integration/Security/Fixtures/CVE2026_56095_deserialization.csv
@@ -1,0 +1,6 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","description"
+,2,1,0,1,"/payload-host","PayloadHostPageSST235568","REPLACED-AT-RUNTIME-WITH-SERIALIZED-GADGET-BYTES"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","sorting"
+,201,2,0,"text","Plain header SST 235568","Plain bodytext of the payload host page",10

--- a/Tests/Integration/Security/Fixtures/Gadget/CVE2026_56095CanaryGadget.php
+++ b/Tests/Integration/Security/Fixtures/Gadget/CVE2026_56095CanaryGadget.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures\Gadget;
+
+/**
+ * Test-only canary for CVE-2026-56095: its magic methods write a marker file, proving the indexer ran unserialize() on attacker-controlled bytes.
+ * PUBLIC properties keep the payload byte-stable through the TEXT cObj stdWrap pipeline
+ * (private-property gadgets like GuzzleHttp\Cookie\FileCookieJar carry NUL bytes that stdWrap mangles).
+ */
+final class CVE2026_56095CanaryGadget
+{
+    public string $canaryPath = '';
+    public string $canaryMarker = '';
+
+    public function __wakeup(): void
+    {
+        // fires synchronously during unserialize(), before later indexer logic could mask the side effect
+        if ($this->canaryPath !== '') {
+            @file_put_contents(
+                $this->canaryPath . '.wakeup',
+                $this->canaryMarker,
+            );
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($this->canaryPath !== '') {
+            @file_put_contents(
+                $this->canaryPath,
+                $this->canaryMarker,
+            );
+        }
+    }
+}

--- a/Tests/Integration/Security/Fixtures/cve_2026_56092_rootline_poisoning.csv
+++ b/Tests/Integration/Security/Fixtures/cve_2026_56092_rootline_poisoning.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","extendToSubpages","module"
+,3,1,0,1,"/parent-restricted-area","ParentRestrictedAreaCVE202656092","1","1",""
+,5,3,0,1,"/parent-restricted-area/child","ChildPageInRestrictedAreaCVE202656092","0","0",""
+,4,1,0,254,"/fe-users-cve202656092","FE Users Folder CVE-2026-56092",,"0","fe_users"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,301,3,0,"text","Parent restricted CVE-2026-56092 header","ROOTLINE_POISON_PARENT_MARKER_PQR234 — parent page content",0,10
+,501,5,0,"text","Child restricted CVE-2026-56092 header","ROOTLINE_POISON_CHILD_MARKER_STU567 — only visible because parent page extendToSubpages=1 + fe_group=1",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"RestrictedReadersCVE202656092"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"member_cve202656092","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/detailaction_access_bypass.csv
+++ b/Tests/Integration/Security/Fixtures/detailaction_access_bypass.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/public-baseline","PublicBaselinePage",,""
+,3,1,0,1,"/classified-area","RestrictedSecretAreaLoggedInOnly","1",""
+,4,1,0,254,"/restricted-fe-users","FE Users Folder",,"fe_users"
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,21,2,0,"text","Public baseline content","Open to anyone visiting the public baseline page",0,10
+,31,3,0,"text","Classified header for logged-in users","CLASSIFIED_BANK_DETAILS_MARKER_ABC123 content must never be visible to anonymous visitors",0,10
+"fe_groups",
+,"uid","pid","title"
+,1,4,"RestrictedReaders"
+"fe_users",
+,"uid","pid","username","password","usergroup"
+,1,4,"restricted_member","dummy_password_hash","1"

--- a/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
+++ b/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/alpha","markeralpha235567",,""
+,3,1,0,1,"/beta","markerbeta235567",,""
+,4,1,0,1,"/gamma","markergamma235567",,""
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,201,2,0,"text","alpha header","body of the alpha test page; unique token bodyalpha235567",0,10
+,301,3,0,"text","beta header","body of the beta test page; unique token bodybeta235567",0,10
+,401,4,0,"text","gamma header","body of the gamma test page; unique token bodygamma235567",0,10

--- a/Tests/Integration/Security/InsecureDeserializationOfCObjOutputTest.php
+++ b/Tests/Integration/Security/InsecureDeserializationOfCObjOutputTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use ApacheSolrForTypo3\Solr\Tests\Integration\Security\Fixtures\Gadget\CVE2026_56095CanaryGadget;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression guard for CVE-2026-56095 (SST #2026011610000017): the EXT:solr indexer must not run unserialize() on
+ * attacker-controlled bytes returned by a cObj.
+ * A record field is rendered through a TEXT cObj that carries serialized canary bytes;
+ * the canary's magic method writing a marker file is the proof the sink fired.
+ * The JSON fix makes json_decode() the only decode step, so no PHP object is ever reconstructed.
+ * Fails on vulnerable code, passes after the fix — no assertion inversion.
+ */
+#[Group('frontend')]
+#[Group('security')]
+class InsecureDeserializationOfCObjOutputTest extends IntegrationTestBase
+{
+    /**
+     * Marker path the canary writes to; randomized per test to avoid cross-run races.
+     */
+    private string $canaryPath = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->canaryPath = sys_get_temp_dir() . '/CVE-2026-56095-poc-marker-' . bin2hex(random_bytes(8));
+        @unlink($this->canaryPath);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->canaryPath);
+        @unlink($this->canaryPath . '.wakeup');
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    /**
+     * Baseline: a benign field value must not create the canary marker — guards against false positives.
+     */
+    #[Test]
+    public function indexingAPageWithoutAnyDeserializationGadgetMustNotInvokeMagicMethods(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE2026_56095_deserialization.csv');
+
+        // baseline runs with a benign value, not the CSV placeholder bytes
+        $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->update(
+                'pages',
+                ['description' => 'plain benign baseline content for SST 235568'],
+                ['uid' => 2],
+            );
+
+        $this->configureIndexingPipelineForDescription();
+        $this->indexPages([2]);
+        $this->assertSolrContainsDocumentCount(1);
+
+        self::assertFileDoesNotExist(
+            $this->canaryPath,
+            'Baseline assumption broken: the canary file was created even without a gadget payload — the test infrastructure is not reliable.',
+        );
+        self::assertFileDoesNotExist(
+            $this->canaryPath . '.wakeup',
+            'Baseline assumption broken: the canary .wakeup file was created without a gadget payload.',
+        );
+    }
+
+    /**
+     * Primary guard: an attacker-controlled record field carrying serialized canary bytes is indexed via a TEXT cObj.
+     * On vulnerable code unserialize() runs and the canary's __wakeup writes the marker; the JSON fix prevents it.
+     */
+    #[Test]
+    public function unserializeOfCObjOutputMustNotInvokeMagicMethodsOnAttackerControlledObject(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/CVE2026_56095_deserialization.csv');
+
+        $payload = $this->buildCanaryGadgetPayload();
+
+        $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->update(
+                'pages',
+                ['description' => $payload],
+                ['uid' => 2],
+            );
+
+        $this->configureIndexingPipelineForDescription();
+        $this->indexPages([2]);
+
+        // __wakeup fires synchronously during unserialize() inside the indexer run, so it is observable here;
+        // __destruct may run only at shutdown, after the assertion.
+        self::assertFileDoesNotExist(
+            $this->canaryPath . '.wakeup',
+            'SST 235568: EXT:solr indexer pipeline ran unserialize() on attacker-controlled bytes; '
+            . 'the canary class\'s __wakeup magic method executed and wrote ' . $this->canaryPath . '.wakeup.',
+        );
+    }
+
+    /**
+     * Builds the serialized canary payload, clearing the local instance's path first so its destructor writes nothing here.
+     */
+    private function buildCanaryGadgetPayload(): string
+    {
+        $gadget = new CVE2026_56095CanaryGadget();
+        $gadget->canaryPath = $this->canaryPath;
+        $gadget->canaryMarker = 'CVE_2026_56095_GADGET_FIRED_FROM_INDEXER';
+        $payload = serialize($gadget);
+
+        // clear the local instance's path so its destructor writes nothing; the serialized string keeps the real path
+        $gadget->canaryPath = '';
+        unset($gadget);
+        @unlink($this->canaryPath);
+
+        return $payload;
+    }
+
+    /**
+     * Maps an existing Solr field to the `description` column via TEXT cObj, forcing the indexer's cObj decode path.
+     */
+    private function configureIndexingPipelineForDescription(): void
+    {
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            plugin.tx_solr.index.queue.pages.fields {
+                sortSubTitle_stringS = TEXT
+                sortSubTitle_stringS.field = description
+            }
+            ',
+        );
+    }
+}

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -79,6 +79,34 @@ class QueryInjectionViaRawSolrSyntaxTest extends IntegrationTestBase
         );
     }
 
+    /** PDF §3.1 — `siteHash:*` must not enumerate documents via field selector. */
+    #[Test]
+    public function wildcardFieldEnumerationOperatorMustNotEnumerateIndexedDocuments(): void
+    {
+        $response = $this->executeSearch('siteHash:*');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567 / PDF §3.1: siteHash:* field enumeration leaked ' . $marker,
+            );
+        }
+    }
+
+    /** Combined field-selector + range against the hex-hash siteHash field must not match the test corpus. */
+    #[Test]
+    public function fieldSelectorOperatorMustNotTargetArbitraryIndexedField(): void
+    {
+        $response = $this->executeSearch('siteHash:[0 TO 9]');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567: field-selector range query against siteHash leaked ' . $marker,
+            );
+        }
+    }
+
     #[Test]
     public function existingFieldWildcardMustNotTriggerSolrCommunicationException(): void
     {

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use ApacheSolrForTypo3\Solr\Tests\Integration\TSFETestBootstrapper;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression guard for SST #2026050810000025:
+ * the highlighter must not surface `field:*` queries as a Solr HTTP 500 field-existence oracle.
+ */
+#[Group('frontend')]
+#[Group('security')]
+class QueryInjectionViaRawSolrSyntaxTest extends IntegrationTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.csv');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            ',
+        );
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sst_2026050810000025_query_injection.csv');
+        $this->indexPages([2, 3, 4]);
+        $this->assertSolrContainsDocumentCount(3);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function literalTokenSearchReturnsExpectedDocument(): void
+    {
+        $response = $this->executeSearch('markeralpha235567');
+        self::assertStringContainsString(
+            'markeralpha235567',
+            $response,
+            'Sanity check failed: literal-token search for the alpha marker did not return the alpha document.',
+        );
+    }
+
+    #[Test]
+    public function existingFieldWildcardMustNotTriggerSolrCommunicationException(): void
+    {
+        GeneralUtility::makeInstance(TSFETestBootstrapper::class)->bootstrap(1);
+        $configuration = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => [
+                'query.' => ['queryFields' => 'content,title'],
+                'results.' => [
+                    'resultsHighlighting' => 1,
+                    'resultsHighlighting.' => [
+                        'fragmentSize' => 50,
+                        'wrap' => '<mark>|</mark>',
+                    ],
+                ],
+            ]]],
+        ]);
+        $query = (new QueryBuilder($configuration))->buildSearchQuery('siteHash:*');
+        try {
+            GeneralUtility::makeInstance(Search::class)->search($query);
+        } catch (SolrCommunicationException $e) {
+            self::fail('SST 235567: highlighter raised ' . $e::class . ' — ' . $e->getMessage());
+        }
+    }
+
+    protected function executeSearch(string $rawQuery): string
+    {
+        return (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/'))
+                ->withPageId(2022)
+                ->withQueryParameter('tx_solr[q]', $rawQuery),
+        )->getBody();
+    }
+}

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -93,6 +93,44 @@ class QueryInjectionViaRawSolrSyntaxTest extends IntegrationTestBase
         }
     }
 
+    /** PDF §3.2 — prefix wildcard must not enable per-character value extraction. */
+    #[Test]
+    public function prefixWildcardOperatorMustNotEnableBlindValueExtraction(): void
+    {
+        $response = $this->executeSearch('title:markeralpha*');
+        self::assertStringNotContainsString(
+            'markeralpha235567',
+            $response,
+            'SST 235567 / PDF §3.2: prefix-wildcard (title:markeralpha*) leaked the alpha document.',
+        );
+    }
+
+    /** PDF §3.3 — `?` wildcard must not enable length detection on indexed values. */
+    #[Test]
+    public function singleCharWildcardOperatorMustNotEnableLengthDetection(): void
+    {
+        $response = $this->executeSearch('title:markeralpha?35567');
+        self::assertStringNotContainsString(
+            'markeralpha235567',
+            $response,
+            'SST 235567 / PDF §3.3: single-character wildcard (?) leaked the alpha document.',
+        );
+    }
+
+    /** PDF §3.4 — range query must not enable binary-search value extraction. */
+    #[Test]
+    public function rangeQueryOperatorMustNotEnableBinarySearchExtraction(): void
+    {
+        $response = $this->executeSearch('title:[m TO n]');
+        foreach (['markeralpha235567', 'markerbeta235567', 'markergamma235567'] as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $response,
+                'SST 235567 / PDF §3.4: range query (title:[m TO n]) leaked ' . $marker,
+            );
+        }
+    }
+
     /** Combined field-selector + range against the hex-hash siteHash field must not match the test corpus. */
     #[Test]
     public function fieldSelectorOperatorMustNotTargetArbitraryIndexedField(): void

--- a/Tests/Integration/Security/RootlineCachePoisoningTest.php
+++ b/Tests/Integration/Security/RootlineCachePoisoningTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\UserGroupDetector;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Regression guard for CVE-2026-56092: an EXT:solr page-indexer
+ * sub-request must not poison the TYPO3 rootline cache with the
+ * `fe_group=''`/`extendToSubpages='0'` values that
+ * UserGroupDetector::getPageOverlay_preProcess() (Classes/IndexQueue/
+ * FrontendHelper/UserGroupDetector.php:130-142) forces onto the `pages`
+ * record via BeforeRecordLanguageOverlayEvent — a value that
+ * RootlineUtility::enrichPageRecordArray() then persists as-is.
+ *
+ * Overrides the `rootline` cache backend to Typo3DatabaseBackend because
+ * FunctionalTestCase defaults it to NullBackend, which would mask the
+ * pollution.
+ */
+#[Group('security')]
+class RootlineCachePoisoningTest extends IntegrationTestBase
+{
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'exceptionalErrors' => E_WARNING | E_RECOVERABLE_ERROR | E_DEPRECATED | E_USER_DEPRECATED,
+            // Production default; FunctionalTestCase overrides this to NullBackend otherwise.
+            'caching' => [
+                'cacheConfigurations' => [
+                    'rootline' => [
+                        'backend' => Typo3DatabaseBackend::class,
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/cve_2026_56092_rootline_poisoning.csv');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            ',
+        );
+        // Start each test from an empty rootline cache.
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('rootline')->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    /**
+     * End-to-end reproduction: indexer sub-request followed by an anonymous
+     * request on the same restricted page. Cannot be modeled in-process —
+     * the indexer and anonymous sub-requests share one PHP process here, so
+     * TSFE rebuilds the rootline from the DB instead of reading the
+     * persisted (poisoned) cache entry that separate workers would share in
+     * production. The pollution itself is proven directly by
+     * rootlineCacheMustNotContainListenerMutatedRecordAfterPageIndexing().
+     */
+    #[Test]
+    public function anonymousVisitorMustNotReachAccessRestrictedPageAfterPageIndexing(): void
+    {
+        self::markTestIncomplete(
+            'CVE-2026-56092: in-process test runner cannot model the cross-worker cache-read scenario; '
+            . 'see rootlineCacheMustNotContainListenerMutatedRecordAfterPageIndexing() for the direct proof.',
+        );
+    }
+
+    /**
+     * Primary regression guard: after indexing, the rootline cache entry for
+     * the restricted page must still carry the DB's `fe_group=1` /
+     * `extendToSubpages=1` — not the listener's forced `''`/`'0'`.
+     */
+    #[Test]
+    public function rootlineCacheMustNotContainListenerMutatedRecordAfterPageIndexing(): void
+    {
+        $this->activateUserGroupDetector();
+        $this->indexPages([5], 1);
+        $this->assertSolrContainsDocumentCount(1);
+
+        // Read every cache entry directly from the rootline cache table.
+        $rows = $this->getConnectionPool()
+            ->getConnectionForTable('cache_rootline')
+            ->select(['identifier', 'content'], 'cache_rootline')
+            ->fetchAllAssociative();
+
+        self::assertNotEmpty(
+            $rows,
+            'cache_rootline is empty after indexing — backend override likely did not take effect.',
+        );
+
+        // Cache content is serialized PHP; concatenate for substring assertions.
+        $aggregated = '';
+        foreach ($rows as $row) {
+            $aggregated .= (string)$row['content'];
+        }
+
+        self::assertStringNotContainsString(
+            's:8:"fe_group";s:0:"";',
+            $aggregated,
+            'Rootline cache persisted the listener-forced empty fe_group.',
+        );
+        self::assertStringNotContainsString(
+            's:16:"extendToSubpages";s:1:"0";',
+            $aggregated,
+            'Rootline cache persisted the listener-forced extendToSubpages="0".',
+        );
+    }
+
+    /**
+     * Guards the officially supported "index restricted pages" feature: a page
+     * whose restriction is only inherited via extendToSubpages must still be
+     * indexed with its real content once the record-forging listener is gone.
+     */
+    #[Test]
+    public function pageRestrictedOnlyViaInheritedExtendToSubpagesIsStillIndexed(): void
+    {
+        $this->activateUserGroupDetector();
+        $this->indexPages([5], 1);
+
+        $solrContent = (string)file_get_contents(
+            $this->getSolrConnectionUriAuthority() . '/solr/core_en/select?q=*:*',
+        );
+        self::assertStringContainsString(
+            'ROOTLINE_POISON_CHILD_MARKER_STU567',
+            $solrContent,
+            'Indexer must still retrieve the content of a page restricted only via inherited extendToSubpages.',
+        );
+    }
+
+    /**
+     * Counter-check: a cache already warmed by a legitimate authenticated
+     * request must stay clean after indexing runs, and access stays enforced.
+     */
+    #[Test]
+    public function cacheWarmupByAuthenticatedRequestBeforeIndexingPreservesAccessRestriction(): void
+    {
+        // Pre-warm via an authenticated request (user 1 is member of fe_group 1).
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+        $this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/en/parent-restricted-area/child'))->withPageId(5),
+            $context,
+        );
+
+        $this->activateUserGroupDetector();
+        $this->indexPages([5], 1);
+
+        $response = (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/en/parent-restricted-area/child'))->withPageId(5),
+        )->getBody();
+
+        self::assertStringNotContainsString(
+            'ROOTLINE_POISON_CHILD_MARKER_STU567',
+            $response,
+            'Anonymous visitor reached the restricted page despite a pre-warmed, clean cache.',
+        );
+    }
+
+    /**
+     * Activates UserGroupDetector explicitly: executePageIndexer() only runs the
+     * indexPage phase, not the findUserGroups phase that activates it in production.
+     * The service is `shared: true` (Configuration/Services.yaml:335-339), so this
+     * affects any frontend sub-request in the same PHP process afterward.
+     */
+    protected function activateUserGroupDetector(): void
+    {
+        GeneralUtility::makeInstance(UserGroupDetector::class)->activate();
+    }
+}

--- a/Tests/Unit/ContentObject/ClassificationTest.php
+++ b/Tests/Unit/ContentObject/ClassificationTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Traversable;
 
+use function json_encode;
+
 /**
  * Tests for the SOLR_CLASSIFICATION cObj.
  */
@@ -53,7 +55,7 @@ class ClassificationTest extends SetUpContentObject
         ];
 
         $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize(['cms']);
+        $expected = json_encode(['cms']);
         self::assertEquals($expected, $actual);
     }
 
@@ -87,7 +89,7 @@ class ClassificationTest extends SetUpContentObject
         ];
 
         $actual = $this->contentObjectRenderer->cObjGetSingle(Classification::CONTENT_OBJECT_NAME, $configuration);
-        $expected = serialize($expectedOutput);
+        $expected = json_encode($expectedOutput);
         self::assertEquals($expected, $actual);
     }
 }

--- a/Tests/Unit/ContentObject/MultivalueTest.php
+++ b/Tests/Unit/ContentObject/MultivalueTest.php
@@ -20,6 +20,8 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\ContentObject;
 use ApacheSolrForTypo3\Solr\ContentObject\Multivalue;
 use PHPUnit\Framework\Attributes\Test;
 
+use function json_encode;
+
 /**
  * Tests for the SOLR_MULTIVALUE cObj.
  */
@@ -31,10 +33,22 @@ class MultivalueTest extends SetUpContentObject
     }
 
     #[Test]
-    public function convertsCommaSeparatedListFromRecordToSerializedArrayOfTrimmedValues(): void
+    public function convertsCommaSeparatedListFromRecordToJsonEncodedArrayOfTrimmedValues(): void
     {
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
+        $expected = json_encode(
+            [
+                'abc',
+                'def',
+                'ghi',
+                'jkl',
+                'mno',
+                'pqr',
+                'stu',
+                'vwx',
+                'yz',
+            ],
+        );
 
         $this->contentObjectRenderer->start(['list' => $list]);
 
@@ -50,10 +64,22 @@ class MultivalueTest extends SetUpContentObject
     }
 
     #[Test]
-    public function convertsCommaSeparatedListFromValueToSerializedArrayOfTrimmedValues(): void
+    public function convertsCommaSeparatedListFromValueToJsonEncodedArrayOfTrimmedValues(): void
     {
         $list = 'abc, def, ghi, jkl, mno, pqr, stu, vwx, yz';
-        $expected = 'a:9:{i:0;s:3:"abc";i:1;s:3:"def";i:2;s:3:"ghi";i:3;s:3:"jkl";i:4;s:3:"mno";i:5;s:3:"pqr";i:6;s:3:"stu";i:7;s:3:"vwx";i:8;s:2:"yz";}';
+        $expected = json_encode(
+            [
+                'abc',
+                'def',
+                'ghi',
+                'jkl',
+                'mno',
+                'pqr',
+                'stu',
+                'vwx',
+                'yz',
+            ],
+        );
 
         $this->contentObjectRenderer->start([]);
 

--- a/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
+++ b/Tests/Unit/Domain/Search/Query/Helper/EscapeHelperTest.php
@@ -38,6 +38,8 @@ class EscapeHelperTest extends SetUpUnitTestCase
         yield '&& character is kept' => ['input' => 'hello && world', 'expectedOutput' => 'hello && world'];
         yield '! character is kept' => ['input' => 'hello !world', 'expectedOutput' => 'hello !world'];
         yield '* character is kept' => ['input' => 'hello *world', 'expectedOutput' => 'hello *world'];
+        yield 'lone asterisk match-all stays literal' => ['input' => '*', 'expectedOutput' => '*'];
+        yield '*:* match-all gets colon escaped' => ['input' => '*:*', 'expectedOutput' => '*\:*'];
         yield '? character is kept' => ['input' => 'hello ?world', 'expectedOutput' => 'hello ?world'];
         yield 'ö character is kept' => ['input' => 'schöner tag', 'expectedOutput' => 'schöner tag'];
         yield 'numeric is kept' => ['input' => 42, 'expectedOutput' => 42];
@@ -48,10 +50,59 @@ class EscapeHelperTest extends SetUpUnitTestCase
 
     #[DataProvider('escapeQueryDataProvider')]
     #[Test]
-    public function canEscapeAsExpected($input, $expectedOutput): void
+    public function escapesOnlySelectorAndRangeCharactersWhenOperatorSyntaxIsAllowed($input, $expectedOutput): void
     {
-        $escapeHelper = new EscapeService();
-        $output = $escapeHelper::escape($input);
-        self::assertSame($expectedOutput, $output, 'Query was not escaped as expected');
+        self::assertSame(
+            $expectedOutput,
+            EscapeService::escape($input, true),
+            'Legacy-mode escape (allowOperatorSyntax=true) did not produce expected output',
+        );
+    }
+
+    #[DataProvider('escapeQueryDataProvider')]
+    #[Test]
+    public function escapeDefaultMirrorsAllowedOperatorSyntaxMode($input, $expectedOutput): void
+    {
+        self::assertSame(
+            $expectedOutput,
+            EscapeService::escape($input),
+            'Default escape() call must behave as legacy mode (allowOperatorSyntax=true)',
+        );
+    }
+
+    public static function escapeQueryWithoutOperatorSyntaxDataProvider(): Traversable
+    {
+        yield 'empty stays empty' => ['input' => '', 'expectedOutput' => ''];
+        yield 'plain word stays plain' => ['input' => 'foo', 'expectedOutput' => 'foo'];
+        yield 'numeric is kept' => ['input' => 42, 'expectedOutput' => 42];
+        yield 'whitespace is preserved literally' => ['input' => 'foo bar baz', 'expectedOutput' => 'foo bar baz'];
+        yield 'umlaut is preserved' => ['input' => 'schöner tag', 'expectedOutput' => 'schöner tag'];
+        yield 'plus operator passes through (required term)' => ['input' => '+foo', 'expectedOutput' => '+foo'];
+        yield 'minus operator passes through (prohibited term)' => ['input' => '-foo', 'expectedOutput' => '-foo'];
+        yield 'bang operator passes through (NOT)' => ['input' => '!foo', 'expectedOutput' => '!foo'];
+        yield 'asterisk wildcard passes through (prefix search)' => ['input' => 'foo*', 'expectedOutput' => 'foo*'];
+        yield 'lone asterisk match-all stays literal' => ['input' => '*', 'expectedOutput' => '*'];
+        yield '*:* match-all has only colon escaped' => ['input' => '*:*', 'expectedOutput' => '*\:*'];
+        yield 'question mark wildcard passes through (single-char)' => ['input' => 'foo?', 'expectedOutput' => 'foo?'];
+        yield 'double ampersand is escaped char by char' => ['input' => 'a && b', 'expectedOutput' => 'a \&\& b'];
+        yield 'double pipe is escaped char by char' => ['input' => 'a || b', 'expectedOutput' => 'a \|\| b'];
+        yield 'single ampersand is escaped' => ['input' => 'a&b', 'expectedOutput' => 'a\&b'];
+        yield 'single pipe is escaped' => ['input' => 'a|b', 'expectedOutput' => 'a\|b'];
+        yield 'semicolon is escaped' => ['input' => 'a;b', 'expectedOutput' => 'a\;b'];
+        yield 'field selector wildcard has only colon escaped' => ['input' => 'siteHash:*', 'expectedOutput' => 'siteHash\:*'];
+        yield 'range query is fully escaped' => ['input' => 'title:[a TO z]', 'expectedOutput' => 'title\:\[a TO z\]'];
+        yield 'rounded brackets are escaped' => ['input' => 'hello (world)', 'expectedOutput' => 'hello \(world\)'];
+        yield 'tilde is escaped' => ['input' => 'foo~2', 'expectedOutput' => 'foo\~2'];
+        yield 'backslash is escaped' => ['input' => 'a\b', 'expectedOutput' => 'a\\\\b'];
+        yield 'slash is escaped' => ['input' => 'a/b', 'expectedOutput' => 'a\/b'];
+        yield 'quoted phrase keeps inner operator literal' => ['input' => '"foo *bar"', 'expectedOutput' => '"foo *bar"'];
+    }
+
+    #[DataProvider('escapeQueryWithoutOperatorSyntaxDataProvider')]
+    #[Test]
+    public function escapesEveryLuceneSpecialCharacterWhenOperatorSyntaxIsDisallowed($input, $expectedOutput): void
+    {
+        $output = EscapeService::escape($input, false);
+        self::assertSame($expectedOutput, $output, 'Strict-mode escape did not produce expected output');
     }
 }

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -123,6 +123,32 @@ class QueryBuilderTest extends SetUpUnitTestCase
     }
 
     #[Test]
+    public function buildSearchQueryDerivesUserFieldsFromQueryFieldsByDefault(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('title content', $this->getAllQueryParameters($query)['uf'], 'The userFields default did not derive the qf field names without boosts');
+    }
+
+    #[Test]
+    public function buildSearchQueryRespectsScalarUserFieldsOverride(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryUserFields')->willReturn('description teaser');
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('description teaser', $this->getAllQueryParameters($query)['uf'], 'The userFields scalar override was not applied as the full whitelist');
+    }
+
+    #[Test]
+    public function buildSearchQueryAppliesAddAndRemoveSubKeysToQueryFieldDerivedUserFields(): void
+    {
+        $this->configurationMock->expects(self::once())->method('getSearchQueryQueryFields')->willReturn('title^10, content^123');
+        $this->configurationMock->expects(self::once())->method('getSearchQueryUserFieldsConfiguration')->willReturn(['add' => 'description', 'remove' => 'title']);
+        $query = $this->builder->buildSearchQuery('foo');
+        self::assertSame('content description', $this->getAllQueryParameters($query)['uf'], 'The userFields add/remove deltas were not applied on top of the qf-derived base list');
+    }
+
+    #[Test]
     public function buildSearchQueryInitializesTrigramPhraseFields(): void
     {
         $this->configurationMock->expects(self::once())->method('getTrigramPhraseSearchIsEnabled')->willReturn(true);

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -354,69 +354,38 @@ class QueryBuilderTest extends SetUpUnitTestCase
         $highlighting->setIsEnabled(true);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        self::assertSame('[A]', $queryParameters['hl.tag.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.tag.post'], 'Can set highlighting hl.tag.post');
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
+        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.simple.pre');
+        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.simple.post');
     }
 
     #[Test]
-    public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed(): void
+    public function unifiedHighlighterIsUsedWhenHighlightingIsEnabled(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting.']['wrap'] = '[A]|[B]';
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
-        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
-
-        $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
-        $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
-        $highlighting->setFragmentSize(17);
-        $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
-        $queryParameters = $this->getAllQueryParameters($query);
-
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting field list');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting field list');
-        self::assertEmpty($queryParameters['hl.tag.pre'], 'When the highlighting fragment size is to small hl.tag.pre should not be used because FastVectoreHighlighter will not be used');
-        self::assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
-    }
-
-    #[Test]
-    public function canUseFastVectorHighlighting(): void
-    {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(200);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Enable highlighting did not set the "hl.method" query parameter to "unified"');
     }
 
     #[Test]
-    public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18(): void
+    public function unifiedHighlighterIsUsedEvenForSmallFragmentSize(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(0);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('false', $queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Highlighting did not stay on the Unified highlighter for small fragmentSize');
     }
 
     #[Test]


### PR DESCRIPTION
Security release for TYPO3 13 LTS, fixing five vulnerabilities:

* **CVE-2026-56092** — Page indexer no longer poisons the rootline cache
* **CVE-2026-56093** — Detail view enforces site and access restrictions
* **CVE-2026-56094** — `additionalFilters` can no longer preempt the `siteHash` filter
* **CVE-2026-56095** — Multi-value cObjs switch to JSON transport (closes a PHP object-injection sink)
* **CVE-2026-56096** — User-controlled Solr query syntax is escaped/whitelisted; closes an FVH `FieldExistsQuery` HTTP 500 oracle

### CVE-2026-56092 — rootline cache poisoning

During a page-indexer sub-request, EXT:solr forced `fe_group` and `extendToSubpages` to public values on every `pages` record it touched, and TYPO3 Core persisted that record into the shared, cross-request rootline cache. An anonymous visitor could therefore reach a page whose access restriction was only inherited via `extendToSubpages` from an ancestor page, for as long as the poisoned cache entry survived — the restricted area's own root page (which carries its `fe_group` directly) was not affected.

The indexer no longer forges these fields. **Flush the rootline cache after updating** — entries written by earlier releases keep the forged values until rebuilt.

### CVE-2026-56093 — detail view access bypass

The `detail` action of the `pi_results` plugin looked up a document by its `documentId` without applying the current site's `siteHash` filter or the frontend user-group access filter. An anonymous visitor who knew or guessed a valid `documentId` could retrieve access-restricted documents through the detail view — a path less restricted than regular search.

The direct lookup now applies the same `siteHash` and frontend user-group filters as the normal search path. A `documentId` that resolves to no accessible document yields the site's configured 404 page, uniformly, so it can't be used to probe existence.

### CVE-2026-56094 — additionalFilters siteHash bypass

Request-provided `tx_solr[additionalFilters]` could register a named `siteHash` filter that the query builder refused to overwrite, so the system `siteHash` filter added later was dropped. In a shared-Solr-core multi-site installation this let an anonymous visitor of one site read public documents of another site sharing the same core.

EXT:solr now strips the reserved filter names `siteHash` and `access` from request-provided `additionalFilters` before they reach the query, and applies the system `siteHash` filter with remove-then-set semantics.

### CVE-2026-56095 — object-injection via serialize()

The `SOLR_MULTIVALUE`, `SOLR_RELATION` and `SOLR_CLASSIFICATION` content objects returned their multi-value payload as `serialize($array)`, and the indexer decoded it with `unserialize()` — a PHP object-injection sink for anyone who could influence an indexed record field. Both sides now use `json_encode()`/`json_decode()`, which never reconstructs PHP objects.

**Breaking:** third-party content objects returning `serialize($array)` for a multi-value Solr field must switch to `json_encode($array)`.

### CVE-2026-56096 — query-syntax injection / FVH oracle

User input on `tx_solr[q]` reached Solr's query parser and the Fast Vector Highlighter without sufficient escaping, allowing field-selector/operator injection and an HTTP 500 oracle via `FieldExistsQuery` against the legacy highlighter. Query syntax is now escaped/whitelisted by default (new `plugin.tx_solr.search.query.userFields` / `allowSolrOperatorSyntax` TypoScript settings govern the exact behaviour), and the Unified Highlighter is enforced unconditionally in PHP.

**Operational recommendation:** existing Solr volumes should be migrated to the updated `ext_solr_13_1_0` configset (bundled idempotent migration script under `Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/`) as defence-in-depth for clients that query Solr directly.

---

Full write-up for all five is already on this branch in `Documentation/Releases/solr-release-13-1.rst`.
