### PR TITLE
[SECURITY] 12.1.4

### DIFF
--- a/Documentation/Releases/solr-release-12-1.rst
+++ b/Documentation/Releases/solr-release-12-1.rst
@@ -101,7 +101,16 @@ provided safely, without touching any persisted cache, by EXT:solr's other, unaf
 
 All Changes
 -----------
-(filled at release time)
+
+*   [SECURITY] Fix CVE-2026-56096 — close FVH FieldExistsQuery HTTP 500 oracle by @dkd-kaehm in `73c4a52af <https://github.com/TYPO3-Solr/ext-solr/commit/73c4a52afb9fcd341656d2a3af546413d6f081a1>`_
+*   [SECURITY] Fix CVE-2026-56096 — edismax uf whitelist by @dkd-kaehm in `918c4c957 <https://github.com/TYPO3-Solr/ext-solr/commit/918c4c957f3aa1a8c4d66a38fc7218a31bcb1477>`_
+*   [SECURITY] Fix CVE-2026-56096 — escape user query syntax by @dkd-kaehm in `a63c3e586 <https://github.com/TYPO3-Solr/ext-solr/commit/a63c3e586fbdb7885b50666a5101b1716e4d9d6f>`_
+*   !!![SECURITY] Fix CVE-2026-56095 — JSON transport for multi-value cObjs by @dkd-kaehm in `268bc8124 <https://github.com/TYPO3-Solr/ext-solr/commit/268bc812417be83a536055109ab41df269f608c2>`_
+*   [SECURITY] Fix CVE-2026-56094 — Prevent request additionalFilters from preempting siteHash filter by @dkd-kaehm in `925596ac2 <https://github.com/TYPO3-Solr/ext-solr/commit/925596ac2e8d88cad86f5009eec7dd95345fbfe1>`_
+*   [SECURITY] Fix CVE-2026-56093 — Enforce siteHash and access filters in detailAction lookup by @dkd-kaehm in `058af60ac <https://github.com/TYPO3-Solr/ext-solr/commit/058af60acd8a18588daff51954e8e67ca50a9943>`_
+*   [TASK] Drop dead checkEnableFields() hook from UserGroupDetector by @dkd-kaehm in `17292d950 <https://github.com/TYPO3-Solr/ext-solr/commit/17292d950086d30899d6f05fb6af2f5e511f31d6>`_
+*   [SECURITY] Fix CVE-2026-56092 — Stop rootline cache poisoning via forged fe_group/extendToSubpages by @dkd-kaehm in `796e9a87f <https://github.com/TYPO3-Solr/ext-solr/commit/796e9a87f9f830f080419e24f952a087076953f0>`_
+
 
 Release 12.1.3
 ==============

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -17,7 +17,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="12.1.3"
+	  release="12.1.4"
 	  version="12.1"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '12.1.3',
+    'version' => '12.1.4',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
Release commit for 12.1.4, following up on the security fixes merged in #4743.

* Bumps `ext_emconf.php` and `Documentation/guides.xml` to 12.1.4.
* Fills in the `Documentation/Releases/solr-release-12-1.rst` "All Changes" list with the real, post-merge commit SHAs for CVE-2026-56092, CVE-2026-56093, CVE-2026-56094, CVE-2026-56095 and CVE-2026-56096 (plus the unrelated `UserGroupDetector` cleanup).

No functional changes beyond the version/changelog bump.

---

Security release for TYPO3 12 LTS, fixing five vulnerabilities.

- CVE-2026-56092: Page indexer no longer forges access fields on page
  records (hardening on this branch; not exploitable as an
  anonymous-access bypass on TYPO3 12 itself)
- CVE-2026-56093: Detail view enforces site and access restrictions
- CVE-2026-56094: additionalFilters can no longer preempt the siteHash
  filter
- CVE-2026-56095: Multi-value cObjs switch to JSON transport (breaking
  change for third-party content objects using serialize())
- CVE-2026-56096: User-controlled Solr query syntax is
  escaped/whitelisted; closes an FVH FieldExistsQuery HTTP 500 oracle

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/12.1/en-us/Releases/solr-release-12-1.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/12.1.4

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
  existing pull requests
* Go to [www.typo3-solr.com](http://www.typo3-solr.com/) or call dkd to sponsor the ongoing
  development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0
