### PR TITLE
[SECURITY] 13.1.4

### DIFF
--- a/Documentation/Releases/solr-release-13-1.rst
+++ b/Documentation/Releases/solr-release-13-1.rst
@@ -104,7 +104,13 @@ provided safely, without touching any persisted cache, by EXT:solr's other, unaf
 All Changes
 -----------
 
-(filled at release time)
+*   [SECURITY] Fix CVE-2026-56096 — close FVH FieldExistsQuery HTTP 500 oracle by @dkd-kaehm in `ef90309d0 <https://github.com/TYPO3-Solr/ext-solr/commit/ef90309d0cbed09569c490afba47086289508a1d>`_
+*   [SECURITY] Fix CVE-2026-56096 — edismax uf whitelist by @dkd-kaehm in `b4abe5b93 <https://github.com/TYPO3-Solr/ext-solr/commit/b4abe5b93fe7fb0a2a5a30954a11cf5a6c62424f>`_
+*   [SECURITY] Fix CVE-2026-56096 — escape user query syntax by @dkd-kaehm in `446e47152 <https://github.com/TYPO3-Solr/ext-solr/commit/446e471521570684cacd501b9826be03c4cb25ab>`_
+*   !!![SECURITY] Fix CVE-2026-56095 — JSON transport for multi-value cObjs by @dkd-kaehm in `961f809e5 <https://github.com/TYPO3-Solr/ext-solr/commit/961f809e58b43839a07e4ab206a9676ede6f1a35>`_
+*   [SECURITY] Fix CVE-2026-56094 — Prevent request additionalFilters from preempting siteHash filter by @dkd-kaehm in `975066c4c <https://github.com/TYPO3-Solr/ext-solr/commit/975066c4c7729819e1cf758d328edfe2c931bfe7>`_
+*   [SECURITY] Fix CVE-2026-56093 — Enforce siteHash and access filters in detailAction lookup by @dkd-kaehm in `7cb8f8de9 <https://github.com/TYPO3-Solr/ext-solr/commit/7cb8f8de95faff62a4feea149e68890afdb9d7ef>`_
+*   [SECURITY] Fix CVE-2026-56092 — Stop rootline cache poisoning via forged fe_group/extendToSubpages by @dkd-kaehm in `589b78f70 <https://github.com/TYPO3-Solr/ext-solr/commit/589b78f70d56ec2668dfb50c3673950738c12f03>`_
 
 
 Release 13.1.3

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,7 +19,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="13.1.3"
+	  release="13.1.4"
 	  version="13.1"
 	  copyright="since 2009 by dkd &amp; contributors"
   />

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Solr for TYPO3 - Enterprise Search',
     'description' => 'Apache Solr for TYPO3 is the enterprise search server you were looking for with special features such as Faceted Search or Synonym Support and incredibly fast response times of results within milliseconds.',
-    'version' => '13.1.3',
+    'version' => '13.1.4',
     'state' => 'stable',
     'category' => 'plugin',
     'author' => 'Rafael Kaehm, Markus Friedrich',


### PR DESCRIPTION
Release commit for 13.1.4, following up on the security fixes merged in #4744.

* Bumps `ext_emconf.php` and `Documentation/guides.xml` to 13.1.4.
* Fills in the `Documentation/Releases/solr-release-13-1.rst` "All Changes" list with the real, post-merge commit SHAs for CVE-2026-56092, CVE-2026-56093, CVE-2026-56094, CVE-2026-56095 and CVE-2026-56096.

No functional changes beyond the version/changelog bump.

---

Security release for TYPO3 13 LTS, fixing five vulnerabilities.

- CVE-2026-56092: Page indexer no longer poisons the rootline cache
- CVE-2026-56093: Detail view enforces site and access restrictions
- CVE-2026-56094: additionalFilters can no longer preempt the siteHash
  filter
- CVE-2026-56095: Multi-value cObjs switch to JSON transport (breaking
  change for third-party content objects using serialize())
- CVE-2026-56096: User-controlled Solr query syntax is
  escaped/whitelisted; closes an FVH FieldExistsQuery HTTP 500 oracle

Please read the release notes:
* https://docs.typo3.org/p/apache-solr-for-typo3/solr/13.1/en-us/Releases/solr-release-13-1.html
* https://github.com/TYPO3-Solr/ext-solr/releases/tag/13.1.4

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on
  existing pull requests
* Go to [www.typo3-solr.com](http://www.typo3-solr.com/) or call dkd to sponsor the ongoing
  development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0
