### PR TITLE
[BUGFIX] fix autosuggestion initialization for multiple search forms on one page

### DIFF
--- a/Resources/Public/JavaScript/suggest_controller.js
+++ b/Resources/Public/JavaScript/suggest_controller.js
@@ -275,7 +275,7 @@ class SuggestController {
     }
     this.autoCompleteInstance = new autoComplete(
       {
-        selector: ".tx-solr-suggest",
+        selector: () => this.form.querySelector('.tx-solr-suggest'),
         data: {
           src: async (query) => {
             const formattedQuery = this.formatQuery(query)


### PR DESCRIPTION
`autoComplete.js` resolved the string selector `.tx-solr-suggest` globally via `document.querySelector()`, so with several search forms on one page every `SuggestController` instance bound its autocomplete to the first form's input instead of its own.
Suggestions then only worked for that first form.

Passing selector as a function scopes the lookup to the controller's own form element (this.form), so each instance finds its own input.

---

@dkd-lehnebach Please give a :+1: on that PR, did I miss something?