### PR TITLE
[BUGFIX] Restore teaser for results without a match in the highlighted field

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -143,6 +143,7 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
         $highlighting->setOffsetSource(SolariumHighlightingInterface::OFFSETSOURCE_ANALYSIS);
         $highlighting->setBoundaryScannerType('WORD');
         $highlighting->setFragsizeIsMinimum(false);
+        $highlighting->setDefaultSummary(true);
 
         if ($this->getPrefix() !== '' && $this->getPostfix() !== '') {
             $highlighting->setSimplePrefix($this->getPrefix());

--- a/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
+++ b/Docker/SolrServer/docker-entrypoint-initdb.d-as-sudo/fix-SST-235567-2026050810000025-highlighter-defaults.sh
@@ -44,3 +44,21 @@ if ! grep -q "${PATCH_MARKER}" "${PATH_AND_FILENAME_SOLRCONFIG}" \
 			<str name=\"hl.bs.type\">WORD</str>\\
 			<str name=\"hl.fragsizeIsMinimum\">false</str>" "${PATH_AND_FILENAME_SOLRCONFIG}"
 fi
+
+# The Unified Highlighter does not support hl.alternateField: replace the
+# leading-text fallback with its hl.defaultSummary equivalent.
+# Runs independently of the block above so that cores migrated by an earlier
+# version of this script are aligned as well. All checks and edits are scoped
+# to the /select request handler to leave customized handlers untouched.
+PATH_AND_FILENAME_BACKUP_SUMMARY="${PATH_SOLRCONFIG}/solrconfig.xml.Backup-unified-defaultSummary"
+SELECT_HANDLER_RANGE='/<requestHandler name="\/select"/,/<\/requestHandler>/'
+
+if sed -n "${SELECT_HANDLER_RANGE}p" "${PATH_AND_FILENAME_SOLRCONFIG}" | grep -q '<str name="f.content.hl.alternateField">content</str>' \
+	&& ! sed -n "${SELECT_HANDLER_RANGE}p" "${PATH_AND_FILENAME_SOLRCONFIG}" | grep -q 'f.content.hl.defaultSummary'; then
+	echo "  replacing f.content.hl.alternateField by f.content.hl.defaultSummary in the /select handler (alternateField is ignored by the Unified Highlighter)"
+
+	cp "${PATH_AND_FILENAME_SOLRCONFIG}" "${PATH_AND_FILENAME_BACKUP_SUMMARY}"
+
+	sed -i "${SELECT_HANDLER_RANGE} s|<str name=\"f.content.hl.alternateField\">content</str>|<str name=\"f.content.hl.defaultSummary\">true</str>|" "${PATH_AND_FILENAME_SOLRCONFIG}"
+	sed -i "${SELECT_HANDLER_RANGE} {/<str name=\"f.content.hl.maxAlternateFieldLength\">/d}" "${PATH_AND_FILENAME_SOLRCONFIG}"
+fi

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -618,12 +618,12 @@ results.resultsHighlighting
 :TS Path: plugin.tx_solr.search.results.resultsHighlighting
 :Since: 1.0
 :Default: 0
-:See: `Apache Solr Wiki / FastVectorHighlighter <https://cwiki.apache.org/confluence/display/solr/FastVector+Highlighter>`_
+:See: `Apache Solr Reference Guide / Highlighting <https://solr.apache.org/guide/solr/9_10/query-guide/highlighting.html>`_
 
 En-/disables search term highlighting on the results page.
 
 ..  note::
-    The FastVectorHighlighter is used by default (Since 4.0) if fragmentSize is set to at least 18 (this is required by the FastVectorHighlighter to work).
+    Since 13.1.4 the Unified Highlighter is used unconditionally, regardless of fragmentSize. If Solr cannot generate a highlighted snippet for a field, it returns a leading-text default summary of approximately hl.snippets * fragmentSize characters.
 
 ..  note::
     The highlighting component will not work for vector search (`query.type=1`), as no classic search term is used/available to be highlighted. Using the siteHighlighting and an adjusted JavaScript could be an alternative approach.
@@ -638,8 +638,8 @@ results.resultsHighlighting.highlightFields
 
 A comma-separated list of fields to highlight.
 
-Note: The highlighting in Solr (based on FastVectorHighlighter requires a field datatype with **termVectors=on**, **termPositions=on** and **termOffsets=on** which is the case for the content field).
-If you add other fields here, make sure that you are using a datatype where this is configured.
+Note: The Unified Highlighter uses **hl.offsetSource=ANALYSIS**, so term vectors are not required.
+Highlighted fields must be stored, and their analysis should be compatible with the queried fields.
 
 results.resultsHighlighting.fragmentSize
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Resources/Private/Solr/configsets/ext_solr_13_1_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_13_1_0/conf/solrconfig.xml
@@ -151,8 +151,7 @@
 			<str name="hl.bs.type">WORD</str>
 			<str name="hl.fragsizeIsMinimum">false</str>
 
-			<str name="f.content.hl.alternateField">content</str>
-			<str name="f.content.hl.maxAlternateFieldLength">200</str>
+			<str name="f.content.hl.defaultSummary">true</str>
 
 			<str name="spellcheck">false</str>
 			<str name="spellcheck.onlyMorePopular">false</str>

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -415,6 +415,19 @@ class QueryBuilderTest extends SetUpUnitTestCase
     }
 
     #[Test]
+    public function defaultSummaryIsRequestedWhenHighlightingIsEnabled(): void
+    {
+        $fakeConfiguration = new TypoScriptConfiguration([]);
+        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
+        $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
+        $highlighting->setIsEnabled(true);
+        $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
+        $queryParameters = $this->getAllQueryParameters($query);
+
+        self::assertSame('true', $queryParameters['hl.defaultSummary'], 'Highlighting did not request hl.defaultSummary, the Unified Highlighter replacement for hl.alternateField');
+    }
+
+    #[Test]
     public function canSetQueryString(): void
     {
         $query = $this->getInitializedTestSearchQuery('i like solr');


### PR DESCRIPTION
## Problem

Since 13.1.4 `Highlighting::build()` enforces the Unified Highlighter unconditionally (part of the SST-235567 security fix). The Unified Highlighter does not support `hl.alternateField` / `hl.maxAlternateFieldLength` — those options only exist for the original and FastVector highlighters — yet the shipped `ext_solr_13_1_0` configset still relies on them in the `/select` handler defaults.

As a result, documents matching only in `title`, `keywords` or heading fields get no highlighting entry from Solr anymore (previously: the first 200 characters via `alternateField`), and `HighlightResultViewHelper` falls back to rendering the entire untruncated `content` field — result lists show teasers of 10,000+ characters.

Verified on Solr 9.10.1 (same core, same title-only-match query): `hl.method=original` → 200 chars, `fastVector` → 200 chars, `unified` → empty.

## What was changed

* `Highlighting::build()` now requests `hl.defaultSummary=true`, the Unified Highlighter's equivalent: it returns the leading portion of the field when no passages match. Solarium 6.4 supports this natively (`setDefaultSummary()`). Set globally in PHP, mirroring how the highlighter method itself is enforced; per-field server overrides (`f.<field>.hl.defaultSummary=false`) remain possible.
* The `ext_solr_13_1_0` configset replaces the dead `f.content.hl.alternateField` / `f.content.hl.maxAlternateFieldLength` defaults with `f.content.hl.defaultSummary=true`.
* The `fix-SST-235567-*-highlighter-defaults.sh` migration script gets a second, independently guarded, idempotent block that applies the same replacement to existing cores — including cores already migrated by an earlier run of the script. All checks and edits are scoped to the `/select` request handler, so customized handlers (e.g. a FastVector handler with its own `alternateField`) are left untouched. It writes its own backup file: `solrconfig.xml.Backup-unified-defaultSummary`.
* `TxSolrSearch.rst` is updated in a separate `[DOCS]` commit: the "FastVector if `fragmentSize` >= 18" rule and the term-vector requirement no longer apply since 13.1.4; the reference now describes the unconditional Unified Highlighter, the default-summary fallback, and links the versioned Solr 9.10 highlighting guide.

## Behavioral note

`hl.defaultSummary` returns leading passages of roughly `hl.snippets × fragmentSize` characters — close to, but not identical with, the former hard 200-character `maxAlternateFieldLength` cap. The Unified Highlighter offers no separate length parameter for the default summary; the only knob (`hl.snippets`) would also reduce the number of fragments for real matches, so the approximate length is accepted.

## Verification

* New unit test `defaultSummaryIsRequestedWhenHighlightingIsEnabled` proves the parameter is emitted; full unit suite green (1019 tests), php-cs-fixer and PHPStan clean.
* Migration script dry-run matrix (all states re-run twice; second run is a byte-identical no-op, XML stays valid):

| Initial state | Result |
|---|---|
| Pre-13.1.4 core (`hl.method=original` + `alternateField`) | `/select` migrated to unified + `defaultSummary` |
| Core already migrated by the previous script version (unified + dead `alternateField`) | `/select` gets `defaultSummary`, dead options removed |
| Custom handler already containing `f.content.hl.defaultSummary` | `/select` still migrated, custom handler untouched |
| Custom FastVector handler with its own `alternateField` + `maxAlternateFieldLength` | Custom handler fully preserved, `/select` migrated |

Fixes #4748