### PR TITLE
[SECURITY] Fix CVE-2026-56096 — close FVH FieldExistsQuery HTTP 500 oracle

### DIFF
--- a/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
+++ b/Classes/Domain/Search/Query/ParameterBuilder/Highlighting.php
@@ -19,6 +19,7 @@ namespace ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\AbstractQueryBuilder;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use Solarium\Component\Highlighting\HighlightingInterface as SolariumHighlightingInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -92,11 +93,6 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
         $this->postfix = $postfix;
     }
 
-    public function getUseFastVectorHighlighter(): bool
-    {
-        return $this->fragmentSize >= 18;
-    }
-
     public static function fromTypoScriptConfiguration(TypoScriptConfiguration $solrConfiguration): Highlighting
     {
         $isEnabled = $solrConfiguration->getIsSearchResultsHighlightingEnabled();
@@ -126,23 +122,18 @@ class Highlighting extends AbstractDeactivatable implements ParameterBuilderInte
             return $parentBuilder;
         }
 
-        $query->getHighlighting()->setFragSize($this->getFragmentSize());
-        $query->getHighlighting()->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
-
-        if ($this->getUseFastVectorHighlighter()) {
-            $query->getHighlighting()->setUseFastVectorHighlighter(true);
-            $query->getHighlighting()->setTagPrefix($this->getPrefix());
-            $query->getHighlighting()->setTagPostfix($this->getPostfix());
-            $query->getHighlighting()->setMethod('fastVector');
-        } else {
-            $query->getHighlighting()->setUseFastVectorHighlighter(false);
-            $query->getHighlighting()->setTagPrefix('');
-            $query->getHighlighting()->setTagPostfix('');
-        }
+        $highlighting = $query->getHighlighting();
+        $highlighting->setFragSize($this->getFragmentSize());
+        $highlighting->setFields(GeneralUtility::trimExplode(',', $this->getHighlightingFieldList()));
+        $highlighting->setMethod(SolariumHighlightingInterface::METHOD_UNIFIED);
+        $highlighting->setOffsetSource(SolariumHighlightingInterface::OFFSETSOURCE_ANALYSIS);
+        $highlighting->setBoundaryScannerType('WORD');
+        $highlighting->setFragsizeIsMinimum(false);
+        $highlighting->setDefaultSummary(true);
 
         if ($this->getPrefix() !== '' && $this->getPostfix() !== '') {
-            $query->getHighlighting()->setSimplePrefix($this->getPrefix());
-            $query->getHighlighting()->setSimplePostfix($this->getPostfix());
+            $highlighting->setSimplePrefix($this->getPrefix());
+            $highlighting->setSimplePostfix($this->getPostfix());
         }
 
         return $parentBuilder;

--- a/Documentation/Configuration/Reference/TxSolrSearch.rst
+++ b/Documentation/Configuration/Reference/TxSolrSearch.rst
@@ -559,12 +559,14 @@ results.resultsHighlighting
 :TS Path: plugin.tx_solr.search.results.resultsHighlighting
 :Since: 1.0
 :Default: 0
-:See: `Apache Solr Reference Guide / FastVector Highlighter <https://solr.apache.org/guide/solr/10_0/query-guide/highlighting.html#fastvector-highlighter>`_
+:See: `Apache Solr Reference Guide / Unified Highlighter <https://solr.apache.org/guide/solr/10_0/query-guide/highlighting.html#the-unified-highlighter>`_
 
 En-/disables search term highlighting on the results page.
 
 ..  note::
-    The FastVectorHighlighter is used by default (Since 4.0) if fragmentSize is set to at least 18 (this is required by the FastVectorHighlighter to work).
+    The Unified Highlighter is used unconditionally (Since 14.0, and 13.1.4).
+    It replaces the FastVectorHighlighter, which crashed with HTTP 500 on ``field:*`` queries
+    and thereby exposed a field-existence oracle on the indexed schema (CVE-2026-56096).
 
 ..  note::
     The highlighting component will not work for vector search (`query.type=1`), as no classic search term is used/available to be highlighted. Using the siteHighlighting and an adjusted JavaScript could be an alternative approach.
@@ -579,8 +581,11 @@ results.resultsHighlighting.highlightFields
 
 A comma-separated list of fields to highlight.
 
-Note: The highlighting in Solr (based on FastVectorHighlighter requires a field datatype with **termVectors=on**, **termPositions=on** and **termOffsets=on** which is the case for the content field).
-If you add other fields here, make sure that you are using a datatype where this is configured.
+Note: The Unified Highlighter is requested with ``hl.offsetSource=ANALYSIS``, so it re-analyzes the stored
+field value at query time instead of reading offsets from the index.
+Highlighted fields therefore only need to be **stored=true**;
+**termVectors**, **termPositions** and **termOffsets** are no longer required.
+If you add other fields here, make sure that they are stored.
 
 results.resultsHighlighting.fragmentSize
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -166,6 +166,43 @@ This also fixes a latent bug where the misspelled term was captured from the arr
 See `#4659 <https://github.com/TYPO3-Solr/ext-solr/issues/4659>`_.
 
 
+Security: CVE-2026-56096 — FieldExistsQuery HTTP 500 Oracle Closed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A stand-alone ``field:*`` query was forwarded through the FastVector Highlighter (FVH).
+Lucene rewrote it to a ``FieldExistsQuery``, which FVH could not handle, and the request failed with HTTP 500 —
+turning the response status into a field-existence oracle on the indexed schema.
+
+Fix: EXT:solr now requests the Unified Highlighter unconditionally, with ``hl.offsetSource=ANALYSIS``
+so that highlighted fields do not need ``storeOffsetsWithPositions``.
+``hl.bs.type=WORD`` and ``hl.fragsizeIsMinimum=false`` are kept,
+so ``fragmentSize`` retains its soft upper bound.
+``hl.defaultSummary=true`` replaces the ``hl.alternateField`` teaser fallback,
+which the Unified Highlighter ignores.
+
+The shipped ``ext_solr_14_0_0`` configset sets the same defaults on the ``/select`` and ``/browse`` request handlers.
+
+..  attention::
+    **Docker users:** the configset is copied into the Solr data volume on first container start,
+    so pulling a new EXT:solr version does not refresh an existing volume.
+    If you already run a Solr container seeded from a pre-release ``ext_solr_14_0_0`` configset,
+    its ``/select`` and ``/browse`` handlers still default to the legacy highlighter
+    and stay vulnerable when queried directly, bypassing EXT:solr.
+    Remove the Solr data volume and restart the container so the patched configset is seeded,
+    then re-index — dropping the volume also drops the index.
+
+    EXT:solr itself enforces the Unified Highlighter in PHP,
+    so this configset alignment is a defence-in-depth measure for clients that query Solr directly.
+
+No stable 14.0.0 release shipped the vulnerable configset,
+so the ``fix-SST-235567-2026050810000025-highlighter-defaults.sh`` migration script
+that accompanies the 13.1.4 release is not part of 14.0.0.
+
+Also released for TYPO3 13 LTS as EXT:solr 13.1.4.
+
+SST ticket: #2026050810000025, dkd: #235567
+
+
 Breaking Changes
 ----------------
 
@@ -433,6 +470,21 @@ Since EXT:solr 9 and Apache Solr 7 dynamic fields based on trie fields are marke
 *   *_tDouble4 (-> _double4M)
 *   *_tDate (-> _dateS)
 *   *_tDate (-> _dateM)
+
+
+!!! Highlighting::getUseFastVectorHighlighter() removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:php:`ApacheSolrForTypo3\Solr\Domain\Search\Query\ParameterBuilder\Highlighting::getUseFastVectorHighlighter()`
+returned whether ``fragmentSize`` was large enough (``>= 18``) for the FastVector Highlighter.
+Since the Unified Highlighter is now used unconditionally (see CVE-2026-56096 above),
+the method had no effect on the built query.
+It was deprecated in 13.1.4 and is removed in 14.0.0.
+
+The related query parameter ``hl.useFastVectorHighlighter`` is no longer sent;
+``hl.method=unified`` is sent instead.
+
+*Migration:* Drop the call. There is no replacement — the highlighter is no longer switchable via ``fragmentSize``.
 
 
 All Changes

--- a/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/solrconfig.xml
+++ b/Resources/Private/Solr/configsets/ext_solr_14_0_0/conf/solrconfig.xml
@@ -146,10 +146,12 @@
 			<int name="hl.snippets">3</int>
 			<str name="hl.mergeContiguous">true</str>
 			<str name="hl.requireFieldMatch">true</str>
-			<str name="hl.method">original</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 
-			<str name="f.content.hl.alternateField">content</str>
-			<str name="f.content.hl.maxAlternateFieldLength">200</str>
+			<str name="f.content.hl.defaultSummary">true</str>
 
 			<str name="spellcheck">false</str>
 			<str name="spellcheck.onlyMorePopular">false</str>
@@ -218,6 +220,10 @@
 			<str name="hl.encoder">html</str>
 			<str name="hl.simple.pre">&lt;b&gt;</str>
 			<str name="hl.simple.post">&lt;/b&gt;</str>
+			<str name="hl.method">unified</str>
+			<str name="hl.offsetSource">ANALYSIS</str>
+			<str name="hl.bs.type">WORD</str>
+			<str name="hl.fragsizeIsMinimum">false</str>
 		</lst>
 		<arr name="last-components">
 			<str>spellcheck</str>

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -87,7 +87,8 @@ final class SearchTest extends IntegrationTestBase
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->indexPages(range(2, 16));
 
-        // fragmentSize 50 => fastVector
+        // The Unified Highlighter keeps fragmentSize as a soft upper bound,
+        // so decreasing it must shorten the returned fragment: 50 > 20 > 10.
         $typoScriptConfiguration = new TypoScriptConfiguration([
             'plugin.' => [
                 'tx_solr.' => [
@@ -109,7 +110,7 @@ final class SearchTest extends IntegrationTestBase
         $parsedData = $this->searchInstance->search($query)->getParsedData();
         $highlightString = current((array)$parsedData->highlighting)?->title[0];
 
-        // fragmentSize 20 => fastVector
+        // fragmentSize 20
         $typoScriptConfiguration->mergeSolrConfiguration([
             'search.' => [
                 'results.' => [
@@ -123,7 +124,7 @@ final class SearchTest extends IntegrationTestBase
         $parsedData = $this->searchInstance->search($query)->getParsedData();
         $highlightString2 = current((array)$parsedData->highlighting)?->title[0];
 
-        // fragmentSize 10 => original
+        // fragmentSize 10
         $typoScriptConfiguration->mergeSolrConfiguration([
             'search.' => [
                 'results.' => [

--- a/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
+++ b/Tests/Integration/Security/Fixtures/sst_2026050810000025_query_injection.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","slug","title","fe_group","module"
+,2,1,0,1,"/alpha","markeralpha235567",,""
+,3,1,0,1,"/beta","markerbeta235567",,""
+,4,1,0,1,"/gamma","markergamma235567",,""
+"tt_content",
+,"uid","pid","colPos","CType","header","bodytext","fe_group","sorting"
+,201,2,0,"text","alpha header","body of the alpha test page; unique token bodyalpha235567",0,10
+,301,3,0,"text","beta header","body of the beta test page; unique token bodybeta235567",0,10
+,401,4,0,"text","gamma header","body of the gamma test page; unique token bodygamma235567",0,10

--- a/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
+++ b/Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Tests\Integration\Security;
+
+use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
+use ApacheSolrForTypo3\Solr\Search;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use ApacheSolrForTypo3\Solr\System\Solr\SolrCommunicationException;
+use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
+use ApacheSolrForTypo3\Solr\Tests\Integration\TSFETestBootstrapper;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Regression guard for SST #2026050810000025:
+ * the highlighter must not surface `field:*` queries as a Solr HTTP 500 field-existence oracle.
+ */
+#[Group('frontend')]
+#[Group('security')]
+class QueryInjectionViaRawSolrSyntaxTest extends IntegrationTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeDefaultSolrTestSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/default_search_results_plugin.csv');
+        $this->addTypoScriptToTemplateRecord(
+            1,
+            /* @lang TYPO3_TypoScript */
+            '
+            config.index_enable = 1
+            [page["uid"] == 2022]
+            page.10 = RECORDS
+            page.10 {
+              source = 2022
+              dontCheckPid = 1
+              tables = tt_content
+              wrap >
+            }
+            [end]
+            ',
+        );
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sst_2026050810000025_query_injection.csv');
+        $this->indexPages([2, 3, 4]);
+        $this->assertSolrContainsDocumentCount(3);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAllCoresOnSolrServerAndAssertEmpty();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function literalTokenSearchReturnsExpectedDocument(): void
+    {
+        $response = $this->executeSearch('markeralpha235567');
+        self::assertStringContainsString(
+            'markeralpha235567',
+            $response,
+            'Sanity check failed: literal-token search for the alpha marker did not return the alpha document.',
+        );
+    }
+
+    #[Test]
+    public function existingFieldWildcardMustNotTriggerSolrCommunicationException(): void
+    {
+        GeneralUtility::makeInstance(TSFETestBootstrapper::class)->bootstrap(1);
+        $configuration = new TypoScriptConfiguration([
+            'plugin.' => ['tx_solr.' => ['search.' => [
+                'query.' => ['queryFields' => 'content,title'],
+                'results.' => [
+                    'resultsHighlighting' => 1,
+                    'resultsHighlighting.' => [
+                        'fragmentSize' => 50,
+                        'wrap' => '<mark>|</mark>',
+                    ],
+                ],
+            ]]],
+        ]);
+        $query = (new QueryBuilder($configuration))->buildSearchQuery('siteHash:*');
+        try {
+            GeneralUtility::makeInstance(Search::class)->search($query);
+        } catch (SolrCommunicationException $e) {
+            self::fail('SST 235567: highlighter raised ' . $e::class . ' — ' . $e->getMessage());
+        }
+    }
+
+    protected function executeSearch(string $rawQuery): string
+    {
+        return (string)$this->executeFrontendSubRequest(
+            (new InternalRequest('http://testone.site/'))
+                ->withPageId(2022)
+                ->withQueryParameter('tx_solr[q]', $rawQuery),
+        )->getBody();
+    }
+}

--- a/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Query/QueryBuilderTest.php
@@ -368,69 +368,51 @@ final class QueryBuilderTest extends SetUpUnitTestCase
         $highlighting->setIsEnabled(true);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
-        self::assertSame('[A]', $queryParameters['hl.tag.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.tag.post'], 'Can set highlighting hl.tag.post');
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.tag.pre');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.tag.post');
+        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting hl.simple.pre');
+        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting hl.simple.post');
     }
 
     #[Test]
-    public function simplePreAndPostIsUsedWhenFastVectorHighlighterCouldNotBeUsed(): void
+    public function unifiedHighlighterIsUsedWhenHighlightingIsEnabled(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting'] = 1;
-        $fakeConfigurationArray['plugin.']['tx_solr.']['search.']['results.']['resultsHighlighting.']['wrap'] = '[A]|[B]';
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
-        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
-
-        $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
-        $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
-        $highlighting->setFragmentSize(17);
-        $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
-        $queryParameters = $this->getAllQueryParameters($query);
-
-        self::assertSame('[A]', $queryParameters['hl.simple.pre'], 'Can set highlighting field list');
-        self::assertSame('[B]', $queryParameters['hl.simple.post'], 'Can set highlighting field list');
-        self::assertEmpty($queryParameters['hl.tag.pre'], 'When the highlighting fragment size is to small hl.tag.pre should not be used because FastVectoreHighlighter will not be used');
-        self::assertEmpty($queryParameters['hl.tag.post'], 'When the highlighting fragment size is to small hl.tag.post should not be used because FastVectoreHighlighter will not be used');
-    }
-
-    #[Test]
-    public function canUseFastVectorHighlighting(): void
-    {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(200);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('true', $queryParameters['hl.useFastVectorHighlighter'], 'Enable highlighting did not set the "hl.useFastVectorHighlighter" query parameter');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Enable highlighting did not set the "hl.method" query parameter to "unified"');
     }
 
     #[Test]
-    public function fastVectorHighlighterIsDisabledWhenFragSizeIsLessThen18(): void
+    public function unifiedHighlighterIsUsedEvenForSmallFragmentSize(): void
     {
-        $fakeConfigurationArray = [];
-        $fakeConfiguration = new TypoScriptConfiguration($fakeConfigurationArray);
-
+        $fakeConfiguration = new TypoScriptConfiguration([]);
         $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
         $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
         $highlighting->setIsEnabled(true);
-        // fragSize 10 is to small for FastVectorHighlighter
         $highlighting->setFragmentSize(0);
         $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
         $queryParameters = $this->getAllQueryParameters($query);
 
         self::assertSame('true', $queryParameters['hl'], 'Enable highlighting did not set the "hl" query parameter');
-        self::assertSame('false', $queryParameters['hl.useFastVectorHighlighter'], 'FastVectorHighlighter was disabled but still requested');
+        self::assertSame('unified', $queryParameters['hl.method'], 'Highlighting did not stay on the Unified highlighter for small fragmentSize');
+    }
+
+    #[Test]
+    public function defaultSummaryIsRequestedWhenHighlightingIsEnabled(): void
+    {
+        $fakeConfiguration = new TypoScriptConfiguration([]);
+        $query = $this->getInitializedTestSearchQuery('test', $fakeConfiguration);
+        $highlighting = Highlighting::fromTypoScriptConfiguration($fakeConfiguration);
+        $highlighting->setIsEnabled(true);
+        $query = $this->builder->startFrom($query)->useHighlighting($highlighting)->getQuery();
+        $queryParameters = $this->getAllQueryParameters($query);
+
+        self::assertSame('true', $queryParameters['hl.defaultSummary'], 'Highlighting did not request hl.defaultSummary, the Unified Highlighter replacement for hl.alternateField');
     }
 
     #[Test]


### PR DESCRIPTION
A stand-alone `field:*` query was forwarded through the "FastVector highlighter" (FVH)
(enabled in f528685c2 to honour fragmentSize on Solr 9);
Lucene rewrote it to `FieldExistsQuery` and FVH crashed with HTTP 500,
turning the response into a field-existence oracle on the indexed schema
(TYPO3_Solr_Security_Report-1.pdf §3.1).

Switch the highlighter to the Unified Highlighter with `hl.offsetSource=ANALYSIS`
(avoids requiring `storeOffsetsWithPositions` on the indexed fields).
Keep `hl.bs.type=WORD` and `hl.fragsizeIsMinimum=false`
so fragmentSize retains its soft upper bound — the original motivation behind the FVH switch.
`hl.defaultSummary=true` replaces the `hl.alternateField` teaser fallback,
which the Unified Highlighter ignores.

`Tests/Integration/Security/QueryInjectionViaRawSolrSyntaxTest` adds the regression guard
against the HTTP 500 oracle.
`QueryBuilderTest` highlighting assertions follow the new `hl.method=unified` parameter set.

TYPO3 14 port notes:

*   `Highlighting::getUseFastVectorHighlighter()` is removed, not deprecated.
    13.1.4 announced the removal for v14, and nothing calls it anymore.
*   `fix-SST-235567-2026050810000025-highlighter-defaults.sh` is not included.
    No stable 14.0.0 shipped the vulnerable ext_solr_14_0_0 configset, so there is
    nothing to migrate; Docker users on a pre-release volume must drop the volume,
    restart and re-index.
*   Release notes go to solr-release-14-0.rst, main does not track 13.1.x notes.
*   TxSolrSearch.rst: hl.offsetSource=ANALYSIS needs stored fields only,
    not termVectors/termPositions/termOffsets.

Only the configset-relevant layers of the CVE fix are ported.
The edismax `uf` whitelist (b4abe5b93) and the query-syntax escaping (446e47152)
are PHP-only and stay on release-13.1.x, so the five §3.1–§3.4 guards of
QueryInjectionViaRawSolrSyntaxTest are intentionally not part of this port.

SST ticket: #2026050810000025
dkd: #235567

(cherry picked from commit ef90309d0cbed09569c490afba47086289508a1d)
(cherry picked from commit 03ba2287afb72a2ce90bd563f9bc0c998d4110d6)

Co-Authored-By: Simeon de Vere Peratoner <peratoner@louis.info>
