### PR TITLE
[TASK] Retire the hand-built IndexingInstructions from the integration tests

### DIFF
--- a/Tests/Integration/Fixtures/Extensions/fake_extension3/Classes/EventListeners/AddExampleDocumentsBeforePageIndexing.php
+++ b/Tests/Integration/Fixtures/Extensions/fake_extension3/Classes/EventListeners/AddExampleDocumentsBeforePageIndexing.php
@@ -18,17 +18,22 @@ declare(strict_types=1);
 namespace ApacheSolrForTypo3\SolrFakeExtension3\EventListeners;
 
 use ApacheSolrForTypo3\Solr\Event\Indexing\BeforePageDocumentIsProcessedForIndexingEvent;
+use ApacheSolrForTypo3\Solr\Util;
 
 final class AddExampleDocumentsBeforePageIndexing
 {
     /**
      * Provides additional documents that should be indexed together with a page.
+     *
+     * Enabled per test through TypoScript, the way a real listener would be configured, because
+     * the production pipeline builds the indexing sub-request itself and carries no query
+     * parameters a test could switch on.
      */
     public function __invoke(BeforePageDocumentIsProcessedForIndexingEvent $event): void
     {
-        $request = $event->getRequest();
-        $queryParams = $request->getQueryParams();
-        if (!($queryParams['additionalTestPageIndexer'] ?? false)) {
+        $isEnabled = Util::getSolrConfiguration()
+            ->getValueByPathOrDefaultValue('plugin.tx_solr.index.queue.pages.addExampleDocuments', 0);
+        if (!$isEnabled) {
             return;
         }
         $pageDocument = $event->getDocument();

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -500,9 +500,10 @@ final class GarbageCollectorTest extends IntegrationTestBase
         $this->assertEmptyEventQueue();
 
         // index all queue items
-        foreach ($this->indexQueue->getAllItems() as $item) {
-            self::assertTrue($this->indexPageQueueItem($item), 'Queue item failed to be indexed.');
-        }
+        self::assertTrue(
+            $this->indexQueuedItems(count($this->indexQueue->getAllItems())),
+            'Queue items failed to be indexed.',
+        );
         $this->waitToBeVisibleInSolr();
         self::assertSolrContainsDocumentCount(2, 'Initial number of documents in index not as expected');
 
@@ -607,14 +608,11 @@ final class GarbageCollectorTest extends IntegrationTestBase
         $this->addTypoScriptToTemplateRecord(1, 'config.index_enable = 1');
         $this->assertEmptyEventQueue();
 
-        // index all queue items
-        foreach ($this->indexQueue->getAllItems() as $item) {
-            self::assertTrue($this->indexPageQueueItem($item), 'Queue item failed to be indexed in default language.');
-            self::assertTrue(
-                $this->indexPageQueueItem($item, 1, 'core_de'),
-                'Queue item failed to be indexed in german translation.',
-            );
-        }
+        // index all queue items, one pass covering every language they are indexable in
+        self::assertTrue(
+            $this->indexQueuedItems(count($this->indexQueue->getAllItems())),
+            'Queue items failed to be indexed.',
+        );
         $this->waitToBeVisibleInSolr();
         $this->waitToBeVisibleInSolr('core_de');
         self::assertSolrContainsDocumentCount(2, 'Initial number of documents in english index not as expected', 'core_en');

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -17,13 +17,8 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration\IndexQueue\FrontendHelper;
 
-use ApacheSolrForTypo3\Solr\Domain\Index\PageIndexer\PageUriBuilder;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTestBase;
 use PHPUnit\Framework\Attributes\Test;
-use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Http\Uri;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Page\CacheHashCalculator;
 
 /**
  * Testcase to check if we can index page documents using the SolrIndexingMiddleware
@@ -114,8 +109,8 @@ final class PageIndexerTest extends IntegrationTestBase
             ',
         );
 
-        $this->indexQueuedPage(4711, 0);
-        $this->indexQueuedPage(4711, 1);
+        // One pass covers every language the page is indexable in.
+        $this->indexQueuedPage();
 
         $this->waitToBeVisibleInSolr('core_en');
         $this->waitToBeVisibleInSolr('core_de');
@@ -301,55 +296,19 @@ final class PageIndexerTest extends IntegrationTestBase
     public function phpProcessDoesNotDieIfPageIsNotAvailable(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/does_not_die_if_page_not_available.csv');
-        $response = $this->indexQueuedPage(forceUrl: 'http://testone.site/?id=1636120156');
 
-        // The new sub-request pipeline returns an error status for unavailable pages
-        // instead of a JSON response — the important thing is that the process doesn't die.
-        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), 'Expected error status for unavailable page');
+        // The queued item points at a page that does not exist. IndexService reports it as not
+        // indexed instead of letting the sub-request take the process down with it.
+        self::assertFalse($this->indexQueuedPage());
     }
 
     /**
-     * Executes a Frontend request to trigger page indexing via SolrIndexingMiddleware.
+     * Indexes the queued page the way the scheduler task does, so the indexing instructions --
+     * the access rootline including the mount point parameter, the languages and the content
+     * access groups -- are the ones production builds.
      */
-    protected function indexQueuedPage(
-        int $indexQueueItem = 4711,
-        int $siteLanguageUid = 0,
-        array $additionalQueryParams = [],
-        string $forceUrl = '',
-    ): ResponseInterface {
-        $item = $this->getIndexQueueItem($indexQueueItem);
-
-        if ($forceUrl !== '') {
-            return $this->executePageIndexer($forceUrl, $item);
-        }
-
-        $uriBuilder = GeneralUtility::makeInstance(PageUriBuilder::class);
-        $mountPointParameter = '';
-        if ($item->hasIndexingProperty('isMountedPage')) {
-            $mountPointParameter = $item->getIndexingProperty('mountPageSource')
-                . '-' . $item->getIndexingProperty('mountPageDestination');
-        }
-        $url = $uriBuilder->getPageIndexingUriFromPageItemAndLanguageId(
-            $item,
-            $siteLanguageUid,
-            $mountPointParameter,
-        );
-
-        if ($additionalQueryParams !== []) {
-            $url = new Uri($url);
-            $queryString = ltrim(
-                $url->getQuery()
-                    . '&id=' . $item->getRecordUid()
-                    . GeneralUtility::implodeArrayForUrl('', $additionalQueryParams),
-                '&',
-            );
-            $cacheHash = GeneralUtility::makeInstance(CacheHashCalculator::class)->generateForParameters($queryString);
-            if ($cacheHash) {
-                $queryString .= '&cHash=' . $cacheHash;
-            }
-            $url = (string)$url->withQuery($queryString);
-        }
-
-        return $this->executePageIndexer($url, $item);
+    protected function indexQueuedPage(int $indexQueueItem = 4711): bool
+    {
+        return $this->indexQueuedItem($this->getIndexQueueItem($indexQueueItem));
     }
 }

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -230,13 +230,14 @@ final class PageIndexerTest extends IntegrationTestBase
             1,
             /* @lang TYPO3_TypoScript */
             '
+            plugin.tx_solr.index.queue.pages.addExampleDocuments = 1
             plugin.tx_solr.index.queue.pages.fields {
               custom_stringS = TEXT
               custom_stringS.value = my text
             }
             ',
         );
-        $this->indexQueuedPage(4711, 0, ['additionalTestPageIndexer' => 1]);
+        $this->indexQueuedPage();
 
         $this->waitToBeVisibleInSolr();
 

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -15,7 +15,6 @@
 
 namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
-use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Index\IndexService;
 use ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository;
@@ -33,16 +32,13 @@ use Doctrine\DBAL\Exception as DBALException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionObject;
 use Symfony\Component\DependencyInjection\Container;
 use Throwable;
-use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
-use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\RequestFactory;
@@ -53,8 +49,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\Domain\Repository\SchedulerTaskRepository;
 use TYPO3\CMS\Scheduler\Scheduler;
 use TYPO3\CMS\Scheduler\Task\TaskSerializer;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -559,71 +553,6 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         }
 
         $this->waitToBeVisibleInSolr();
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     * @throws DBALException
-     */
-    protected function indexPageQueueItem(Item $item, int $language = 0, string $coreName = 'core_en'): bool
-    {
-        $parameters = [];
-        if ($item->hasIndexingProperty('isMountedPage')) {
-            $parameters['MP'] = $item->getIndexingProperty('mountPageSource')
-                . '-' . $item->getIndexingProperty('mountPageDestination');
-        }
-
-        if ($language > 0) {
-            $parameters['_language'] = $language;
-        }
-
-        $frontendUrl = $item->getSite()->getTypo3SiteObject()->getRouter()->generateUri(
-            $item->getRecordUid(),
-            $parameters,
-        );
-
-        $response = $this->executePageIndexer((string)$frontendUrl, $item);
-
-        $connection = $this->getConnectionPool()->getConnectionForTable('sys_template');
-        $connection->update(
-            'tx_solr_indexqueue_item',
-            ['indexed' => time()],
-            ['uid' => $item->getIndexQueueUid()],
-        );
-
-        return $response->getStatusCode() === 200;
-    }
-
-    /**
-     * Executes a Frontend sub-request to trigger page indexing via the new
-     * IndexingInstructions pipeline (SolrIndexingMiddleware).
-     */
-    protected function executePageIndexer(string $url, Item $item, ?int $frontendUserId = null): ResponseInterface
-    {
-        $instructions = new IndexingInstructions(
-            items: [$item],
-            action: IndexingInstructions::ACTION_INDEX_PAGE,
-            language: 0,
-            accessRootline: (string)Rootline::getAccessRootlineByPageId($item->getRecordUid()),
-            parameters: ['item' => $item->getIndexQueueUid()],
-        );
-
-        $request = new InternalRequest($url);
-        $request = $request->withAttribute('solr.indexingInstructions', $instructions);
-
-        $requestContext = null;
-        if ($frontendUserId !== null) {
-            $requestContext = (new InternalRequestContext())->withFrontendUserId($frontendUserId);
-        }
-
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-
-        /** @var VariableFrontend $runtimeCache */
-        $runtimeCache = GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime');
-        $runtimeCache->flush();
-
-        $response->getBody()->rewind();
-        return $response;
     }
 
     /**

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -642,6 +642,34 @@ abstract class IntegrationTestBase extends FunctionalTestCase
      */
     protected function indexQueuedItems(int $limit, int $rootPageId = 1): void
     {
+        $this->useIndexingServiceForTesting();
+
+        $site = GeneralUtility::makeInstance(SiteRepository::class)->getSiteByRootPageId($rootPageId);
+        GeneralUtility::makeInstance(IndexService::class, $site)->indexItems($limit);
+    }
+
+    /**
+     * Indexes one queue item the way IndexService does it, so that the item's indexing
+     * instructions come from production: the access rootline including the mount point
+     * parameter, and one sub-request per language and content access group.
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function indexQueuedItem(Item $item): bool
+    {
+        return $this->useIndexingServiceForTesting()->indexItems([$item]);
+    }
+
+    /**
+     * Replaces IndexingService with the test subclass that supplies the typo3.testing.context
+     * attribute the testing-framework's FrontendUserHandler middleware expects.
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    private function useIndexingServiceForTesting(): IndexingService
+    {
         /** @var Container $container */
         $container = $this->getContainer();
         GeneralUtility::setContainer($container);
@@ -649,14 +677,11 @@ abstract class IntegrationTestBase extends FunctionalTestCase
         // The container refuses to replace an already initialized service, and a test may index
         // more than once.
         if (!$indexingService instanceof IndexingServiceForTesting) {
-            $container->set(
-                IndexingService::class,
-                IndexingServiceForTesting::fromProductionService($indexingService),
-            );
+            $indexingService = IndexingServiceForTesting::fromProductionService($indexingService);
+            $container->set(IndexingService::class, $indexingService);
         }
 
-        $site = GeneralUtility::makeInstance(SiteRepository::class)->getSiteByRootPageId($rootPageId);
-        GeneralUtility::makeInstance(IndexService::class, $site)->indexItems($limit);
+        return $indexingService;
     }
 
     /**

--- a/Tests/Integration/IntegrationTestBase.php
+++ b/Tests/Integration/IntegrationTestBase.php
@@ -640,12 +640,12 @@ abstract class IntegrationTestBase extends FunctionalTestCase
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    protected function indexQueuedItems(int $limit, int $rootPageId = 1): void
+    protected function indexQueuedItems(int $limit, int $rootPageId = 1): bool
     {
         $this->useIndexingServiceForTesting();
 
         $site = GeneralUtility::makeInstance(SiteRepository::class)->getSiteByRootPageId($rootPageId);
-        GeneralUtility::makeInstance(IndexService::class, $site)->indexItems($limit);
+        return GeneralUtility::makeInstance(IndexService::class, $site)->indexItems($limit);
     }
 
     /**


### PR DESCRIPTION
Slice 3 of the dead-code EPIC. The branch is based on slice 2 (#4755), but targets `main` so the workflows actually run, so until #4755 merges this diff also contains slices 1 and 2. **Slice 3 is the last five commits**, `4704c528c` .. `413014ef6`.

## What this closes

`executePageIndexer()` was a second implementation of what `IndexingService` does in production, and it differed in three ways — the brief only knew about the first:

```php
// production - IndexingService::buildAccessRootline()
Rootline::getAccessRootlineByPageId($uid, $mountPointParameter)   // mount point parameter
    ->push(new RootlineElement('c:' . $contentAccessGroup));      // content access group
// ... and one sub-request per language, from getPageSolrConnections()

// the shim - executePageIndexer()
Rootline::getAccessRootlineByPageId($uid)                          // no mount point
language: 0                                                        // one language only
```

Three of the twelve tests it served are the mounted-page tests, so they asserted mount-point indexing against instructions that never carried a mount point. That is the observation this EPIC was opened on.

Both shims are gone. No add-on ever used either of them, so slice 6's contract step for these two is already done.

## Commits

| commit | |
|---|---|
| `4704c528c` | `IndexingService::indexItems()` as the production entry for one specific item |
| `a82341aba` | fixture listener switches on TypoScript, not an injected query parameter |
| `4be6682a7` | `PageIndexerTest` (12 tests) onto the production pipeline |
| `f2c7385e4` | `GarbageCollectorTest`'s mount page scenarios onto `IndexService` |
| `413014ef6` | delete `executePageIndexer()` and `indexPageQueueItem()` |

**Please rebase-merge, do not squash.** The commit split is the deliverable.

## Two deliberate changes worth review

**`canExecuteAdditionalPageIndexer` needed its fixture reworked.** The listener switched itself on when the request carried an `additionalTestPageIndexer` query parameter, which only a hand-built URL could supply — production's `buildPageParameters()` emits nothing but `pageUserGroup`. It now reads a TypoScript setting, which is how a real listener would be configured. The alternative was keeping `executePageIndexer()` alive for one test, which defeats the slice.

**`GarbageCollectorTest` loses 20 assertions, by necessity.** They were per-item and per-language `assertTrue($this->indexPageQueueItem($item))` calls inside loops. They cannot be kept: the item state, and therefore the "items that need reindexing" assertion, derives from `changed > indexed`, which only `IndexService` stamps — the per-item entry does not. So those scenarios moved to the full queue-worker path, which indexes in one call. What each language actually produced is still asserted by the per-core document counts, and `indexQueuedItems()` now returns `IndexService`'s success flag so one `assertTrue` survives per scenario.

## Verification

| check | result | slice 2 |
|---|---|---|
| integration | 417 tests, **2646** assertions | 417 / 2667 |
| unit | 970 / 2443 | |
| `tests:known-tests` | no test lost — 1086 methods, 1387 cases | unchanged |
| phpstan | no errors, 633 files | |
| coding standards | 0 of 647 files | |

The −21 is accounted for exactly: −20 from the `GarbageCollectorTest` loops (8 data rows × 1, plus 4 rows × 3), and −1 from a testing-framework assertion inside the faked sub-request that `phpProcessDoesNotDieIfPageIsNotAvailable` no longer performs — its own assertion is unchanged, it now asserts that `IndexService` reports the item as not indexed, which is the production guard, instead of an HTTP status from a request production never sends. Test count, skips and incompletes are identical at every step.

## Downstream

All three add-ons are green against this branch with **no changes required**, so there is no sync PR for slice 3:

| | phpstan | unit | integration | known-tests | CS |
|---|---|---|---|---|---|
| solrfal | OK | 59 / 154 | 159 / 1658 | 145 / 218 | 0 / 119 |
| tika | OK | 21 / 48 | 49 / 64 | 46 / 70 | 0 / 36 |
| solrconsole | OK | 26 / 161 | 1 / 26 | 27 / 27 | 0 / 57 |

solrfal is the only one touching the changed surface (`indexQueuedItems()` in `PageContextDetectorTest`); widening its return from `void` to `bool` left the assertion count identical at 1658.