### PR TITLE
[!!!][BUGFIX] Report why an Index Queue item failed, and stop queueing foreign sites' pages

### DIFF
--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -124,6 +124,14 @@ class IndexService
                         if ($itemChangedDateAfterIndex > $itemToIndex->getChanged() && $itemChangedDateAfterIndex > time()) {
                             $this->indexQueue->setForcedChangeTimeByItem($itemToIndex, $itemChangedDateAfterIndex);
                         }
+                    } else {
+                        // Without this the item keeps changed > indexed and errors = '', so it is
+                        // fetched again on every run and the queue stops making progress silently.
+                        $errors++;
+                        $this->indexQueue->markItemAsFailed(
+                            $itemToIndex,
+                            'Indexing returned false without raising an exception, see the TYPO3 log for the reason.',
+                        );
                     }
 
                     $afterIndexItemEvent = new AfterItemHasBeenIndexedEvent($itemToIndex, $this->getContextTask(), $indexRunId);

--- a/Classes/Domain/Index/IndexService.php
+++ b/Classes/Domain/Index/IndexService.php
@@ -138,7 +138,7 @@ class IndexService
                     $this->eventDispatcher->dispatch($afterIndexItemEvent);
                 } catch (Throwable $e) {
                     $errors++;
-                    $this->indexQueue->markItemAsFailed($itemToIndex, $e->getCode() . ': ' . $e->__toString());
+                    $this->indexQueue->markItemAsFailed($itemToIndex, $this->buildItemErrorMessage($e));
                     $this->generateIndexingErrorLog($itemToIndex, $e);
                 }
             }
@@ -192,6 +192,28 @@ class IndexService
     /**
      * Generates a message in the error log when an error occurred.
      */
+    /**
+     * The message the Index Queue module shows on a failed item: the messages of the whole
+     * exception chain, without the stack traces.
+     *
+     * `Throwable::__toString()` puts the traces of every exception in the chain into one string
+     * and starts with the innermost one, so the sentence naming the item and the action ends up
+     * last. An indexing sub-request nests the same throwable several times, which made that
+     * string exceed what the column can hold. The traces stay in the log, see
+     * generateIndexingErrorLog().
+     */
+    protected function buildItemErrorMessage(Throwable $e): string
+    {
+        $messages = [];
+        $cause = $e;
+        while ($cause !== null) {
+            $messages[] = $cause::class . ' (' . $cause->getCode() . '): ' . $cause->getMessage();
+            $cause = $cause->getPrevious();
+        }
+
+        return implode("\n\nCaused by: ", $messages);
+    }
+
     protected function generateIndexingErrorLog(Item $itemToIndex, Throwable $e): void
     {
         $message = 'Failed indexing Index Queue item ' . $itemToIndex->getIndexQueueUid();

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -284,6 +284,37 @@ class Site
         return $this->pagesRepository->findAllSubPageIdsByRootPage($pageId, $initialPagesAdditionalWhereClause);
     }
 
+    /**
+     * Same as getPages(), except that the pages of sites nested into this one are left out.
+     *
+     * Used when initializing the Index Queue: a nested site's pages belong to that site's queue.
+     *
+     * @return int[]
+     *
+     * @throws DBALException
+     */
+    public function getPagesWithinSite(
+        ?string $indexQueueConfigurationName = null,
+        ?string $additionalWhereClause = null,
+    ): array {
+        $initialPagesAdditionalWhereClause = '';
+        if ($indexQueueConfigurationName !== null) {
+            $initialPagesAdditionalWhereClause = $this->getSolrConfiguration()
+                ->getInitialPagesAdditionalWhereClause($indexQueueConfigurationName);
+        }
+
+        if ($additionalWhereClause !== null) {
+            $initialPagesAdditionalWhereClause .=
+                ($initialPagesAdditionalWhereClause !== '' ? ' AND ' : '')
+                . '(' . $additionalWhereClause . ')';
+        }
+
+        return $this->pagesRepository->findAllSubPageIdsByRootPageWithinSite(
+            (int)$this->rootPageRecord['uid'],
+            $initialPagesAdditionalWhereClause,
+        );
+    }
+
     public function getSiteHash(): string
     {
         return $this->siteHash;

--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -408,7 +408,17 @@ readonly class IndexingService
                     'exception' => $e->__toString(),
                 ],
             );
-            return null;
+
+            // Returning null here would reach the caller as "not indexed" and leave nothing but
+            // this log entry behind. Handing the throwable on lets IndexService record it on the
+            // queue item, so the reason is visible where the failure is.
+            throw new SolrIndexRuntimeException(
+                'The "' . $instructions->getAction() . '" sub-request for Index Queue item '
+                . $item->getIndexQueueUid() . ' (' . $item->getType() . ':' . $item->getRecordUid()
+                . ', language ' . $language . ') failed: ' . $e->getMessage(),
+                1788263400,
+                $e,
+            );
         }
     }
 

--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -425,7 +425,25 @@ readonly class IndexingService
     {
         $pageUid = $this->resolvePageUid($item);
         $site = $this->siteFinder->getSiteByPageId($pageUid);
-        $siteLanguage = $site->getLanguageById($language);
+
+        try {
+            $siteLanguage = $site->getLanguageById($language);
+        } catch (\InvalidArgumentException $languageDoesNotExist) {
+            // The languages come from the Solr connections of the site the queue item belongs to,
+            // while the page resolves to a site of its own. TYPO3 assigns language ids per site,
+            // so the two sets need not agree, and it will not reconcile them: see the closing of
+            // https://forge.typo3.org/issues/95688.
+            throw new SolrIndexRuntimeException(
+                'Language ' . $language . ' is configured for the Solr connections of the Index Queue'
+                . ' item\'s site (root page ' . $item->getRootPageUid() . '), but site "'
+                . $site->getIdentifier() . '", which owns page ' . $pageUid . ', does not define it.'
+                . ' Give every site that shares a page tree the same language ids, or index those'
+                . ' pages from their own site. See the note on'
+                . ' useConfigurationTrackRecordsOutsideSiteroot in the documentation.',
+                1788259200,
+                $languageDoesNotExist,
+            );
+        }
 
         $uri = $site->getRouter()->generateUri($pageUid, $language > 0 ? ['_language' => $language] : []);
 

--- a/Classes/IndexQueue/Initializer/AbstractInitializer.php
+++ b/Classes/IndexQueue/Initializer/AbstractInitializer.php
@@ -240,7 +240,7 @@ abstract class AbstractInitializer implements IndexQueueInitializer
      */
     protected function getPages(): array
     {
-        $pages = $this->site->getPages(null, $this->indexingConfigurationName);
+        $pages = $this->site->getPagesWithinSite($this->indexingConfigurationName);
         $additionalPageIds = [];
         if (!empty($this->indexingConfiguration['additionalPageIds'])) {
             $additionalPageIds = GeneralUtility::intExplode(',', $this->indexingConfiguration['additionalPageIds']);

--- a/Classes/System/Records/Pages/PagesRepository.php
+++ b/Classes/System/Records/Pages/PagesRepository.php
@@ -174,6 +174,82 @@ class PagesRepository extends AbstractRepository
     }
 
     /**
+     * Same as findAllSubPageIdsByRootPage(), except that pages starting a site of their own, and
+     * their subtrees, are left out.
+     *
+     * A nested site's pages belong to that site's Index Queue. Collecting them for the outer site
+     * produces items whose "root" is the outer site while the page itself resolves to the inner
+     * one, and the two sites' language sets then disagree during indexing.
+     *
+     * @return int[]
+     *
+     * @throws DBALException
+     */
+    public function findAllSubPageIdsByRootPageWithinSite(
+        int $rootPageId,
+        string $initialPagesAdditionalWhereClause = '',
+    ): array {
+        $cacheIdentifier = hash('sha1', 'getPagesWithinSite' . $rootPageId . $initialPagesAdditionalWhereClause);
+        if ($this->transientVariableCache->get($cacheIdentifier) !== false) {
+            return $this->transientVariableCache->get($cacheIdentifier);
+        }
+
+        $pageIds = $this->getSubPageIdsWithoutNestedSites($rootPageId);
+
+        if (!empty($initialPagesAdditionalWhereClause)) {
+            $pageIds = $this->filterPageIdsByInitialPagesAdditionalWhereClause($pageIds, $initialPagesAdditionalWhereClause);
+        }
+
+        $this->transientVariableCache->set($cacheIdentifier, $pageIds);
+        return $pageIds;
+    }
+
+    /**
+     * Collects the given page and its descendants, stopping at every page that carries
+     * is_siteroot, because such a page starts a site of its own.
+     *
+     * Deliberately not folded into getTreeList(): that helper is also used for garbage
+     * collection and mount page resolution, which must keep seeing the whole tree.
+     *
+     * @return int[]
+     *
+     * @throws DBALException
+     */
+    protected function getSubPageIdsWithoutNestedSites(int $rootPageId, int $depth = 9999): array
+    {
+        $pageIds = [$rootPageId];
+        if ($depth <= 0) {
+            return $pageIds;
+        }
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $childPages = $queryBuilder
+            ->select('uid', 'is_siteroot')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($rootPageId, ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('sys_language_uid', 0),
+            )
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($childPages as $childPage) {
+            if ((int)$childPage['is_siteroot'] === 1) {
+                continue;
+            }
+
+            $pageIds = array_merge(
+                $pageIds,
+                $this->getSubPageIdsWithoutNestedSites((int)$childPage['uid'], $depth - 1),
+            );
+        }
+
+        return $pageIds;
+    }
+
+    /**
      * This method retrieves the pages ids from the current tree level a calls getPages recursive,
      * when the maxDepth has not been reached.
      *

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -402,6 +402,47 @@ should check the ``solr.indexingInstructions`` request attribute instead.
 those calls — the sub-request pipeline handles CWD automatically.
 
 
+!!! A failed Index Queue item states why it failed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An item whose indexing failed without an exception kept ``changed > indexed`` and no error,
+so every run fetched it again and the Index Queue stopped making progress without showing a
+reason. Such an item is now marked as failed.
+
+The reason is recorded as well. Executing an indexing sub-request caught every throwable,
+wrote one log entry and reported the item as "not indexed", so the cause was only in the
+TYPO3 log. It is handed on now and ends up on the item, naming the sub-request action, the
+item and the language.
+
+``tx_solr_indexqueue_item.errors`` is a ``mediumtext`` for that. The messages of the whole
+exception chain are recorded, the stack traces stay in the TYPO3 log: a sub-request nests
+the same throwable several times, and all of its traces together exceeded the previous
+column, which turned marking an item as failed into a "Data too long" error.
+
+Impact
+""""""
+
+**The column change needs a database update**, so this does not take effect by updating the
+extension alone. Until the update ran, an item that fails with a long enough reason still
+aborts the indexing run:
+
+#.  Run *Analyze Database Structure* in the Upgrade module, or
+    ``vendor/bin/typo3 extension:setup``.
+#.  Empty ``tx_solr_indexqueue_item``.
+#.  Re-initialize the Index Queue, which also takes care of the items described in the next
+    section.
+
+.. note::
+   One reason that becomes visible with this is a TYPO3 issue rather than one of EXT:solr.
+   Indexing from the Index Queue module can fail on an installation with a single site, where
+   the module selects that site by itself and the page tree has page ``0`` selected while
+   *Index Now* is clicked. Fluid then aborts with "No Content Object definition found at
+   TypoScript object path", because ``f:cObject`` took the TypoScript from the backend context
+   instead of the indexing sub-request. TYPO3 solves it in
+   `6ceccf85 <https://github.com/TYPO3/typo3/commit/6ceccf85b31389c193dfd7feb97b3ff8b39ba1ce>`_,
+   part of TYPO3 14.3.7.
+
+
 !!! Index Queue initialization stops at nested site roots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -402,6 +402,52 @@ should check the ``solr.indexingInstructions`` request attribute instead.
 those calls — the sub-request pipeline handles CWD automatically.
 
 
+!!! Index Queue initialization stops at nested site roots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Initializing the Index Queue no longer collects the pages, and the records
+stored on them, of a site nested inside another site's page tree. A page
+carrying ``is_siteroot`` starts a site of its own, so its subtree belongs to
+that site's Index Queue alone.
+
+Until now the traversal ran through the whole subtree, so an outer site's queue
+also held the inner site's pages, with the outer site's root page written into
+``tx_solr_indexqueue_item.root``. Indexing such an item took the Solr
+connections from the outer site while the page itself resolved to the inner one.
+TYPO3 assigns language ids per site, the two sets need not agree, and core will
+not reconcile them -- see the closing of
+`forge #95688 <https://forge.typo3.org/issues/95688>`__ and its conclusion that
+"the only real solution is to define languages per page tree root". Such an item
+either failed with "Language X does not exist on site Y", or produced a document
+carrying one site's ``siteHash`` in another site's core, where neither site
+could find it.
+
+:php:`Site::getPagesWithinSite()` and
+:php:`PagesRepository::findAllSubPageIdsByRootPageWithinSite()` are new.
+:php:`Site::getPages()` and :php:`PagesRepository::getTreeList()` keep their
+previous behaviour, so mount point resolution and garbage collection are
+unaffected.
+
+Impact
+""""""
+
+**Re-initialize the Index Queue after updating.** Items written before this
+release still carry the outer site's root page and are not corrected
+automatically.
+
+**A site that relied on indexing a nested site's pages loses those documents**
+from its own cores; the nested site indexes them into its cores instead. Two
+supported ways to keep the previous search results:
+
+*   ``plugin.tx_solr.search.query.allowedSites`` lets one search span several
+    sites. This is the intended way to search across a shared page tree, and it
+    keeps each site's documents in its own cores.
+*   ``plugin.tx_solr.index.queue.[indexConfig].additionalPageIds`` still adds
+    individual pages explicitly, a nested site's pages included. It stays the
+    opt-in for an outer site that really has to index foreign pages, and the
+    language ids of the sites involved have to match for that to work.
+
+
 !!! The ``indexer`` Index Queue setting has been removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Tests/Integration/Domain/Index/Fixtures/indexing_returns_false_for_hidden_page.csv
+++ b/Tests/Integration/Domain/Index/Fixtures/indexing_returns_false_for_hidden_page.csv
@@ -1,0 +1,7 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","hidden","slug","title","tstamp"
+,1,0,1,1,0,"/","Root page",1007007007
+,2,1,0,1,1,"/hidden","Hidden page",1007007007
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","errors","pages_mountidentifier","item_pid"
+,4711,1,"pages",2,"pages",1449151778,0,0,0,"",,2

--- a/Tests/Integration/Domain/Index/Fixtures/subrequest_failure_cause_is_recorded.csv
+++ b/Tests/Integration/Domain/Index/Fixtures/subrequest_failure_cause_is_recorded.csv
@@ -1,0 +1,6 @@
+"pages",
+,"uid","pid","is_siteroot","doktype","hidden","slug","title","tstamp"
+,1,0,1,1,0,"/","Root page",1007007007
+"tx_solr_indexqueue_item",
+,"uid","root","item_type","item_uid","indexing_configuration","changed","indexed","has_indexing_properties","indexing_priority","errors","pages_mountidentifier","item_pid"
+,4712,1,"pages",1,"pages",1449151778,0,0,0,"",,1

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -80,6 +80,32 @@ final class IndexServiceTest extends IntegrationTestBase
         $this->indexQueue->updateItem($table, $uid, time());
     }
 
+    #[Test]
+    public function itemIsMarkedAsFailedWhenIndexingReturnsFalse(): void
+    {
+        // The queued page is hidden, so IndexingService reports the item as not indexed without
+        // raising an exception. The page record itself exists, so the item is not dropped as an
+        // orphan before it reaches IndexService.
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/indexing_returns_false_for_hidden_page.csv');
+
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $site = $siteRepository->getFirstAvailableSite();
+        GeneralUtility::makeInstance(IndexService::class, $site)->indexItems(1);
+
+        $row = $this->getConnectionPool()
+            ->getConnectionForTable('tx_solr_indexqueue_item')
+            ->select(['uid', 'changed', 'indexed', 'errors'], 'tx_solr_indexqueue_item', ['uid' => 4711])
+            ->fetchAssociative();
+
+        self::assertIsArray($row, 'The queue item was removed instead of being marked as failed');
+        self::assertNotSame(
+            '',
+            (string)$row['errors'],
+            'An item that failed to index keeps no error, so it is fetched again on every run'
+            . ' and the queue stops making progress without showing a reason',
+        );
+    }
+
     public static function canResolveBaseAsPrefixDataProvider(): Traversable
     {
         yield 'absRefPrefixIsFoo' => [

--- a/Tests/Integration/Domain/Index/IndexServiceTest.php
+++ b/Tests/Integration/Domain/Index/IndexServiceTest.php
@@ -106,6 +106,32 @@ final class IndexServiceTest extends IntegrationTestBase
         );
     }
 
+    #[Test]
+    public function theCauseOfAFailedSubRequestIsRecordedOnTheItem(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/subrequest_failure_cause_is_recorded.csv');
+
+        // A base without a host makes buildServerRequest() throw inside executeSubRequest().
+        $this->mergeSiteConfiguration('integration_tree_one', ['base' => '/']);
+
+        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+        $site = $siteRepository->getFirstAvailableSite();
+        GeneralUtility::makeInstance(IndexService::class, $site)->indexItems(1);
+
+        $row = $this->getConnectionPool()
+            ->getConnectionForTable('tx_solr_indexqueue_item')
+            ->select(['uid', 'errors'], 'tx_solr_indexqueue_item', ['uid' => 4712])
+            ->fetchAssociative();
+
+        self::assertIsArray($row, 'The queue item is gone instead of carrying the failure');
+        self::assertStringContainsString(
+            'generated a URI without host',
+            (string)$row['errors'],
+            'The reason the sub-request failed has to reach the queue item, otherwise the Index'
+            . ' Queue module shows a failure with no way to tell what caused it',
+        );
+    }
+
     public static function canResolveBaseAsPrefixDataProvider(): Traversable
     {
         yield 'absRefPrefixIsFoo' => [

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -57,7 +57,7 @@ CREATE TABLE tx_solr_indexqueue_item (
 	indexing_priority int(11) DEFAULT '0' NOT NULL,
 	changed int(11) unsigned DEFAULT '0' NOT NULL,
 	indexed int(11) DEFAULT '0' NOT NULL,
-	errors text NOT NULL,
+	errors mediumtext NOT NULL,
 	pages_mountidentifier varchar(255) DEFAULT '' NOT NULL,
 
 	PRIMARY KEY (uid),


### PR DESCRIPTION
Next step of the dead-code EPIC, and this one is release-relevant rather than cleanup: it fixes three reported issues found while migrating `IndexerTest`. The branch is based on #4758, but targets `main` so the workflows actually run, so until #4758 merges this diff also contains the earlier slices. **This slice is the last four commits**, `bfa8e217e` .. `d39cc72ad`.

Fixes: #4707
Relates: #4675
Replaces: #4677

## The three defects, and how they compound

**#4707 — the queue stops silently.** `IndexingService::indexItems()` can return `false` without raising an exception. `IndexService` stamped the index time only on success and marked an item as failed only from its `catch`, so such an item kept `changed > indexed` and `errors = ''`. It stayed at the top of the queue ordering and was refetched every run. Once as many items failed that way as `documentsToIndexLimit` allows, every run picked the same batch, all failed again, and the queue made **no progress at all** — while the Index Queue module showed no error on any item.

**The reason was thrown away.** `executeSubRequest()` caught every `Throwable`, wrote one log entry and returned `null`, which the caller read as "not indexed". So even once #4707 makes the failure visible, the message was "Indexing returned false without raising an exception". The throwable is handed on now, wrapped with the action, the item, its type and record uid and the language. `buildServerRequest()` runs inside the same `try`, so the two exceptions it raises — a site without a fully qualified base URL, and a language the page's site does not define — were swallowed identically and now arrive too.

A response with status >= 400 keeps returning `null`: that is an answer, not a failure, and `findUserGroups` legitimately gets one for a page that denies access.

**#4675 — an outer site queues a nested site's pages.** Initialization collected the whole subtree below a site root, so an outer site's queue also held the pages, and the records stored on them, of a site nested in its page tree, carrying the outer site's root in `tx_solr_indexqueue_item.root`. Indexing then took the Solr connections from the outer site while the page resolved to the inner one. TYPO3 assigns language ids per site and will not reconcile them — forge [#95688](https://forge.typo3.org/issues/95688) was closed with "the only real solution is to define languages per page tree root". The item either failed with "Language X does not exist on site Y" or produced a document carrying one site's `siteHash` in another site's core, where neither site can find it.

Together these explain why #4675 was reported as an exception by one user and as a stuck queue by another: the same contamination, surfacing through two different failure paths, neither of which recorded anything on the item.

## Why the language filter of #4677 is not the fix

#4677 intersected the connection list with the languages of the page's own site. That helps only while the two sites do not use the same id for different languages. With A `1=de` and B `1=zh-CN`, `getLanguageById(1)` succeeds on B, nothing is filtered, the sub-request renders zh-CN and the result is written into A's German core with B's `siteHash` — a wrong document in a core where neither site can find it, which is worse than the error it removes.

A locale comparison would avoid that trap, but with the boundary in place there is nothing left for it to guard: newly created items cannot carry a foreign root, stale ones are removed by the re-initialization the release note asks for, and the remaining paths are explicit opt-ins whose precondition core itself documents. So the cause is removed at the source instead: a page carrying `is_siteroot` starts a site of its own and its subtree belongs to that site's queue alone.

`Site::getPagesWithinSite()` and `PagesRepository::findAllSubPageIdsByRootPageWithinSite()` are new. `Site::getPages()` and `PagesRepository::getTreeList()` are untouched, so mount point resolution, garbage collection and EXT:solrconsole's verification keep their behaviour. `additionalPageIds` still adds foreign pages explicitly, and searching across a shared page tree stays the job of `allowedSites`.

`Site::getLanguageById()` throws a bare `\InvalidArgumentException` reading "Language 1 does not exist on site B", which says nothing about why EXT:solr asked B for a language it never configured. That message now names the item's root page, the site owning the page and the language id, and points at the setting whose documentation covers the constraint.

## Breaking, and what integrators have to do

Two reasons, both in the release note:

* Queue initialization no longer collects a nested site's pages. A site that relied on that loses those documents from its cores; the nested site indexes them into its own. `allowedSites` is the supported way to search across a shared page tree.
* `tx_solr_indexqueue_item.errors` becomes a `mediumtext`, which **needs a database update before the fix takes effect**. `Throwable::__toString()` collects the traces of the whole chain and starts with the innermost exception, so a nested sub-request produced a string that exceeded the previous column — and marking an item as failed then died with "Data too long", aborting the whole request. The messages of the chain are recorded now, the traces stay in the log.

So: *Analyze Database Structure*, empty `tx_solr_indexqueue_item`, re-initialize. One instruction covers both.

## Verified against a real installation, not only the harness

The delegation was written after tracing a production failure with the Xdebug MCP: a queue item reported only "Indexing returned false", and the swallowed cause turned out to be `TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException: No Content Object definition found at TypoScript object path "lib.dynamicContent"`, thrown three levels deep in `CObjectViewHelper`. That is a TYPO3 issue, fixed in core by [`6ceccf85`](https://github.com/TYPO3/typo3/commit/6ceccf85b31389c193dfd7feb97b3ff8b39ba1ce) and part of 14.3.7, and the release note records it — this PR is what made it identifiable at all.

Both regression tests were checked in the only way that counts, by reverting the fix:

| test | without the fix | with it |
|---|---|---|
| `itemIsMarkedAsFailedWhenIndexingReturnsFalse` | item keeps `errors = ''` | marked failed |
| `theCauseOfAFailedSubRequestIsRecordedOnTheItem` | `errors` reads "Indexing returned false without raising an exception" | `errors` names the cause |

| check | result |
|---|---|
| PHPStan level 6 | no errors |
| coding standards | 0 of 647 files |
| `IndexServiceTest` | 9 tests, 49 assertions |
| initializer / site / queue | 39 tests, 236 assertions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)