### PR TITLE
[FEATURE] Allow modifying page indexing subrequests through a PSR-14 event

### DIFF
--- a/Classes/Event/Indexing/AfterFrontendSubrequestHasBeenGeneratedEvent.php
+++ b/Classes/Event/Indexing/AfterFrontendSubrequestHasBeenGeneratedEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace ApacheSolrForTypo3\Solr\Event\Indexing;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\Item;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AfterFrontendSubrequestHasBeenGeneratedEvent
+{
+    public function __construct(
+        protected readonly Item $item,
+        protected ServerRequestInterface $request
+    ) {
+    }
+
+    public function getItem(): Item
+    {
+        return $this->item;
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    public function setRequest(ServerRequestInterface $request): self
+    {
+        $this->request = $request;
+        return $this;
+    }
+}

--- a/Classes/IndexQueue/IndexingService.php
+++ b/Classes/IndexQueue/IndexingService.php
@@ -22,6 +22,7 @@ use ApacheSolrForTypo3\Solr\Access\RootlineElement;
 use ApacheSolrForTypo3\Solr\Access\RootlineElementFormatException;
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\Domain\Site\Site;
+use ApacheSolrForTypo3\Solr\Event\Indexing\AfterFrontendSubrequestHasBeenGeneratedEvent;
 use ApacheSolrForTypo3\Solr\Event\Indexing\BeforeIndexingSubRequestIsPreparedEvent;
 use ApacheSolrForTypo3\Solr\Exception\InvalidArgumentException;
 use ApacheSolrForTypo3\Solr\Exception\InvalidConnectionException;
@@ -276,6 +277,10 @@ readonly class IndexingService
             );
 
             $request = $this->buildServerRequest($item, $language);
+            $event = new AfterFrontendSubrequestHasBeenGeneratedEvent($item, $request);
+            $this->eventDispatcher->dispatch($event);
+            $request = $event->getRequest();
+
             $request = $request->withAttribute('solr.indexingInstructions', $instructions);
 
             // Disable the page cache BEFORE the frontend middleware chain runs.


### PR DESCRIPTION
# What this pr does

Adds a new PSR-14 event, `ApacheSolrForTypo3\Solr\Event\Indexing\AfterFrontendSubrequestHasBeenGeneratedEvent`, dispatched in `IndexingService::executeSubRequest()` immediately after the internal indexing subrequest is built via `buildServerRequest()`.

The event exposes:

`getItem()`: Item — the index queue item currently being processed
`getRequest()`: ServerRequestInterface — the generated subrequest
`setRequest(ServerRequestInterface $request)` — lets a listener replace the request with a modified one

The (possibly modified) request returned by the event is then used for the rest of the indexing subrequest.

# Why is this needed?

Since EXT:solr builds page indexing requests as internal `ServerRequestInterface` subrequests instead of real HTTP calls, there was no extension point to inspect or modify that request before it runs through the frontend middleware chain — e.g. to add custom headers, query parameters, or request attributes that other middlewares/extensions rely on during indexing. This event restores that customization point in a way that's compatible with the subrequest-based indexing pipeline.

# How to test

```php
use ApacheSolrForTypo3\Solr\Event\Indexing\AfterFrontendSubrequestHasBeenGeneratedEvent;
use TYPO3\CMS\Core\Attribute\AsEventListener;

#[AsEventListener]
final class ModifyIndexingSubrequest
{
    public function __invoke(AfterFrontendSubrequestHasBeenGeneratedEvent $event): void
    {
        $request = $event->getRequest()->withHeader('Authorization', 'Basic ' . base64_encode('foouser:barpassword'));
        $event->setRequest($request);
    }
}

```

Fixes: #4765
