### PR TITLE
[Release] 14.0.1 TER/classic-mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Used versions (please complete the following information):**
  - TYPO3 Version: [e.g. 14.3.0]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 14.0.0]
+ - EXT:solr Version: [e.g. 14.0.1]
  - Used Apache Solr Version: [e.g. 10.0.1]
  - PHP Version: [e.g. 8.3.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Releases/solr-release-14-0.rst
+++ b/Documentation/Releases/solr-release-14-0.rst
@@ -4,6 +4,18 @@
 Releases 14.0
 =============
 
+Release 14.0.1
+==============
+
+This release solves the troubles within TER/classic-mode TYPO3 instances and is only relevant for classic-mode installations.
+
+All Changes
+-----------
+
+*   [FEATURE] simplify release process by @dkd-kaehm in `#4769 <https://github.com/TYPO3-Solr/ext-solr/pull/4769>`_
+*   [BUGFIX] Make EXT:solr compatible with non-Composer/classic TYPO3 instances by @dkd-kaehm in `#4768 <https://github.com/TYPO3-Solr/ext-solr/pull/4768>`_
+
+
 Release 14.0.0
 ==============
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,7 +19,7 @@
   />
   <project
 	  title="Apache Solr for TYPO3"
-	  release="14.0.0"
+	  release="14.0.1"
 	  version="14.0"
 	  copyright="since 2009 by dkd &amp; contributors"
   />


### PR DESCRIPTION
This release solves the troubles within TER/classic-mode TYPO3 instances 
and is only relevant for classic-mode installations.

Please Read the release notes:
https://docs.typo3.org/p/apache-solr-for-typo3/solr/14.0/en-us/Releases/solr-release-14-0.html